### PR TITLE
i18n Setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,6 +751,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,11 +1010,13 @@ dependencies = [
  "raw-window-handle",
  "rssp",
  "rubato",
+ "rust-ini",
  "serde",
  "serde_json",
  "shaderc",
  "smithay-client-toolkit 0.20.0",
  "softbuffer",
+ "sys-locale",
  "tokio",
  "tungstenite",
  "twox-hash",
@@ -1083,6 +1105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading 0.8.9",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1554,6 +1585,12 @@ dependencies = [
  "num-traits",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2981,6 +3018,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3578,6 +3625,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,6 +4091,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "7.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4144,6 +4210,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,10 @@ directories = "6.0.0"
 # Song cache
 bincode = "2.0.1"
 twox-hash = "2.1.2"
+
+# Localization
+rust-ini = "0.21"
+sys-locale = "0.3"
 tokio = { version = "1.51.1", features = ["rt"] }
 bitflags = "2.11.0"
 

--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -1,0 +1,789 @@
+; DeadSync English language file
+; Format: ITGmania-compatible INI with [Section] Key=Value
+; Keys are PascalCase. Sections map to screens or logical groupings.
+
+[Meta]
+NativeName=English
+
+; ============================================================
+; Common UI strings shared across multiple screens
+; ============================================================
+[Common]
+Yes=Yes
+No=No
+Back=Back
+Confirm=Confirm
+Cancel=Cancel
+Exit=Exit
+Open=Open
+Start=Start
+Loading=Loading
+PressStart=PRESS START
+InsertCard=INSERT CARD
+EventMode=EVENT MODE
+On=On
+Off=Off
+Auto=Auto
+
+; ============================================================
+; Screen header bar titles
+; ============================================================
+[ScreenTitles]
+SelectMusic=SELECT MUSIC
+SelectCourse=SELECT COURSE
+SelectMode=SELECT MODE
+SelectStyle=SELECT STYLE
+SelectAColor=SELECT A COLOR
+ManageProfiles=MANAGE PROFILES
+
+; ============================================================
+; Main menu screen
+; ============================================================
+[Menu]
+Gameplay=GAMEPLAY
+Options=OPTIONS
+Exit=EXIT
+Disabled=Disabled
+FailedToLoad=Failed to Load 😞
+MachineOffline=Machine Offline
+CannotConnect=Cannot Connect
+TimedOut=Timed Out
+HostBlocked=Host Blocked
+GrooveStatsDisabled=❌ GrooveStats
+GrooveStatsWarn=⚠ GrooveStats
+GetScoresDisabled=❌ Get Scores
+LeaderboardDisabled=❌ Leaderboard
+AutoSubmitDisabled=❌ Auto-Submit
+ArrowCloudDisabled=❌ Arrow Cloud
+ArrowCloudPending=     Arrow Cloud
+ArrowCloudConnected=✔ Arrow Cloud
+
+; ============================================================
+; Options screen - top-level category items and help text
+; ============================================================
+[Options]
+SystemOptions=System Options
+GraphicsOptions=Graphics / Display Options
+SoundOptions=Sound / Audio Options
+InputOptions=Input Options
+MachineOptions=Machine Options
+GameplayOptions=Gameplay Options
+SelectMusicOptions=Select Music Options
+AdvancedOptions=Advanced Options
+CourseOptions=Course Options
+ManageLocalProfiles=Manage Local Profiles
+OnlineScoreServices=Online Score Services
+NullOrDieOptions=Null-or-Die Options
+ReloadSongsCourses=Reload Songs/Courses
+Credits=Credits
+Exit=Exit
+
+; ============================================================
+; Options screen - help text for each category
+; ============================================================
+[OptionsHelp]
+SystemOptionsHelp=Adjust high-level settings like game type, theme, language, and more.
+GraphicsOptionsHelp=Change screen aspect ratio, resolution, graphics quality, and timing visuals.
+SoundOptionsHelp=Adjust audio output settings and feedback sounds.
+InputOptionsHelp=Configure control mappings and input diagnostics.
+MachineOptionsHelp=Choose which startup and post-session screens are shown.
+GameplayOptionsHelp=Adjust gameplay presentation settings.
+SelectMusicOptionsHelp=Adjust behavior and display for the Select Music screen.
+AdvancedOptionsHelp=Adjust machine-level fail and cache/parsing behavior.
+CourseOptionsHelp=Adjust options related to course selection and course play behavior.
+ManageLocalProfilesHelp=Create, edit, and manage player profiles that are stored on this computer.\n\nYou'll need a keyboard to use this screen.
+OnlineScoreServicesHelp=Configure online score services and import tools.
+NullOrDieOptionsHelp=Configure null-or-die analysis behavior and bulk sync tools.
+ReloadSongsCoursesHelp=Reload all songs and courses from disk without restarting.
+CreditsHelp=View deadsync and project credits.
+ExitHelp=Return to the main menu.
+ThemeHelp=Stored in deadsync.ini for compatibility; theme switching is not implemented yet.
+LanguageHelp=Stored in deadsync.ini for compatibility; runtime language switching is not implemented yet.
+
+; ============================================================
+; System Options submenu
+; ============================================================
+[OptionsSystem]
+Game=Game
+Theme=Theme
+Language=Language
+LogLevel=Log Level
+LogFile=Log File
+DefaultNoteSkin=Default NoteSkin
+DanceGame=dance
+SimplyLoveTheme=Simply Love
+EnglishLanguage=English
+LogLevelError=Error
+LogLevelWarn=Warn
+LogLevelInfo=Info
+LogLevelDebug=Debug
+LogLevelTrace=Trace
+
+; ============================================================
+; Graphics / Display Options submenu
+; ============================================================
+[OptionsGraphics]
+VideoRenderer=Video Renderer
+SoftwareRendererThreads=Software Renderer Threads
+PresentMode=Present Mode
+MaxFPS=Max FPS
+FPSLimit=FPS Limit
+ValidationLayers=Validation Layers
+DisplayMode=Display Mode
+FullscreenType=Fullscreen Type
+VSync=VSync
+ShowStats=Show Stats
+SoftwareThreadsAuto=Auto
+Windowed=Windowed
+Fullscreen=Fullscreen
+Borderless=Borderless
+FullscreenTypeExclusive=Exclusive
+FullscreenTypeBorderless=Borderless
+PresentModeMailbox=Mailbox
+PresentModeImmediate=Immediate
+ShowStatsOff=Off
+ShowStatsFPS=FPS
+ShowStatsFPSStutter=FPS+Stutter
+ShowStatsFPSStutterTiming=FPS+Stutter+Timing
+RendererOpenGL=OpenGL
+RendererVulkan=Vulkan
+RendererDirectX=DirectX
+RendererOpenGLWgpu=OpenGL (wgpu)
+RendererVulkanWgpu=Vulkan (wgpu)
+RendererSoftware=Software
+
+; ============================================================
+; Sound / Audio Options submenu
+; ============================================================
+[OptionsSound]
+MasterVolume=Master Volume
+SFXVolume=SFX Volume
+AssistTickVolume=Assist Tick Volume
+MusicVolume=Music Volume
+SoundDevice=Sound Device
+AudioOutputMode=Audio Output Mode
+LinuxAudioBackend=Linux Audio Backend
+ExclusiveMode=Exclusive Mode
+AudioSampleRate=Audio Sample Rate
+MineSounds=Mine Sounds
+GlobalOffsetMs=Global Offset (ms)
+RateModPreservesPitch=RateMod Preserves Pitch
+OutputModeAuto=Auto
+OutputModeShared=Shared
+LinuxBackendAuto=Auto
+AutoDevice=Auto
+DefaultDeviceSuffix= (Default)
+
+; ============================================================
+; Input Options submenu
+; ============================================================
+[OptionsInput]
+ConfigureKeyboardPadMappings=Configure Keyboard/Pad Mappings
+TestInput=Test Input
+InputOptions=Input Options
+GamepadBackend=Gamepad Backend
+MenuNavigation=Menu Navigation
+OptionsNavigation=Options Navigation
+MenuButtons=Menu Buttons
+DebounceMsLabel=Debounce (ms)
+BackendRawInput=W32 Raw Input
+BackendWGICompat=WGI (compat)
+BackendMacosIOHID=macOS IOHID
+BackendLinuxEvdev=Linux evdev
+BackendPlatformDefault=Platform Default
+MenuNavigationFiveKey=Five Key Menu
+MenuNavigationThreeKey=Three Key Menu
+OptionsNavigationStepMania=StepMania Style
+OptionsNavigationArcade=Arcade Style
+DedicatedMenuButtonsGameplay=Use Gameplay Buttons
+DedicatedMenuButtonsOnly=Only Dedicated Buttons
+
+; ============================================================
+; Mappings screen
+; ============================================================
+[Mappings]
+Player1=Player 1
+Player2=Player 2
+Primary=Primary
+Secondary=Secondary
+
+; ============================================================
+; Test Input screen
+; ============================================================
+[TestInput]
+HoldBackToReturn=Hold &BACK; to return to Options.
+RawEventPolling=RAW EVENT POLLING
+
+; ============================================================
+; Machine Options submenu
+; ============================================================
+[OptionsMachine]
+SelectProfile=Select Profile
+SelectColor=Select Color
+SelectStyle=Select Style
+PreferredStyle=Preferred Style
+SelectPlayMode=Select Play Mode
+PreferredMode=Preferred Mode
+EvalSummary=Eval Summary
+NameEntry=Name Entry
+GameoverScreen=Gameover Screen
+MenuMusic=Menu Music
+Replays=Replays
+AllowPerPlayerGlobalOffsets=Allow Per Player Global Offsets
+KeyboardFeatures=Keyboard Features
+VideoBGs=Video BGs
+WriteCurrentScreen=Write Current Screen
+
+; ============================================================
+; Gameplay Options submenu
+; ============================================================
+[OptionsGameplay]
+BGBrightness=BG Brightness
+CenteredP1Notefield=Centered P1 Notefield
+ZmodRatingBox=Zmod Rating Box
+ShowDecimalInBPM=Show Decimal in BPM
+AutoScreenshot=Auto Screenshot
+
+; ============================================================
+; Select Music Options submenu
+; ============================================================
+[OptionsSelectMusic]
+ShowBanners=Show Banners
+ShowVideoBanners=Show Video Banners
+ShowBreakdown=Show Breakdown
+BreakdownStyle=Breakdown Style
+ShowNativeLanguage=Show Native Language
+MusicWheelSpeed=Music Wheel Speed
+MusicWheelStyle=Music Wheel Style
+ShowCDTitles=Show CDTitles
+ShowMusicWheelGrades=Show Music Wheel Grades
+ShowMusicWheelLamps=Show Music Wheel Lamps
+ITLWheelData=ITL Wheel Data
+NewPackBadge=New Pack Badge
+ShowPatternInfo=Show Pattern Info
+ChartInfo=Chart Info
+MusicPreviews=Music Previews
+PreviewMarker=Preview Marker
+LoopMusic=Loop Music
+ShowGameplayTimer=Show Gameplay Timer
+ShowGSBox=Show GS Box
+GSBoxPlacement=GS Box Placement
+GSBoxLeaderboards=GS Box Leaderboards
+WheelSpeedSlow=Slow
+WheelSpeedNormal=Normal
+WheelSpeedFast=Fast
+WheelSpeedFaster=Faster
+WheelSpeedRidiculous=Ridiculous
+WheelSpeedLudicrous=Ludicrous
+WheelSpeedPlaid=Plaid
+ScoreboxCycleITG=ITG
+ScoreboxCycleEX=EX
+ScoreboxCycleHEX=H.EX
+ScoreboxCycleTournaments=Tournaments
+ChartInfoPeakNPS=Peak NPS
+ChartInfoMatrixRating=Matrix Rating
+
+; ============================================================
+; Advanced Options submenu
+; ============================================================
+[OptionsAdvanced]
+DefaultFailType=Default Fail Type
+BannerCache=Banner Cache
+CDTitleCache=CDTitle Cache
+SongParsingThreads=Song Parsing Threads
+CacheSongs=Cache Songs
+FastLoad=Fast Load
+
+; ============================================================
+; Course Options submenu
+; ============================================================
+[OptionsCourse]
+ShowRandomCourses=Show Random Courses
+ShowMostPlayed=Show Most Played
+ShowIndividualScoresForCourse=Show Individual Scores for Course
+AutosubmitScoresIndividually=Autosubmit Scores in Courses Individually
+
+; ============================================================
+; Online Scoring Options submenu
+; ============================================================
+[OptionsOnlineScoring]
+GrooveStatsBoogieStatsOptions=GrooveStats / BoogieStats Options
+ArrowCloudOptions=ArrowCloud Options
+ScoreImport=Score Import
+NullOrDieOptions=Null-or-Die Options
+SyncPacks=Sync Packs
+SubmitFails=Submit Fails
+
+; ============================================================
+; GrooveStats Options submenu
+; ============================================================
+[OptionsGrooveStats]
+EnableGrooveStats=Enable GrooveStats
+EnableBoogieStats=Enable BoogieStats
+AutoPopulateScores=Auto Populate GS Scores
+AutoDownloadUnlocks=Auto Download Unlocks
+SeparateUnlocksByPlayer=Separate Unlocks By Player
+EnableArrowCloud=Enable ArrowCloud
+ArrowCloudSubmitFails=Submit Fails
+
+; ============================================================
+; Score Import Options submenu
+; ============================================================
+[OptionsScoreImport]
+APIEndpoint=API Endpoint
+Profile=Profile
+Pack=Pack
+OnlyMissingGSScores=Only Missing GS Scores
+Start=Start
+AllPacks=All
+
+; ============================================================
+; Sync Pack Options submenu
+; ============================================================
+[OptionsSyncPack]
+Pack=Pack
+Start=Start
+AllPacks=All Packs
+
+; ============================================================
+; Null-or-Die Options submenu
+; ============================================================
+[OptionsNullOrDie]
+SyncGraph=Sync Graph
+SyncConfidence=Sync Confidence
+PackSyncThreads=Pack Sync Threads
+FingerprintMs=Fingerprint (ms)
+WindowMs=Window (ms)
+StepMs=Step (ms)
+MagicOffsetMs=Magic Offset (ms)
+KernelTarget=Kernel Target
+KernelType=Kernel Type
+FullSpectrogram=Full Spectrogram
+SyncGraphFrequency=Frequency
+SyncGraphBeatIndex=Beat index
+SyncGraphPostKernelFingerprint=Post-kernel fingerprint
+KernelTargetDigest=Digest
+KernelTargetAccumulator=Accumulator
+KernelTypeRising=Rising
+KernelTypeLoudest=Loudest
+
+; ============================================================
+; Player Options screen
+; ============================================================
+[PlayerOptions]
+ChooseDifferentCourse=Choose a Different Course
+ChooseDifferentSong=Choose a Different Song
+WhatComesNextGameplay=Gameplay
+WhatComesNextAdvancedModifiers=Advanced Modifiers
+WhatComesNextUncommonModifiers=Uncommon Modifiers
+WhatComesNextMainModifiers=Main Modifiers
+CurrentStepchartLabel=(Current)
+MatchNoteSkinLabel=Same as NoteSkin
+NoTapExplosionLabel=None
+TypeOfSpeedMod=Type of Speed Mod
+SpeedModTypeX=X (multiplier)
+SpeedModTypeC=C (constant)
+SpeedModTypeM=M (maximum)
+SpeedMod=Speed Mod
+Mini=Mini
+Perspective=Perspective
+PerspectiveOverhead=Overhead
+PerspectiveHallway=Hallway
+PerspectiveDistant=Distant
+PerspectiveIncoming=Incoming
+PerspectiveSpace=Space
+NoteSkin=NoteSkin
+MineSkin=MineSkin
+ReceptorSkin=ReceptorSkin
+TapExplosionSkin=TapExplosionSkin
+JudgmentFont=Judgment Font
+JudgmentOffsetX=Judgment Offset X
+JudgmentOffsetY=Judgment Offset Y
+JudgmentTilt=Judgment Tilt
+JudgmentTiltIntensity=Judgment Tilt Intensity
+JudgmentBehindArrows=Judgment Behind Arrows
+ComboFont=Combo Font
+ComboFontWendy=Wendy
+ComboFontArialRounded=Arial Rounded
+ComboFontAsap=Asap
+ComboFontBebasNeue=Bebas Neue
+ComboFontSourceCode=Source Code
+ComboFontWork=Work
+ComboFontWendyCursed=Wendy (Cursed)
+ComboFontNone=None
+ComboOffsetX=Combo Offset X
+ComboOffsetY=Combo Offset Y
+HoldJudgment=Hold Judgment
+BackgroundFilter=Background Filter
+BackgroundFilterOff=Off
+BackgroundFilterDark=Dark
+BackgroundFilterDarker=Darker
+BackgroundFilterDarkest=Darkest
+NoteFieldOffsetX=NoteField Offset X
+NoteFieldOffsetY=NoteField Offset Y
+VisualDelay=Visual Delay
+GlobalOffsetShift=Global Offset Shift
+MeasureCounter=Measure Counter
+MeasureCounterLookahead=Measure Counter Lookahead
+MeasureCounterOptions=Measure Counter Options
+ErrorBar=Error Bar
+ErrorBarTrim=Error Bar Trim
+ErrorBarOptions=Error Bar Options
+ErrorBarOffsetX=Error Bar Offset X
+ErrorBarOffsetY=Error Bar Offset Y
+CustomBlueFantasticWindow=Custom Blue Fantastic Window
+CustomBlueFantasticWindowMs=Custom Blue Fantastic Window (ms)
+CarryCombo=Carry Combo
+Hide=Hide
+ResultsExtras=Results Extras
+ComboColors=Combo Colors
+ComboColorMode=Combo Color Mode
+LifeMeterType=LifeMeter Type
+LifeBarOptions=Life Bar Options
+IndicatorScoreType=Indicator Score Type
+DataVisualizations=Data Visualizations
+DataVisualizationsNone=None
+DataVisualizationsTargetScoreGraph=Target Score Graph
+DataVisualizationsStepStatistics=Step Statistics
+TargetScore=Target Score
+TargetScoreMissPolicy=Target Score Miss Policy
+MiniIndicator=Mini Indicator
+MiniIndicatorNone=None
+MiniIndicatorSubtractiveScoring=Subtractive Scoring
+MiniIndicatorPredictiveScoring=Predictive Scoring
+MiniIndicatorPaceScoring=Pace Scoring
+MiniIndicatorRivalScoring=Rival Scoring
+MiniIndicatorPacemaker=Pacemaker
+MiniIndicatorStreamProg=Stream Progress
+ComboColorMode=Combo Color Mode
+ComboColorModeFullCombo=FullCombo
+ComboColorModeCurrentCombo=CurrentCombo
+TimingWindows=Timing Windows
+TimingWindowsNone=None
+TimingWindowsWayOffs=Way Offs
+TimingWindowsDecentsAndWayOffs=Decents + Way Offs
+TimingWindowsFantasticsAndExcellents=Fantastics + Excellents
+
+; ============================================================
+; Player Options help text
+; ============================================================
+[PlayerOptionsHelp]
+TypeOfSpeedModHelp=Change the way arrows react to changing BPMs.
+SpeedModHelp=Adjust the speed at which arrows travel toward the targets.
+MiniHelp=Change the size of your arrows.
+PerspectiveHelp=Change the viewing angle of the arrow stream.
+NoteSkinHelp=Change the appearance of the arrows.
+MineSkinHelp=Change mine graphics independently from the main noteskin.
+ReceptorSkinHelp=Change receptor graphics independently from the main noteskin.
+TapExplosionSkinHelp=Change tap explosion graphics independently from the main noteskin.
+JudgmentFontHelp=Pick your judgment font.
+JudgmentOffsetXHelp=Adjust the horizontal position of the judgment display.
+JudgmentOffsetYHelp=Adjust the vertical position of the judgment display.
+ComboFontHelp=Choose the font to count your combo. This font will also be used\nfor the Measure Counter if that is enabled.
+ComboOffsetXHelp=Adjust the horizontal position of the combo counter.
+ComboOffsetYHelp=Adjust the vertical position of the combo counter.
+HoldJudgmentHelp=Change the judgment graphics displayed for hold notes.
+BackgroundFilterHelp=Darken the underside of the playing field.\nThis will partially obscure background art.
+NoteFieldOffsetXHelp=Adjust the horizontal position of the notefield (relative to the\ncenter).
+NoteFieldOffsetYHelp=Adjust the vertical position of the notefield.
+VisualDelayHelp=Player specific visual delay. Negative values shifts the arrows\nupwards, while positive values move them down.
+GlobalOffsetShiftHelp=Player specific timing shift added on top of the machine global\noffset. Use this for controller-specific latency differences.
+DataVisualizationsHelp=Choose solid or transparent gameplay density graph background.
+TargetScoreMissPolicyHelp=Decide what happens if you fall behind your target score.
+MiniIndicatorHelp=Choose a small scoring indicator to display on the notefield.
+ComboColorModeHelp=Choose whether combo colors use full combo or current combo.
+LifeBarOptionsHelp=Adjust the aesthetics of the lifebar display.
+TimingWindowsHelp=Choose which timing windows to show on the evaluation screen.
+ResultsExtrasHelp=Show early-hit subtotals and rescored early-hit totals on evaluation.
+
+; ============================================================
+; Select Music screen
+; ============================================================
+[SelectMusic]
+PressStartForOptions=Press &START; for options
+EnteringOptions=Entering Options...
+ExitGamePrompt=Do you want to exit this game?
+KeepPlayingInfo=Keep playing.
+FinishedInfo=I'm finished.
+RecentlyPlayed=Recently Played
+MostPopular=Most Popular
+ArtistLabel=ARTIST
+BPMLabel=BPM
+LengthLabel=LENGTH
+StepsLabel=STEPS
+ExScore=EX Score
+ItgScore=ITG Score
+NewBadge=NEW
+OptionsMenuLabel=OPTIONS
+ViewDownloads=View Downloads
+PlayReplay=Play Replay
+ReplayHelpText=START: PLAY REPLAY    BACK/SELECT: CANCEL
+SearchResultsFor=Search Results For:
+SortsMenuLabel=SORTS...
+SortBy=Sort By
+Genre=Genre
+MachineTopScores=Machine Top Scores
+P1MostPlayed=P1 Most Played
+P2MostPlayed=P2 Most Played
+P1RecentSongs=P1 Recent Songs
+P2RecentSongs=P2 Recent Songs
+P1ClearRank=P1 Clear Rank
+P2ClearRank=P2 Clear Rank
+ChangeStyleTo=Change Style To
+TestInputPrompt=Feeling salty?
+SongSearchPrompt=Wherefore Art Thou?
+ProfileSwitchPrompt=Next Please
+ReloadPrompt=Take a Breather~
+LobbiesPrompt=Friends Online?
+DownloadsPrompt=Need More RAM
+SyncLabel=Sync
+NullOrDieLabel=null-or-die
+MachineDataLabel=Machine Data
+GrooveStatsLabel=GrooveStats
+FavoritesTogglePrompt=I'm Lovin' It
+FavoritesSortPrompt=Check Out My Mix Tape
+OptionsLabel=Options
+
+; ============================================================
+; Select Music - Pattern info labels
+; ============================================================
+[PatternInfo]
+Boxes=Boxes
+Anchors=Anchors
+Sweeps=Sweeps
+Triangles=Triangles
+HipBreakers=Hip Breakers
+Doritos=Doritos
+Towers=Towers
+Spirals=Spirals
+Copters=Copters
+TotalStream=Total Stream
+Crossovers=Crossovers
+Footswitches=Footswitches
+Sideswitches=Sideswitches
+Jacks=Jacks
+Brackets=Brackets
+
+; ============================================================
+; Select Mode screen
+; ============================================================
+[SelectMode]
+Regular=Regular
+Marathon=Marathon
+RegularDescription=Choose your songs with a\nshort break between each.\n\nThese are dance games\nas we know and love them!
+MarathonDescription=Play a predetermined course\nof songs without any\nbreak between.\n\nMany courses have scripted\nmodifiers!
+
+; ============================================================
+; Select Style screen
+; ============================================================
+[SelectStyle]
+SinglePlayer=1 Player
+TwoPlayers=2 Players
+Double=Double
+
+; ============================================================
+; Select Course screen
+; ============================================================
+[SelectCourse]
+UntitledCourse=Untitled Course
+ChallengeDifficulty=Challenge
+HardDifficulty=Hard
+MediumDifficulty=Medium
+EasyDifficulty=Easy
+BeginnerDifficulty=Beginner
+EditDifficulty=Edit
+SelectCourseHint=Select a course to view songs.
+PickCoursePrompt=Pick a course
+
+; ============================================================
+; Evaluation screen
+; ============================================================
+[Evaluation]
+NoScoreDataAvailable=NO SCORE DATA AVAILABLE
+Barely=Barely!
+DisqualifiedFromRanking=Disqualified From Ranking
+ITGLabel=ITG
+EarlyLabel=EARLY
+HeldLabel=HELD
+EXLabel=EX
+HardEXLabel=H.EX
+
+; ============================================================
+; Evaluation Summary screen
+; ============================================================
+[EvaluationSummary]
+NoStageDataAvailable=NO STAGE DATA AVAILABLE
+SingleLabel=Single
+DoubleLabel=Double
+UnknownLabel=Unknown
+PageFormat=Page {page}/{pages}
+
+; ============================================================
+; Score submission status
+; ============================================================
+[SubmitStatus]
+Submitting=Submitting ...
+Submitted=Submitted!
+SubmitFailed=Submit Failed
+TimedOutRetry=Timed Out - F5 Retry
+BSLabel=BS
+GSLabel=GS
+ACLabel=AC
+
+; ============================================================
+; Score records
+; ============================================================
+[Records]
+MachineRecordFormat=Machine Record {rank}
+PersonalRecordFormat=Personal Record {rank}
+PersonalBest=Personal Best!
+WorldRecord=World Record!
+WorldRecordEx=World Record! (EX)
+
+; ============================================================
+; Gameplay screen
+; ============================================================
+[Gameplay]
+AutoPlay=AutoPlay
+AssistTick=Assist Tick
+HitTick=Hit Tick
+AutoSyncSong=AutoSync Song
+AutoSyncMachine=AutoSync Machine
+ContinueHoldingStartGiveUp=Continue holding &START; to give up
+ContinueHoldingBackGiveUp=Continue holding &BACK; to give up
+DontGoBack=Don't go back!
+EventDefault=EVENT
+CModOn=CMod On
+EarlyLabel=Early
+LateLabel=Late
+HoldsLabel=holds
+MinesLabel=mines
+RollsLabel=rolls
+HandsLabel=hands
+
+; ============================================================
+; Game Over screen
+; ============================================================
+[GameOver]
+GameText=GAME
+OverText=OVER
+NoAvatar=No Avatar
+CaloriesBurnedToday=Calories Burned Today
+TotalSongsPlayed=Total Songs Played
+SongsPlayedThisGame=Songs Played This Game
+NotesHitThisGame=Notes Hit This Game
+TimeSpentThisGame=Time Spent This Game
+
+; ============================================================
+; Profile management screen
+; ============================================================
+[Profiles]
+SetP1=Set P1
+SetP2=Set P2
+Rename=Rename
+Delete=Delete
+NameCannotBeBlank=Profile name cannot be blank.
+NameConflict=The name you chose conflicts with another profile. Please use a different name.
+CreateFailed=Failed to create profile.
+RenameFailed=Failed to rename profile.
+DeleteFailed=Failed to delete profile.
+P1P2Assigned=P1+P2
+P1Assigned=P1
+P2Assigned=P2
+CreateProfileTitle=Create a new local profile.
+EnterProfileNamePrompt=Enter a name for the profile.
+PressStartConfirm=Press Start to confirm.
+PressBackCancel=Press Back to cancel.
+ReturnToOptions=Return to Options.
+LocalProfilePrefix=Local profile: 
+AssignedFormat=Assigned: {tag}
+AssignedNone=Assigned: (none)
+IdFormat=ID: {id}
+OpenActionsPrompt=Press Start to open profile actions.
+DeleteConfirmFormat=Are you sure you want to delete the profile '{name}'?
+CannotBeUndone=This cannot be undone.
+YesNoPrompt=Start: Yes    Back: No
+CreateProfileButton=Create Profile
+ExitButton=Exit
+
+; ============================================================
+; Initials / Name Entry screen
+; ============================================================
+[Initials]
+OutOfRanking=Out of Ranking
+MonthJan=Jan
+MonthFeb=Feb
+MonthMar=Mar
+MonthApr=Apr
+MonthMay=May
+MonthJun=Jun
+MonthJul=Jul
+MonthAug=Aug
+MonthSep=Sep
+MonthOct=Oct
+MonthNov=Nov
+MonthDec=Dec
+
+; ============================================================
+; Pack Sync screen
+; ============================================================
+[PackSync]
+AllPacksLabel=All Packs
+SyncingPackTitle=Syncing pack...
+ReviewTitle=Sync Pack Review
+CompleteTitle=Sync Pack Complete
+RowsPaginationFormat=Rows {start}-{end} / {total}
+SongColumnHeader=SONG
+ProgressColumnHeader=PROGRESS
+ResultColumnHeader=RESULT
+HelpTextRunning=UP/DOWN: SCROLL    LEFT/RIGHT: PAGE    START/BACK/SELECT: CANCEL
+HelpTextReview=UP/DOWN: SCROLL    MENULEFT/MENURIGHT: PAGE    LEFT/RIGHT: CHOOSE    START: ACCEPT    BACK/SELECT: CANCEL
+HelpTextComplete=UP/DOWN: SCROLL    MENULEFT/MENURIGHT: PAGE    START/BACK/SELECT: CLOSE
+YesOption=YES
+NoOption=NO
+StatusQueued=Queued
+StatusStarting=Starting
+ProgressFormat=Beat {current} / {total}
+StatusReady=Ready
+StatusBelowThresholdFormat=Below {threshold}%
+StatusNoChange=No change
+StatusError=Error
+StatusWorking=Working
+AnalysisFailed=Analysis failed
+NothingToSaveMessage=No pack sync changes are ready to save.\n{below} song(s) are below {threshold}% confidence, {nochange} have no change, and {failed} failed.\nPress START/BACK/SELECT to close.
+SaveConfirmFormat=Save {count} pack sync change(s)?\n{below} song(s) below {threshold}% confidence, {nochange} with no change, and {failed} failed will be skipped.\nChoosing NO will discard all pack sync changes.
+
+; ============================================================
+; Init / Loading screen
+; ============================================================
+[Init]
+TitleText=DEAD SYNC
+DoneText=Done!
+InitializingText=Initializing...
+LoadingSongsText=Loading songs...
+LoadingCoursesText=Loading courses...
+CachingArtworkText=Caching artwork...
+CompilingNoteskinsText=Compiling noteskins...
+
+; ============================================================
+; Credits screen
+; ============================================================
+[Credits]
+ReturnPrompt=Press &START; and &BACK; to return
+
+; ============================================================
+; Online lobby messages
+; ============================================================
+[Lobby]
+WaitingForPlayersGameplay=Waiting for players to finish gameplay...
+WaitingForReadyUp=Waiting for players to ready up...
+WaitingForSync=Waiting for players to sync screens...
+DisconnectBasicPrompt=Hold &START; to disconnect from the lobby.
+DisconnectHoldingFormat=Continue holding &START; for {remaining} more second{s} to disconnect...
+OnlineLobbies=Online Lobbies
+PressStartToConnect=Press &START; to connect.
+Connecting=Connecting...
+AvailableLobbies=Available Lobbies
+NoLobbiesFound=No lobbies found.
+JoinedLobby=Joined Lobby
+WaitingForPlayers=Waiting for players...

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -259,7 +259,7 @@ impl Default for Config {
             display_monitor: 0,
             game_flag: GameFlag::Dance,
             theme_flag: ThemeFlag::SimplyLove,
-            language_flag: LanguageFlag::English,
+            language_flag: LanguageFlag::Auto,
             log_level: LogLevel::Warn,
             log_to_file: true,
             write_current_screen: false,

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -442,13 +442,24 @@ impl FromStr for ThemeFlag {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageFlag {
+    Auto,
     English,
 }
 
 impl LanguageFlag {
+    /// Returns the locale code persisted to `deadsync.ini`.
     pub const fn as_str(self) -> &'static str {
         match self {
+            Self::Auto => "auto",
             Self::English => "English",
+        }
+    }
+
+    /// Returns the locale code used by the i18n system.
+    pub const fn locale_code(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::English => "en",
         }
     }
 }
@@ -458,7 +469,8 @@ impl FromStr for LanguageFlag {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.trim().to_ascii_lowercase().as_str() {
-            "english" => Ok(Self::English),
+            "auto" => Ok(Self::Auto),
+            "english" | "en" => Ok(Self::English),
             _ => Err(()),
         }
     }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -1,0 +1,266 @@
+use crate::config;
+use ini::Ini;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, OnceLock, RwLock};
+
+/// Loaded language data: active locale strings + English fallback.
+struct LangData {
+    /// Active (non-English) language strings: section → (key → value).
+    /// Empty when the active language is English.
+    active: HashMap<Box<str>, HashMap<Box<str>, Arc<str>>>,
+    /// English fallback strings (always loaded).
+    fallback: HashMap<Box<str>, HashMap<Box<str>, Arc<str>>>,
+    /// Current locale code (e.g. "en", "es", "ja").
+    locale: String,
+}
+
+static LANG: OnceLock<RwLock<LangData>> = OnceLock::new();
+
+// ---------------------------------------------------------------------------
+// INI loading
+// ---------------------------------------------------------------------------
+
+fn load_ini_to_map(path: &Path) -> HashMap<Box<str>, HashMap<Box<str>, Arc<str>>> {
+    let ini = match Ini::load_from_file(path) {
+        Ok(ini) => ini,
+        Err(e) => {
+            log::warn!("Failed to load language file {}: {e}", path.display());
+            return HashMap::new();
+        }
+    };
+    let mut sections: HashMap<Box<str>, HashMap<Box<str>, Arc<str>>> = HashMap::new();
+    for (section, props) in &ini {
+        let section_name: Box<str> = section.unwrap_or("").into();
+        let entries = sections.entry(section_name).or_default();
+        for (key, value) in props.iter() {
+            entries.insert(key.into(), Arc::from(value));
+        }
+    }
+    sections
+}
+
+// ---------------------------------------------------------------------------
+// Initialization
+// ---------------------------------------------------------------------------
+
+/// Initialize the i18n system. Call once at startup after config is loaded.
+///
+/// `locale` is the resolved locale code (e.g. `"en"`, `"es"`). If the locale
+/// is `"en"`, only the fallback map is populated and the active map stays empty.
+pub fn init(locale: &str) {
+    let dirs = config::dirs::app_dirs();
+    let fallback = load_ini_to_map(&dirs.resolve_asset_path("assets/languages/en.ini"));
+    let active = if locale != "en" {
+        let path = dirs.resolve_asset_path(&format!("assets/languages/{locale}.ini"));
+        load_ini_to_map(&path)
+    } else {
+        HashMap::new()
+    };
+    let data = LangData {
+        active,
+        fallback,
+        locale: locale.to_string(),
+    };
+    let _ = LANG.set(RwLock::new(data));
+}
+
+// ---------------------------------------------------------------------------
+// Lookup API
+// ---------------------------------------------------------------------------
+
+/// Look up a localized string by section and key.
+///
+/// Falls back to English if the key is missing from the active language.
+/// Returns `"Section.Key"` if the key is missing from English too (makes
+/// untranslated strings visible during development).
+pub fn tr(section: &str, key: &str) -> Arc<str> {
+    let lang = LANG.get().expect("i18n not initialized").read().unwrap();
+
+    // Try active language first.
+    if let Some(section_map) = lang.active.get(section) {
+        if let Some(val) = section_map.get(key) {
+            return val.clone();
+        }
+    }
+    // Fall back to English.
+    if let Some(section_map) = lang.fallback.get(section) {
+        if let Some(val) = section_map.get(key) {
+            return val.clone();
+        }
+    }
+    // Missing everywhere — return "Section.Key" so it's visible.
+    Arc::from(format!("{section}.{key}"))
+}
+
+/// Look up a localized string with named placeholder substitution.
+///
+/// Each `{name}` in the translated string is replaced with the corresponding
+/// value from `args`. Named placeholders allow translators to reorder
+/// arguments freely (e.g. Japanese word order differs from English).
+pub fn tr_fmt(section: &str, key: &str, args: &[(&str, &str)]) -> Arc<str> {
+    let mut s = tr(section, key).to_string();
+    for (name, value) in args {
+        s = s.replace(&format!("{{{name}}}"), value);
+    }
+    Arc::from(s)
+}
+
+// ---------------------------------------------------------------------------
+// Language switching (runtime)
+// ---------------------------------------------------------------------------
+
+/// Switch the active language at runtime. Called when the user changes the
+/// Language option. Re-reads the new `.ini` file into the active map.
+///
+/// All subsequent `tr()` calls will return strings from the new language.
+pub fn set_locale(locale: &str) {
+    let mut lang = LANG.get().expect("i18n not initialized").write().unwrap();
+    let dirs = config::dirs::app_dirs();
+    lang.active = if locale != "en" {
+        let path = dirs.resolve_asset_path(&format!("assets/languages/{locale}.ini"));
+        load_ini_to_map(&path)
+    } else {
+        HashMap::new()
+    };
+    lang.locale = locale.to_string();
+}
+
+/// Returns the currently active locale code (e.g. `"en"`, `"es"`).
+pub fn current_locale() -> String {
+    LANG.get()
+        .expect("i18n not initialized")
+        .read()
+        .unwrap()
+        .locale
+        .clone()
+}
+
+// ---------------------------------------------------------------------------
+// OS language detection
+// ---------------------------------------------------------------------------
+
+/// Detect the best locale from the OS settings, falling back to `"en"` if
+/// no matching language file is found.
+pub fn detect_os_locale() -> String {
+    let raw = sys_locale::get_locale().unwrap_or_else(|| "en".to_string());
+    let code = normalize_locale(&raw);
+
+    if locale_file_exists(&code) {
+        return code;
+    }
+    // Try base language without region (e.g. "ja-JP" → "ja").
+    if let Some(base) = code.split('-').next() {
+        if base != code && locale_file_exists(base) {
+            return base.to_string();
+        }
+    }
+    "en".to_string()
+}
+
+/// Normalize an OS locale string to our file-naming convention.
+///
+/// - `"ja-JP"` → `"ja"`
+/// - `"fr-FR"` → `"fr"`
+/// - `"zh-TW"` / `"zh-HK"` → `"zh-Hant"`
+/// - `"zh-CN"` / `"zh-SG"` → `"zh-Hans"`
+fn normalize_locale(raw: &str) -> String {
+    let lower = raw.replace('_', "-").to_ascii_lowercase();
+
+    // Handle Chinese variants (match ITGmania convention).
+    if lower.starts_with("zh") {
+        if lower.contains("hant") || lower.contains("tw") || lower.contains("hk") {
+            return "zh-Hant".to_string();
+        }
+        if lower.contains("hans") || lower.contains("cn") || lower.contains("sg") {
+            return "zh-Hans".to_string();
+        }
+        return "zh-Hans".to_string();
+    }
+
+    // For most locales, just use the primary language subtag.
+    lower
+        .split('-')
+        .next()
+        .unwrap_or("en")
+        .to_string()
+}
+
+fn locale_file_exists(code: &str) -> bool {
+    let dirs = config::dirs::app_dirs();
+    let path = dirs.resolve_asset_path(&format!("assets/languages/{code}.ini"));
+    path.exists()
+}
+
+// ---------------------------------------------------------------------------
+// Available locales (for the Language option)
+// ---------------------------------------------------------------------------
+
+/// Scan `assets/languages/*.ini` and return `(locale_code, native_name)` pairs
+/// sorted by locale code. The native name comes from each file's `[Meta]
+/// NativeName` value.
+pub fn available_locales() -> Vec<(String, String)> {
+    let dirs = config::dirs::app_dirs();
+    let languages_dir = dirs.resolve_asset_path("assets/languages");
+    let mut locales = Vec::new();
+
+    let entries = match std::fs::read_dir(&languages_dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            log::warn!(
+                "Failed to read languages directory {}: {e}",
+                languages_dir.display()
+            );
+            return locales;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("ini") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        // Skip pseudo-localization file.
+        if stem == "pseudo" {
+            continue;
+        }
+        let locale_code = stem.to_string();
+        let native_name = match Ini::load_from_file(&path) {
+            Ok(ini) => ini
+                .get_from(Some("Meta"), "NativeName")
+                .unwrap_or(&locale_code)
+                .to_string(),
+            Err(_) => locale_code.clone(),
+        };
+        locales.push((locale_code, native_name));
+    }
+
+    locales.sort_by(|a, b| a.0.cmp(&b.0));
+    locales
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_locale_strips_region() {
+        assert_eq!(normalize_locale("en-US"), "en");
+        assert_eq!(normalize_locale("ja-JP"), "ja");
+        assert_eq!(normalize_locale("fr_FR"), "fr");
+    }
+
+    #[test]
+    fn normalize_locale_handles_chinese_variants() {
+        assert_eq!(normalize_locale("zh-TW"), "zh-Hant");
+        assert_eq!(normalize_locale("zh-HK"), "zh-Hant");
+        assert_eq!(normalize_locale("zh-Hant-TW"), "zh-Hant");
+        assert_eq!(normalize_locale("zh-CN"), "zh-Hans");
+        assert_eq!(normalize_locale("zh-SG"), "zh-Hans");
+        assert_eq!(normalize_locale("zh-Hans-CN"), "zh-Hans");
+        assert_eq!(normalize_locale("zh"), "zh-Hans");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,6 @@ pub mod assets;
 pub mod config;
 pub mod engine;
 pub mod game;
+pub mod i18n;
 pub mod screens;
 pub mod test_support;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use deadsync::{app, config, engine, game};
+use deadsync::{app, config, engine, game, i18n};
 use std::backtrace::Backtrace;
 use std::panic::PanicHookInfo;
 
@@ -198,6 +198,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cfg = config::get();
     log::set_max_level(cfg.log_level.as_level_filter());
     engine::logging::write_startup_report(&startup_lines(&cfg));
+
+    // Initialize localization after config (which provides the language preference)
+    // and before profile/audio/screens which may use tr() for display strings.
+    let locale = match cfg.language_flag {
+        config::LanguageFlag::Auto => i18n::detect_os_locale(),
+        flag => flag.locale_code().to_string(),
+    };
+    i18n::init(&locale);
+
     #[cfg(windows)]
     let _windows_timing = boost_windows_runtime_timing();
     game::profile::load();


### PR DESCRIPTION
## Summary

Adds the foundation for multi-language support (internationalization) to DeadSync.

### Commits

1. **Add rust-ini and sys-locale dependencies** - INI parser for ITGmania-compatible language files + cross-platform OS language detection.

2. **Create English baseline (en.ini)** - Complete extraction of all user-visible strings (~750 lines) from every screen module into assets/languages/en.ini. Organized into INI sections matching screens/logical groupings with PascalCase keys.

3. **Add localization module with tr() lookup and OS detection** - src/i18n.rs provides:
   - tr(section, key) lookup with fallback chain: active language, then English, then "Section.Key" (visible missing key)
   - tr_fmt() for named placeholder substitution
   - init(locale) / set_locale(locale) for startup and runtime switching
   - detect_os_locale() via sys-locale (Windows/macOS/Linux)
   - available_locales() scans assets/languages/*.ini for the options UI
   - Nested HashMap avoids per-lookup heap allocations
   - Chinese variant normalization (zh-TW to zh-Hant, zh-CN to zh-Hans)
   - Extends LanguageFlag with Auto variant (new default)
   - Wired into main.rs after config load, before screens