### PR TITLE
Extend Select Music Menu Sorts

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6827,6 +6827,7 @@ mod tests {
             translit_title: String::new(),
             translit_subtitle: String::new(),
             artist: String::new(),
+            genre: String::new(),
             banner_path: None,
             background_path: None,
             background_changes: Vec::new(),

--- a/src/game/gameplay.rs
+++ b/src/game/gameplay.rs
@@ -14996,6 +14996,7 @@ mod tests {
             translit_title: String::new(),
             translit_subtitle: String::new(),
             artist: "Tests".to_string(),
+            genre: String::new(),
             banner_path: None,
             background_path: None,
             background_changes: Vec::new(),

--- a/src/game/parsing/simfile.rs
+++ b/src/game/parsing/simfile.rs
@@ -585,6 +585,7 @@ struct SerializableSongData {
     translit_title: String,
     translit_subtitle: String,
     artist: String,
+    genre: String,
     banner_path: Option<String>,
     background_path: Option<String>,
     background_changes: Vec<SerializableSongBackgroundChange>,
@@ -650,6 +651,7 @@ struct CachedSongMeta {
     translit_title: String,
     translit_subtitle: String,
     artist: String,
+    genre: String,
     banner_path: Option<String>,
     background_path: Option<String>,
     background_changes: Vec<SerializableSongBackgroundChange>,
@@ -953,6 +955,7 @@ fn build_song_meta(song: SerializableSongData, global_offset_seconds: f32) -> So
         translit_title: song.translit_title,
         translit_subtitle: song.translit_subtitle,
         artist: song.artist,
+        genre: song.genre,
         banner_path: song.banner_path.map(PathBuf::from),
         background_path: song.background_path.map(PathBuf::from),
         background_changes: song
@@ -998,6 +1001,7 @@ fn build_cached_song_meta(
         translit_title: song.translit_title.clone(),
         translit_subtitle: song.translit_subtitle.clone(),
         artist: song.artist.clone(),
+        genre: song.genre.clone(),
         banner_path: song.banner_path.clone(),
         background_path: song.background_path.clone(),
         background_changes: song.background_changes.clone(),
@@ -1031,6 +1035,7 @@ fn build_song_meta_from_cache(song: CachedSongMeta) -> SongData {
         translit_title: song.translit_title,
         translit_subtitle: song.translit_subtitle,
         artist: song.artist,
+        genre: song.genre,
         banner_path: song.banner_path.map(PathBuf::from),
         background_path: song.background_path.map(PathBuf::from),
         background_changes: song
@@ -1967,6 +1972,7 @@ fn parse_and_process_song_file(
             translit_title: summary.titletranslit_str,
             translit_subtitle: summary.subtitletranslit_str,
             artist: summary.artist_str,
+            genre: extract_genre_tag(&simfile_data),
             banner_path: banner_path.map(|p| p.to_string_lossy().into_owned()),
             background_path: background_path_opt.map(|p| p.to_string_lossy().into_owned()),
             background_changes,
@@ -1996,6 +2002,26 @@ fn parse_and_process_song_file(
         },
         content_hash,
     ))
+}
+
+/// Extracts the `#GENRE:` tag value from raw simfile bytes.
+/// Returns an empty string if the tag is not found.
+fn extract_genre_tag(data: &[u8]) -> String {
+    let tag = b"#GENRE:";
+    let data_len = data.len();
+    let tag_len = tag.len();
+    for i in 0..data_len.saturating_sub(tag_len) {
+        if data[i..i + tag_len].eq_ignore_ascii_case(tag) {
+            let start = i + tag_len;
+            let mut end = start;
+            while end < data_len && data[end] != b';' && data[end] != b'\n' && data[end] != b'\r'
+            {
+                end += 1;
+            }
+            return String::from_utf8_lossy(&data[start..end]).trim().to_string();
+        }
+    }
+    String::new()
 }
 
 /// Computes the length of the music file in seconds when the decode layer supports it.

--- a/src/game/scores.rs
+++ b/src/game/scores.rs
@@ -567,6 +567,45 @@ pub fn played_chart_counts_for_machine() -> Vec<(String, u32)> {
     ranked
 }
 
+/// Returns chart hashes ordered by latest local play time for a single profile.
+pub fn recent_played_chart_hashes_for_profile(profile_id: &str) -> Vec<String> {
+    let profiles_root = dirs::app_dirs().profiles_root();
+    let local_root = profiles_root.join(profile_id).join("scores").join("local");
+    if !local_root.is_dir() {
+        return Vec::new();
+    }
+
+    let mut latest_by_chart: HashMap<String, i64> = HashMap::new();
+    collect_recent_plays_in_root(&local_root, &mut latest_by_chart);
+
+    let mut ranked: Vec<(i64, String)> = latest_by_chart
+        .into_iter()
+        .map(|(chart_hash, played_at_ms)| (played_at_ms, chart_hash))
+        .collect();
+    ranked.sort_unstable_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+    ranked
+        .into_iter()
+        .map(|(_, chart_hash)| chart_hash)
+        .collect()
+}
+
+/// Returns `(chart_hash, play_count)` pairs for a single profile, ordered by
+/// play count descending.
+pub fn played_chart_counts_for_profile(profile_id: &str) -> Vec<(String, u32)> {
+    let profiles_root = dirs::app_dirs().profiles_root();
+    let local_root = profiles_root.join(profile_id).join("scores").join("local");
+    if !local_root.is_dir() {
+        return Vec::new();
+    }
+
+    let mut counts_by_chart: HashMap<String, u32> = HashMap::new();
+    collect_play_counts_in_root(&local_root, &mut counts_by_chart);
+
+    let mut ranked: Vec<(String, u32)> = counts_by_chart.into_iter().collect();
+    ranked.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    ranked
+}
+
 #[inline(always)]
 fn shard2_for_hash(hash: &str) -> &str {
     if hash.len() >= 2 { &hash[..2] } else { "00" }

--- a/src/game/scores/itl.rs
+++ b/src/game/scores/itl.rs
@@ -1451,6 +1451,7 @@ mod tests {
             translit_title: String::new(),
             translit_subtitle: String::new(),
             artist: String::new(),
+            genre: String::new(),
             banner_path: None,
             background_path: None,
             background_changes: Vec::new(),

--- a/src/game/song.rs
+++ b/src/game/song.rs
@@ -29,6 +29,7 @@ pub struct SongData {
     pub translit_title: String,
     pub translit_subtitle: String,
     pub artist: String,
+    pub genre: String,
     pub banner_path: Option<PathBuf>,
     pub background_path: Option<PathBuf>,
     pub background_changes: Vec<SongBackgroundChange>,

--- a/src/screens/components/select_music/select_music_menu/mod.rs
+++ b/src/screens/components/select_music/select_music_menu/mod.rs
@@ -27,6 +27,7 @@ pub enum Action {
     SortByPopularity,
     SortByRecent,
     SortByGenre,
+    SortByTopGrades,
     SwitchToSingle,
     SwitchToDouble,
     TestInput,
@@ -98,6 +99,11 @@ pub const ITEM_SORT_BY_GENRE: Item = Item {
     bottom_label: "Genre",
     action: Action::SortByGenre,
 };
+pub const ITEM_SORT_BY_TOP_GRADES: Item = Item {
+    top_label: "Sort By",
+    bottom_label: "Top Grades",
+    action: Action::SortByTopGrades,
+};
 pub const ITEM_SWITCH_TO_SINGLE: Item = Item {
     top_label: "Change Style To",
     bottom_label: "Single",
@@ -164,7 +170,7 @@ const ITEM_GO_BACK: Item = Item {
     action: Action::BackToMain,
 };
 
-pub const ITEMS_SORTS: [Item; 10] = [
+pub const ITEMS_SORTS: [Item; 11] = [
     ITEM_SORT_BY_GROUP,
     ITEM_SORT_BY_TITLE,
     ITEM_SORT_BY_ARTIST,
@@ -174,6 +180,7 @@ pub const ITEMS_SORTS: [Item; 10] = [
     ITEM_SORT_BY_METER,
     ITEM_SORT_BY_POPULARITY,
     ITEM_SORT_BY_RECENT,
+    ITEM_SORT_BY_TOP_GRADES,
     ITEM_GO_BACK,
 ];
 

--- a/src/screens/components/select_music/select_music_menu/mod.rs
+++ b/src/screens/components/select_music/select_music_menu/mod.rs
@@ -26,6 +26,7 @@ pub enum Action {
     SortByMeter,
     SortByPopularity,
     SortByRecent,
+    SortByGenre,
     SwitchToSingle,
     SwitchToDouble,
     TestInput,
@@ -91,6 +92,11 @@ const ITEM_SORT_BY_RECENT: Item = Item {
     top_label: "Sort By",
     bottom_label: "Recently Played",
     action: Action::SortByRecent,
+};
+pub const ITEM_SORT_BY_GENRE: Item = Item {
+    top_label: "Sort By",
+    bottom_label: "Genre",
+    action: Action::SortByGenre,
 };
 pub const ITEM_SWITCH_TO_SINGLE: Item = Item {
     top_label: "Change Style To",
@@ -158,10 +164,11 @@ const ITEM_GO_BACK: Item = Item {
     action: Action::BackToMain,
 };
 
-pub const ITEMS_SORTS: [Item; 9] = [
+pub const ITEMS_SORTS: [Item; 10] = [
     ITEM_SORT_BY_GROUP,
     ITEM_SORT_BY_TITLE,
     ITEM_SORT_BY_ARTIST,
+    ITEM_SORT_BY_GENRE,
     ITEM_SORT_BY_BPM,
     ITEM_SORT_BY_LENGTH,
     ITEM_SORT_BY_METER,

--- a/src/screens/components/select_music/select_music_menu/mod.rs
+++ b/src/screens/components/select_music/select_music_menu/mod.rs
@@ -28,6 +28,12 @@ pub enum Action {
     SortByRecent,
     SortByGenre,
     SortByTopGrades,
+    SortByPopularityP1,
+    SortByPopularityP2,
+    SortByRecentP1,
+    SortByRecentP2,
+    SortByTopGradesP1,
+    SortByTopGradesP2,
     SwitchToSingle,
     SwitchToDouble,
     TestInput,
@@ -101,8 +107,38 @@ pub const ITEM_SORT_BY_GENRE: Item = Item {
 };
 pub const ITEM_SORT_BY_TOP_GRADES: Item = Item {
     top_label: "Sort By",
-    bottom_label: "Top Grades",
+    bottom_label: "Machine Top Scores",
     action: Action::SortByTopGrades,
+};
+pub const ITEM_SORT_BY_POPULARITY_P1: Item = Item {
+    top_label: "Sort By",
+    bottom_label: "P1 Most Played",
+    action: Action::SortByPopularityP1,
+};
+pub const ITEM_SORT_BY_POPULARITY_P2: Item = Item {
+    top_label: "Sort By",
+    bottom_label: "P2 Most Played",
+    action: Action::SortByPopularityP2,
+};
+pub const ITEM_SORT_BY_RECENT_P1: Item = Item {
+    top_label: "Sort By",
+    bottom_label: "P1 Recent Songs",
+    action: Action::SortByRecentP1,
+};
+pub const ITEM_SORT_BY_RECENT_P2: Item = Item {
+    top_label: "Sort By",
+    bottom_label: "P2 Recent Songs",
+    action: Action::SortByRecentP2,
+};
+pub const ITEM_SORT_BY_TOP_GRADES_P1: Item = Item {
+    top_label: "Sort By",
+    bottom_label: "P1 Clear Rank",
+    action: Action::SortByTopGradesP1,
+};
+pub const ITEM_SORT_BY_TOP_GRADES_P2: Item = Item {
+    top_label: "Sort By",
+    bottom_label: "P2 Clear Rank",
+    action: Action::SortByTopGradesP2,
 };
 pub const ITEM_SWITCH_TO_SINGLE: Item = Item {
     top_label: "Change Style To",

--- a/src/screens/select_course.rs
+++ b/src/screens/select_course.rs
@@ -752,6 +752,7 @@ fn make_course_song(meta: &CourseMeta) -> SongData {
         } else {
             meta.scripter.clone()
         },
+        genre: String::new(),
         banner_path: meta.banner_path.clone(),
         background_path: None,
         background_changes: Vec::new(),

--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -808,6 +808,7 @@ enum WheelSortMode {
     Group,
     Title,
     Artist,
+    Genre,
     Bpm,
     Length,
     Meter,
@@ -882,6 +883,7 @@ pub struct State {
     group_entries: Vec<MusicWheelEntry>,
     title_entries: Vec<MusicWheelEntry>,
     artist_entries: Vec<MusicWheelEntry>,
+    genre_entries: Vec<MusicWheelEntry>,
     bpm_entries: Vec<MusicWheelEntry>,
     length_entries: Vec<MusicWheelEntry>,
     meter_entries: Vec<MusicWheelEntry>,
@@ -951,6 +953,7 @@ pub struct State {
     group_pack_song_counts: HashMap<String, usize>,
     title_pack_song_counts: HashMap<String, usize>,
     artist_pack_song_counts: HashMap<String, usize>,
+    genre_pack_song_counts: HashMap<String, usize>,
     bpm_pack_song_counts: HashMap<String, usize>,
     length_pack_song_counts: HashMap<String, usize>,
     meter_pack_song_counts: HashMap<String, usize>,
@@ -1520,6 +1523,55 @@ fn build_artist_grouped_entries(
     (entries, counts)
 }
 
+const UNKNOWN_GENRE_HEADER: &str = "Unknown Genre";
+
+fn build_genre_grouped_entries(
+    grouped_entries: &[MusicWheelEntry],
+) -> (Vec<MusicWheelEntry>, HashMap<String, usize>) {
+    let mut songs: Vec<Arc<SongData>> = grouped_entries
+        .iter()
+        .filter_map(|e| match e {
+            MusicWheelEntry::Song(song) => Some(song.clone()),
+            MusicWheelEntry::PackHeader { .. } => None,
+        })
+        .collect();
+
+    songs.sort_by_cached_key(|song| {
+        let genre = if song.genre.trim().is_empty() {
+            UNKNOWN_GENRE_HEADER.to_ascii_lowercase()
+        } else {
+            song.genre.to_ascii_lowercase()
+        };
+        (genre, song_title_sort_key(song.as_ref()))
+    });
+
+    let mut entries: Vec<MusicWheelEntry> = Vec::with_capacity(songs.len().saturating_add(32));
+    let mut counts: HashMap<String, usize> = HashMap::with_capacity(32);
+    let mut current_group: Option<String> = None;
+    let mut header_idx = 0usize;
+
+    for song in songs {
+        let group_name = if song.genre.trim().is_empty() {
+            UNKNOWN_GENRE_HEADER.to_string()
+        } else {
+            song.genre.clone()
+        };
+        if current_group.as_deref() != Some(group_name.as_str()) {
+            entries.push(MusicWheelEntry::PackHeader {
+                name: group_name.clone(),
+                original_index: header_idx,
+                banner_path: None,
+            });
+            current_group = Some(group_name.clone());
+            header_idx += 1;
+        }
+        *counts.entry(group_name).or_insert(0) += 1;
+        entries.push(MusicWheelEntry::Song(song));
+    }
+
+    (entries, counts)
+}
+
 #[inline(always)]
 fn song_bpm_for_sort(song: &SongData) -> i32 {
     song_display_bpm_range(song).map_or(0, |(_lo, hi)| hi.max(0.0) as i32)
@@ -1907,6 +1959,14 @@ fn apply_wheel_sort(state: &mut State, sort_mode: WheelSortMode) {
                 .and_then(|song| group_name_for_song(&state.artist_entries, song))
                 .or_else(|| first_header_name(&state.artist_entries));
         }
+        WheelSortMode::Genre => {
+            state.all_entries = state.genre_entries.clone();
+            state.pack_song_counts = state.genre_pack_song_counts.clone();
+            state.expanded_pack_name = selected_song
+                .as_ref()
+                .and_then(|song| group_name_for_song(&state.genre_entries, song))
+                .or_else(|| first_header_name(&state.genre_entries));
+        }
         WheelSortMode::Bpm => {
             state.all_entries = state.bpm_entries.clone();
             state.pack_song_counts = state.bpm_pack_song_counts.clone();
@@ -2092,6 +2152,7 @@ pub fn init() -> State {
 
     let (title_entries, title_pack_song_counts) = build_title_grouped_entries(&all_entries);
     let (artist_entries, artist_pack_song_counts) = build_artist_grouped_entries(&all_entries);
+    let (genre_entries, genre_pack_song_counts) = build_genre_grouped_entries(&all_entries);
     let (bpm_entries, bpm_pack_song_counts) = build_bpm_grouped_entries(&all_entries);
     let (length_entries, length_pack_song_counts) = build_length_grouped_entries(&all_entries);
     let (meter_entries, meter_pack_song_counts) =
@@ -2111,6 +2172,7 @@ pub fn init() -> State {
         group_entries: all_entries,
         title_entries,
         artist_entries,
+        genre_entries,
         bpm_entries,
         length_entries,
         meter_entries,
@@ -2215,6 +2277,7 @@ pub fn init() -> State {
         group_pack_song_counts: pack_song_counts,
         title_pack_song_counts,
         artist_pack_song_counts,
+        genre_pack_song_counts,
         bpm_pack_song_counts,
         length_pack_song_counts,
         meter_pack_song_counts,
@@ -2305,6 +2368,7 @@ pub fn init_placeholder() -> State {
         group_entries: Vec::new(),
         title_entries: Vec::new(),
         artist_entries: Vec::new(),
+        genre_entries: Vec::new(),
         bpm_entries: Vec::new(),
         length_entries: Vec::new(),
         meter_entries: Vec::new(),
@@ -2409,6 +2473,7 @@ pub fn init_placeholder() -> State {
         group_pack_song_counts: HashMap::new(),
         title_pack_song_counts: HashMap::new(),
         artist_pack_song_counts: HashMap::new(),
+        genre_pack_song_counts: HashMap::new(),
         bpm_pack_song_counts: HashMap::new(),
         length_pack_song_counts: HashMap::new(),
         meter_pack_song_counts: HashMap::new(),
@@ -2675,11 +2740,12 @@ fn sort_submenu_index_for_mode(sort_mode: WheelSortMode) -> usize {
         WheelSortMode::Group => 0,
         WheelSortMode::Title => 1,
         WheelSortMode::Artist => 2,
-        WheelSortMode::Bpm => 3,
-        WheelSortMode::Length => 4,
-        WheelSortMode::Meter => 5,
-        WheelSortMode::Popularity => 6,
-        WheelSortMode::Recent => 7,
+        WheelSortMode::Genre => 3,
+        WheelSortMode::Bpm => 4,
+        WheelSortMode::Length => 5,
+        WheelSortMode::Meter => 6,
+        WheelSortMode::Popularity => 7,
+        WheelSortMode::Recent => 8,
     }
 }
 
@@ -5560,6 +5626,11 @@ fn dispatch_menu_action(state: &mut State, action: select_music_menu::Action) ->
         }
         select_music_menu::Action::SortByRecent => {
             apply_wheel_sort(state, WheelSortMode::Recent);
+            hide_select_music_menu(state);
+            ScreenAction::None
+        }
+        select_music_menu::Action::SortByGenre => {
+            apply_wheel_sort(state, WheelSortMode::Genre);
             hide_select_music_menu(state);
             ScreenAction::None
         }
@@ -8671,6 +8742,7 @@ mod tests {
             translit_title: String::new(),
             translit_subtitle: String::new(),
             artist: String::new(),
+            genre: String::new(),
             banner_path: None,
             background_path: None,
             background_changes: Vec::new(),

--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -815,6 +815,12 @@ enum WheelSortMode {
     Popularity,
     Recent,
     TopGrades,
+    PopularityP1,
+    PopularityP2,
+    RecentP1,
+    RecentP2,
+    TopGradesP1,
+    TopGradesP2,
 }
 
 #[derive(Clone, Debug)]
@@ -891,6 +897,12 @@ pub struct State {
     popularity_entries: Vec<MusicWheelEntry>,
     recent_entries: Vec<MusicWheelEntry>,
     top_grades_entries: Vec<MusicWheelEntry>,
+    popularity_p1_entries: Vec<MusicWheelEntry>,
+    popularity_p2_entries: Vec<MusicWheelEntry>,
+    recent_p1_entries: Vec<MusicWheelEntry>,
+    recent_p2_entries: Vec<MusicWheelEntry>,
+    top_grades_p1_entries: Vec<MusicWheelEntry>,
+    top_grades_p2_entries: Vec<MusicWheelEntry>,
     expanded_pack_name: Option<String>,
     bg: heart_bg::State,
     last_requested_banner_path: Option<PathBuf>,
@@ -962,6 +974,12 @@ pub struct State {
     popularity_pack_song_counts: HashMap<String, usize>,
     recent_pack_song_counts: HashMap<String, usize>,
     top_grades_pack_song_counts: HashMap<String, usize>,
+    popularity_p1_pack_song_counts: HashMap<String, usize>,
+    popularity_p2_pack_song_counts: HashMap<String, usize>,
+    recent_p1_pack_song_counts: HashMap<String, usize>,
+    recent_p2_pack_song_counts: HashMap<String, usize>,
+    top_grades_p1_pack_song_counts: HashMap<String, usize>,
+    top_grades_p2_pack_song_counts: HashMap<String, usize>,
     new_pack_names: HashSet<String>,
 }
 
@@ -2039,6 +2057,194 @@ fn grade_group_name(grade: scores::Grade) -> String {
     }
 }
 
+fn build_popularity_grouped_entries_for_profile(
+    grouped_entries: &[MusicWheelEntry],
+    profile_id: &str,
+) -> (Vec<MusicWheelEntry>, HashMap<String, usize>) {
+    let songs: Vec<Arc<SongData>> = grouped_entries
+        .iter()
+        .filter_map(|e| match e {
+            MusicWheelEntry::Song(song) => Some(song.clone()),
+            MusicWheelEntry::PackHeader { .. } => None,
+        })
+        .collect();
+    let mut hash_to_song_ix: HashMap<&str, usize> =
+        HashMap::with_capacity(songs.len().saturating_mul(8));
+    for (song_ix, song) in songs.iter().enumerate() {
+        for chart in &song.charts {
+            if !chart.has_note_data {
+                continue;
+            }
+            hash_to_song_ix
+                .entry(chart.short_hash.as_str())
+                .or_insert(song_ix);
+        }
+    }
+    let mut song_play_counts = vec![0u32; songs.len()];
+    for (chart_hash, chart_plays) in scores::played_chart_counts_for_profile(profile_id) {
+        let Some(&song_ix) = hash_to_song_ix.get(chart_hash.as_str()) else {
+            continue;
+        };
+        song_play_counts[song_ix] = song_play_counts[song_ix].saturating_add(chart_plays);
+    }
+    let mut ranked: Vec<(Arc<SongData>, u32)> = songs
+        .into_iter()
+        .enumerate()
+        .filter(|(song_ix, _)| song_play_counts[*song_ix] > 0)
+        .map(|(song_ix, song)| (song, song_play_counts[song_ix]))
+        .collect();
+    ranked.sort_by_cached_key(|(song, play_count)| {
+        (Reverse(*play_count), song_title_sort_key(song.as_ref()))
+    });
+    ranked.truncate(POPULAR_SONGS_TO_SHOW);
+
+    let count = ranked.len();
+    let header = format!("{POPULAR_SORT_HEADER} (Profile)");
+    let mut entries: Vec<MusicWheelEntry> = Vec::with_capacity(count.saturating_add(1));
+    entries.push(MusicWheelEntry::PackHeader {
+        name: header.clone(),
+        original_index: 0,
+        banner_path: None,
+    });
+    entries.extend(ranked.into_iter().map(|(song, _)| MusicWheelEntry::Song(song)));
+
+    let mut counts: HashMap<String, usize> = HashMap::with_capacity(1);
+    counts.insert(header, count);
+    (entries, counts)
+}
+
+fn build_recent_grouped_entries_for_profile(
+    grouped_entries: &[MusicWheelEntry],
+    profile_id: &str,
+) -> (Vec<MusicWheelEntry>, HashMap<String, usize>) {
+    let songs: Vec<Arc<SongData>> = grouped_entries
+        .iter()
+        .filter_map(|e| match e {
+            MusicWheelEntry::Song(song) => Some(song.clone()),
+            MusicWheelEntry::PackHeader { .. } => None,
+        })
+        .collect();
+
+    let mut hash_to_song_ix: HashMap<&str, usize> =
+        HashMap::with_capacity(songs.len().saturating_mul(8));
+    for (song_ix, song) in songs.iter().enumerate() {
+        for chart in &song.charts {
+            if !chart.has_note_data {
+                continue;
+            }
+            hash_to_song_ix
+                .entry(chart.short_hash.as_str())
+                .or_insert(song_ix);
+        }
+    }
+
+    let mut recent_song_ixs: Vec<usize> = Vec::with_capacity(RECENT_SONGS_TO_SHOW);
+    let mut seen_song_ix = vec![false; songs.len()];
+
+    for chart_hash in scores::recent_played_chart_hashes_for_profile(profile_id) {
+        let Some(&song_ix) = hash_to_song_ix.get(chart_hash.as_str()) else {
+            continue;
+        };
+        if seen_song_ix[song_ix] {
+            continue;
+        }
+        seen_song_ix[song_ix] = true;
+        recent_song_ixs.push(song_ix);
+        if recent_song_ixs.len() >= RECENT_SONGS_TO_SHOW {
+            break;
+        }
+    }
+
+    let count = recent_song_ixs.len();
+    let header = format!("{RECENT_SORT_HEADER} (Profile)");
+    let mut entries: Vec<MusicWheelEntry> = Vec::with_capacity(count.saturating_add(1));
+    entries.push(MusicWheelEntry::PackHeader {
+        name: header.clone(),
+        original_index: 0,
+        banner_path: None,
+    });
+    entries.extend(
+        recent_song_ixs
+            .into_iter()
+            .map(|song_ix| MusicWheelEntry::Song(songs[song_ix].clone())),
+    );
+
+    let mut counts: HashMap<String, usize> = HashMap::with_capacity(1);
+    counts.insert(header, count);
+    (entries, counts)
+}
+
+fn build_top_grades_grouped_entries_for_side(
+    grouped_entries: &[MusicWheelEntry],
+    chart_type: &str,
+    side: profile::PlayerSide,
+) -> (Vec<MusicWheelEntry>, HashMap<String, usize>) {
+    let songs: Vec<Arc<SongData>> = grouped_entries
+        .iter()
+        .filter_map(|e| match e {
+            MusicWheelEntry::Song(song) => Some(song.clone()),
+            MusicWheelEntry::PackHeader { .. } => None,
+        })
+        .collect();
+
+    let mut graded_songs: Vec<(Arc<SongData>, Option<scores::Grade>)> =
+        Vec::with_capacity(songs.len());
+    for song in songs {
+        let mut best_grade: Option<scores::Grade> = None;
+        for chart in &song.charts {
+            if !chart.chart_type.eq_ignore_ascii_case(chart_type) || !chart.has_note_data {
+                continue;
+            }
+            let Some(score) = scores::get_cached_score_for_side(&chart.short_hash, side) else {
+                continue;
+            };
+            if score.grade != scores::Grade::Failed || score.score_percent > 0.0 {
+                let grade = score.grade;
+                if best_grade.is_none()
+                    || grade_sort_order(grade) < grade_sort_order(best_grade.unwrap())
+                {
+                    best_grade = Some(grade);
+                }
+            }
+        }
+        graded_songs.push((song, best_grade));
+    }
+
+    graded_songs.sort_by_cached_key(|(song, best)| {
+        let grade_key = match best {
+            Some(g) => grade_sort_order(*g),
+            None => u8::MAX,
+        };
+        (grade_key, song_title_sort_key(song.as_ref()))
+    });
+
+    let mut entries: Vec<MusicWheelEntry> =
+        Vec::with_capacity(graded_songs.len().saturating_add(20));
+    let mut counts: HashMap<String, usize> = HashMap::with_capacity(20);
+    let mut current_group: Option<String> = None;
+    let mut header_idx = 0usize;
+
+    for (song, best) in graded_songs {
+        let group_name = match best {
+            Some(g) => grade_group_name(g),
+            None => TOP_GRADES_UNPLAYED_HEADER.to_string(),
+        };
+        if current_group.as_deref() != Some(group_name.as_str()) {
+            entries.push(MusicWheelEntry::PackHeader {
+                name: group_name.clone(),
+                original_index: header_idx,
+                banner_path: None,
+            });
+            current_group = Some(group_name.clone());
+            header_idx += 1;
+        }
+        *counts.entry(group_name).or_insert(0) += 1;
+        entries.push(MusicWheelEntry::Song(song));
+    }
+
+    (entries, counts)
+}
+
 fn refresh_recent_cache(state: &mut State) {
     let (recent_entries, recent_pack_song_counts) =
         build_recent_grouped_entries(&state.group_entries);
@@ -2140,6 +2346,42 @@ fn apply_wheel_sort(state: &mut State, sort_mode: WheelSortMode) {
                 .as_ref()
                 .and_then(|song| group_name_for_song(&state.top_grades_entries, song))
                 .or_else(|| first_header_name(&state.top_grades_entries));
+        }
+        WheelSortMode::PopularityP1 => {
+            state.all_entries = state.popularity_p1_entries.clone();
+            state.pack_song_counts = state.popularity_p1_pack_song_counts.clone();
+            state.expanded_pack_name = first_header_name(&state.popularity_p1_entries);
+        }
+        WheelSortMode::PopularityP2 => {
+            state.all_entries = state.popularity_p2_entries.clone();
+            state.pack_song_counts = state.popularity_p2_pack_song_counts.clone();
+            state.expanded_pack_name = first_header_name(&state.popularity_p2_entries);
+        }
+        WheelSortMode::RecentP1 => {
+            state.all_entries = state.recent_p1_entries.clone();
+            state.pack_song_counts = state.recent_p1_pack_song_counts.clone();
+            state.expanded_pack_name = first_header_name(&state.recent_p1_entries);
+        }
+        WheelSortMode::RecentP2 => {
+            state.all_entries = state.recent_p2_entries.clone();
+            state.pack_song_counts = state.recent_p2_pack_song_counts.clone();
+            state.expanded_pack_name = first_header_name(&state.recent_p2_entries);
+        }
+        WheelSortMode::TopGradesP1 => {
+            state.all_entries = state.top_grades_p1_entries.clone();
+            state.pack_song_counts = state.top_grades_p1_pack_song_counts.clone();
+            state.expanded_pack_name = selected_song
+                .as_ref()
+                .and_then(|song| group_name_for_song(&state.top_grades_p1_entries, song))
+                .or_else(|| first_header_name(&state.top_grades_p1_entries));
+        }
+        WheelSortMode::TopGradesP2 => {
+            state.all_entries = state.top_grades_p2_entries.clone();
+            state.pack_song_counts = state.top_grades_p2_pack_song_counts.clone();
+            state.expanded_pack_name = selected_song
+                .as_ref()
+                .and_then(|song| group_name_for_song(&state.top_grades_p2_entries, song))
+                .or_else(|| first_header_name(&state.top_grades_p2_entries));
         }
     }
 
@@ -2296,6 +2538,40 @@ pub fn init() -> State {
     let (recent_entries, recent_pack_song_counts) = build_recent_grouped_entries(&all_entries);
     let (top_grades_entries, top_grades_pack_song_counts) =
         build_top_grades_grouped_entries(&all_entries, target_chart_type);
+
+    // Per-player sort entries (keyed by profile ID for popularity/recent, by side for grades)
+    let p1_profile_id = profile::active_local_profile_id_for_side(profile::PlayerSide::P1);
+    let p2_profile_id = profile::active_local_profile_id_for_side(profile::PlayerSide::P2);
+
+    let (popularity_p1_entries, popularity_p1_pack_song_counts) = p1_profile_id
+        .as_deref()
+        .map(|id| build_popularity_grouped_entries_for_profile(&all_entries, id))
+        .unwrap_or_default();
+    let (popularity_p2_entries, popularity_p2_pack_song_counts) = p2_profile_id
+        .as_deref()
+        .map(|id| build_popularity_grouped_entries_for_profile(&all_entries, id))
+        .unwrap_or_default();
+    let (recent_p1_entries, recent_p1_pack_song_counts) = p1_profile_id
+        .as_deref()
+        .map(|id| build_recent_grouped_entries_for_profile(&all_entries, id))
+        .unwrap_or_default();
+    let (recent_p2_entries, recent_p2_pack_song_counts) = p2_profile_id
+        .as_deref()
+        .map(|id| build_recent_grouped_entries_for_profile(&all_entries, id))
+        .unwrap_or_default();
+    let (top_grades_p1_entries, top_grades_p1_pack_song_counts) =
+        build_top_grades_grouped_entries_for_side(
+            &all_entries,
+            target_chart_type,
+            profile::PlayerSide::P1,
+        );
+    let (top_grades_p2_entries, top_grades_p2_pack_song_counts) =
+        build_top_grades_grouped_entries_for_side(
+            &all_entries,
+            target_chart_type,
+            profile::PlayerSide::P2,
+        );
+
     let new_pack_names = sync_new_pack_names(
         &joined_profile_ids,
         pack_song_counts.keys().cloned().collect(),
@@ -2315,6 +2591,12 @@ pub fn init() -> State {
         popularity_entries,
         recent_entries,
         top_grades_entries,
+        popularity_p1_entries,
+        popularity_p2_entries,
+        recent_p1_entries,
+        recent_p2_entries,
+        top_grades_p1_entries,
+        top_grades_p2_entries,
         entries: Vec::new(),
         selected_index: 0,
         selected_steps_index: initial_diff_index,
@@ -2421,6 +2703,12 @@ pub fn init() -> State {
         popularity_pack_song_counts,
         recent_pack_song_counts,
         top_grades_pack_song_counts,
+        popularity_p1_pack_song_counts,
+        popularity_p2_pack_song_counts,
+        recent_p1_pack_song_counts,
+        recent_p2_pack_song_counts,
+        top_grades_p1_pack_song_counts,
+        top_grades_p2_pack_song_counts,
         new_pack_names,
     };
 
@@ -2513,6 +2801,12 @@ pub fn init_placeholder() -> State {
         popularity_entries: Vec::new(),
         recent_entries: Vec::new(),
         top_grades_entries: Vec::new(),
+        popularity_p1_entries: Vec::new(),
+        popularity_p2_entries: Vec::new(),
+        recent_p1_entries: Vec::new(),
+        recent_p2_entries: Vec::new(),
+        top_grades_p1_entries: Vec::new(),
+        top_grades_p2_entries: Vec::new(),
         entries: Vec::new(),
         selected_index: 0,
         selected_steps_index: initial_diff_index,
@@ -2619,6 +2913,12 @@ pub fn init_placeholder() -> State {
         popularity_pack_song_counts: HashMap::new(),
         recent_pack_song_counts: HashMap::new(),
         top_grades_pack_song_counts: HashMap::new(),
+        popularity_p1_pack_song_counts: HashMap::new(),
+        popularity_p2_pack_song_counts: HashMap::new(),
+        recent_p1_pack_song_counts: HashMap::new(),
+        recent_p2_pack_song_counts: HashMap::new(),
+        top_grades_p1_pack_song_counts: HashMap::new(),
+        top_grades_p2_pack_song_counts: HashMap::new(),
         new_pack_names: HashSet::new(),
     }
 }
@@ -2887,6 +3187,13 @@ fn sort_submenu_index_for_mode(sort_mode: WheelSortMode) -> usize {
         WheelSortMode::Popularity => 7,
         WheelSortMode::Recent => 8,
         WheelSortMode::TopGrades => 9,
+        // Per-player sorts are not in the classic sort submenu; default to 0.
+        WheelSortMode::PopularityP1
+        | WheelSortMode::PopularityP2
+        | WheelSortMode::RecentP1
+        | WheelSortMode::RecentP2
+        | WheelSortMode::TopGradesP1
+        | WheelSortMode::TopGradesP2 => 0,
     }
 }
 
@@ -5777,6 +6084,36 @@ fn dispatch_menu_action(state: &mut State, action: select_music_menu::Action) ->
         }
         select_music_menu::Action::SortByTopGrades => {
             apply_wheel_sort(state, WheelSortMode::TopGrades);
+            hide_select_music_menu(state);
+            ScreenAction::None
+        }
+        select_music_menu::Action::SortByPopularityP1 => {
+            apply_wheel_sort(state, WheelSortMode::PopularityP1);
+            hide_select_music_menu(state);
+            ScreenAction::None
+        }
+        select_music_menu::Action::SortByPopularityP2 => {
+            apply_wheel_sort(state, WheelSortMode::PopularityP2);
+            hide_select_music_menu(state);
+            ScreenAction::None
+        }
+        select_music_menu::Action::SortByRecentP1 => {
+            apply_wheel_sort(state, WheelSortMode::RecentP1);
+            hide_select_music_menu(state);
+            ScreenAction::None
+        }
+        select_music_menu::Action::SortByRecentP2 => {
+            apply_wheel_sort(state, WheelSortMode::RecentP2);
+            hide_select_music_menu(state);
+            ScreenAction::None
+        }
+        select_music_menu::Action::SortByTopGradesP1 => {
+            apply_wheel_sort(state, WheelSortMode::TopGradesP1);
+            hide_select_music_menu(state);
+            ScreenAction::None
+        }
+        select_music_menu::Action::SortByTopGradesP2 => {
+            apply_wheel_sort(state, WheelSortMode::TopGradesP2);
             hide_select_music_menu(state);
             ScreenAction::None
         }

--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -814,6 +814,7 @@ enum WheelSortMode {
     Meter,
     Popularity,
     Recent,
+    TopGrades,
 }
 
 #[derive(Clone, Debug)]
@@ -889,6 +890,7 @@ pub struct State {
     meter_entries: Vec<MusicWheelEntry>,
     popularity_entries: Vec<MusicWheelEntry>,
     recent_entries: Vec<MusicWheelEntry>,
+    top_grades_entries: Vec<MusicWheelEntry>,
     expanded_pack_name: Option<String>,
     bg: heart_bg::State,
     last_requested_banner_path: Option<PathBuf>,
@@ -959,6 +961,7 @@ pub struct State {
     meter_pack_song_counts: HashMap<String, usize>,
     popularity_pack_song_counts: HashMap<String, usize>,
     recent_pack_song_counts: HashMap<String, usize>,
+    top_grades_pack_song_counts: HashMap<String, usize>,
     new_pack_names: HashSet<String>,
 }
 
@@ -1913,6 +1916,129 @@ fn build_recent_grouped_entries(
     (entries, counts)
 }
 
+const TOP_GRADES_UNPLAYED_HEADER: &str = "Unplayed";
+
+fn build_top_grades_grouped_entries(
+    grouped_entries: &[MusicWheelEntry],
+    chart_type: &str,
+) -> (Vec<MusicWheelEntry>, HashMap<String, usize>) {
+    let songs: Vec<Arc<SongData>> = grouped_entries
+        .iter()
+        .filter_map(|e| match e {
+            MusicWheelEntry::Song(song) => Some(song.clone()),
+            MusicWheelEntry::PackHeader { .. } => None,
+        })
+        .collect();
+
+    let mut graded_songs: Vec<(Arc<SongData>, Option<scores::Grade>)> =
+        Vec::with_capacity(songs.len());
+    for song in songs {
+        let mut best_grade: Option<scores::Grade> = None;
+        for chart in &song.charts {
+            if !chart.chart_type.eq_ignore_ascii_case(chart_type) || !chart.has_note_data {
+                continue;
+            }
+            for side in [profile::PlayerSide::P1, profile::PlayerSide::P2] {
+                let Some(score) = scores::get_cached_score_for_side(&chart.short_hash, side)
+                else {
+                    continue;
+                };
+                if score.grade != scores::Grade::Failed || score.score_percent > 0.0 {
+                    let grade = score.grade;
+                    if best_grade.is_none()
+                        || grade_sort_order(grade) < grade_sort_order(best_grade.unwrap())
+                    {
+                        best_grade = Some(grade);
+                    }
+                }
+            }
+        }
+        graded_songs.push((song, best_grade));
+    }
+
+    graded_songs.sort_by_cached_key(|(song, best)| {
+        let grade_key = match best {
+            Some(g) => grade_sort_order(*g),
+            None => u8::MAX,
+        };
+        (grade_key, song_title_sort_key(song.as_ref()))
+    });
+
+    let mut entries: Vec<MusicWheelEntry> =
+        Vec::with_capacity(graded_songs.len().saturating_add(20));
+    let mut counts: HashMap<String, usize> = HashMap::with_capacity(20);
+    let mut current_group: Option<String> = None;
+    let mut header_idx = 0usize;
+
+    for (song, best) in graded_songs {
+        let group_name = match best {
+            Some(g) => grade_group_name(g),
+            None => TOP_GRADES_UNPLAYED_HEADER.to_string(),
+        };
+        if current_group.as_deref() != Some(group_name.as_str()) {
+            entries.push(MusicWheelEntry::PackHeader {
+                name: group_name.clone(),
+                original_index: header_idx,
+                banner_path: None,
+            });
+            current_group = Some(group_name.clone());
+            header_idx += 1;
+        }
+        *counts.entry(group_name).or_insert(0) += 1;
+        entries.push(MusicWheelEntry::Song(song));
+    }
+
+    (entries, counts)
+}
+
+fn grade_sort_order(grade: scores::Grade) -> u8 {
+    match grade {
+        scores::Grade::Quint => 0,
+        scores::Grade::Tier01 => 1,
+        scores::Grade::Tier02 => 2,
+        scores::Grade::Tier03 => 3,
+        scores::Grade::Tier04 => 4,
+        scores::Grade::Tier05 => 5,
+        scores::Grade::Tier06 => 6,
+        scores::Grade::Tier07 => 7,
+        scores::Grade::Tier08 => 8,
+        scores::Grade::Tier09 => 9,
+        scores::Grade::Tier10 => 10,
+        scores::Grade::Tier11 => 11,
+        scores::Grade::Tier12 => 12,
+        scores::Grade::Tier13 => 13,
+        scores::Grade::Tier14 => 14,
+        scores::Grade::Tier15 => 15,
+        scores::Grade::Tier16 => 16,
+        scores::Grade::Tier17 => 17,
+        scores::Grade::Failed => 18,
+    }
+}
+
+fn grade_group_name(grade: scores::Grade) -> String {
+    match grade {
+        scores::Grade::Quint => "\u{2605}\u{2605}\u{2605}\u{2605}\u{2605}".to_string(),
+        scores::Grade::Tier01 => "\u{2605}\u{2605}\u{2605}\u{2605}".to_string(),
+        scores::Grade::Tier02 => "\u{2605}\u{2605}\u{2605}".to_string(),
+        scores::Grade::Tier03 => "\u{2605}\u{2605}".to_string(),
+        scores::Grade::Tier04 => "\u{2605}".to_string(),
+        scores::Grade::Tier05 => "S+".to_string(),
+        scores::Grade::Tier06 => "S".to_string(),
+        scores::Grade::Tier07 => "S-".to_string(),
+        scores::Grade::Tier08 => "A+".to_string(),
+        scores::Grade::Tier09 => "A".to_string(),
+        scores::Grade::Tier10 => "A-".to_string(),
+        scores::Grade::Tier11 => "B+".to_string(),
+        scores::Grade::Tier12 => "B".to_string(),
+        scores::Grade::Tier13 => "B-".to_string(),
+        scores::Grade::Tier14 => "C+".to_string(),
+        scores::Grade::Tier15 => "C".to_string(),
+        scores::Grade::Tier16 => "C-".to_string(),
+        scores::Grade::Tier17 => "D".to_string(),
+        scores::Grade::Failed => "Failed".to_string(),
+    }
+}
+
 fn refresh_recent_cache(state: &mut State) {
     let (recent_entries, recent_pack_song_counts) =
         build_recent_grouped_entries(&state.group_entries);
@@ -2006,6 +2132,14 @@ fn apply_wheel_sort(state: &mut State, sort_mode: WheelSortMode) {
                 .as_ref()
                 .and_then(|song| group_name_for_song(&state.recent_entries, song))
                 .or_else(|| first_header_name(&state.recent_entries));
+        }
+        WheelSortMode::TopGrades => {
+            state.all_entries = state.top_grades_entries.clone();
+            state.pack_song_counts = state.top_grades_pack_song_counts.clone();
+            state.expanded_pack_name = selected_song
+                .as_ref()
+                .and_then(|song| group_name_for_song(&state.top_grades_entries, song))
+                .or_else(|| first_header_name(&state.top_grades_entries));
         }
     }
 
@@ -2160,6 +2294,8 @@ pub fn init() -> State {
     let (popularity_entries, popularity_pack_song_counts) =
         build_popularity_grouped_entries(&all_entries);
     let (recent_entries, recent_pack_song_counts) = build_recent_grouped_entries(&all_entries);
+    let (top_grades_entries, top_grades_pack_song_counts) =
+        build_top_grades_grouped_entries(&all_entries, target_chart_type);
     let new_pack_names = sync_new_pack_names(
         &joined_profile_ids,
         pack_song_counts.keys().cloned().collect(),
@@ -2178,6 +2314,7 @@ pub fn init() -> State {
         meter_entries,
         popularity_entries,
         recent_entries,
+        top_grades_entries,
         entries: Vec::new(),
         selected_index: 0,
         selected_steps_index: initial_diff_index,
@@ -2283,6 +2420,7 @@ pub fn init() -> State {
         meter_pack_song_counts,
         popularity_pack_song_counts,
         recent_pack_song_counts,
+        top_grades_pack_song_counts,
         new_pack_names,
     };
 
@@ -2374,6 +2512,7 @@ pub fn init_placeholder() -> State {
         meter_entries: Vec::new(),
         popularity_entries: Vec::new(),
         recent_entries: Vec::new(),
+        top_grades_entries: Vec::new(),
         entries: Vec::new(),
         selected_index: 0,
         selected_steps_index: initial_diff_index,
@@ -2479,6 +2618,7 @@ pub fn init_placeholder() -> State {
         meter_pack_song_counts: HashMap::new(),
         popularity_pack_song_counts: HashMap::new(),
         recent_pack_song_counts: HashMap::new(),
+        top_grades_pack_song_counts: HashMap::new(),
         new_pack_names: HashSet::new(),
     }
 }
@@ -2746,6 +2886,7 @@ fn sort_submenu_index_for_mode(sort_mode: WheelSortMode) -> usize {
         WheelSortMode::Meter => 6,
         WheelSortMode::Popularity => 7,
         WheelSortMode::Recent => 8,
+        WheelSortMode::TopGrades => 9,
     }
 }
 
@@ -5631,6 +5772,11 @@ fn dispatch_menu_action(state: &mut State, action: select_music_menu::Action) ->
         }
         select_music_menu::Action::SortByGenre => {
             apply_wheel_sort(state, WheelSortMode::Genre);
+            hide_select_music_menu(state);
+            ScreenAction::None
+        }
+        select_music_menu::Action::SortByTopGrades => {
+            apply_wheel_sort(state, WheelSortMode::TopGrades);
             hide_select_music_menu(state);
             ScreenAction::None
         }

--- a/src/test_support/music_wheel_bench.rs
+++ b/src/test_support/music_wheel_bench.rs
@@ -112,6 +112,7 @@ fn bench_song(pack_idx: usize, song_idx: usize) -> Arc<SongData> {
         translit_title: String::new(),
         translit_subtitle: String::new(),
         artist: format!("Bench Artist {}", pack_idx + 1),
+        genre: String::new(),
         banner_path: None,
         background_path: None,
         background_changes: Vec::new(),

--- a/src/test_support/notefield_bench.rs
+++ b/src/test_support/notefield_bench.rs
@@ -238,6 +238,7 @@ fn bench_song() -> SongData {
         translit_title: String::new(),
         translit_subtitle: String::new(),
         artist: "Bench Artist".to_string(),
+        genre: String::new(),
         banner_path: None,
         background_path: None,
         background_changes: Vec::new(),

--- a/src/test_support/pane_stats_bench.rs
+++ b/src/test_support/pane_stats_bench.rs
@@ -142,6 +142,7 @@ fn bench_song() -> SongData {
         translit_title: String::new(),
         translit_subtitle: String::new(),
         artist: "Bench Artist".to_string(),
+        genre: String::new(),
         banner_path: None,
         background_path: None,
         background_changes: Vec::new(),


### PR DESCRIPTION
## Add Genre, Top Grades, and per-player sort orders to the select music menu

### Summary

Adds three new sort categories to the music wheel, closing the gap with Simply Love's sort menu options.

### What changed

**Genre sort** — Songs group alphabetically by the `#GENRE` simfile tag. Since rssp doesn't parse this tag yet, `extract_genre_tag()` reads it directly from raw simfile bytes. Songs with no genre are grouped under "Unknown Genre".

**Top Grades sort** — Songs group by best achieved grade tier (★★★★★ through Failed), with unplayed songs at the bottom. Queries `get_cached_score_for_side()` across both player sides to find the best grade per song.

**Per-player sorts (6 variants)** — Popularity P1/P2, Recent P1/P2, and Top Grades P1/P2. These filter by individual profile instead of aggregating across all machine profiles. Two new score query functions (`recent_played_chart_hashes_for_profile`, `played_chart_counts_for_profile`) scope filesystem reads to a single profile directory.

### Data model

- Added `genre: String` to `SongData`, `SerializableSongData`, and `CachedSongMeta`
- Added `extract_genre_tag()` in `simfile.rs` for case-insensitive `#GENRE:` tag extraction
- Added `grade_sort_order()` and `grade_group_name()` helpers for grade-tier grouping

### Wiring

Each new sort follows the existing pattern: `WheelSortMode` variant, `Action` variant, `ITEM_*` constant in `ITEMS_SORTS`, `build_*_grouped_entries()` function, State fields for entries/counts, and arms in `apply_wheel_sort`, `dispatch_menu_action`, and `sort_submenu_index_for_mode`.

Note: The per-player sorts are fully wired but not yet exposed in the classic menu's item list — they'll become accessible once the categories UI is implemented (Profile category). Genre and Top Grades are in the sorts submenu now.