### PR TITLE
Select Menu Set Summary Navigation

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6189,7 +6189,13 @@ impl App {
                         .active_color_index
                 }
             };
-            self.state.screens.evaluation_summary_state = evaluation_summary::init();
+            self.state.screens.evaluation_summary_state = if prev == CurrentScreen::SelectMusic
+                || prev == CurrentScreen::SelectCourse
+            {
+                evaluation_summary::init_for_set_summary()
+            } else {
+                evaluation_summary::init()
+            };
             self.state
                 .screens
                 .evaluation_summary_state

--- a/src/screens/components/select_music/select_music_menu/mod.rs
+++ b/src/screens/components/select_music/select_music_menu/mod.rs
@@ -48,6 +48,7 @@ pub enum Action {
     SyncPack,
     PlayReplay,
     ShowLeaderboard,
+    ShowSetSummary,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -221,6 +222,11 @@ pub const ITEM_GO_BACK_STANDALONE: Item = Item {
     top_label: "",
     bottom_label: "Go Back",
     action: Action::BackToMain,
+};
+pub const ITEM_SET_SUMMARY: Item = Item {
+    top_label: "Relive Your Memories",
+    bottom_label: "Set Summary",
+    action: Action::ShowSetSummary,
 };
 
 pub const ITEMS_SORTS: [Item; 11] = [

--- a/src/screens/evaluation_summary.rs
+++ b/src/screens/evaluation_summary.rs
@@ -30,16 +30,26 @@ pub struct State {
     bg: heart_bg::State,
     pub page: usize,
     pub elapsed: f32,
+    pub return_to: Screen,
     menu_lr_chord: screen_input::MenuLrChordTracker,
     menu_lr_undo: [i8; 2],
 }
 
 pub fn init() -> State {
+    init_with_return(Screen::Initials)
+}
+
+pub fn init_for_set_summary() -> State {
+    init_with_return(Screen::SelectMusic)
+}
+
+fn init_with_return(return_to: Screen) -> State {
     State {
-        active_color_index: color::DEFAULT_COLOR_INDEX, // overwritten by app
+        active_color_index: color::DEFAULT_COLOR_INDEX,
         bg: heart_bg::State::new(),
         page: 1,
         elapsed: 0.0,
+        return_to,
         menu_lr_chord: screen_input::MenuLrChordTracker::default(),
         menu_lr_undo: [0; 2],
     }
@@ -95,7 +105,7 @@ pub fn handle_input(state: &mut State, num_stages: usize, ev: &InputEvent) -> Sc
         VirtualAction::p1_back
         | VirtualAction::p1_start
         | VirtualAction::p2_back
-        | VirtualAction::p2_start => ScreenAction::Navigate(Screen::Initials),
+        | VirtualAction::p2_start => ScreenAction::Navigate(state.return_to),
 
         VirtualAction::p1_menu_left
         | VirtualAction::p1_left

--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -3418,6 +3418,7 @@ fn build_category_item_lists(
     if downloads_enabled {
         advanced.push(select_music_menu::ITEM_VIEW_DOWNLOADS);
     }
+    advanced.push(select_music_menu::ITEM_SET_SUMMARY);
     if has_pack_selected {
         advanced.push(select_music_menu::ITEM_SYNC_PACK);
     }
@@ -6574,6 +6575,10 @@ fn dispatch_menu_action(state: &mut State, action: select_music_menu::Action) ->
             hide_select_music_menu(state);
             show_leaderboard_overlay(state);
             ScreenAction::None
+        }
+        select_music_menu::Action::ShowSetSummary => {
+            hide_select_music_menu(state);
+            ScreenAction::Navigate(crate::screens::Screen::EvaluationSummary)
         }
     }
 }


### PR DESCRIPTION
Add 'Relive Your Memories / Set Summary' item to the Advanced Options category, matching Simply Love's ScreenEvaluationSummarySet.

- Add Action::ShowSetSummary and ITEM_SET_SUMMARY
- Wire dispatch to navigate to EvaluationSummary screen
- Add return_to field to evaluation_summary::State
- init_for_set_summary() returns to SelectMusic instead of Initials
- App detects when navigating from SelectMusic/SelectCourse and uses the set summary init path