### PR TITLE
feat(eval): add per-column early judgment tracking for Exc & Great

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1571,8 +1571,10 @@ fn build_course_summary_stage(course: &CourseRunState) -> Option<stage_stats::St
         let mut meter_count = 0u32;
         let mut any_failed = false;
         let mut show_w0 = false;
+        let mut show_fa_plus_pane = false;
         let mut show_ex = false;
         let mut show_hard_ex = false;
+        let mut track_early_judgments = false;
         let mut counts = crate::game::timing::WindowCounts::default();
         let mut counts_10ms = crate::game::timing::WindowCounts::default();
         let mut first_player: Option<&stage_stats::PlayerStageSummary> = None;
@@ -1593,8 +1595,10 @@ fn build_course_summary_stage(course: &CourseRunState) -> Option<stage_stats::St
             meter_count = meter_count.saturating_add(1);
             any_failed |= player.grade == scores::Grade::Failed;
             show_w0 |= player.show_w0;
+            show_fa_plus_pane |= player.show_fa_plus_pane;
             show_ex |= player.show_ex_score;
             show_hard_ex |= player.show_hard_ex_score;
+            track_early_judgments |= player.track_early_judgments;
             counts = merge_window_counts(counts, player.window_counts);
             counts_10ms = merge_window_counts(counts_10ms, player.window_counts_10ms);
         }
@@ -1646,8 +1650,10 @@ fn build_course_summary_stage(course: &CourseRunState) -> Option<stage_stats::St
             window_counts: counts,
             window_counts_10ms: counts_10ms,
             show_w0,
+            show_fa_plus_pane,
             show_ex_score: show_ex,
             show_hard_ex_score: show_hard_ex,
+            track_early_judgments,
         });
     }
 
@@ -1771,13 +1777,13 @@ fn score_info_from_stage(
         show_fa_plus_window: player.show_w0,
         show_ex_score: player.show_ex_score,
         show_hard_ex_score: player.show_hard_ex_score,
-        show_fa_plus_pane: player.show_w0,
+        show_fa_plus_pane: player.show_fa_plus_pane,
+        track_early_judgments: player.track_early_judgments,
         machine_records,
         machine_record_highlight_rank,
         personal_records,
         personal_record_highlight_rank,
         show_machine_personal_split: !earned_machine_record && earned_top2_personal,
-        track_early_judgments: profile::get_for_side(side).track_early_judgments,
     })
 }
 
@@ -1947,8 +1953,10 @@ fn stage_summary_from_eval(eval: &evaluation::State) -> Option<stage_stats::Stag
         window_counts: si.window_counts,
         window_counts_10ms: si.window_counts_10ms,
         show_w0: (si.show_fa_plus_window && si.show_fa_plus_pane) || si.show_ex_score,
+        show_fa_plus_pane: si.show_fa_plus_pane,
         show_ex_score: si.show_ex_score,
         show_hard_ex_score: si.show_hard_ex_score,
