### PR TITLE
Auto Screenshot Fix

### DIFF
--- a/src/app/screenshot.rs
+++ b/src/app/screenshot.rs
@@ -44,7 +44,7 @@ pub(super) fn should_auto_screenshot_eval(eval: &evaluation::State, mask: u8) ->
     }
     for info in eval.score_info.iter().flatten() {
         let is_fail = info.fail_time.is_some();
-        let is_pb = info.personal_record_highlight_rank.is_some();
+        let is_pb = info.personal_record_highlight_rank == Some(1);
         let is_quad = matches!(info.grade, scores::Grade::Tier01);
         let is_quint = matches!(info.grade, scores::Grade::Quint);
         if (mask & crate::config::AUTO_SS_PBS) != 0 && is_pb {
@@ -53,7 +53,7 @@ pub(super) fn should_auto_screenshot_eval(eval: &evaluation::State, mask: u8) ->
         if (mask & crate::config::AUTO_SS_FAILS) != 0 && is_fail {
             return true;
         }
-        if (mask & crate::config::AUTO_SS_CLEARS) != 0 && !is_fail && !is_pb {
+        if (mask & crate::config::AUTO_SS_CLEARS) != 0 && !is_fail {
             return true;
         }
         if (mask & crate::config::AUTO_SS_QUADS) != 0 && is_quad {


### PR DESCRIPTION
The is_pb check used .is_some() on personal_record_highlight_rank, which treated any leaderboard placement as a PB. This caused the Clears condition (!is_fail && !is_pb) to be skipped for scores that placed on the personal leaderboard but weren't the top score.

Changed is_pb to only match rank 1 (actual personal best) and removed the !is_pb guard from the Clears condition so clears are no longer blocked by non-top placements.