### PR TITLE
Song Search Double Type Fix

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4529,8 +4529,10 @@ impl App {
         event_loop: &ActiveEventLoop,
         key_event: winit::event::KeyEvent,
     ) {
-        if let Some(text) = key_event.text.as_deref() {
-            self.handle_key_text(event_loop, text);
+        if key_event.state == winit::event::ElementState::Pressed {
+            if let Some(text) = key_event.text.as_deref() {
+                self.handle_key_text(event_loop, text);
+            }
         }
 
         let winit::keyboard::PhysicalKey::Code(code) = key_event.physical_key else {


### PR DESCRIPTION
## Fix: double-typed characters in song search on Linux

On Linux, winit 0.30's XKB layer populates `KeyEvent.text` for both key-press and key-release events (unlike Windows/macOS where `text` is `None` on release). The `handle_window_key_event` function processed text unconditionally for every `KeyboardInput` event, causing each keystroke to append the character twice — once on press, once on release.

This affected any text entry screen routed through `handle_key_text`, including song search and profile name entry.

The fix gates text processing on `ElementState::Pressed` so release events are ignored.

Addresses #122 