### PR TITLE
P2 GS Refresh Fix

### DIFF
--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -6657,6 +6657,13 @@ pub fn update(state: &mut State, dt: f32) -> ScreenAction {
                     .cached_chart_ix_p2
                     .map(|ix| song.charts[ix].short_hash.as_str());
 
+                if show_select_music_leaderboards {
+                    maybe_refresh_select_music_leaderboard(
+                        &mut state.last_refreshed_leaderboard_hash_p2,
+                        profile::PlayerSide::P2,
+                        desired_hash_p2,
+                    );
+                }
                 if state.last_requested_chart_hash_p2.as_deref() != desired_hash_p2 {
                     state.last_requested_chart_hash_p2 = desired_hash_p2.map(str::to_string);
                     return ScreenAction::RequestDensityGraph {
@@ -6672,13 +6679,6 @@ pub fn update(state: &mut State, dt: f32) -> ScreenAction {
                             }
                         }),
                     };
-                }
-                if show_select_music_leaderboards {
-                    maybe_refresh_select_music_leaderboard(
-                        &mut state.last_refreshed_leaderboard_hash_p2,
-                        profile::PlayerSide::P2,
-                        desired_hash_p2,
-                    );
                 }
             } else {
                 state.displayed_chart_p2 = None;


### PR DESCRIPTION
Move the P2 `maybe_refresh_select_music_leaderboard` call to before the density graph early return so it always executes when the chart hash changes, matching P1's behavior.

Addresses #157 
