### PR TITLE
fix(flake): reduce amount of dependencies, add app

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1768758878,
+        "narHash": "sha256-DhKT7bQsXukpqxsX57+tGaR8WhdO/BpIbhn1yTy0P54=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "7c431ed49f516251a5f9867d4f36417394ae3a88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -20,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760878510,
-        "narHash": "sha256-K5Osef2qexezUfs0alLvZ7nQFTGS9DL2oTVsIXsqLgs=",
+        "lastModified": 1768564909,
+        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e2a59a5b1a82f89f2c7e598302a9cacebb72a67",
+        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
         "type": "github"
       },
       "original": {
@@ -34,45 +49,11 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "oxalica": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1761014195,
-        "narHash": "sha256-PlIZkwQM0an4ptA7vEC39ZlJcXPxqtKWtsRCwKz3I4w=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "f34ca7f18bd13e9f4487b0bff3017d3188f21904",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "oxalica": "oxalica"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,53 +4,79 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    oxalica.url = "github:oxalica/rust-overlay";
+    crane.url = "github:ipetkov/crane";
+    self.submodules = true;
   };
 
-  outputs = { self, nixpkgs, flake-utils, oxalica }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      crane,
+    }:
     with flake-utils.lib;
-    eachSystem allSystems (system:
+    eachSystem allSystems (
+      system:
       let
-        pkgs = nixpkgs.legacyPackages.${system}.extend oxalica.overlays.default;
-      in rec {
+        pkgs = nixpkgs.legacyPackages.${system};
+        craneLib = crane.mkLib pkgs;
+      in
+      {
+        packages = rec {
+          deadsync = craneLib.buildPackage rec {
+            src = ./.;
+            strictDeps = true;
 
-        packages = {
-          deadsync = let
-            rustPlatform = pkgs.makeRustPlatform {
-              cargo = pkgs.rust-bin.stable.latest.minimal;
-              rustc = pkgs.rust-bin.stable.latest.minimal;
-            };
-          in rustPlatform.buildRustPackage rec {
-            name = "deadsync";
-            src = self;
-            nativeBuildInputs = with pkgs; [ pkg-config ];
-            buildInputs = with pkgs; [
-                            alsa-lib.dev
-                            udev.dev 
-                            xorg.libX11
-                            xorg.libXrandr
-                            xorg.libXcursor
-                            xorg.libxcb
-                            xorg.libXi
-                            wayland
-                            libxkbcommon
-                            libxkbcommon.dev
-                            vulkan-loader
-                            vulkan-tools
-                            glfw
-                            libGL.dev
-                            libGL
-                            glew.dev
-                            glew
-                            egl-wayland
-                            egl-wayland.dev
-                            xorg.xf86videoamdgpu  # notice this line might not match your needs or desires
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+              makeWrapper
             ];
-            cargoLock = { lockFile = ./Cargo.lock; };
+            buildInputs = with pkgs; [
+              alsa-lib
+              libGL
+              libxcursor
+              libxi
+              libxkbcommon
+              shaderc # NB: this should be in nativeBuildInputs, but otherwise shaderc-sys builds its own copy of shaderc
+              udev
+              vulkan-loader
+              wayland
+              xorg.libX11
+              xorg.libxcb
+            ];
+
+            doCheck = false;
+
             LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
+            VK_LAYER_PATH = "${pkgs.vulkan-validation-layers}/share/vulkan/explicit_layer.d";
+            postInstall = ''
+              wrapProgram \
+                "$out/bin/deadsync" \
+                --set LD_LIBRARY_PATH ${LD_LIBRARY_PATH} \
+                --set VK_LAYER_PATH ${VK_LAYER_PATH}
+            '';
           };
+          default = deadsync;
         };
-        defaultPackage = packages.deadsync;
+
+        apps = rec {
+          deadsync = flake-utils.lib.mkApp {
+            drv = self.packages.${system}.deadsync;
+          };
+          default = deadsync;
+        };
+
+        devShells.default =
+          let
+            inherit (self.packages.${system}) deadsync;
+          in
+          craneLib.devShell {
+            inputsFrom = [ deadsync ];
+            inherit (deadsync) LD_LIBRARY_PATH VK_LAYER_PATH;
+          };
+
         formatter = pkgs.nixfmt;
-      });
+      }
+    );
 }


### PR DESCRIPTION
TL;DR: NIH'd `flake.nix`

What changed:
* Add `inputs.self.submodules = true`, avoids the need to append `?submodules=1` to path on every nix invocation
* Build every create as a derivation using `crate`
* Remove `rust-overlay` ~~because I couldn't figure out how to make it work with `crate`~~
* Reduce amount of buildInputs
* Add `shaderc` to buildInputs to avoid building it with cargo
* Add `VK_LAYER_PATH`, fixes Vulkan (non-wgpu) backend on my machine
* Add `apps.deadsync`, makes it possible to run `deadsync` with `nix run github:pnn64/deadsync` <sub>(provided that you have `assets/` in your pwd)</sub>