### PR TITLE
Extract Evaluation and Game Screen Strings

### DIFF
--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -630,7 +630,11 @@ SingleLabel=Single
 DoubleLabel=Double
 UnknownLabel=Unknown
 PageFormat=Page {page}/{pages}
-
+ScreenTitle=EVALUATION
+ITGLabel=ITG
+BpmDisplay={bpm} bpm
+BpmWithRate={bpm} bpm ({rate}x Music Rate)
+DifficultyFormat={style} / {difficulty}
 ; ============================================================
 ; Score submission status
 ; ============================================================
@@ -674,6 +678,8 @@ HoldsLabel=holds
 MinesLabel=mines
 RollsLabel=rolls
 HandsLabel=hands
+PressStartToReadyUp=Press START to ready up.
+RateDisplay={rate}x rate
 
 ; ============================================================
 ; Game Over screen
@@ -687,6 +693,8 @@ TotalSongsPlayed=Total Songs Played
 SongsPlayedThisGame=Songs Played This Game
 NotesHitThisGame=Notes Hit This Game
 TimeSpentThisGame=Time Spent This Game
+TimeFormatHMS={hours}hr. {minutes}min. {seconds}sec.
+TimeFormatMS={minutes}min. {seconds}sec.
 
 ; ============================================================
 ; Profile management screen

--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -615,6 +615,11 @@ EarlyLabel=EARLY
 HeldLabel=HELD
 EXLabel=EX
 HardEXLabel=H.EX
+BpmSingle={bpm} bpm
+BpmRange={min} - {max} bpm
+BpmWithRate={base} ({rate}x Music Rate)
+DifficultyFormat={style} / {difficulty}
+TotalLabel=Total
 
 ; ============================================================
 ; Evaluation Summary screen
@@ -637,6 +642,7 @@ TimedOutRetry=Timed Out - F5 Retry
 BSLabel=BS
 GSLabel=GS
 ACLabel=AC
+SubmittedCombined=Submitted! {gs_glyph} {gs_label} {ac_glyph} {ac_label}
 
 ; ============================================================
 ; Score records

--- a/src/screens/evaluation.rs
+++ b/src/screens/evaluation.rs
@@ -13,6 +13,7 @@ use crate::screens::components::{
     shared::{banner as shared_banner, heart_bg, lobby_hud, mode_pads, screen_bar, timers},
 };
 
+use crate::assets::i18n::{tr, tr_fmt};
 use crate::assets::AssetManager;
 use crate::engine::present::font;
 use crate::game::chart::ChartData;