+        track_early_judgments: si.track_early_judgments,
     };
 
     match play_style {
@@ -2201,12 +2209,13 @@ impl ScreensState {
         now: Instant,
         session: &SessionState,
         asset_manager: &AssetManager,
+        shift_held: bool,
     ) -> Option<ScreenAction> {
         match self.current_screen {
             CurrentScreen::Gameplay => self
                 .gameplay_state
                 .as_mut()
-                .map(|gs| gameplay::update(gs, delta_time)),
+                .map(|gs| gameplay::update(gs, delta_time, shift_held)),
             CurrentScreen::Init => Some(init::update(&mut self.init_state, delta_time)),
             CurrentScreen::Options => {
                 options::update(&mut self.options_state, delta_time, asset_manager)
@@ -2744,7 +2753,7 @@ impl App {
                 if self.state.screens.current_screen == CurrentScreen::Gameplay
                     && let Some(gs) = self.state.screens.gameplay_state.as_mut()
                 {
-                    let _ = gameplay::update(gs, delta_time);
+                    let _ = gameplay::update(gs, delta_time, self.state.shell.shift_held);
                 }
 
                 if finished
@@ -2772,6 +2781,7 @@ impl App {
                         redraw_started,
                         &self.state.session,
                         &self.asset_manager,
+                        self.state.shell.shift_held,
                     ) && !matches!(action, ScreenAction::None)
                     {
                         let _ = self.handle_action(action, event_loop);

--- a/src/game/profile.rs
+++ b/src/game/profile.rs
@@ -1083,6 +1083,45 @@ impl core::fmt::Display for MiniIndicator {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MiniIndicatorScoreType {
+    #[default]
+    Itg,
+    Ex,
+    HardEx,
+}
+
+impl FromStr for MiniIndicatorScoreType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut key = String::with_capacity(s.len());
+        for ch in s.trim().chars() {
+            if ch.is_ascii_alphanumeric() {
+                key.push(ch.to_ascii_lowercase());
+            }
+        }
+        match key.as_str() {
+            "" | "itg" => Ok(Self::Itg),
+            "ex" => Ok(Self::Ex),
+            "hardex" | "hex" => Ok(Self::HardEx),
+            other => Err(format!(
+                "'{other}' is not a valid MiniIndicatorScoreType setting"
+            )),
+        }
+    }
+}
+
+impl core::fmt::Display for MiniIndicatorScoreType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Itg => write!(f, "ITG"),
+            Self::Ex => write!(f, "Ex"),
+            Self::HardEx => write!(f, "HardEx"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TargetScoreSetting {
     CMinus,
     C,
@@ -1202,7 +1241,7 @@ pub struct Profile {
     pub show_fa_plus_pane: bool,
     // 10ms blue Fantastic window for FA+ window display (Arrow Cloud: "SmallerWhite").
     pub fa_plus_10ms_blue_window: bool,
-    // Track and display per-column early judgment counts on evaluation (Simply Love: TrackEarlyJudgments).
+    // Track and display per-column early judgment counts on evaluation (zmod/Arrow Cloud semantics).
     pub track_early_judgments: bool,
     // Custom blue Fantastic window in milliseconds (1..22), shared by FA+ W0 and H.EX split.
     pub custom_fantastic_window: bool,
@@ -1256,6 +1295,7 @@ pub struct Profile {
     pub nps_graph_at_top: bool,
     pub transparent_density_graph_bg: bool,
     pub mini_indicator: MiniIndicator,
+    pub mini_indicator_score_type: MiniIndicatorScoreType,
     // Mini modifier as a percentage, mirroring Simply Love semantics.
     // 0 = normal size, 100 = 100% Mini (smaller), negative values enlarge.
     pub mini_percent: i32,
@@ -1363,6 +1403,7 @@ impl Default for Profile {
             nps_graph_at_top: false,
             transparent_density_graph_bg: false,
             mini_indicator: MiniIndicator::None,
+            mini_indicator_score_type: MiniIndicatorScoreType::Itg,
             mini_percent: 0,
             perspective: Perspective::default(),
             note_field_offset_x: 0,
@@ -1739,6 +1780,10 @@ fn ensure_local_profile_files(id: &str) -> Result<(), std::io::Error> {
             default_profile.mini_indicator
         ));
         content.push_str(&format!(
+            "MiniIndicatorScoreType = {}\n",
+            default_profile.mini_indicator_score_type
+        ));
+        content.push_str(&format!(
             "ReverseScroll = {}\n",
             i32::from(default_profile.reverse_scroll)
         ));
@@ -2059,6 +2104,10 @@ fn save_profile_ini_for_side(side: PlayerSide) {
         i32::from(profile.transparent_density_graph_bg)
     ));
     content.push_str(&format!("MiniIndicator={}\n", profile.mini_indicator));
+    content.push_str(&format!(
+        "MiniIndicatorScoreType={}\n",
+        profile.mini_indicator_score_type
+    ));
     content.push_str(&format!(
         "ReverseScroll={}\n",
         i32::from(profile.reverse_scroll)
@@ -2816,6 +2865,10 @@ fn load_for_side(side: PlayerSide) {
             if profile.mini_indicator == MiniIndicator::Pacemaker {
                 profile.pacemaker = true;
             }
+            profile.mini_indicator_score_type = profile_conf
+                .get("PlayerOptions", "MiniIndicatorScoreType")
+                .and_then(|s| MiniIndicatorScoreType::from_str(&s).ok())
+                .unwrap_or(default_profile.mini_indicator_score_type);
             profile.scroll_option = profile_conf
                 .get("PlayerOptions", "Scroll")
                 .and_then(|s| ScrollOption::from_str(&s).ok())
@@ -3906,6 +3959,21 @@ pub fn update_mini_indicator_for_side(side: PlayerSide, setting: MiniIndicator) 
             return;
         }
         profile.mini_indicator = setting;
+    }
+    save_profile_ini_for_side(side);
+}
+
+pub fn update_mini_indicator_score_type_for_side(
+    side: PlayerSide,
+    setting: MiniIndicatorScoreType,
+) {
+    {
+        let mut profiles = lock_profiles();
+        let profile = &mut profiles[side_ix(side)];
+        if profile.mini_indicator_score_type == setting {
+            return;
+        }
+        profile.mini_indicator_score_type = setting;
     }
     save_profile_ini_for_side(side);
 }

--- a/src/game/stage_stats.rs
+++ b/src/game/stage_stats.rs
@@ -29,4 +29,6 @@ pub struct PlayerStageSummary {
     pub show_w0: bool,
     pub show_ex_score: bool,
     pub show_hard_ex_score: bool,
+    pub show_fa_plus_pane: bool,
+    pub track_early_judgments: bool,
 }

--- a/src/screens/components/evaluation/pane_column.rs
+++ b/src/screens/components/evaluation/pane_column.rs
@@ -90,6 +90,8 @@ pub fn build_column_judgments_pane(
         kind: RowKind,
         label: &'static str,
         color: [f32; 4],
+        show_early: bool,
+        show_all: bool,
     }
 
     let show_fa_plus_rows = score_info.show_fa_plus_window && score_info.show_fa_plus_pane;
@@ -99,36 +101,50 @@ pub fn build_column_judgments_pane(
                 kind: RowKind::FanW0,
                 label: "FANTASTIC",
                 color: color::JUDGMENT_RGBA[0],
+                show_early: false,
+                show_all: false,
             },
             RowInfo {
                 kind: RowKind::FanW1,
                 label: "FANTASTIC",
                 color: color::JUDGMENT_FA_PLUS_WHITE_RGBA,
+                show_early: true,
+                show_all: false,
             },
             RowInfo {
                 kind: RowKind::Ex,
                 label: "EXCELLENT",
                 color: color::JUDGMENT_RGBA[1],
+                show_early: true,
+                show_all: false,
             },
             RowInfo {
                 kind: RowKind::Gr,
                 label: "GREAT",
                 color: color::JUDGMENT_RGBA[2],
+                show_early: true,
+                show_all: false,
             },
             RowInfo {
                 kind: RowKind::Dec,
                 label: "DECENT",
                 color: color::JUDGMENT_RGBA[3],
+                show_early: true,
+                show_all: true,
             },
             RowInfo {
                 kind: RowKind::Wo,
                 label: "WAY OFF",
                 color: color::JUDGMENT_RGBA[4],
+                show_early: true,
+                show_all: true,
             },
             RowInfo {
                 kind: RowKind::Miss,
                 label: "MISS",
                 color: color::JUDGMENT_RGBA[5],
+                show_early: false,
+                show_all: false,
             },
         ]
     } else {
@@ -137,31 +153,43 @@ pub fn build_column_judgments_pane(
                 kind: RowKind::FanCombined,
                 label: "FANTASTIC",
                 color: color::JUDGMENT_RGBA[0],
+                show_early: false,
+                show_all: false,
             },
             RowInfo {
                 kind: RowKind::Ex,
                 label: "EXCELLENT",
                 color: color::JUDGMENT_RGBA[1],
+                show_early: true,
+                show_all: false,
             },
             RowInfo {
                 kind: RowKind::Gr,
                 label: "GREAT",
                 color: color::JUDGMENT_RGBA[2],
+                show_early: true,
+                show_all: false,
             },
             RowInfo {
                 kind: RowKind::Dec,
                 label: "DECENT",
                 color: color::JUDGMENT_RGBA[3],
+                show_early: true,
+                show_all: true,
             },
             RowInfo {
                 kind: RowKind::Wo,
                 label: "WAY OFF",
                 color: color::JUDGMENT_RGBA[4],
+                show_early: true,
+                show_all: true,
             },
             RowInfo {
                 kind: RowKind::Miss,
                 label: "MISS",
                 color: color::JUDGMENT_RGBA[5],
+                show_early: false,
+                show_all: false,
             },
         ]
     };
@@ -197,16 +225,54 @@ pub fn build_column_judgments_pane(
     let preview_time = preview_elapsed.max(0.0);
     let preview_beat = preview_time * (PREVIEW_BPM / 60.0);
 
-    let count_for = |cj: ColumnJudgments, kind: RowKind| -> (u32, Option<u32>) {
+    struct RowCounts {
+        count: u32,
+        early: Option<u32>,
+        all: Option<u32>,
+    }
+
+    let count_for = |cj: ColumnJudgments, kind: RowKind| -> RowCounts {
         match kind {
-            RowKind::FanCombined => (cj.w0.saturating_add(cj.w1), None),
-            RowKind::FanW0 => (cj.w0, None),
-            RowKind::FanW1 => (cj.w1, None),
-            RowKind::Ex => (cj.w2, Some(cj.early_w2)),
-            RowKind::Gr => (cj.w3, Some(cj.early_w3)),
-            RowKind::Dec => (cj.w4, Some(cj.early_w4)),
-            RowKind::Wo => (cj.w5, Some(cj.early_w5)),
-            RowKind::Miss => (cj.miss, None),
+            RowKind::FanCombined => RowCounts {
+                count: cj.w0.saturating_add(cj.w1),
+                early: None,
+                all: None,
+            },
+            RowKind::FanW0 => RowCounts {
+                count: cj.w0,
+                early: None,
+                all: None,
+            },
+            RowKind::FanW1 => RowCounts {
+                count: cj.w1,
+                early: Some(cj.early_w1),
+                all: None,
+            },
+            RowKind::Ex => RowCounts {
+                count: cj.w2,
+                early: Some(cj.early_w2),
+                all: None,
+            },
+            RowKind::Gr => RowCounts {
+                count: cj.w3,
+                early: Some(cj.early_w3),
+                all: None,
+            },
+            RowKind::Dec => RowCounts {
+                count: cj.w4,
+                early: Some(cj.early_w4),
+                all: Some(cj.early_total_w4),
+            },
+            RowKind::Wo => RowCounts {
+                count: cj.w5,
+                early: Some(cj.early_w5),
+                all: Some(cj.early_total_w5),
+            },
+            RowKind::Miss => RowCounts {
+                count: cj.miss,
+                early: None,
+                all: None,
+            },
         }
     };
 
@@ -229,6 +295,31 @@ pub fn build_column_judgments_pane(
                     diffuse(row.color[0], row.color[1], row.color[2], row.color[3]):
                     z(101)
                 ));
+
+                if score_info.track_early_judgments && row.show_early {
+                    let label_width =
+                        font::measure_line_width_logical(miso_font, row.label, all_fonts) as f32
+                            * label_zoom;
+                    let info_x = labels_right_x - label_width / 1.15;
+                    if row.show_all {
+                        actors.push(act!(text: font("miso"): settext("(ALL)".to_string()):
+                            align(1.0, 0.5):
+                            xy(info_x, y - (row_height * 0.70)):
+                            zoom(0.6):
+                            horizalign(right):
+                            diffuse(row.color[0], row.color[1], row.color[2], row.color[3]):
+                            z(101)
+                        ));
+                    }
+                    actors.push(act!(text: font("miso"): settext("EARLY".to_string()):
+                        align(1.0, 0.5):
+                        xy(info_x, y - (row_height * 0.35)):
+                        zoom(0.6):
+                        horizalign(right):
+                        diffuse(row.color[0], row.color[1], row.color[2], row.color[3]):
+                        z(101)
+                    ));
+                }
             }
 
             // "HELD" label at the bottom, aligned relative to the MISS label width.
@@ -251,14 +342,13 @@ pub fn build_column_judgments_pane(
                 let cj = score_info.column_judgments[col_idx];
                 let col_center_x = (col_idx as f32 + 1.0).mul_add(col_width, base_x);
 
-                // Measure the widest number across all rows for this column,
-                // so early/held sub-numbers are positioned clear of any main count.
+                // Measure the widest main count so side annotations clear every row.
                 let mut max_count_width: f32 = 0.0;
                 for row in &rows {
-                    let (count, _) = count_for(cj, row.kind);
+                    let counts = count_for(cj, row.kind);
                     let w = font::measure_line_width_logical(
                         miso_font,
-                        &count.to_string(),
+                        &counts.count.to_string(),
                         all_fonts,
                     ) as f32
                         * number_zoom;
@@ -488,9 +578,9 @@ pub fn build_column_judgments_pane(
                 }
 
                 for (row_idx, row) in rows.iter().enumerate() {
-                    let (count, early_opt) = count_for(cj, row.kind);
+                    let counts = count_for(cj, row.kind);
                     let y = labels_frame_y + (row_idx as f32 + 1.0).mul_add(row_height, 0.0);
-                    actors.push(act!(text: font("miso"): settext(count.to_string()):
+                    actors.push(act!(text: font("miso"): settext(counts.count.to_string()):
                         align(0.5, 0.5):
                         xy(col_center_x, y):
                         zoom(number_zoom):
@@ -498,11 +588,24 @@ pub fn build_column_judgments_pane(
                         z(101)
                     ));
 
-                    if score_info.track_early_judgments && let Some(early) = early_opt {
-                        let early_y = y - (row_height * 0.35);
+                    if score_info.track_early_judgments
+                        && let Some(all) = counts.all
+                    {
+                        actors.push(act!(text: font("miso"): settext(all.to_string()):
+                            align(0.0, 0.5):
+                            xy(right_edge_x, y - (row_height * 0.70)):
+                            zoom(small_zoom):
+                            horizalign(left):
+                            z(101)
+                        ));
+                    }
+
+                    if score_info.track_early_judgments
+                        && let Some(early) = counts.early
+                    {
                         actors.push(act!(text: font("miso"): settext(early.to_string()):
                             align(1.0, 0.5):
-                            xy(right_edge_x, early_y):
+                            xy(right_edge_x, y - (row_height * 0.35)):
                             zoom(small_zoom):
                             horizalign(right):
                             z(101)

--- a/src/screens/evaluation.rs
+++ b/src/screens/evaluation.rs
@@ -244,17 +244,52 @@ pub struct ColumnJudgments {
     pub w4: u32,
     pub w5: u32,
     pub miss: u32,
+    pub early_w1: u32,
     pub early_w2: u32,
     pub early_w3: u32,
     pub early_w4: u32,
     pub early_w5: u32,
+    pub early_total_w0: u32,
+    pub early_total_w1: u32,
+    pub early_total_w2: u32,
+    pub early_total_w3: u32,
+    pub early_total_w4: u32,
+    pub early_total_w5: u32,
     pub held_miss: u32,
+}
+
+#[inline(always)]
+fn add_early_total(
+    slot: &mut ColumnJudgments,
+    judgment: &crate::game::judgment::Judgment,
+    include_bad: bool,
+) {
+    if matches!(
+        judgment.window,
+        Some(crate::game::judgment::TimingWindow::W0)
+    ) {
+        slot.early_total_w0 = slot.early_total_w0.saturating_add(1);
+        return;
+    }
+    match judgment.grade {
+        JudgeGrade::Fantastic => slot.early_total_w1 = slot.early_total_w1.saturating_add(1),
+        JudgeGrade::Excellent => slot.early_total_w2 = slot.early_total_w2.saturating_add(1),
+        JudgeGrade::Great => slot.early_total_w3 = slot.early_total_w3.saturating_add(1),
+        JudgeGrade::Decent if include_bad => {
+            slot.early_total_w4 = slot.early_total_w4.saturating_add(1)
+        }
+        JudgeGrade::WayOff if include_bad => {
+            slot.early_total_w5 = slot.early_total_w5.saturating_add(1)
+        }
+        _ => {}
+    }
 }
 
 fn compute_column_judgments(
     notes: &[crate::game::note::Note],
     cols_per_player: usize,
     col_offset: usize,
+    show_fa_plus_window: bool,
 ) -> Vec<ColumnJudgments> {
     let cols = cols_per_player.max(0);
     let mut out = vec![ColumnJudgments::default(); cols];
@@ -280,7 +315,12 @@ fn compute_column_judgments(
                 Some(crate::game::judgment::TimingWindow::W0) => {
                     slot.w0 = slot.w0.saturating_add(1)
                 }
-                _ => slot.w1 = slot.w1.saturating_add(1),
+                _ => {
+                    slot.w1 = slot.w1.saturating_add(1);
+                    if show_fa_plus_window && j.time_error_ms < 0.0 {
+                        slot.early_w1 = slot.early_w1.saturating_add(1);
+                    }
+                }
             },
             JudgeGrade::Excellent => {
                 slot.w2 = slot.w2.saturating_add(1);
@@ -313,9 +353,93 @@ fn compute_column_judgments(
                 }
             }
         }
+
+        if let Some(early) = note.early_result.as_ref() {
+            add_early_total(slot, j, false);
+            add_early_total(slot, early, true);
+        }
     }
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compute_column_judgments;
+    use crate::game::judgment::{JudgeGrade, Judgment, TimingWindow};
+    use crate::game::note::{Note, NoteType};
+
+    fn tap_note(column: usize, result: Judgment, early_result: Option<Judgment>) -> Note {
+        Note {
+            beat: 0.0,
+            quantization_idx: 0,
+            column,
+            note_type: NoteType::Tap,
+            row_index: 0,
+            result: Some(result),
+            early_result,
+            hold: None,
+            mine_result: None,
+            is_fake: false,
+            can_be_judged: true,
+        }
+    }
+
+    fn judgment(grade: JudgeGrade, window: Option<TimingWindow>, time_error_ms: f32) -> Judgment {
+        Judgment {
+            time_error_ms,
+            grade,
+            window,
+            miss_because_held: false,
+        }
+    }
+
+    #[test]
+    fn compute_column_judgments_tracks_split_white_early_fantastics() {
+        let notes = [tap_note(
+            0,
+            judgment(JudgeGrade::Fantastic, Some(TimingWindow::W1), -8.0),
+            None,
+        )];
+
+        let with_fa = compute_column_judgments(&notes, 1, 0, true);
+        let without_fa = compute_column_judgments(&notes, 1, 0, false);
+
+        assert_eq!(with_fa[0].w1, 1);
+        assert_eq!(with_fa[0].early_w1, 1);
+        assert_eq!(without_fa[0].early_w1, 0);
+    }
+
+    #[test]
+    fn compute_column_judgments_tracks_rescored_early_totals() {
+        let notes = [tap_note(
+            0,
+            judgment(JudgeGrade::Excellent, Some(TimingWindow::W2), -18.0),
+            Some(judgment(JudgeGrade::WayOff, Some(TimingWindow::W5), -18.0)),
+        )];
+
+        let out = compute_column_judgments(&notes, 1, 0, false);
+
+        assert_eq!(out[0].w2, 1);
+        assert_eq!(out[0].early_w2, 1);
+        assert_eq!(out[0].early_total_w2, 1);
+        assert_eq!(out[0].early_total_w5, 1);
+    }
+
+    #[test]
+    fn compute_column_judgments_tracks_w0_rescore_target() {
+        let notes = [tap_note(
+            0,
+            judgment(JudgeGrade::Fantastic, Some(TimingWindow::W0), -4.0),
+            Some(judgment(JudgeGrade::Decent, Some(TimingWindow::W4), -16.0)),
+        )];
+
+        let out = compute_column_judgments(&notes, 1, 0, true);
+
+        assert_eq!(out[0].w0, 1);
+        assert_eq!(out[0].early_total_w0, 1);
+        assert_eq!(out[0].early_total_w4, 1);
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -706,7 +830,12 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
                 grade = scores::Grade::Quint;
             }
 
-            let column_judgments = compute_column_judgments(notes, cols_per_player, col_offset);
+            let column_judgments = compute_column_judgments(
+                notes,
+                cols_per_player,
+                col_offset,
+                prof.show_fa_plus_window,
+            );
 
             score_info[player_idx] = Some(ScoreInfo {
                 song: gs.song.clone(),

--- a/src/screens/player_options.rs
+++ b/src/screens/player_options.rs
@@ -358,6 +358,9 @@ pub struct State {
     // For Gameplay Extras (More) row: bitmask of which options are enabled.
     // bit0 = Column Cues, bit1 = Display Scorebox.
     pub gameplay_extras_more_active_mask: [u8; PLAYER_SLOTS],
+    // For Results Extras row: bitmask of which options are enabled.
+    // bit0 = Track Early Judgments.
+    pub results_extras_active_mask: [u8; PLAYER_SLOTS],
     // For Life Bar Options row: bitmask of which options are enabled.
     // bit0 = Rainbow Max, bit1 = Responsive Colors, bit2 = Show Life Percentage.
     pub life_bar_options_active_mask: [u8; PLAYER_SLOTS],
@@ -1152,6 +1155,16 @@ fn build_advanced_rows(return_screen: Screen) -> Vec<Row> {
             choice_difficulty_indices: None,
         },
         Row {
+            name: ROW_INDICATOR_SCORE_TYPE.to_string(),
+            choices: vec!["ITG".to_string(), "EX".to_string(), "H.EX".to_string()],
+            selected_choice_index: [0; PLAYER_SLOTS],
+            help: vec![
+                "Choose which score formula the mini indicator tracks:".to_string(),
+                "ITG, EX (FA+), or H.EX (Hard EX).".to_string(),
+            ],
+            choice_difficulty_indices: None,
+        },
+        Row {
             name: "Gameplay Extras".to_string(),
             choices: gameplay_extras_choices,
             selected_choice_index: [0; PLAYER_SLOTS],
@@ -1341,6 +1354,15 @@ fn build_advanced_rows(return_screen: Screen) -> Vec<Row> {
             choice_difficulty_indices: None,
         },
         Row {
+            name: ROW_RESULTS_EXTRAS.to_string(),
+            choices: vec!["Track Early Judgments".to_string()],
+            selected_choice_index: [0; PLAYER_SLOTS],
+            help: vec![
+                "Show early-hit subtotals and rescored early-hit totals on evaluation.".to_string(),
+            ],
+            choice_difficulty_indices: None,
+        },
+        Row {
             name: "Timing Windows".to_string(),
             choices: vec![
                 "None".to_string(),
@@ -1362,7 +1384,6 @@ fn build_advanced_rows(return_screen: Screen) -> Vec<Row> {
                 "Display H.EX Score".to_string(),
                 "Display FA+ Pane".to_string(),
                 "10ms Blue Window".to_string(),
-                "Track Early Judgments".to_string(),
             ],
             selected_choice_index: [0; PLAYER_SLOTS],
             help: vec![
@@ -1588,6 +1609,7 @@ fn apply_profile_defaults(
     u8,
     u8,
     u8,
+    u8,
 ) {
     let mut scroll_active_mask: u8 = 0;
     let mut hide_active_mask: u8 = 0;
@@ -1601,6 +1623,7 @@ fn apply_profile_defaults(
     let mut early_dw_active_mask: u8 = 0;
     let mut gameplay_extras_active_mask: u8 = 0;
     let mut gameplay_extras_more_active_mask: u8 = 0;
+    let mut results_extras_active_mask: u8 = 0;
     let mut life_bar_options_active_mask: u8 = 0;
     let mut error_bar_active_mask: u8 =
         crate::game::profile::normalize_error_bar_mask(profile.error_bar_active_mask);
@@ -1946,6 +1969,22 @@ fn apply_profile_defaults(
     if let Some(row) = rows.iter_mut().find(|r| r.name == "Rescore Early Hits") {
         row.selected_choice_index[player_idx] = if profile.rescore_early_hits { 1 } else { 0 };
     }
+    if profile.track_early_judgments {
+        results_extras_active_mask |= 1u8 << 0;
+    }
+    if let Some(row) = rows.iter_mut().find(|r| r.name == ROW_RESULTS_EXTRAS) {
+        if results_extras_active_mask != 0 {
+            let first_idx = (0..row.choices.len())
+                .find(|i| {
+                    let bit = 1u8 << (*i as u8);
+                    (results_extras_active_mask & bit) != 0
+                })
+                .unwrap_or(0);
+            row.selected_choice_index[player_idx] = first_idx;
+        } else {
+            row.selected_choice_index[player_idx] = 0;
+        }
+    }
     if let Some(row) = rows.iter_mut().find(|r| r.name == "Mini Indicator") {
         row.selected_choice_index[player_idx] = match profile.mini_indicator {
             crate::game::profile::MiniIndicator::None => 0,
@@ -1955,6 +1994,14 @@ fn apply_profile_defaults(
             crate::game::profile::MiniIndicator::RivalScoring => 4,
             crate::game::profile::MiniIndicator::Pacemaker => 5,
             crate::game::profile::MiniIndicator::StreamProg => 6,
+        }
+        .min(row.choices.len().saturating_sub(1));
+    }
+    if let Some(row) = rows.iter_mut().find(|r| r.name == ROW_INDICATOR_SCORE_TYPE) {
+        row.selected_choice_index[player_idx] = match profile.mini_indicator_score_type {
+            crate::game::profile::MiniIndicatorScoreType::Itg => 0,
+            crate::game::profile::MiniIndicatorScoreType::Ex => 1,
+            crate::game::profile::MiniIndicatorScoreType::HardEx => 2,
         }
         .min(row.choices.len().saturating_sub(1));
     }
@@ -2000,9 +2047,6 @@ fn apply_profile_defaults(
     }
     if profile.fa_plus_10ms_blue_window {
         fa_plus_active_mask |= 1u8 << 4;
-    }
-    if profile.track_early_judgments {
-        fa_plus_active_mask |= 1u8 << 5;
     }
     if let Some(row) = rows
         .iter_mut()
@@ -2283,6 +2327,7 @@ fn apply_profile_defaults(
         early_dw_active_mask,
         gameplay_extras_active_mask,
         gameplay_extras_more_active_mask,
+        results_extras_active_mask,
         life_bar_options_active_mask,
         error_bar_active_mask,
         error_bar_options_active_mask,
@@ -2369,6 +2414,7 @@ pub fn init(
         early_dw_active_mask_p1,
         gameplay_extras_active_mask_p1,
         gameplay_extras_more_active_mask_p1,
+        results_extras_active_mask_p1,
         life_bar_options_active_mask_p1,
         error_bar_active_mask_p1,
         error_bar_options_active_mask_p1,
@@ -2387,6 +2433,7 @@ pub fn init(
         early_dw_active_mask_p2,
         gameplay_extras_active_mask_p2,
         gameplay_extras_more_active_mask_p2,
+        results_extras_active_mask_p2,
         life_bar_options_active_mask_p2,
         error_bar_active_mask_p2,
         error_bar_options_active_mask_p2,
@@ -2447,6 +2494,7 @@ pub fn init(
             gameplay_extras_more_active_mask_p1,
             gameplay_extras_more_active_mask_p2,
         ],
+        results_extras_active_mask: [results_extras_active_mask_p1, results_extras_active_mask_p2],
         life_bar_options_active_mask: [
             life_bar_options_active_mask_p1,
             life_bar_options_active_mask_p2,
@@ -2575,10 +2623,12 @@ const ROW_CUSTOM_FANTASTIC_WINDOW: &str = "Custom Blue Fantastic Window";
 const ROW_CUSTOM_FANTASTIC_WINDOW_MS: &str = "Custom Blue Fantastic Window (ms)";
 const ROW_CARRY_COMBO: &str = "Carry Combo";
 const ROW_HIDE: &str = "Hide";
+const ROW_RESULTS_EXTRAS: &str = "Results Extras";
 const ROW_COMBO_COLORS: &str = "Combo Colors";
 const ROW_COMBO_COLOR_MODE: &str = "Combo Color Mode";
 const ROW_LIFEMETER_TYPE: &str = "LifeMeter Type";
 const ROW_LIFE_BAR_OPTIONS: &str = "Life Bar Options";
+const ROW_INDICATOR_SCORE_TYPE: &str = "Indicator Score Type";
 
 #[derive(Clone, Copy, Debug)]
 struct RowVisibility {
@@ -2589,6 +2639,7 @@ struct RowVisibility {
     show_density_graph_background: bool,
     show_combo_rows: bool,
     show_lifebar_rows: bool,
+    show_indicator_score_type: bool,
 }
 
 #[inline(always)]
@@ -2617,6 +2668,9 @@ fn row_visible_with_flags(row_name: &str, visibility: RowVisibility) -> bool {
     if row_name == ROW_LIFEMETER_TYPE || row_name == ROW_LIFE_BAR_OPTIONS {
         return visibility.show_lifebar_rows;
     }
+    if row_name == ROW_INDICATOR_SCORE_TYPE {
+        return visibility.show_indicator_score_type;
+    }
     true
 }
 
@@ -2644,6 +2698,9 @@ fn conditional_row_parent(row_name: &str) -> Option<&'static str> {
         || row_name == ROW_LIFE_BAR_OPTIONS
     {
         return Some(ROW_HIDE);
+    }
+    if row_name == ROW_INDICATOR_SCORE_TYPE {
+        return Some("Mini Indicator");
     }
     None
 }
@@ -2775,6 +2832,26 @@ fn lifebar_rows_visible(
     !any_active
 }
 
+fn indicator_score_type_visible(rows: &[Row], active: [bool; PLAYER_SLOTS]) -> bool {
+    let Some(row) = rows.iter().find(|r| r.name == "Mini Indicator") else {
+        return true;
+    };
+    let max_choice = row.choices.len().saturating_sub(1);
+    let mut any_active = false;
+    for player_idx in 0..PLAYER_SLOTS {
+        if !active[player_idx] {
+            continue;
+        }
+        any_active = true;
+        let choice_idx = row.selected_choice_index[player_idx].min(max_choice);
+        // Visible for Subtractive(1), Predictive(2), Pace(3)
+        if choice_idx >= 1 && choice_idx <= 3 {
+            return true;
+        }
+    }
+    !any_active
+}
+
 #[inline(always)]
 fn row_visibility(
     rows: &[Row],
@@ -2790,6 +2867,7 @@ fn row_visibility(
         show_density_graph_background: density_graph_background_visible(rows, active),
         show_combo_rows: combo_rows_visible(active, hide_active_mask),
         show_lifebar_rows: lifebar_rows_visible(active, hide_active_mask),
+        show_indicator_score_type: indicator_score_type_visible(rows, active),
     }
 }
 
@@ -2953,6 +3031,7 @@ fn row_shows_all_choices_inline(row_name: &str) -> bool {
         || row_name == "Timing Windows"
         || row_name == ROW_JUDGMENT_TILT
         || row_name == "Mini Indicator"
+        || row_name == ROW_INDICATOR_SCORE_TYPE
         || row_name == "Turn"
         || row_name == "Scroll"
         || row_name == "Hide"
@@ -2964,6 +3043,7 @@ fn row_shows_all_choices_inline(row_name: &str) -> bool {
         || row_name == "Combo Color Mode"
         || row_name == ROW_CARRY_COMBO
         || row_name.starts_with("Gameplay Extras")
+        || row_name == ROW_RESULTS_EXTRAS
         || row_name == "Rescore Early Hits"
         || row_name == ROW_CUSTOM_FANTASTIC_WINDOW
         || row_name == "Early Decent/Way Off Options"
@@ -2996,6 +3076,7 @@ fn row_toggles_with_start(row_name: &str) -> bool {
         || row_name == "Life Bar Options"
         || row_name == "Gameplay Extras"
         || row_name == "Gameplay Extras (More)"
+        || row_name == ROW_RESULTS_EXTRAS
         || row_name == "Error Bar"
         || row_name == "Error Bar Options"
         || row_name == "Measure Counter Options"
@@ -3598,6 +3679,25 @@ fn change_choice_for_player(
                 subtractive_scoring,
                 pacemaker,
                 profile_ref.nps_graph_at_top,
+            );
+        }
+        visibility_changed = true;
+    } else if row_name == ROW_INDICATOR_SCORE_TYPE {
+        let choice = row
+            .choices
+            .get(row.selected_choice_index[player_idx])
+            .map(|s| s.as_str())
+            .unwrap_or("ITG");
+        let score_type = match choice {
+            "EX" => crate::game::profile::MiniIndicatorScoreType::Ex,
+            "H.EX" => crate::game::profile::MiniIndicatorScoreType::HardEx,
+            _ => crate::game::profile::MiniIndicatorScoreType::Itg,
+        };
+        state.player_profiles[player_idx].mini_indicator_score_type = score_type;
+        if should_persist {
+            crate::game::profile::update_mini_indicator_score_type_for_side(
+                persist_side,
+                score_type,
             );
         }
     } else if row_name == "Density Graph Background" {
@@ -4740,7 +4840,7 @@ fn toggle_fa_plus_row(state: &mut State, player_idx: usize) {
     }
 
     let choice_index = state.rows[row_index].selected_choice_index[idx];
-    let bit = if choice_index < 6 {
+    let bit = if choice_index < 5 {
         1u8 << (choice_index as u8)
     } else {
         0
@@ -4761,13 +4861,11 @@ fn toggle_fa_plus_row(state: &mut State, player_idx: usize) {
     let hard_ex_enabled = (state.fa_plus_active_mask[idx] & (1u8 << 2)) != 0;
     let pane_enabled = (state.fa_plus_active_mask[idx] & (1u8 << 3)) != 0;
     let ten_ms_enabled = (state.fa_plus_active_mask[idx] & (1u8 << 4)) != 0;
-    let track_early = (state.fa_plus_active_mask[idx] & (1u8 << 5)) != 0;
     state.player_profiles[idx].show_fa_plus_window = window_enabled;
     state.player_profiles[idx].show_ex_score = ex_enabled;
     state.player_profiles[idx].show_hard_ex_score = hard_ex_enabled;
     state.player_profiles[idx].show_fa_plus_pane = pane_enabled;
     state.player_profiles[idx].fa_plus_10ms_blue_window = ten_ms_enabled;
-    state.player_profiles[idx].track_early_judgments = track_early;
     let play_style = crate::game::profile::get_session_play_style();
     let should_persist = play_style == crate::game::profile::PlayStyle::Versus
         || idx == session_persisted_player_idx();
@@ -4782,7 +4880,51 @@ fn toggle_fa_plus_row(state: &mut State, player_idx: usize) {
         crate::game::profile::update_show_hard_ex_score_for_side(side, hard_ex_enabled);
         crate::game::profile::update_show_fa_plus_pane_for_side(side, pane_enabled);
         crate::game::profile::update_fa_plus_10ms_blue_window_for_side(side, ten_ms_enabled);
-        crate::game::profile::update_track_early_judgments_for_side(side, track_early);
+    }
+
+    audio::play_sfx("assets/sounds/change_value.ogg");
+}
+
+fn toggle_results_extras_row(state: &mut State, player_idx: usize) {
+    let idx = player_idx.min(PLAYER_SLOTS - 1);
+    let row_index = state.selected_row[idx];
+    if let Some(row) = state.rows.get(row_index) {
+        if row.name != ROW_RESULTS_EXTRAS {
+            return;
+        }
+    } else {
+        return;
+    }
+
+    let choice_index = state.rows[row_index].selected_choice_index[idx];
+    let bit = if choice_index < 1 {
+        1u8 << (choice_index as u8)
+    } else {
+        0
+    };
+    if bit == 0 {
+        return;
+    }
+
+    if (state.results_extras_active_mask[idx] & bit) != 0 {
+        state.results_extras_active_mask[idx] &= !bit;
+    } else {
+        state.results_extras_active_mask[idx] |= bit;
+    }
+
+    let track_early_judgments = (state.results_extras_active_mask[idx] & (1u8 << 0)) != 0;
+    state.player_profiles[idx].track_early_judgments = track_early_judgments;
+
+    let play_style = crate::game::profile::get_session_play_style();
+    let should_persist = play_style == crate::game::profile::PlayStyle::Versus
+        || idx == session_persisted_player_idx();
+    if should_persist {
+        let side = if idx == P1 {
+            crate::game::profile::PlayerSide::P1
+        } else {
+            crate::game::profile::PlayerSide::P2
+        };
+        crate::game::profile::update_track_early_judgments_for_side(side, track_early_judgments);
     }
 
     audio::play_sfx("assets/sounds/change_value.ogg");
@@ -5130,6 +5272,7 @@ fn apply_pane(state: &mut State, pane: OptionsPane) {
         early_dw_active_mask_p1,
         gameplay_extras_active_mask_p1,
         gameplay_extras_more_active_mask_p1,
+        results_extras_active_mask_p1,
         life_bar_options_active_mask_p1,
         error_bar_active_mask_p1,
         error_bar_options_active_mask_p1,
@@ -5148,6 +5291,7 @@ fn apply_pane(state: &mut State, pane: OptionsPane) {
         early_dw_active_mask_p2,
         gameplay_extras_active_mask_p2,
         gameplay_extras_more_active_mask_p2,
+        results_extras_active_mask_p2,
         life_bar_options_active_mask_p2,
         error_bar_active_mask_p2,
         error_bar_options_active_mask_p2,
@@ -5176,6 +5320,8 @@ fn apply_pane(state: &mut State, pane: OptionsPane) {
         gameplay_extras_more_active_mask_p1,
         gameplay_extras_more_active_mask_p2,
     ];
+    state.results_extras_active_mask =
+        [results_extras_active_mask_p1, results_extras_active_mask_p2];
     state.life_bar_options_active_mask = [
         life_bar_options_active_mask_p1,
         life_bar_options_active_mask_p2,
@@ -5334,6 +5480,10 @@ fn handle_start_event(
     }
     if row_name == "Gameplay Extras (More)" {
         toggle_gameplay_extras_more_row(state, player_idx);
+        return None;
+    }
+    if row_name == ROW_RESULTS_EXTRAS {
+        toggle_results_extras_row(state, player_idx);
         return None;
     }
     if row_name == "Error Bar" {
@@ -6333,6 +6483,46 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                         continue;
                     }
                     let mask = state.gameplay_extras_more_active_mask[player_idx];
+                    if mask == 0 {
+                        continue;
+                    }
+                    let underline_y = underline_y_for(player_idx);
+                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
+                    line_color[3] *= a;
+                    for idx in 0..row.choices.len() {
+                        let bit = 1u8 << (idx as u8);
+                        if (mask & bit) == 0 {
+                            continue;
+                        }
+                        if let Some(sel_x) = x_positions.get(idx).copied() {
+                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
+                            let underline_w = draw_w.ceil();
+                            actors.push(act!(quad:
+                                align(0.0, 0.5):
+                                xy(sel_x, underline_y):
+                                zoomto(underline_w, line_thickness):
+                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
+                                z(101)
+                            ));
+                        }
+                    }
+                }
+            } else if row.name == ROW_RESULTS_EXTRAS {
+                let line_thickness = widescale(2.0, 2.5).round().max(1.0);
+                let offset = widescale(3.0, 4.0);
+                let underline_base_y = current_row_y + text_h * 0.5 + offset;
+                let underline_y_for = |player_idx: usize| {
+                    if active[P1] && active[P2] {
+                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
+                    } else {
+                        underline_base_y
+                    }
+                };
+                for player_idx in 0..PLAYER_SLOTS {
+                    if !active[player_idx] {
+                        continue;
+                    }
+                    let mask = state.results_extras_active_mask[player_idx];
                     if mask == 0 {
                         continue;
                     }

--- a/src/test_support/pane_stats_bench.rs
+++ b/src/test_support/pane_stats_bench.rs
@@ -121,7 +121,7 @@ fn bench_score_info() -> ScoreInfo {
         show_ex_score: true,
         show_hard_ex_score: true,
         show_fa_plus_pane: true,
-        track_early_judgments: false,
+        track_early_judgments: true,
         machine_records: Vec::new(),
         machine_record_highlight_rank: None,
         personal_records: Vec::new(),


### PR DESCRIPTION
Extend the Column pane (Pane3) to show early hit counts for Excellent and Great, matching Simply Love's TrackEarlyJudgments behavior. Early counts are always computed but only displayed when the new "Track Early Judgments" toggle is enabled in FA+ Options.

- Add early_w2/early_w3 fields to ColumnJudgments
- Track negative time_error_ms as early in compute_column_judgments()
- Gate early sub-number rendering on track_early_judgments profile flag
- Add "Track Early Judgments" toggle to FA+ Options row (bit 5)
- Persist toggle in profile ini as TrackEarlyJudgments
- Fix early sub-number positioning: use row_height * 0.35 instead of fixed 10px offset to prevent overlap in FA+ 7-row mode
- Fix right_edge_x alignment: measure widest count across all rows instead of only Miss width