### PR TITLE
Ogg Vorbis Seek Fix

### DIFF
--- a/src/engine/audio/decode/mod.rs
+++ b/src/engine/audio/decode/mod.rs
@@ -4,7 +4,6 @@ pub(crate) mod ogg_vorbis;
 pub(crate) mod opus;
 pub(crate) mod wav;
 
-use lewton::inside_ogg::OggStreamReader;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
@@ -18,7 +17,7 @@ pub(crate) struct OpenFile {
 pub(crate) enum Reader {
     Flac(flac::Reader),
     Mp3(mp3::Reader<BufReader<File>>),
-    Ogg(OggStreamReader<BufReader<File>>),
+    Ogg(ogg_vorbis::Reader),
     Opus(opus::Reader),
     Wav(wav::Reader),
 }
@@ -30,7 +29,7 @@ impl Reader {
         match self {
             Self::Flac(reader) => reader.read_dec_packet_itl(),
             Self::Mp3(reader) => reader.read_dec_packet_itl(),
-            Self::Ogg(reader) => Ok(reader.read_dec_packet_itl()?),
+            Self::Ogg(reader) => reader.read_dec_packet_itl(),
             Self::Opus(reader) => reader.read_dec_packet_itl(),
             Self::Wav(reader) => reader.read_dec_packet_itl(),
         }
@@ -43,10 +42,7 @@ impl Reader {
         match self {
             Self::Flac(reader) => reader.seek_frame(frame),
             Self::Mp3(reader) => reader.seek_frame(frame),
-            Self::Ogg(reader) => {
-                reader.seek_absgp_pg(frame)?;
-                Ok(())
-            }
+            Self::Ogg(reader) => reader.seek_frame(frame),
             Self::Opus(reader) => reader.seek_frame(frame),
             Self::Wav(reader) => reader.seek_frame(frame),
         }

--- a/src/engine/audio/decode/ogg_vorbis.rs
+++ b/src/engine/audio/decode/ogg_vorbis.rs
@@ -8,9 +8,16 @@ const OGG_PAGE_HEADER_LEN: usize = 27;
 const OGG_SCAN_CHUNK_BYTES: usize = 64 * 1024;
 
 pub(crate) struct OpenFile {
-    pub reader: OggStreamReader<BufReader<File>>,
+    pub reader: Reader,
     pub channels: usize,
     pub sample_rate_hz: u32,
+}
+
+pub(crate) struct Reader {
+    inner: OggStreamReader<BufReader<File>>,
+    channels: usize,
+    pending: Option<Vec<i16>>,
+    cursor_frames: u64,
 }
 
 #[inline(always)]
@@ -22,12 +29,130 @@ pub(crate) fn path_is_ogg_vorbis(path: &Path) -> bool {
 
 pub(crate) fn open_file(path: &Path) -> Result<OpenFile, Box<dyn std::error::Error + Send + Sync>> {
     let file = File::open(path)?;
-    let reader = OggStreamReader::new(BufReader::new(file))?;
+    let inner = OggStreamReader::new(BufReader::new(file))?;
+    let channels = inner.ident_hdr.audio_channels.max(1) as usize;
+    let sample_rate_hz = inner.ident_hdr.audio_sample_rate;
     Ok(OpenFile {
-        channels: reader.ident_hdr.audio_channels as usize,
-        sample_rate_hz: reader.ident_hdr.audio_sample_rate,
-        reader,
+        reader: Reader {
+            inner,
+            channels,
+            pending: None,
+            cursor_frames: 0,
+        },
+        channels,
+        sample_rate_hz,
     })
+}
+
+impl Reader {
+    pub(crate) fn read_dec_packet_itl(
+        &mut self,
+    ) -> Result<Option<Vec<i16>>, Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(packet) = self.pending.take() {
+            self.cursor_frames = self
+                .cursor_frames
+                .saturating_add((packet.len() / self.channels) as u64);
+            return Ok(Some(packet));
+        }
+        let Some(packet) = self.inner.read_dec_packet_itl()? else {
+            return Ok(None);
+        };
+        self.cursor_frames = self
+            .cursor_frames
+            .saturating_add((packet.len() / self.channels) as u64);
+        Ok(Some(packet))
+    }
+
+    pub(crate) fn seek_frame(
+        &mut self,
+        target_frame: u64,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.inner.seek_absgp_pg(target_frame)?;
+        self.pending = None;
+
+        // After `seek_absgp_pg`, lewton resets its internal `cur_absgp` to
+        // None.  It only becomes Some again after we read the last packet on
+        // the first page (`last_in_page`).  Stash all packets until that
+        // calibration point so we can compute their absolute positions via
+        // backward traversal from the page's absgp.
+        let mut stashed: Vec<Vec<i16>> = Vec::new();
+        let calibrated_absgp: u64;
+
+        loop {
+            let Some(pkt) = self.inner.read_dec_packet_itl()? else {
+                self.cursor_frames = target_frame;
+                return Ok(());
+            };
+            stashed.push(pkt);
+            if let Some(absgp) = self.inner.get_last_absgp() {
+                calibrated_absgp = absgp;
+                break;
+            }
+        }
+
+        // Assign positions to stashed packets by walking backwards from
+        // `calibrated_absgp` (the page's end granule).
+        let mut positions: Vec<(u64, u64)> = Vec::with_capacity(stashed.len());
+        let mut pos = calibrated_absgp;
+        for pkt in stashed.iter().rev() {
+            let frames = (pkt.len() / self.channels) as u64;
+            let start = pos.saturating_sub(frames);
+            positions.push((start, frames));
+            pos = start;
+        }
+        positions.reverse();
+
+        let page_start = positions.first().map_or(calibrated_absgp, |&(s, _)| s);
+        self.cursor_frames = page_start;
+
+        // Replay stashed packets, discarding/trimming to reach target.
+        for (i, &(pkt_start, pkt_frames)) in positions.iter().enumerate() {
+            if pkt_frames == 0 {
+                continue; // Skip warmup packets with no decoded audio.
+            }
+            if pkt_start >= target_frame {
+                // This packet is entirely at or past the target — stash it
+                // for the next read_dec_packet_itl call.
+                self.pending = Some(stashed.into_iter().nth(i).unwrap());
+                self.cursor_frames = target_frame;
+                return Ok(());
+            }
+            if pkt_start + pkt_frames > target_frame {
+                // Target is within this packet — trim leading samples.
+                let skip = (target_frame - pkt_start) as usize;
+                let drop_samples = skip * self.channels;
+                let pkt = &stashed[i];
+                if drop_samples < pkt.len() {
+                    self.pending = Some(pkt[drop_samples..].to_vec());
+                }
+                self.cursor_frames = target_frame;
+                return Ok(());
+            }
+            self.cursor_frames = pkt_start + pkt_frames;
+        }
+
+        // Target is beyond this page — continue reading forward.
+        // From here, lewton's cur_absgp is calibrated and increments
+        // correctly with each decoded packet.
+        while self.cursor_frames < target_frame {
+            let Some(pkt) = self.inner.read_dec_packet_itl()? else {
+                return Ok(());
+            };
+            let pkt_frames = (pkt.len() / self.channels) as u64;
+            let remaining = (target_frame - self.cursor_frames) as usize;
+            if remaining < pkt_frames as usize {
+                let drop_samples = remaining * self.channels;
+                if drop_samples < pkt.len() {
+                    self.pending = Some(pkt[drop_samples..].to_vec());
+                }
+                self.cursor_frames = target_frame;
+                return Ok(());
+            }
+            self.cursor_frames += pkt_frames;
+        }
+
+        Ok(())
+    }
 }
 
 pub(crate) fn file_length_seconds(path: &Path) -> Result<f32, String> {


### PR DESCRIPTION
### Problem

`lewton::OggStreamReader::seek_absgp_pg` performs page-granular seeking — it lands at the start of the OGG page containing the target frame, not the frame itself. The old code called `seek_absgp_pg` directly and returned, leaking up to several milliseconds of audio before the intended start point. This caused audible sync issues on Music Select song previews (and any other seek-dependent playback).

Additionally, `seek_absgp_pg` resets lewton's internal `cur_absgp` to `None`, making `get_last_absgp()` unavailable until the first full page is read. Without this calibration, any frame-tracking logic based on the post-seek position is wrong.

### Fix

Wrap `OggStreamReader` in a new `ogg_vorbis::Reader` that provides `seek_frame(target)` with sample-accurate positioning:

1. Call `seek_absgp_pg` to jump to the correct page region
2. Decode packets until `get_last_absgp()` calibrates (returns `Some`), stashing decoded audio
3. Walk backwards from the calibrated absgp to assign absolute frame positions to each stashed packet
4. Replay stashed packets, discarding/trimming samples before `target_frame`
5. If the target is beyond the landing page, continue decoding forward with lewton's now-calibrated cursor

The Reader also handles:
- **Warmup packets** (0 output frames) produced by Vorbis after seek — skipped during replay
- **Partial packet trimming** — when the target falls mid-packet, leading samples are dropped and the remainder is stashed as `pending` for the next `read_dec_packet_itl` call

### Changes

- **`ogg_vorbis.rs`**: New `Reader` struct wrapping `OggStreamReader` with `read_dec_packet_itl()` and `seek_frame()`. Tracks `cursor_frames` and `pending` for sample-accurate positioning.
- **`decode/mod.rs`**: `Reader::Ogg` variant now holds `ogg_vorbis::Reader` instead of a raw `OggStreamReader`. Removed the direct `lewton` import and inlined `seek_absgp_pg` call.

Addresses #158 