@@ -126,12 +127,12 @@ fn cached_bpm_text(min_bpm: f64, max_bpm: f64, music_rate: f32) -> Arc<str> {
     let max = (max_bpm * rate_f64).round() as i32;
     cached_text(&BPM_TEXT_CACHE, (min, max, rate.to_bits()), || {
         let base = if min == max {
-            format!("{min} bpm")
+            tr_fmt("Evaluation", "BpmSingle", &[("bpm", &min.to_string())]).to_string()
         } else {
-            format!("{min} - {max} bpm")
+            tr_fmt("Evaluation", "BpmRange", &[("min", &min.to_string()), ("max", &max.to_string())]).to_string()
         };
         if (rate - 1.0).abs() > 0.001 {
-            format!("{base} ({rate:.2}x Music Rate)")
+            tr_fmt("Evaluation", "BpmWithRate", &[("base", &base), ("rate", &format!("{rate:.2}"))]).to_string()
         } else {
             base
         }
@@ -157,40 +158,40 @@ fn cached_record_text(is_machine: bool, rank: u32) -> Arc<str> {
         (rank, if is_machine { 0 } else { 1 }),
         || {
             if is_machine {
-                format!("Machine Record {rank}")
+                tr_fmt("Records", "MachineRecordFormat", &[("rank", &rank.to_string())]).to_string()
             } else {
-                format!("Personal Record {rank}")
+                tr_fmt("Records", "PersonalRecordFormat", &[("rank", &rank.to_string())]).to_string()
             }
         },
     )
 }
 
 #[inline(always)]
-const fn submit_record_text(banner: scores::GrooveStatsSubmitRecordBanner) -> &'static str {
+fn submit_record_text(banner: scores::GrooveStatsSubmitRecordBanner) -> Arc<str> {
     match banner {
-        scores::GrooveStatsSubmitRecordBanner::PersonalBest => "Personal Best!",
-        scores::GrooveStatsSubmitRecordBanner::WorldRecord => "World Record!",
-        scores::GrooveStatsSubmitRecordBanner::WorldRecordEx => "World Record! (EX)",
+        scores::GrooveStatsSubmitRecordBanner::PersonalBest => tr("Records", "PersonalBest"),
+        scores::GrooveStatsSubmitRecordBanner::WorldRecord => tr("Records", "WorldRecord"),
+        scores::GrooveStatsSubmitRecordBanner::WorldRecordEx => tr("Records", "WorldRecordEx"),
     }
 }
 
 #[inline(always)]
-const fn groovestats_submit_status_text(status: scores::GrooveStatsSubmitUiStatus) -> &'static str {
+fn groovestats_submit_status_text(status: scores::GrooveStatsSubmitUiStatus) -> Arc<str> {
     match status {
-        scores::GrooveStatsSubmitUiStatus::Submitting => "Submitting ...",
-        scores::GrooveStatsSubmitUiStatus::Submitted => "Submitted!",
-        scores::GrooveStatsSubmitUiStatus::SubmitFailed => "Submit Failed",
-        scores::GrooveStatsSubmitUiStatus::TimedOut => "Timed Out - F5 Retry",
+        scores::GrooveStatsSubmitUiStatus::Submitting => tr("SubmitStatus", "Submitting"),
+        scores::GrooveStatsSubmitUiStatus::Submitted => tr("SubmitStatus", "Submitted"),
+        scores::GrooveStatsSubmitUiStatus::SubmitFailed => tr("SubmitStatus", "SubmitFailed"),
+        scores::GrooveStatsSubmitUiStatus::TimedOut => tr("SubmitStatus", "TimedOutRetry"),
     }
 }
 
 #[inline(always)]
-const fn arrowcloud_submit_status_text(status: scores::ArrowCloudSubmitUiStatus) -> &'static str {
+fn arrowcloud_submit_status_text(status: scores::ArrowCloudSubmitUiStatus) -> Arc<str> {
     match status {
-        scores::ArrowCloudSubmitUiStatus::Submitting => "Submitting ...",
-        scores::ArrowCloudSubmitUiStatus::Submitted => "Submitted!",
-        scores::ArrowCloudSubmitUiStatus::SubmitFailed => "Submit Failed",
-        scores::ArrowCloudSubmitUiStatus::TimedOut => "Timed Out - F5 Retry",
+        scores::ArrowCloudSubmitUiStatus::Submitting => tr("SubmitStatus", "Submitting"),
+        scores::ArrowCloudSubmitUiStatus::Submitted => tr("SubmitStatus", "Submitted"),
+        scores::ArrowCloudSubmitUiStatus::SubmitFailed => tr("SubmitStatus", "SubmitFailed"),
+        scores::ArrowCloudSubmitUiStatus::TimedOut => tr("SubmitStatus", "TimedOutRetry"),
     }
 }
 
@@ -234,11 +235,11 @@ const fn submit_footer_status_glyph(status: SubmitFooterStatus) -> &'static str 
 }
 
 #[inline(always)]
-fn submit_footer_gs_label() -> &'static str {
+fn submit_footer_gs_label() -> Arc<str> {
     if online::is_boogiestats_active() {
-        "BS"
+        tr("SubmitStatus", "BSLabel")
     } else {
-        "GS"
+        tr("SubmitStatus", "GSLabel")
     }
 }
 
@@ -246,12 +247,12 @@ fn combined_submit_footer_text(
     gs_status: SubmitFooterStatus,
     ac_status: SubmitFooterStatus,
 ) -> Arc<str> {
-    Arc::<str>::from(format!(
-        "Submitted! {} {} {} AC",
-        submit_footer_status_glyph(gs_status),
-        submit_footer_gs_label(),
-        submit_footer_status_glyph(ac_status),
-    ))
+    tr_fmt("SubmitStatus", "SubmittedCombined", &[
+        ("gs_glyph", submit_footer_status_glyph(gs_status)),
+        ("gs_label", &submit_footer_gs_label()),
+        ("ac_glyph", submit_footer_status_glyph(ac_status)),
+        ("ac_label", &tr("SubmitStatus", "ACLabel")),
+    ])
 }
 
 #[inline(always)]
@@ -284,7 +285,7 @@ fn submit_footer_lines(
         return Vec::new();
     }
     if gs_pending || ac_pending {
-        return vec![cached_str_ref("Submitting ...")];
+        return vec![tr("SubmitStatus", "Submitting")];
     }
     if matches!(gs_status, Some(SubmitFooterStatus::TimedOut))
         || matches!(ac_status, Some(SubmitFooterStatus::TimedOut))
@@ -293,8 +294,8 @@ fn submit_footer_lines(
         let mut lines = Vec::with_capacity(2);
         if let Some(status) = gs_status {
             lines.push(submit_footer_service_line(
-                submit_footer_gs_label(),
-                groovestats_submit_status_text(match status {
+                &submit_footer_gs_label(),
+                &groovestats_submit_status_text(match status {
                     SubmitFooterStatus::Submitting => scores::GrooveStatsSubmitUiStatus::Submitting,
                     SubmitFooterStatus::Submitted => scores::GrooveStatsSubmitUiStatus::Submitted,
                     SubmitFooterStatus::SubmitFailed => {
@@ -307,8 +308,8 @@ fn submit_footer_lines(
         }
         if let Some(status) = ac_status {
             lines.push(submit_footer_service_line(
-                "AC",
-                arrowcloud_submit_status_text(match status {
+                &tr("SubmitStatus", "ACLabel"),
+                &arrowcloud_submit_status_text(match status {
                     SubmitFooterStatus::Submitting => scores::ArrowCloudSubmitUiStatus::Submitting,
                     SubmitFooterStatus::Submitted => scores::ArrowCloudSubmitUiStatus::Submitted,
                     SubmitFooterStatus::SubmitFailed => {
@@ -327,18 +328,18 @@ fn submit_footer_lines(
             if matches!(gs_status, SubmitFooterStatus::SubmitFailed)
                 && matches!(ac_status, SubmitFooterStatus::SubmitFailed)
             {
-                vec![cached_str_ref("Submit Failed")]
+                vec![tr("SubmitStatus", "SubmitFailed")]
             } else {
                 vec![combined_submit_footer_text(gs_status, ac_status)]
             }
         }
         (Some(SubmitFooterStatus::Submitted), None)
         | (None, Some(SubmitFooterStatus::Submitted)) => {
-            vec![cached_str_ref("Submitted!")]
+            vec![tr("SubmitStatus", "Submitted")]
         }
         (Some(SubmitFooterStatus::SubmitFailed), None)
         | (None, Some(SubmitFooterStatus::SubmitFailed)) => {
-            vec![cached_str_ref("Submit Failed")]
+            vec![tr("SubmitStatus", "SubmitFailed")]
         }
         _ => Vec::new(),
     }
@@ -347,16 +348,14 @@ fn submit_footer_lines(
 #[inline(always)]
 fn cached_difficulty_text(style_label: &'static str, difficulty: &'static str) -> Arc<str> {
     cached_text(&DIFFICULTY_TEXT_CACHE, (style_label, difficulty), || {
-        format!("{style_label} / {difficulty}")
+        tr_fmt("Evaluation", "DifficultyFormat", &[("style", style_label), ("difficulty", difficulty)]).to_string()
     })
 }
 
 #[inline(always)]
 fn cached_total_label_text(total: u32) -> Arc<str> {
     cached_text(&TOTAL_LABEL_CACHE, total, || {
-        let mut s = total.to_string();
-        s.push_str(" Total");
-        s
+        format!("{} {}", total, tr("Evaluation", "TotalLabel"))
     })
 }
 
@@ -2378,7 +2377,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     let Some(score_info) = state.score_info.iter().find_map(|s| s.as_ref()) else {
         actors.push(act!(text:
             font("wendy"):
-            settext("NO SCORE DATA AVAILABLE"):
+            settext(tr("Evaluation", "NoScoreDataAvailable")):
             align(0.5, 0.5): xy(screen_center_x(), screen_center_y()):
             zoom(0.8): horizalign(center):
             z(100)
@@ -3286,7 +3285,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                             let arrow_end_y = anchor_y + 20.0;
 
                             life_children.push(act!(text:
-                                font("miso"): settext("Barely!"):
+                                font("miso"): settext(tr("Evaluation", "Barely")):
                                 align(0.5, 0.5): xy(x, text_start_y):
                                 zoom(0.75):
                                 diffuse(1.0, 1.0, 1.0, 1.0): alpha(0.0):
@@ -3434,7 +3433,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
 
             actors.push(act!(text:
                 font("wendy"):
-                settext("Disqualified From Ranking"):
+                settext(tr("Evaluation", "DisqualifiedFromRanking")):
                 align(0.5, 0.5):
                 xy(center_x, label_y):
                 zoom(label_zoom):
@@ -3478,7 +3477,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                 };
                 actors.push(act!(text:
                     font("wendy"):
-                    settext(cached_str_ref(submit_record_text(banner))):
+                    settext(submit_record_text(banner)):
                     align(0.5, 0.5):
                     xy(x, AUTO_SUBMIT_RECORD_TEXT_Y):
                     zoom(AUTO_SUBMIT_RECORD_TEXT_ZOOM):
@@ -3533,7 +3532,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     // --- "ITG" text and Pads (top right) ---
     {
         let itg_text_x = screen_width() - widescale(55.0, 62.0);
-        actors.push(act!(text: font("wendy"): settext("ITG"): align(1.0, 0.5): xy(itg_text_x, 15.0): zoom(widescale(0.5, 0.6)): z(121): diffuse(1.0, 1.0, 1.0, 1.0) ));
+        actors.push(act!(text: font("wendy"): settext(tr("Evaluation", "ITGLabel")): align(1.0, 0.5): xy(itg_text_x, 15.0): zoom(widescale(0.5, 0.6)): z(121): diffuse(1.0, 1.0, 1.0, 1.0) ));
         actors.extend(mode_pads::build());
     }
 

--- a/src/screens/evaluation_summary.rs
+++ b/src/screens/evaluation_summary.rs
@@ -1,4 +1,5 @@
 use crate::act;
+use crate::assets::i18n::{tr, tr_fmt};
 use crate::assets::AssetManager;
 use crate::engine::input::{InputEvent, VirtualAction};
 use crate::engine::present::actors::{Actor, SizeSpec};
@@ -18,6 +19,7 @@ use crate::screens::input as screen_input;
 use crate::screens::{Screen, ScreenAction};
 use chrono::Local;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 /* ---------------------------- transitions ---------------------------- */
 const TRANSITION_IN_DURATION: f32 = 0.4;
@@ -204,13 +206,13 @@ fn stringify_display_bpms(song: &SongData, chart: Option<&ChartData>, music_rate
     }
 }
 
-fn steps_type_label(chart_type: &str) -> &'static str {
+fn steps_type_label(chart_type: &str) -> Arc<str> {
     if chart_type.eq_ignore_ascii_case("dance-single") {
-        "Single"
+        tr("EvaluationSummary", "SingleLabel")
     } else if chart_type.eq_ignore_ascii_case("dance-double") {
-        "Double"
+        tr("EvaluationSummary", "DoubleLabel")
     } else {
-        "Unknown"
+        tr("EvaluationSummary", "UnknownLabel")
     }
 }
 
@@ -339,7 +341,7 @@ fn build_player_stats(
     {
         let style = steps_type_label(&p.chart.chart_type);
         let diff = difficulty_display_name(&p.chart.difficulty, zmod_rating_box_text);
-        let text = format!("{style} / {diff}");
+        let text = tr_fmt("EvaluationSummary", "DifficultyFormat", &[("style", &style), ("difficulty", &diff)]);
         let mut a = act!(text:
             font("miso"):
             settext(text):
@@ -484,13 +486,14 @@ fn build_row(
     let bpm_line = if bpm_str.is_empty() {
         String::new()
     } else if (stage.music_rate - 1.0).abs() > 0.001 {
-        format!(
-            "{} bpm ({}x Music Rate)",
-            bpm_str,
-            format_rate_x(stage.music_rate)
+        tr_fmt(
+            "EvaluationSummary",
+            "BpmWithRate",
+            &[("bpm", &bpm_str), ("rate", &format_rate_x(stage.music_rate))],
         )
+        .to_string()
     } else {
-        format!("{bpm_str} bpm")
+        tr_fmt("EvaluationSummary", "BpmDisplay", &[("bpm", &bpm_str)]).to_string()
     };
 
     let mut children: Vec<Actor> = Vec::with_capacity(64);
@@ -575,8 +578,9 @@ pub fn get_actors(
     }));
 
     // Top Bar
+    let eval_title = tr("EvaluationSummary", "ScreenTitle");
     actors.push(screen_bar::build(ScreenBarParams {
-        title: "EVALUATION",
+        title: &eval_title,
         title_placement: ScreenBarTitlePlacement::Left,
         position: ScreenBarPosition::Top,
         transparent: false,
@@ -591,7 +595,7 @@ pub fn get_actors(
     if stages.is_empty() {
         actors.push(act!(text:
             font("wendy"):
-            settext("NO STAGE DATA AVAILABLE"):
+            settext(tr("EvaluationSummary", "NoStageDataAvailable")):
             align(0.5, 0.5):
             xy(screen_center_x(), screen_height() * 0.5):
             zoom(0.8):
@@ -608,7 +612,7 @@ pub fn get_actors(
     // Centered "Page x/y"
     actors.push(act!(text:
         font("wendy"):
-        settext(format!("Page {page}/{pages}")):
+        settext(tr_fmt("EvaluationSummary", "PageFormat", &[("page", &page.to_string()), ("pages", &pages.to_string())])):
         align(0.5, 0.5):
         xy(screen_center_x(), 15.0):
         zoom(widescale(0.5, 0.6)):
@@ -622,7 +626,7 @@ pub fn get_actors(
         let itg_text_x = screen_width() - 10.0;
         actors.push(act!(text:
                 font("wendy"):
-                settext("ITG"):
+                settext(tr("EvaluationSummary", "ITGLabel")):
                 align(1.0, 0.5):
             xy(itg_text_x, 15.0):
             zoom(widescale(0.5, 0.6)):

--- a/src/screens/gameover.rs
+++ b/src/screens/gameover.rs
@@ -1,4 +1,5 @@
 use crate::act;
+use crate::assets::i18n::{tr, tr_fmt};
 use crate::assets::AssetManager;
 use crate::engine::input::{InputEvent, VirtualAction};
 use crate::engine::present::actors::Actor;
@@ -88,9 +89,26 @@ fn format_time_spent(seconds_total: f32) -> String {
     let seconds = total % 60;
 
     if hours > 0 {
-        format!("{hours}hr. {minutes}min. {seconds}sec.")
+        tr_fmt(
+            "GameOver",
+            "TimeFormatHMS",
+            &[
+                ("hours", &hours.to_string()),
+                ("minutes", &minutes.to_string()),
+                ("seconds", &seconds.to_string()),
+            ],
+        )
+        .to_string()
     } else {
-        format!("{minutes}min. {seconds}sec.")
+        tr_fmt(
+            "GameOver",
+            "TimeFormatMS",
+            &[
+                ("minutes", &minutes.to_string()),
+                ("seconds", &seconds.to_string()),
+            ],
+        )
+        .to_string()
     }
 }
 
@@ -113,19 +131,20 @@ fn build_player_lines(
             } else {
                 0
             };
-            profile_lines.push(format!("Calories Burned Today\n{cals}"));
+            profile_lines.push(format!("{}\n{cals}", tr("GameOver", "CaloriesBurnedToday")));
         }
 
-        profile_lines.push(format!("Total Songs Played\n{total_songs_played}"));
+        profile_lines.push(format!("{}\n{total_songs_played}", tr("GameOver", "TotalSongsPlayed")));
     }
 
     // General stats (no profile required)
     let stats = session_stats_for_side(side, stages);
     let general_lines: Vec<String> = vec![
-        format!("Songs Played This Game\n{}", stats.songs_played),
-        format!("Notes Hit This Game\n{}", stats.notes_hit),
+        format!("{}\n{}", tr("GameOver", "SongsPlayedThisGame"), stats.songs_played),
+        format!("{}\n{}", tr("GameOver", "NotesHitThisGame"), stats.notes_hit),
         format!(
-            "Time Spent This Game\n{}",
+            "{}\n{}",
+            tr("GameOver", "TimeSpentThisGame"),
             format_time_spent(stats.duration_seconds)
         ),
     ];
@@ -228,7 +247,7 @@ pub fn get_actors(
 
         actors.push(act!(text:
             font("wendy_white"):
-            settext("GAME"):
+            settext(tr("GameOver", "GameText")):
             align(0.5, 0.5):
             xy(cx, cy - 40.0):
             croptop(1.0): fadetop(1.0):
@@ -239,7 +258,7 @@ pub fn get_actors(
         ));
         actors.push(act!(text:
             font("wendy_white"):
-            settext("OVER"):
+            settext(tr("GameOver", "OverText")):
             align(0.5, 0.5):
             xy(cx, cy + 40.0):
             croptop(1.0): fadetop(1.0):
@@ -281,7 +300,7 @@ pub fn get_actors(
                 ));
                 actors.push(act!(text:
                     font("miso"):
-                    settext("No Avatar"):
+                    settext(tr("GameOver", "NoAvatar")):
                     align(0.5, 0.5):
                     xy(x_pos, AVATAR_Y + AVATAR_DIM - 18.0):
                     zoom(0.9):

--- a/src/screens/gameplay.rs
+++ b/src/screens/gameplay.rs
@@ -1,4 +1,5 @@
 use crate::act;
+use crate::assets::i18n::{tr, tr_fmt};
 use crate::assets::AssetManager;
 use crate::engine::gfx::{BlendMode, MeshMode, MeshVertex};
 use crate::engine::input::{InputEvent, VirtualAction};
@@ -374,12 +375,13 @@ fn gameplay_lobby_wait_text_for(
     }
 
     let mut message = if all_in_gameplay {
-        "Waiting for players to ready up...".to_string()
+        tr("Lobby", "WaitingForReadyUp").to_string()
     } else {
-        "Waiting for players to sync screens...".to_string()
+        tr("Lobby", "WaitingForSync").to_string()
     };
     if !local_players_ready {
-        message.push_str("\nPress START to ready up.");
+        message.push('\n');
+        message.push_str(&tr("Gameplay", "PressStartToReadyUp"));
     }
     Some(message)
 }
@@ -402,15 +404,22 @@ fn gameplay_lobby_wait_text(state: &State) -> Option<String> {
 fn gameplay_lobby_disconnect_prompt(state: &State) -> Option<String> {
     gameplay_lobby_wait_text(state)?;
     let Some(elapsed) = lobby_disconnect_hold_elapsed(state) else {
-        return Some("Hold &START; to disconnect from the lobby.".to_string());
+        return Some(tr("Lobby", "DisconnectBasicPrompt").to_string());
     };
     let remaining =
         (crate::game::online::lobbies::LOBBY_DISCONNECT_HOLD_SECONDS - elapsed).ceil() as i32;
     let remaining = remaining.max(0);
-    Some(format!(
-        "Continue holding &START; for {remaining} more second{} to disconnect...",
-        if remaining == 1 { "" } else { "s" }
-    ))
+    Some(
+        tr_fmt(
+            "Lobby",
+            "DisconnectHoldingFormat",
+            &[
+                ("remaining", &remaining.to_string()),
+                ("s", if remaining == 1 { "" } else { "s" }),
+            ],
+        )
+        .to_string(),
+    )
 }
 
 fn gameplay_lobby_hud_status_text(state: &State) -> Option<String> {
@@ -561,7 +570,7 @@ fn cached_rate_text(rate: f32) -> Arc<str> {
         return empty_text();
     }
     cached_text(&RATE_TEXT_CACHE, rate.to_bits(), TEXT_CACHE_LIMIT, || {
-        format!("{rate:.2}x rate")
+        tr_fmt("Gameplay", "RateDisplay", &[("rate", &format!("{rate:.2}"))]).to_string()
     })
 }
 
@@ -703,15 +712,10 @@ pub fn prewarm_text_layout(
     cache.prewarm_text(fonts, "miso", "Hit Tick", None);
     cache.prewarm_text(fonts, "miso", "AutoSync Song", None);
     cache.prewarm_text(fonts, "miso", "AutoSync Machine", None);
-    cache.prewarm_text(fonts, "miso", "Continue holding &START; to give up", None);
-    cache.prewarm_text(fonts, "miso", "Continue holding &BACK; to give up", None);
-    cache.prewarm_text(
-        fonts,
-        "miso",
-        "Hold &START; to disconnect from the lobby.",
-        None,
-    );
-    cache.prewarm_text(fonts, "miso", "Don't go back!", None);
+    cache.prewarm_text(fonts, "miso", &tr("Gameplay", "ContinueHoldingStartGiveUp"), None);
+    cache.prewarm_text(fonts, "miso", &tr("Gameplay", "ContinueHoldingBackGiveUp"), None);
+    cache.prewarm_text(fonts, "miso", &tr("Lobby", "DisconnectBasicPrompt"), None);
+    cache.prewarm_text(fonts, "miso", &tr("Gameplay", "DontGoBack"), None);
     if let Some(text) = state.replay_status_text.as_ref() {
         cache.prewarm_text(fonts, "miso", text.as_ref(), None);
     }
@@ -2729,10 +2733,10 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
         {
             let s = match key {
                 crate::game::gameplay::HoldToExitKey::Start => {
-                    Some("Continue holding &START; to give up")
+                    Some(tr("Gameplay", "ContinueHoldingStartGiveUp"))
                 }
                 crate::game::gameplay::HoldToExitKey::Back => {
-                    Some("Continue holding &BACK; to give up")
+                    Some(tr("Gameplay", "ContinueHoldingBackGiveUp"))
                 }
             };
             let alpha = (start.elapsed().as_secs_f32() / HOLD_FADE_IN_S).clamp(0.0, 1.0);
@@ -2742,15 +2746,15 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
             match exit.kind {
                 crate::game::gameplay::ExitTransitionKind::Out => {
                     let alpha = (1.0 - t / ABORT_FADE_OUT_S).clamp(0.0, 1.0);
-                    Some(("Continue holding &START; to give up".to_string(), alpha))
+                    Some((tr("Gameplay", "ContinueHoldingStartGiveUp").to_string(), alpha))
                 }
                 crate::game::gameplay::ExitTransitionKind::Cancel => {
-                    Some(("Continue holding &BACK; to give up".to_string(), 1.0))
+                    Some((tr("Gameplay", "ContinueHoldingBackGiveUp").to_string(), 1.0))
                 }
             }
         } else if let Some(at) = state.hold_to_exit_aborted_at {
             let alpha = (1.0 - at.elapsed().as_secs_f32() / ABORT_FADE_OUT_S).clamp(0.0, 1.0);
-            Some(("Don't go back!".to_string(), alpha))
+            Some((tr("Gameplay", "DontGoBack").to_string(), alpha))
         } else {
             None
         };
@@ -3765,10 +3769,11 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     let p1_guest = hud_snapshot.p1.guest;
     let p2_guest = hud_snapshot.p2.guest;
 
+    let insert_card_text = tr("Common", "InsertCard");
     let (p1_footer_text, p1_footer_avatar) = if p1_joined {
         (
             Some(if p1_guest {
-                "INSERT CARD"
+                &*insert_card_text
             } else {
                 hud_snapshot.p1.display_name.as_str()
             }),
@@ -3780,7 +3785,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     let (p2_footer_text, p2_footer_avatar) = if p2_joined {
         (
             Some(if p2_guest {
-                "INSERT CARD"
+                &*insert_card_text
             } else {
                 hud_snapshot.p2.display_name.as_str()
             }),
@@ -3906,6 +3911,10 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
 mod tests {
     use super::*;
     use crate::engine::present::actors::SizeSpec;
+
+    fn ensure_i18n() {
+        crate::assets::i18n::init("en");
+    }
 
     fn test_proxy_overlay(player_index: usize) -> SongLuaOverlayActor {
         SongLuaOverlayActor {
@@ -4221,11 +4230,17 @@ mod tests {
 
     #[test]
     fn gameplay_wait_text_requires_ready_up_for_solo_lobby_player() {
+        ensure_i18n();
         let joined = test_joined_lobby(vec![test_lobby_player("ScreenGameplay", false)]);
 
+        let expected = format!(
+            "{}\n{}",
+            tr("Lobby", "WaitingForReadyUp"),
+            tr("Gameplay", "PressStartToReadyUp"),
+        );
         assert_eq!(
             gameplay_lobby_wait_text_for(&joined, false, None).as_deref(),
-            Some("Waiting for players to ready up...\nPress START to ready up.")
+            Some(expected.as_str())
         );
     }
 


### PR DESCRIPTION
## i18n: Extract evaluation and game screen strings

Replace all hardcoded UI strings across the evaluation, gameplay, and game over screens with `tr()`/`tr_fmt()` localization calls, continuing the i18n effort from #177.

### Screens extracted

| Screen | File | Strings extracted |
|---|---|---|
| Evaluation | `evaluation.rs` | ~30 strings |
| Evaluation Summary | `evaluation_summary.rs` | ~9 strings |
| Gameplay | `gameplay.rs` | ~9 strings |
| Game Over | `gameover.rs` | ~10 strings |

### Changes

**`evaluation.rs`**:
- Changed 5 `const fn` to regular `fn` returning `Arc<str>` for `tr()` compatibility
- BPM display format strings (single, range, with music rate) → `tr_fmt("Evaluation", ...)`
- Record text (machine/personal record, personal best, world record) → `tr("Records", ...)`
- Submit status text (submitting, submitted, failed, timed out) → `tr("SubmitStatus", ...)`
- Submit footer service labels (GS/BS/AC) and combined format → `tr("SubmitStatus", ...)`
- Difficulty/style format, total label, no score data, barely marker, disqualified, ITG label

**`evaluation_summary.rs`**:
- Steps type labels (Single, Double, Unknown) → `tr("EvaluationSummary", ...)`
- BPM display and with-rate format strings → `tr_fmt()`
- Screen bar title ("EVALUATION"), page format, ITG label, no stage data
- Style/difficulty separator → `tr_fmt("EvaluationSummary", "DifficultyFormat")`

**`gameplay.rs`**:
- Lobby waiting/disconnect messages → `tr("Lobby", ...)`
- Give-up hold text and "Don't go back!" → `tr("Gameplay", ...)`
- INSERT CARD footer for guest players → `tr("Common", ...)`
- Music rate display ("1.50x rate") → `tr_fmt("Gameplay", "RateDisplay")`
- "Press START to ready up" prompt

**`gameover.rs`**:
- GAME/OVER text, No Avatar placeholder → `tr("GameOver", ...)`
- All 5 stat labels (calories, songs played, notes hit, time spent) → `tr("GameOver", ...)`
- Time format strings (hr/min/sec) → `tr_fmt("GameOver", "TimeFormatHMS"/"TimeFormatMS")`

**`en.ini`**:
- Added 16 new keys across `[Evaluation]`, `[EvaluationSummary]`, `[SubmitStatus]`, `[Gameplay]`, and `[GameOver]` sections
