### PR TITLE
fix(eval): default non-player timing graph to TimingEx when FA+ is enabled

### DIFF
--- a/src/screens/evaluation.rs
+++ b/src/screens/evaluation.rs
@@ -936,7 +936,13 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
                 let primary = score_info[0].as_ref().map_or(EvalPane::Standard, |si| {
                     eval_pane_default_for(si.show_fa_plus_pane)
                 });
-                let secondary = EvalPane::Timing;
+                let secondary = score_info[0].as_ref().map_or(EvalPane::Timing, |si| {
+                    if si.show_fa_plus_pane {
+                        EvalPane::TimingEx
+                    } else {
+                        EvalPane::Timing
+                    }
+                });
                 active_pane = match joined {
                     profile::PlayerSide::P1 => [primary, secondary],
                     profile::PlayerSide::P2 => [secondary, primary],


### PR DESCRIPTION
In single/double play, the evaluation screen's non-player side always
defaulted to the ITG timing histogram, ignoring the FA+ preference.
Now defaults to TimingEx when show_fa_plus_pane is enabled.

Addresses #19 

<img width="1232" height="809" alt="image" src="https://github.com/user-attachments/assets/f8c338b4-ca77-4587-90c1-c77420b8bd7b" />
