### PR TITLE
Parallelize song loading with Tokio and Rayon

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -999,7 +999,7 @@ impl ApplicationHandler for App {
     }
 }
 
-pub fn run() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let _ = env_logger::builder().filter_level(log::LevelFilter::Info).try_init();
     let config = crate::config::get();
     let backend_type = config.video_renderer;
@@ -1008,7 +1008,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
     let show_stats = config.show_stats;
     let color_index = config.simply_love_color;
 
-    song_loading::scan_and_load_songs("songs");
+    song_loading::scan_and_load_songs("songs").await;
     let event_loop = EventLoop::new()?;
     let mut app = App::new(backend_type, vsync_enabled, fullscreen_enabled, show_stats, color_index);
     event_loop.run_app(&mut app)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@ mod config;
 mod gameplay;
 mod assets;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     config::load();
     gameplay::profile::load();
     if let Err(e) = core::audio::init() {
@@ -15,5 +16,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     core::network::init();
     // env_logger is initialized in app::run()
-    app::run()
+    app::run().await
 }


### PR DESCRIPTION
This PR introduces a refactoring of the initial song loading process to dramatically reduce application startup time, especially for users with large song libraries. It replaces the previous synchronous, single-threaded approach with a multi-stage, parallel pipeline leveraging tokio for asynchronous I/O and rayon for CPU-bound parsing.

This is currently a proof-of-concept on a separate branch to gather feedback on the approach and its added complexity.
- Uses Tokio for concurrent file I/O (metadata checks, cache reads).
- Uses Rayon to parallelize CPU-bound simfile analysis across all cores.

Questions:
1. Complexity vs. Performance: This change introduces tokio and rayon as major dependencies and adds complexity to the loading logic. Is the dramatic performance gain worth this trade-off for the project at this stage?
2. Alternative Approaches: Could we achieve "good enough" performance with a simpler approach? (e.g., using std::thread and rayon without the full async runtime, or a different structuring of the pipeline).

If you have a better way of structuring this or see clear opportunities for improvement, please feel free to comment or contribute.