### PR TITLE
Add Windows Build Workflow

### DIFF
--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -25,3 +25,9 @@ jobs:
       tag: ${{ inputs.tag }}
       arch: all
     secrets: inherit
+
+  release-windows:
+    uses: ./.github/workflows/release-windows.yml
+    with:
+      tag: ${{ inputs.tag }}
+    secrets: inherit

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,0 +1,91 @@
+name: release-windows
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag (example: v0.2.22)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (example: v0.2.22)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build-release:
+    runs-on: windows-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Install Vulkan SDK
+        shell: pwsh
+        run: scripts/install-vulkan-sdk.ps1
+
+      - name: Install Ninja
+        shell: pwsh
+        run: scripts/install-ninja.ps1
+
+      - name: Install CMake
+        shell: pwsh
+        run: scripts/install-cmake.ps1
+
+      - name: Resolve release tag
+        id: tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ github.event.inputs.tag }}"
+          elif [ "${{ github.event_name }}" = "workflow_call" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${GITHUB_REF_NAME}"
+          fi
+          tag="${tag#refs/tags/}"
+          if [ -z "${tag}" ]; then
+            echo "Release tag is required." >&2
+            exit 1
+          fi
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build release
+        run: cargo build --release --locked
+
+      - name: Package Windows release
+        id: package
+        shell: pwsh
+        run: scripts/package-windows-release.ps1 -Tag "${{ steps.tag.outputs.tag }}" -Arch x86_64
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: deadsync-windows-${{ steps.tag.outputs.tag }}-x86_64
+          if-no-files-found: error
+          path: ${{ steps.package.outputs.archive }}
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          target_commitish: ${{ github.sha }}
+          files: ${{ steps.package.outputs.archive }}
+          generate_release_notes: true
+          prerelease: ${{ contains(steps.tag.outputs.tag, '-') }}
+          fail_on_unmatched_files: true

--- a/scripts/install-cmake.ps1
+++ b/scripts/install-cmake.ps1
@@ -1,0 +1,40 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (Get-Command cmake -ErrorAction SilentlyContinue) {
+    $existing = (cmake --version | Select-Object -First 1).Trim()
+    Write-Host "CMake already installed: $existing"
+    return
+}
+
+$isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+    [Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Error 'This script must be run as Administrator.'
+    exit 1
+}
+
+$version = '3.31.6'
+$url = "https://github.com/Kitware/CMake/releases/download/v${version}/cmake-${version}-windows-x86_64.zip"
+$zip = Join-Path $env:TEMP 'cmake-win.zip'
+$dest = Join-Path $env:ProgramFiles 'cmake'
+
+Write-Host "Downloading CMake v${version}..."
+Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+
+Write-Host "Extracting to $dest..."
+if (Test-Path $dest) { Remove-Item $dest -Recurse -Force }
+Expand-Archive -Path $zip -DestinationPath $dest
+
+# The zip extracts into a versioned subdirectory; find the bin folder.
+$binDir = Get-ChildItem $dest -Recurse -Directory -Filter 'bin' | Select-Object -First 1
+if (-not $binDir) {
+    Write-Error '::error::CMake extraction failed — no bin directory found.'
+    exit 1
+}
+
+if ($env:GITHUB_PATH) {
+    $binDir.FullName | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+}
+
+Write-Host "CMake v${version} installed at: $($binDir.FullName)"

--- a/scripts/install-mvsc-toolset.ps1
+++ b/scripts/install-mvsc-toolset.ps1
@@ -1,0 +1,93 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ---------- self-elevate if needed ----------
+$isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+    [Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Host "Relaunching as Administrator..."
+    Start-Process pwsh -Verb RunAs -Wait -ArgumentList "-ExecutionPolicy Bypass -File `"$PSCommandPath`""
+    exit $LASTEXITCODE
+}
+
+# ---------- locate VS Installer ----------
+$progX86 = [Environment]::GetFolderPath('ProgramFilesX86')
+$vsWhere = "$progX86\Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path $vsWhere)) {
+    Write-Error "vswhere.exe not found - is Visual Studio installed?"
+    exit 1
+}
+
+$vsInfo = & $vsWhere -latest -products * -format json | ConvertFrom-Json
+if (-not $vsInfo) {
+    Write-Error "No Visual Studio installation found."
+    exit 1
+}
+
+$installPath = $vsInfo[0].installationPath
+$vsVersion   = $vsInfo[0].installationVersion
+Write-Host "Found Visual Studio at: $installPath"
+Write-Host "Version: $vsVersion"
+
+# ---------- show current toolsets ----------
+$msvcRoot = Join-Path $installPath "VC\Tools\MSVC"
+Write-Host "`nCurrently installed MSVC toolsets:"
+Get-ChildItem $msvcRoot -Directory | ForEach-Object { Write-Host "  $($_.Name)" }
+
+# ---------- step 1: update VS to latest ----------
+# The 14.42 toolset component requires VS 17.12+. If VS is older, we must
+# update first. We always run update; it's a no-op if already current.
+$vsInstaller = "$progX86\Microsoft Visual Studio\Installer\vs_installer.exe"
+if (-not (Test-Path $vsInstaller)) {
+    Write-Error "vs_installer.exe not found at expected path."
+    exit 1
+}
+
+# Close any running VS processes that would block the update.
+Write-Host "`nClosing Visual Studio processes..."
+$vsProcs = @('devenv', 'PerfWatson2', 'ServiceHub.Host.CLR', 'ServiceHub.Host.dotnet',
+             'ServiceHub.IdentityHost', 'ServiceHub.IndexingService', 'ServiceHub.ThreadedWaitDialog',
+             'Microsoft.ServiceHub.Controller', 'vstest.console')
+foreach ($name in $vsProcs) {
+    Get-Process -Name $name -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "`nStep 1: Updating Visual Studio to latest version (required for newer toolsets)..."
+Write-Host "This may take a long time. Please be patient.`n"
+
+$updateArgs = @(
+    "update"
+    "--installPath", "`"$installPath`""
+    "--passive"
+    "--force"
+)
+
+Start-Process -FilePath $vsInstaller -ArgumentList $updateArgs -Wait
+
+# Re-query version after update
+$vsInfo = & $vsWhere -latest -products * -format json | ConvertFrom-Json
+$vsVersion = $vsInfo[0].installationVersion
+Write-Host "`nVisual Studio updated to: $vsVersion"
+
+# ---------- step 2: add the 14.42 toolset component ----------
+$componentId = "Microsoft.VisualStudio.Component.VC.14.42.17.12.x86.x64"
+Write-Host "`nStep 2: Installing toolset component $componentId..."
+
+$modifyArgs = @(
+    "modify"
+    "--installPath", "`"$installPath`""
+    "--add", $componentId
+    "--passive"
+    "--force"
+)
+
+Start-Process -FilePath $vsInstaller -ArgumentList $modifyArgs -Wait
+
+# ---------- verify ----------
+Write-Host "`nInstalled MSVC toolsets after update:"
+Get-ChildItem $msvcRoot -Directory | ForEach-Object { Write-Host "  $($_.Name)" }
+
+Write-Host "`nDone. You can now run 'cargo clean' and 'cargo build --release'."
+Write-Host "If the new toolset is not picked up automatically, you may need to"
+Write-Host "open a fresh 'Developer Command Prompt for VS 2022' or 'x64 Native"
+Write-Host "Tools Command Prompt' so the updated paths take effect."

--- a/scripts/install-ninja.ps1
+++ b/scripts/install-ninja.ps1
@@ -1,0 +1,33 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (Get-Command ninja -ErrorAction SilentlyContinue) {
+    $existing = (ninja --version 2>&1).Trim()
+    Write-Host "Ninja already installed: $existing"
+    return
+}
+
+$isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+    [Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Error 'This script must be run as Administrator.'
+    exit 1
+}
+
+$version = '1.12.1'
+$url = "https://github.com/ninja-build/ninja/releases/download/v${version}/ninja-win.zip"
+$zip = Join-Path $env:TEMP 'ninja-win.zip'
+$dest = Join-Path $env:ProgramFiles 'ninja'
+
+Write-Host "Downloading Ninja v${version}..."
+Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+
+Write-Host "Extracting to $dest..."
+if (Test-Path $dest) { Remove-Item $dest -Recurse -Force }
+Expand-Archive -Path $zip -DestinationPath $dest
+
+if ($env:GITHUB_PATH) {
+    $dest | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+}
+
+Write-Host "Ninja v${version} installed at: $dest"

--- a/scripts/install-vulkan-sdk.ps1
+++ b/scripts/install-vulkan-sdk.ps1
@@ -1,0 +1,44 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+    [Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Error 'This script must be run as Administrator.'
+    exit 1
+}
+
+$installerUrl = 'https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe'
+$installer = Join-Path $env:TEMP 'vulkan-sdk.exe'
+
+Write-Host 'Downloading Vulkan SDK...'
+Invoke-WebRequest -Uri $installerUrl -OutFile $installer -UseBasicParsing
+
+Write-Host 'Installing Vulkan SDK...'
+$installerArgs = '--accept-licenses', '--default-answer', '--confirm-command', 'install'
+Start-Process -FilePath $installer -ArgumentList $installerArgs -NoNewWindow -Wait
+
+$vulkanRoot = Join-Path $env:SystemDrive 'VulkanSDK'
+
+if (-not (Test-Path $vulkanRoot)) {
+    Write-Error "::error::Vulkan SDK installation failed — $vulkanRoot does not exist."
+    exit 1
+}
+
+$sdkDir = Get-ChildItem $vulkanRoot -Directory | Sort-Object Name -Descending | Select-Object -First 1
+if (-not $sdkDir) {
+    Write-Host "Contents of ${vulkanRoot}:"
+    Get-ChildItem $vulkanRoot -Force | Format-Table Name, Mode, LastWriteTime
+    Write-Error "::error::Vulkan SDK installation failed — no version directory found under $vulkanRoot."
+    exit 1
+}
+$sdkPath = $sdkDir.FullName
+
+Write-Host "Vulkan SDK installed at: $sdkPath"
+
+if ($env:GITHUB_ENV) {
+    "VULKAN_SDK=$sdkPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+}
+if ($env:GITHUB_PATH) {
+    "$sdkPath\Bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+}

--- a/scripts/package-windows-release.ps1
+++ b/scripts/package-windows-release.ps1
@@ -1,0 +1,66 @@
+#Requires -Version 5.1
+param(
+    [Parameter(Mandatory)]
+    [string]$Tag,
+
+    [string]$Arch
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Map-Arch([string]$Value) {
+    switch ($Value.ToLowerInvariant()) {
+        { $_ -in 'x64', 'amd64', 'x86_64' } { return 'x86_64' }
+        { $_ -in 'arm64', 'aarch64' }        { return 'arm64' }
+        default {
+            Write-Error "unknown arch: $Value"
+            exit 1
+        }
+    }
+}
+
+if (-not $Arch) {
+    $archRaw = if ($env:RUNNER_ARCH) { $env:RUNNER_ARCH } else { $env:PROCESSOR_ARCHITECTURE }
+    $Arch = Map-Arch $archRaw
+} else {
+    $Arch = Map-Arch $Arch
+}
+
+$binPath = 'target\release\deadsync.exe'
+
+if (-not (Test-Path $binPath)) {
+    Write-Error "missing executable: $binPath"
+    exit 1
+}
+foreach ($dir in 'assets', 'songs', 'courses') {
+    if (-not (Test-Path $dir -PathType Container)) {
+        Write-Error "missing directory: $dir"
+        exit 1
+    }
+}
+
+$distDir     = 'dist'
+$pkgName     = "deadsync-$Tag-$Arch-windows"
+$stageDir    = Join-Path $distDir 'deadsync'
+$archivePath = Join-Path $distDir "$pkgName.zip"
+
+if (Test-Path $stageDir) { Remove-Item $stageDir -Recurse -Force }
+New-Item -ItemType Directory -Path $stageDir -Force | Out-Null
+
+Copy-Item $binPath       -Destination $stageDir
+Copy-Item 'assets'       -Destination $stageDir -Recurse
+Copy-Item 'songs'        -Destination $stageDir -Recurse
+Copy-Item 'courses'      -Destination $stageDir -Recurse
+Copy-Item 'README.md'    -Destination $stageDir
+Copy-Item 'LICENSE'      -Destination $stageDir
+
+if (Test-Path $archivePath) { Remove-Item $archivePath -Force }
+Compress-Archive -Path $stageDir -DestinationPath $archivePath
+
+if ($env:GITHUB_OUTPUT) {
+    "archive=$archivePath"  | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    "stage=$stageDir"       | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+}
+
+Write-Host "Packaged: $archivePath"


### PR DESCRIPTION
Add release-windows.yml triggered by tag pushes, workflow_call, and workflow_dispatch, matching the existing linux and macos release patterns. Runs on windows-latest with x86_64 target, builds with cargo, and packages into a zip archive for upload to GitHub releases.

Add PowerShell scripts for CI dependency setup:
- install-vulkan-sdk.ps1: download and install LunarG Vulkan SDK
- install-ninja.ps1: download Ninja build system if not present
- install-cmake.ps1: download CMake if not present
- install-mvsc-toolset.ps1: update VS and install the 14.42 MSVC toolset

All install scripts check for admin privileges before proceeding.

Add package-windows-release.ps1 to stage the binary, assets, songs, courses, and docs into a distributable zip archive.

Wire release-windows into release-all.yml.

Addresses #103 