### PR TITLE
Transliteration Support

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4484,6 +4484,12 @@ impl App {
             config::update_show_stats_mode(mode);
             options::sync_show_stats_mode(&mut self.state.screens.options_state, mode);
         }
+        if raw_key.pressed && !raw_key.repeat && raw_key.code == KeyCode::F9 {
+            let new_value = !config::get().translated_titles;
+            config::update_translated_titles(new_value);
+            options::sync_translated_titles(&mut self.state.screens.options_state, new_value);
+            crate::engine::audio::play_sfx("assets/sounds/change.ogg");
+        }
         if raw_key.pressed
             && !raw_key.repeat
             && self.state.shell.ctrl_held

--- a/src/screens/options.rs
+++ b/src/screens/options.rs
@@ -5502,6 +5502,17 @@ pub fn sync_show_stats_mode(state: &mut State, mode: u8) {
     clear_render_cache(state);
 }
 
+pub fn sync_translated_titles(state: &mut State, enabled: bool) {
+    set_choice_by_label(
+        &mut state.sub_choice_indices_select_music,
+        SELECT_MUSIC_OPTIONS_ROWS,
+        SELECT_MUSIC_ROW_NATIVE_LANGUAGE,
+        translated_titles_choice_index(enabled),
+    );
+    sync_submenu_cursor_indices(state);
+    clear_render_cache(state);
+}
+
 pub fn sync_max_fps(state: &mut State, max_fps: u16) {
     let had_explicit_cap = state.max_fps_at_load != 0;
     state.max_fps_at_load = max_fps;


### PR DESCRIPTION
# Add F9 hotkey to toggle translated song titles

## Summary

Adds an F9 keyboard shortcut to toggle between native and transliterated (romanized) song titles, matching ITGMania's F9 behavior.

## Changes

- **F9 key handler** (`src/app/mod.rs`): Toggles the `translated_titles` config on keypress, persists the setting to disk, syncs the options screen, and plays the change sound effect. Handled at the app level alongside F3 (stats overlay) so it works from any screen.
- **Options sync** (`src/screens/options.rs`): Adds `sync_translated_titles()` to keep the "Show Native Language" row in the options screen consistent when toggled via F9.

![transliteration gif](https://github.com/user-attachments/assets/0197e031-9b47-48bf-a8b2-60d87afc3291)

Addresses #119 