### PR TITLE
feat: support user-renamed profile folders

### DIFF
--- a/src/game/profile.rs
+++ b/src/game/profile.rs
@@ -2872,6 +2872,14 @@ fn is_local_profile_id(s: &str) -> bool {
         && !s.contains(['/', '\\', '\0'])
 }
 
+#[inline(always)]
+fn cmp_profile_ids_case_insensitive(a: &str, b: &str) -> std::cmp::Ordering {
+    a.chars()
+        .flat_map(char::to_lowercase)
+        .cmp(b.chars().flat_map(char::to_lowercase))
+        .then_with(|| a.cmp(b))
+}
+
 pub fn scan_local_profiles() -> Vec<LocalProfileSummary> {
     let root = Path::new(PROFILES_ROOT);
     let Ok(read_dir) = fs::read_dir(root) else {
@@ -2921,7 +2929,7 @@ pub fn scan_local_profiles() -> Vec<LocalProfileSummary> {
         });
     }
 
-    out.sort_by(|a, b| a.id.to_lowercase().cmp(&b.id.to_lowercase()));
+    out.sort_by(|a, b| cmp_profile_ids_case_insensitive(&a.id, &b.id));
     out
 }
 


### PR DESCRIPTION
Relax is_local_profile_id to accept any valid directory name (up to 64 chars) instead of requiring exactly 8 hex digits. This allows profiles whose folders have been manually renamed on disk to be recognized.

Sort scanned profiles case-insensitively so that renamed folders appear in a natural order regardless of casing.

Add fallback logic in load_for_side: if the configured default profile folder no longer exists, fall back to the first available local profile or Guest instead of silently failing.

Validated by:
1. Create profile 
2. Exit game 
3. Rename folder on disk 
4. Open game
5. Validate Profile still appears in Manage Profiles / Select Profile.

No profile loss, no forced recreate flow.

Addresses #22 