### PR TITLE
Extract Profile and Utility Screen Strings

### DIFF
--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -35,6 +35,7 @@ SelectMode=SELECT MODE
 SelectStyle=SELECT STYLE
 SelectAColor=SELECT A COLOR
 ManageProfiles=MANAGE PROFILES
+SelectProfile=SELECT PROFILE
 
 ; ============================================================
 ; Main menu screen
@@ -703,7 +704,7 @@ EnterProfileNamePrompt=Enter a name for the profile.
 PressStartConfirm=Press Start to confirm.
 PressBackCancel=Press Back to cancel.
 ReturnToOptions=Return to Options.
-LocalProfilePrefix=Local profile: 
+LocalProfileFormat=Local profile: {name}
 AssignedFormat=Assigned: {tag}
 AssignedNone=Assigned: (none)
 IdFormat=ID: {id}
@@ -713,6 +714,30 @@ CannotBeUndone=This cannot be undone.
 YesNoPrompt=Start: Yes    Back: No
 CreateProfileButton=Create Profile
 ExitButton=Exit
+
+; ============================================================
+; Select Profile screen
+; ============================================================
+[SelectProfile]
+JoinText=Press &START; to join!
+WaitingText=Waiting ...
+GuestLabel=[ GUEST ]
+NoAvatar=No Avatar
+NotPresent=NOT PRESENT
+SongPlayedSingular={count} Song Played
+SongPlayedPlural={count} Songs Played
+Reverse=Reverse
+Split=Split
+Alternate=Alternate
+Cross=Cross
+Centered=Centered
+Overhead=Overhead
+SubtractiveScoring=Subtractive Scoring
+PredictiveScoring=Predictive Scoring
+PaceScoring=Pace Scoring
+RivalScoring=Rival Scoring
+Pacemaker=Pacemaker
+StreamProgress=Stream Progress
 
 ; ============================================================
 ; Initials / Name Entry screen

--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -783,6 +783,8 @@ StatusNoChange=No change
 StatusError=Error
 StatusWorking=Working
 AnalysisFailed=Analysis failed
+ResultConfidenceFormat={bias} ms\n{confidence}% confidence
+ResultNoChangeFormat=0.00 ms\n{confidence}% confidence
 NothingToSaveMessage=No pack sync changes are ready to save.\n{below} song(s) are below {threshold}% confidence, {nochange} have no change, and {failed} failed.\nPress START/BACK/SELECT to close.
 SaveConfirmFormat=Save {count} pack sync change(s)?\n{below} song(s) below {threshold}% confidence, {nochange} with no change, and {failed} failed will be skipped.\nChoosing NO will discard all pack sync changes.
 

--- a/src/screens/components/shared/profile_boxes.rs
+++ b/src/screens/components/shared/profile_boxes.rs
@@ -1,4 +1,5 @@
 use crate::act;
+use crate::assets::i18n::{tr, tr_fmt};
 use crate::assets::{self, AssetManager};
 use crate::config::dirs;
 use crate::engine::audio;
@@ -78,8 +79,6 @@ const TOTAL_SONGS_ZOOM: f32 = 0.65; // SL: TotalSongs zoom(0.65)
 const MODS_ZOOM: f32 = 0.625; // SL: RecentMods zoom(0.625)
 const MODS_Y_OFF: f32 = 47.0; // SL: RecentMods xy(...,47)
 
-const JOIN_TEXT: &str = "Press &START; to join!";
-const WAITING_TEXT: &str = "Waiting ...";
 const SELECTED_NAME_Y_OFF: f32 = 160.0; // SL: SelectedProfileText y(160)
 const SELECTED_NAME_ZOOM: f32 = 1.35; // SL: SelectedProfileText zoom(1.35)
 
@@ -186,10 +185,11 @@ fn preview_noteskin_for_choice(
 
 #[inline(always)]
 fn format_total_songs_played(count: u32) -> String {
+    let count_str = count.to_string();
     if count == 1 {
-        format!("{count} Song Played")
+        tr_fmt("SelectProfile", "SongPlayedSingular", &[("count", &count_str)]).to_string()
     } else {
-        format!("{count} Songs Played")
+        tr_fmt("SelectProfile", "SongPlayedPlural", &[("count", &count_str)]).to_string()
     }
 }
 
@@ -228,33 +228,39 @@ fn format_recent_mods(
 
     push(speed_mod.trim());
     if scroll.contains(profile::ScrollOption::Reverse) {
-        push("Reverse");
+        let s = tr("SelectProfile", "Reverse");
+        push(&s);
     }
     if scroll.contains(profile::ScrollOption::Split) {
-        push("Split");
+        let s = tr("SelectProfile", "Split");
+        push(&s);
     }
     if scroll.contains(profile::ScrollOption::Alternate) {
-        push("Alternate");
+        let s = tr("SelectProfile", "Alternate");
+        push(&s);
     }
     if scroll.contains(profile::ScrollOption::Cross) {
-        push("Cross");
+        let s = tr("SelectProfile", "Cross");
+        push(&s);
     }
     if scroll.contains(profile::ScrollOption::Centered) {
-        push("Centered");
+        let s = tr("SelectProfile", "Centered");
+        push(&s);
     }
-    push("Overhead");
+    let overhead = tr("SelectProfile", "Overhead");
+    push(&overhead);
     push(noteskin.as_str());
     let mini_indicator_label = match mini_indicator {
         profile::MiniIndicator::None => None,
-        profile::MiniIndicator::SubtractiveScoring => Some("Subtractive Scoring"),
-        profile::MiniIndicator::PredictiveScoring => Some("Predictive Scoring"),
-        profile::MiniIndicator::PaceScoring => Some("Pace Scoring"),
-        profile::MiniIndicator::RivalScoring => Some("Rival Scoring"),
-        profile::MiniIndicator::Pacemaker => Some("Pacemaker"),
-        profile::MiniIndicator::StreamProg => Some("Stream Progress"),
+        profile::MiniIndicator::SubtractiveScoring => Some(tr("SelectProfile", "SubtractiveScoring")),
+        profile::MiniIndicator::PredictiveScoring => Some(tr("SelectProfile", "PredictiveScoring")),
+        profile::MiniIndicator::PaceScoring => Some(tr("SelectProfile", "PaceScoring")),
+        profile::MiniIndicator::RivalScoring => Some(tr("SelectProfile", "RivalScoring")),
+        profile::MiniIndicator::Pacemaker => Some(tr("SelectProfile", "Pacemaker")),
+        profile::MiniIndicator::StreamProg => Some(tr("SelectProfile", "StreamProgress")),
     };
     if let Some(label) = mini_indicator_label {
-        push(label);
+        push(&label);
     }
     out
 }
@@ -269,7 +275,7 @@ fn build_choices() -> Vec<Choice> {
     let player_options_section = profile::player_options_section(profile::get_session_play_style());
     out.push(Choice {
         kind: ActiveProfile::Guest,
-        display_name: "[ GUEST ]".to_string(),
+        display_name: tr("SelectProfile", "GuestLabel").to_string(),
         speed_mod: guest_speed_mod,
         avatar_key: None,
         total_songs: String::new(),
@@ -1312,7 +1318,11 @@ fn push_scroller_frame(
                 z(104)
             ));
 
-            let label = if is_guest { "[ GUEST ]" } else { "No Avatar" };
+            let label = if is_guest {
+                tr("SelectProfile", "GuestLabel")
+            } else {
+                tr("SelectProfile", "NoAvatar")
+            };
             out.push(act!(text:
                 align(0.5, 0.0):
                 xy(avatar_x + avatar_dim * 0.5, avatar_y + AVATAR_TEXT_Y):
@@ -1609,6 +1619,11 @@ fn build_box_actors(
         p1_ui.extend(scroller_ui);
 
         let mut join_ui: Vec<Actor> = Vec::new();
+        let join_text = if state.p1_ready {
+            tr("SelectProfile", "WaitingText")
+        } else {
+            tr("SelectProfile", "JoinText")
+        };
         push_join_prompt(
             &mut join_ui,
             p1_cx,
@@ -1617,11 +1632,7 @@ fn build_box_actors(
             border_rgba,
             inner_alpha,
             state.preview_time,
-            if state.p1_ready {
-                WAITING_TEXT
-            } else {
-                JOIN_TEXT
-            },
+            &join_text,
         );
         for a in &mut join_ui {
             apply_alpha_to_actor(a, if show_join { 1.0 } else { 0.0 });
@@ -1632,7 +1643,7 @@ fn build_box_actors(
             let name = state
                 .choices
                 .get(state.p1_selected_index)
-                .map_or_else(|| "[ GUEST ]".to_string(), |c| c.display_name.clone());
+                .map_or_else(|| tr("SelectProfile", "GuestLabel").to_string(), |c| c.display_name.clone());
             let a = act!(text:
                 align(0.5, 0.5):
                 xy(p1_cx, cy + SELECTED_NAME_Y_OFF):
@@ -1694,6 +1705,11 @@ fn build_box_actors(
         p2_ui.extend(scroller_ui);
 
         let mut join_ui: Vec<Actor> = Vec::new();
+        let join_text = if state.p2_ready {
+            tr("SelectProfile", "WaitingText")
+        } else {
+            tr("SelectProfile", "JoinText")
+        };
         push_join_prompt(
             &mut join_ui,
             p2_cx,
@@ -1702,11 +1718,7 @@ fn build_box_actors(
             border_rgba,
             inner_alpha,
             state.preview_time,
-            if state.p2_ready {
-                WAITING_TEXT
-            } else {
-                JOIN_TEXT
-            },
+            &join_text,
         );
         for a in &mut join_ui {
             apply_alpha_to_actor(a, if show_join { 1.0 } else { 0.0 });
@@ -1717,7 +1729,7 @@ fn build_box_actors(
             let name = state
                 .choices
                 .get(state.p2_selected_index)
-                .map_or_else(|| "[ GUEST ]".to_string(), |c| c.display_name.clone());
+                .map_or_else(|| tr("SelectProfile", "GuestLabel").to_string(), |c| c.display_name.clone());
             let a = act!(text:
                 align(0.5, 0.5):
                 xy(p2_cx, cy + SELECTED_NAME_Y_OFF):
@@ -1783,8 +1795,9 @@ pub fn get_actors(
     }));
 
     let fg = [1.0, 1.0, 1.0, 1.0];
+    let title = tr("ScreenTitles", "SelectProfile");
     actors.push(screen_bar::build(ScreenBarParams {
-        title: "SELECT PROFILE",
+        title: &title,
         title_placement: ScreenBarTitlePlacement::Left,
         position: ScreenBarPosition::Top,
         transparent: false,
@@ -1796,14 +1809,17 @@ pub fn get_actors(
         right_avatar: None,
     }));
 
+    let press_start = tr("Common", "PressStart");
+    let not_present = tr("SelectProfile", "NotPresent");
     let (footer_left, footer_right) = match (state.p1_joined, state.p2_joined) {
-        (false, false) => (Some("PRESS START"), Some("PRESS START")),
-        (true, false) => (None, Some("NOT PRESENT")),
-        (false, true) => (Some("NOT PRESENT"), None),
+        (false, false) => (Some(press_start.as_ref()), Some(press_start.as_ref())),
+        (true, false) => (None, Some(not_present.as_ref())),
+        (false, true) => (Some(not_present.as_ref()), None),
         (true, true) => (None, None),
     };
+    let event_mode = tr("Common", "EventMode");
     actors.push(screen_bar::build(ScreenBarParams {
-        title: "EVENT MODE",
+        title: &event_mode,
         title_placement: ScreenBarTitlePlacement::Center,
         position: ScreenBarPosition::Bottom,
         transparent: false,

--- a/src/screens/credits.rs
+++ b/src/screens/credits.rs
@@ -1,4 +1,5 @@
 use crate::act;
+use crate::assets::i18n::tr;
 use crate::engine::input::{InputEvent, VirtualAction};
 use crate::engine::present::actors::Actor;
 use crate::engine::present::color;
@@ -294,9 +295,10 @@ pub fn get_actors(state: &State) -> Vec<Actor> {
         ));
     }
 
+    let return_prompt = tr("Credits", "ReturnPrompt");
     actors.push(act!(text:
         font("miso"):
-        settext("Press &START; and &BACK; to return"):
+        settext(return_prompt):
         align(0.5, 0.5):
         xy(screen_center_x(), screen_h - CINEMATIC_BAR_MAX_H * 0.5):
         zoom(0.7):

--- a/src/screens/init.rs
+++ b/src/screens/init.rs
@@ -1,4 +1,5 @@
 use crate::act;
+use crate::assets::i18n::tr;
 use crate::config::dirs;
 use crate::engine::input::{InputEvent, VirtualAction};
 use crate::engine::present::actors::Actor;
@@ -130,18 +131,6 @@ impl LoadingState {
 }
 
 static EMPTY_TEXT: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from(""));
-static INIT_TITLE_TEXT: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("DEAD SYNC"));
-static DONE_TEXT: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("Done!"));
-static INITIALIZING_TEXT: LazyLock<Arc<str>> =
-    LazyLock::new(|| Arc::<str>::from("Initializing..."));
-static SONGS_PHASE_TEXT: LazyLock<Arc<str>> =
-    LazyLock::new(|| Arc::<str>::from("Loading songs..."));
-static COURSES_PHASE_TEXT: LazyLock<Arc<str>> =
-    LazyLock::new(|| Arc::<str>::from("Loading courses..."));
-static ARTWORK_PHASE_TEXT: LazyLock<Arc<str>> =
-    LazyLock::new(|| Arc::<str>::from("Caching artwork..."));
-static NOTESKINS_PHASE_TEXT: LazyLock<Arc<str>> =
-    LazyLock::new(|| Arc::<str>::from("Compiling noteskins..."));
 
 /* ----------------------- auto-advance ----------------------- */
 #[inline(always)]
@@ -298,10 +287,10 @@ fn cache_progress_lines(path: Option<&Path>) -> (String, String) {
 #[inline(always)]
 fn arc_phase_label(phase: LoadingPhase) -> Arc<str> {
     match phase {
-        LoadingPhase::Songs => SONGS_PHASE_TEXT.clone(),
-        LoadingPhase::Courses => COURSES_PHASE_TEXT.clone(),
-        LoadingPhase::Artwork => ARTWORK_PHASE_TEXT.clone(),
-        LoadingPhase::Noteskins => NOTESKINS_PHASE_TEXT.clone(),
+        LoadingPhase::Songs => tr("Init", "LoadingSongsText"),
+        LoadingPhase::Courses => tr("Init", "LoadingCoursesText"),
+        LoadingPhase::Artwork => tr("Init", "CachingArtworkText"),
+        LoadingPhase::Noteskins => tr("Init", "CompilingNoteskinsText"),
     }
 }
 
@@ -330,7 +319,7 @@ fn loading_progress_values(loading: &LoadingState) -> (usize, usize, f32) {
 fn refresh_loading_count_text(loading: &mut LoadingState) {
     let (done, total, _) = loading_progress_values(loading);
     loading.count_text = if loading.done || (total > 0 && done >= total) {
-        DONE_TEXT.clone()
+        tr("Init", "DoneText")
     } else if total == 0 {
         EMPTY_TEXT.clone()
     } else {
@@ -661,18 +650,20 @@ fn push_loading_overlay(state: &State, actors: &mut Vec<Actor>, loading_elapsed_
         diffuse(0.0, 0.0, 0.0, 0.8):
         z(104.0)
     ));
+    let title_text = tr("Init", "TitleText");
     actors.push(act!(text:
         font("wendy"):
-        settext(INIT_TITLE_TEXT.clone()):
+        settext(title_text):
         align(0.5, 0.5):
         xy(screen_center_x(), bar_cy - 136.0):
         zoom(0.82):
         horizalign(center):
         z(110.0)
     ));
+    let phase_label = loading.map_or_else(|| tr("Init", "InitializingText"), |_| arc_phase_label(phase));
     actors.push(act!(text:
         font("miso"):
-        settext(loading.map_or_else(|| INITIALIZING_TEXT.clone(), |_| arc_phase_label(phase))):
+        settext(phase_label):
         align(0.5, 0.5):
         xy(screen_center_x(), bar_cy - 96.0):
         zoom(1.05):

--- a/src/screens/initials.rs
+++ b/src/screens/initials.rs
@@ -1,4 +1,5 @@
 use crate::act;
+use crate::assets::i18n::tr;
 use crate::assets::AssetManager;
 use crate::engine::audio;
 use crate::engine::input::{InputEvent, VirtualAction};
@@ -288,9 +289,17 @@ impl Wheel {
     }
 }
 
-const MONTH_ABBR: [&str; 12] = [
-    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
-];
+fn month_abbr(index: usize) -> std::sync::Arc<str> {
+    const KEYS: [&str; 12] = [
+        "MonthJan", "MonthFeb", "MonthMar", "MonthApr", "MonthMay", "MonthJun",
+        "MonthJul", "MonthAug", "MonthSep", "MonthOct", "MonthNov", "MonthDec",
+    ];
+    if index < KEYS.len() {
+        tr("Initials", KEYS[index])
+    } else {
+        std::sync::Arc::from("???")
+    }
+}
 
 fn format_highscore_date(date: &str) -> String {
     let trimmed = date.trim();
@@ -308,7 +317,7 @@ fn format_highscore_date(date: &str) -> String {
         .parse::<usize>()
         .ok()
         .and_then(|m| m.checked_sub(1))
-        .filter(|m| *m < MONTH_ABBR.len())
+        .filter(|m| *m < 12)
     else {
         return trimmed.to_string();
     };
@@ -316,7 +325,7 @@ fn format_highscore_date(date: &str) -> String {
         return trimmed.to_string();
     };
 
-    format!("{} {}, {}", MONTH_ABBR[month_idx], day_num, year)
+    format!("{} {}, {}", month_abbr(month_idx), day_num, year)
 }
 
 #[inline(always)]
@@ -828,9 +837,10 @@ fn build_banner_and_title(state: &State, stages: &[stage_stats::StageSummary]) -
     ));
 
     if stages.is_empty() {
+        let no_data = tr("EvaluationSummary", "NoStageDataAvailable");
         actors.push(act!(text:
             font("miso"):
-            settext("NO STAGE DATA AVAILABLE"):
+            settext(no_data):
             align(0.5, 0.5):
             xy(cx, 54.0):
             zoom(0.8):
@@ -1115,9 +1125,10 @@ fn build_player_frame(side: profile::PlayerSide, state: &State) -> Actor {
         }
     } else if p.joined {
         let pc = player_color_rgba(side, state.active_color_index);
+        let out_of_ranking = tr("Initials", "OutOfRanking");
         children.push(act!(text:
             font("miso"):
-            settext("Out of Ranking"):
+            settext(out_of_ranking):
             align(0.5, 0.5):
             xy(0.0, CURSOR_Y_IN_FRAME):
             zoom(0.7):

--- a/src/screens/manage_local_profiles.rs
+++ b/src/screens/manage_local_profiles.rs
@@ -1,4 +1,5 @@
 use crate::act;
+use crate::assets::i18n::{tr, tr_fmt};
 use crate::assets::AssetManager;
 use crate::engine::audio;
 use crate::engine::input::{InputEvent, RawKeyboardEvent, VirtualAction};
@@ -12,6 +13,7 @@ use crate::screens::components::shared::screen_bar::{
 };
 use crate::screens::input as screen_input;
 use crate::screens::{Screen, ScreenAction};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use winit::keyboard::KeyCode;
 
@@ -81,7 +83,7 @@ enum NavDirection {
 struct NameEntryState {
     mode: NameEntryMode,
     value: String,
-    error: Option<&'static str>,
+    error: Option<Arc<str>>,
     blink_t: f32,
 }
 
@@ -99,13 +101,12 @@ enum ProfileMenuAction {
     Delete,
 }
 
-#[inline(always)]
-const fn profile_menu_action_label(action: ProfileMenuAction) -> &'static str {
+fn profile_menu_action_label(action: ProfileMenuAction) -> Arc<str> {
     match action {
-        ProfileMenuAction::SetP1 => "Set P1",
-        ProfileMenuAction::SetP2 => "Set P2",
-        ProfileMenuAction::Rename => "Rename",
-        ProfileMenuAction::Delete => "Delete",
+        ProfileMenuAction::SetP1 => tr("Profiles", "SetP1"),
+        ProfileMenuAction::SetP2 => tr("Profiles", "SetP2"),
+        ProfileMenuAction::Rename => tr("Profiles", "Rename"),
+        ProfileMenuAction::Delete => tr("Profiles", "Delete"),
     }
 }
 
@@ -127,7 +128,7 @@ struct ProfileMenuState {
 struct DeleteConfirmState {
     id: String,
     display_name: String,
-    error: Option<&'static str>,
+    error: Option<Arc<str>>,
 }
 
 pub struct State {
@@ -319,10 +320,10 @@ fn validate_profile_name(
     state: &State,
     mode: &NameEntryMode,
     name: &str,
-) -> Result<(), &'static str> {
+) -> Result<(), Arc<str>> {
     let trimmed = name.trim();
     if trimmed.is_empty() {
-        return Err("Profile name cannot be blank.");
+        return Err(tr("Profiles", "NameCannotBeBlank"));
     }
 
     let skip_id = match mode {
@@ -330,9 +331,7 @@ fn validate_profile_name(
         NameEntryMode::Rename { id } => Some(id.as_str()),
     };
     if name_conflicts(state, trimmed, skip_id) {
-        return Err(
-            "The name you chose conflicts with another profile. Please use a different name.",
-        );
+        return Err(tr("Profiles", "NameConflict"));
     }
     Ok(())
 }
@@ -340,16 +339,16 @@ fn validate_profile_name(
 fn try_submit_name_entry(
     state: &mut State,
     entry: &NameEntryState,
-) -> Result<String, &'static str> {
+) -> Result<String, Arc<str>> {
     validate_profile_name(state, &entry.mode, &entry.value)?;
     let trimmed = entry.value.trim();
     match &entry.mode {
         NameEntryMode::Create => {
-            profile::create_local_profile(trimmed).map_err(|_| "Failed to create profile.")
+            profile::create_local_profile(trimmed).map_err(|_| tr("Profiles", "CreateFailed"))
         }
         NameEntryMode::Rename { id } => profile::rename_local_profile(id, trimmed)
             .map(|()| id.clone())
-            .map_err(|_| "Failed to rename profile."),
+            .map_err(|_| tr("Profiles", "RenameFailed")),
     }
 }
 
@@ -527,7 +526,7 @@ fn confirm_delete(state: &mut State) {
             state.delete_confirm = Some(DeleteConfirmState {
                 id: confirm.id,
                 display_name: confirm.display_name,
-                error: Some("Failed to delete profile."),
+                error: Some(tr("Profiles", "DeleteFailed")),
             });
         }
     }
@@ -871,13 +870,13 @@ fn apply_alpha_to_actor(actor: &mut Actor, alpha: f32) {
     }
 }
 
-fn indicator_text(id: &str, p1_id: Option<&str>, p2_id: Option<&str>) -> Option<&'static str> {
+fn indicator_text(id: &str, p1_id: Option<&str>, p2_id: Option<&str>) -> Option<Arc<str>> {
     let is_p1 = p1_id.is_some_and(|p1| p1 == id);
     let is_p2 = p2_id.is_some_and(|p2| p2 == id);
     match (is_p1, is_p2) {
-        (true, true) => Some("P1+P2"),
-        (true, false) => Some("P1"),
-        (false, true) => Some("P2"),
+        (true, true) => Some(tr("Profiles", "P1P2Assigned")),
+        (true, false) => Some(tr("Profiles", "P1Assigned")),
+        (false, true) => Some(tr("Profiles", "P2Assigned")),
         (false, false) => None,
     }
 }
@@ -889,29 +888,25 @@ fn help_for_selected(state: &State, p1_id: Option<&str>, p2_id: Option<&str>) ->
 
     match &row.kind {
         RowKind::CreateNew => {
-            let title = "Create a new local profile.";
-            let bullets = make_bullets(&[
-                "Enter a name for the profile.",
-                "Press Start to confirm.",
-                "Press Back to cancel.",
-            ]);
+            let title = tr("Profiles", "CreateProfileTitle");
+            let b1 = tr("Profiles", "EnterProfileNamePrompt");
+            let b2 = tr("Profiles", "PressStartConfirm");
+            let b3 = tr("Profiles", "PressBackCancel");
+            let bullets = make_bullets(&[&b1, &b2, &b3]);
             (title.to_string(), bullets)
         }
-        RowKind::Exit => ("Return to Options.".to_string(), String::new()),
+        RowKind::Exit => (tr("Profiles", "ReturnToOptions").to_string(), String::new()),
         RowKind::Profile { id, display_name } => {
-            let mut title = String::new();
-            title.push_str("Local profile: ");
-            title.push_str(display_name);
+            let title =
+                tr_fmt("Profiles", "LocalProfileFormat", &[("name", display_name)]).to_string();
 
             let assigned = match indicator_text(id, p1_id, p2_id) {
-                Some(tag) => format!("Assigned: {tag}"),
-                None => "Assigned: (none)".to_string(),
+                Some(tag) => tr_fmt("Profiles", "AssignedFormat", &[("tag", &tag)]).to_string(),
+                None => tr("Profiles", "AssignedNone").to_string(),
             };
-            let bullets = make_bullets(&[
-                &format!("ID: {id}"),
-                &assigned,
-                "Press Start to open profile actions.",
-            ]);
+            let b1 = tr_fmt("Profiles", "IdFormat", &[("id", id)]).to_string();
+            let b3 = tr("Profiles", "OpenActionsPrompt");
+            let bullets = make_bullets(&[&b1, &assigned, &b3]);
             (title, bullets)
         }
     }
@@ -1019,12 +1014,13 @@ fn push_name_entry_overlay(ui: &mut Vec<Actor>, state: &State) {
         z(1002)
     ));
 
+    let name_prompt = tr("Profiles", "EnterProfileNamePrompt");
     ui.push(act!(text:
         align(0.5, 0.5):
         xy(cx, top_cy):
         font("miso"):
         zoom(1.0):
-        settext("Enter a name for the profile."):
+        settext(name_prompt):
         diffuse(1.0, 1.0, 1.0, 1.0):
         z(1003):
         horizalign(center)
@@ -1047,7 +1043,7 @@ fn push_name_entry_overlay(ui: &mut Vec<Actor>, state: &State) {
         horizalign(center)
     ));
 
-    let Some(err) = entry.error else {
+    let Some(err) = &entry.error else {
         return;
     };
     ui.push(act!(text:
@@ -1056,7 +1052,7 @@ fn push_name_entry_overlay(ui: &mut Vec<Actor>, state: &State) {
         font("miso"):
         zoom(0.9):
         maxwidth(box_w - 40.0):
-        settext(err):
+        settext(err.clone()):
         diffuse(1.0, 0.2, 0.2, 1.0):
         z(1003):
         horizalign(center)
@@ -1078,9 +1074,10 @@ fn push_delete_confirm_overlay(ui: &mut Vec<Actor>, state: &State) {
     push_overlay_backdrop(ui, w, h);
     push_overlay_box(ui, cx, cy, box_w, box_h);
 
-    let prompt = format!(
-        "Are you sure you want to delete the profile '{}'?",
-        confirm.display_name
+    let prompt = tr_fmt(
+        "Profiles",
+        "DeleteConfirmFormat",
+        &[("name", &confirm.display_name)],
     );
     ui.push(act!(text:
         align(0.5, 0.0):
@@ -1093,28 +1090,30 @@ fn push_delete_confirm_overlay(ui: &mut Vec<Actor>, state: &State) {
         z(1002):
         horizalign(center)
     ));
+    let cannot_be_undone = tr("Profiles", "CannotBeUndone");
     ui.push(act!(text:
         align(0.5, 0.0):
         xy(cx, cy - box_h * 0.5 + 58.0):
         font("miso"):
         zoom(0.9):
-        settext("This cannot be undone."):
+        settext(cannot_be_undone):
         diffuse(1.0, 1.0, 1.0, 1.0):
         z(1002):
         horizalign(center)
     ));
+    let yes_no = tr("Profiles", "YesNoPrompt");
     ui.push(act!(text:
         align(0.5, 1.0):
         xy(cx, cy + box_h * 0.5 - 10.0):
         font("miso"):
         zoom(0.9):
-        settext("Start: Yes    Back: No"):
+        settext(yes_no):
         diffuse(1.0, 1.0, 1.0, 1.0):
         z(1002):
         horizalign(center)
     ));
 
-    push_overlay_error(ui, confirm.error, cx, cy, box_w, box_h);
+    push_overlay_error(ui, confirm.error.as_ref(), cx, cy, box_w, box_h);
 }
 
 fn push_overlay_backdrop(ui: &mut Vec<Actor>, w: f32, h: f32) {
@@ -1139,7 +1138,7 @@ fn push_overlay_box(ui: &mut Vec<Actor>, cx: f32, cy: f32, w: f32, h: f32) {
 
 fn push_overlay_error(
     ui: &mut Vec<Actor>,
-    err: Option<&'static str>,
+    err: Option<&Arc<str>>,
     cx: f32,
     cy: f32,
     box_w: f32,
@@ -1154,7 +1153,7 @@ fn push_overlay_error(
         font("miso"):
         zoom(0.9):
         maxwidth(box_w - 40.0):
-        settext(err):
+        settext(err.clone()):
         diffuse(1.0, 0.2, 0.2, 1.0):
         z(1002):
         horizalign(center)
@@ -1197,11 +1196,11 @@ struct RowColors {
     black: [f32; 4],
 }
 
-fn row_label(kind: &RowKind) -> &str {
+fn row_label(kind: &RowKind) -> Arc<str> {
     match kind {
-        RowKind::CreateNew => "Create Profile",
-        RowKind::Exit => "Exit",
-        RowKind::Profile { display_name, .. } => display_name.as_str(),
+        RowKind::CreateNew => tr("Profiles", "CreateProfileButton"),
+        RowKind::Exit => tr("Common", "Exit"),
+        RowKind::Profile { display_name, .. } => Arc::from(display_name.as_str()),
     }
 }
 
@@ -1477,8 +1476,9 @@ pub fn get_actors(
     }
 
     let mut ui = Vec::new();
+    let title = tr("ScreenTitles", "ManageProfiles");
     ui.push(screen_bar::build(screen_bar::ScreenBarParams {
-        title: "MANAGE PROFILES",
+        title: &title,
         title_placement: ScreenBarTitlePlacement::Left,
         position: ScreenBarPosition::Top,
         transparent: false,

--- a/src/screens/pack_sync.rs
+++ b/src/screens/pack_sync.rs
@@ -1,4 +1,5 @@
 use crate::act;
+use crate::assets::i18n::{tr, tr_fmt};
 use crate::config;
 use crate::engine::audio;
 use crate::engine::input::{InputEvent, VirtualAction};
@@ -23,7 +24,9 @@ const ROW_STEP: f32 = 43.0;
 const PROGRESS_STEP_BEATS: usize = 4;
 const MAX_MSGS_PER_FRAME: usize = 64;
 const POLL_BUDGET: Duration = Duration::from_millis(2);
-pub(crate) const ALL_LABEL: &str = "All Packs";
+pub(crate) fn all_label() -> std::sync::Arc<str> {
+    tr("PackSync", "AllPacksLabel")
+}
 
 pub(crate) struct TargetSpec {
     pub simfile_path: PathBuf,
@@ -187,11 +190,11 @@ pub(crate) fn build_overlay(state: &OverlayState, active_color_index: i32) -> Op
     let fill = color::decorative_rgba(active_color_index);
     let start = overlay.scroll_index.min(scroll_limit(overlay.rows.len()));
     let title = if overlay.phase == OverlayPhase::Running {
-        "Syncing pack..."
+        tr("PackSync", "SyncingPackTitle")
     } else if can_save(overlay) {
-        "Sync Pack Review"
+        tr("PackSync", "ReviewTitle")
     } else {
-        "Sync Pack Complete"
+        tr("PackSync", "CompleteTitle")
     };
     let counts_text = format!(
         "{}/{} chart(s) analyzed - {} ready, {} below {}%, {} no change, {} failed",
@@ -204,11 +207,14 @@ pub(crate) fn build_overlay(state: &OverlayState, active_color_index: i32) -> Op
         summary.failed
     );
     let scroll_text = (summary.total > VIEW_ROWS).then(|| {
-        format!(
-            "Rows {}-{} / {}",
-            start + 1,
-            (start + VIEW_ROWS).min(summary.total),
-            summary.total
+        tr_fmt(
+            "PackSync",
+            "RowsPaginationFormat",
+            &[
+                ("start", &(start + 1).to_string()),
+                ("end", &(start + VIEW_ROWS).min(summary.total).to_string()),
+                ("total", &summary.total.to_string()),
+            ],
         )
     });
     let counts_maxwidth = if scroll_text.is_some() {
@@ -287,9 +293,10 @@ pub(crate) fn build_overlay(state: &OverlayState, active_color_index: i32) -> Op
             horizalign(right)
         ));
     }
+    let col_song = tr("PackSync", "SongColumnHeader");
     actors.push(act!(text:
         font("miso"):
-        settext("SONG"):
+        settext(col_song):
         align(0.0, 0.5):
         xy(song_x, row_top - 20.0):
         zoom(0.75):
@@ -297,9 +304,10 @@ pub(crate) fn build_overlay(state: &OverlayState, active_color_index: i32) -> Op
         z(OVERLAY_Z + 3):
         horizalign(left)
     ));
+    let col_progress = tr("PackSync", "ProgressColumnHeader");
     actors.push(act!(text:
         font("miso"):
-        settext("PROGRESS"):
+        settext(col_progress):
         align(0.0, 0.5):
         xy(bar_x, row_top - 20.0):
         zoom(0.75):
@@ -307,9 +315,10 @@ pub(crate) fn build_overlay(state: &OverlayState, active_color_index: i32) -> Op
         z(OVERLAY_Z + 3):
         horizalign(left)
     ));
+    let col_result = tr("PackSync", "ResultColumnHeader");
     actors.push(act!(text:
         font("miso"):
-        settext("RESULT"):
+        settext(col_result):
         align(1.0, 0.5):
         xy(result_x, row_top - 20.0):
         zoom(0.75):
@@ -397,9 +406,10 @@ pub(crate) fn build_overlay(state: &OverlayState, active_color_index: i32) -> Op
 
     match overlay.phase {
         OverlayPhase::Running => {
+            let help = tr("PackSync", "HelpTextRunning");
             actors.push(act!(text:
                 font("miso"):
-                settext("UP/DOWN: SCROLL    LEFT/RIGHT: PAGE    START/BACK/SELECT: CANCEL"):
+                settext(help):
                 align(0.5, 0.5):
                 xy(pane_cx, pane_top + pane_h - 24.0):
                 zoom(0.8):
@@ -438,9 +448,10 @@ pub(crate) fn build_overlay(state: &OverlayState, active_color_index: i32) -> Op
                     z(OVERLAY_Z + 4):
                     horizalign(center)
                 ));
+                let yes_label = tr("PackSync", "YesOption");
                 actors.push(act!(text:
                     font("wendy"):
-                    settext("YES"):
+                    settext(yes_label):
                     align(0.5, 0.5):
                     xy(choice_yes_x, answer_y):
                     zoom(0.72):
@@ -448,9 +459,10 @@ pub(crate) fn build_overlay(state: &OverlayState, active_color_index: i32) -> Op
                     z(OVERLAY_Z + 4):
                     horizalign(center)
                 ));
+                let no_label = tr("PackSync", "NoOption");
                 actors.push(act!(text:
                     font("wendy"):
-                    settext("NO"):
+                    settext(no_label):
                     align(0.5, 0.5):
                     xy(choice_no_x, answer_y):
                     zoom(0.72):
@@ -458,9 +470,10 @@ pub(crate) fn build_overlay(state: &OverlayState, active_color_index: i32) -> Op
                     z(OVERLAY_Z + 4):
                     horizalign(center)
                 ));
+                let help = tr("PackSync", "HelpTextReview");
                 actors.push(act!(text:
                     font("miso"):
-                    settext("UP/DOWN: SCROLL    MENULEFT/MENURIGHT: PAGE    LEFT/RIGHT: CHOOSE    START: ACCEPT    BACK/SELECT: CANCEL"):
+                    settext(help):
                     align(0.5, 0.5):
                     xy(pane_cx, pane_top + pane_h - 18.0):
                     zoom(0.74):
@@ -480,9 +493,10 @@ pub(crate) fn build_overlay(state: &OverlayState, active_color_index: i32) -> Op
                     z(OVERLAY_Z + 4):
                     horizalign(center)
                 ));
+                let help = tr("PackSync", "HelpTextComplete");
                 actors.push(act!(text:
                     font("miso"):
-                    settext("UP/DOWN: SCROLL    MENULEFT/MENURIGHT: PAGE    START/BACK/SELECT: CLOSE"):
+                    settext(help):
                     align(0.5, 0.5):
                     xy(pane_cx, pane_top + pane_h - 18.0):
                     zoom(0.74):
@@ -946,15 +960,30 @@ fn save_prompt(overlay: &OverlayStateData) -> String {
     let summary = summary(overlay);
     let min_conf_pct = confidence_threshold_percent();
     if summary.eligible == 0 {
-        return format!(
-            "No pack sync changes are ready to save.\n{} song(s) are below {}% confidence, {} have no change, and {} failed.\nPress START/BACK/SELECT to close.",
-            summary.below_threshold, min_conf_pct, summary.no_change, summary.failed
-        );
+        return tr_fmt(
+            "PackSync",
+            "NothingToSaveMessage",
+            &[
+                ("below", &summary.below_threshold.to_string()),
+                ("threshold", &min_conf_pct.to_string()),
+                ("nochange", &summary.no_change.to_string()),
+                ("failed", &summary.failed.to_string()),
+            ],
+        )
+        .to_string();
     }
-    format!(
-        "Save {} pack sync change(s)?\n{} song(s) below {}% confidence, {} with no change, and {} failed will be skipped.\nChoosing NO will discard all pack sync changes.",
-        summary.eligible, summary.below_threshold, min_conf_pct, summary.no_change, summary.failed
+    tr_fmt(
+        "PackSync",
+        "SaveConfirmFormat",
+        &[
+            ("count", &summary.eligible.to_string()),
+            ("below", &summary.below_threshold.to_string()),
+            ("threshold", &min_conf_pct.to_string()),
+            ("nochange", &summary.no_change.to_string()),
+            ("failed", &summary.failed.to_string()),
+        ],
     )
+    .to_string()
 }
 
 #[inline(always)]
@@ -979,27 +1008,40 @@ fn progress(row: &RowState) -> f32 {
 
 fn bar_label(row: &RowState, min_confidence: f64) -> String {
     match row_disposition(row, min_confidence) {
-        RowDisposition::Pending => "Queued".to_string(),
+        RowDisposition::Pending => tr("PackSync", "StatusQueued").to_string(),
         RowDisposition::Running => match row.total_beats.max(row.beats_processed) {
-            0 => "Starting".to_string(),
-            total => format!("Beat {} / {}", row.beats_processed.min(total), total),
+            0 => tr("PackSync", "StatusStarting").to_string(),
+            total => tr_fmt(
+                "PackSync",
+                "ProgressFormat",
+                &[
+                    ("current", &row.beats_processed.min(total).to_string()),
+                    ("total", &total.to_string()),
+                ],
+            )
+            .to_string(),
         },
-        RowDisposition::Eligible => "Ready".to_string(),
-        RowDisposition::BelowThreshold => format!("Below {}%", confidence_threshold_percent()),
-        RowDisposition::NoChange => "No change".to_string(),
-        RowDisposition::Failed => "Error".to_string(),
+        RowDisposition::Eligible => tr("PackSync", "StatusReady").to_string(),
+        RowDisposition::BelowThreshold => tr_fmt(
+            "PackSync",
+            "StatusBelowThresholdFormat",
+            &[("threshold", &confidence_threshold_percent().to_string())],
+        )
+        .to_string(),
+        RowDisposition::NoChange => tr("PackSync", "StatusNoChange").to_string(),
+        RowDisposition::Failed => tr("PackSync", "StatusError").to_string(),
     }
 }
 
 fn result_text(row: &RowState, min_confidence: f64) -> String {
     let confidence_pct = confidence_percent(row.final_confidence);
     match row_disposition(row, min_confidence) {
-        RowDisposition::Pending => "Queued".to_string(),
+        RowDisposition::Pending => tr("PackSync", "StatusQueued").to_string(),
         RowDisposition::Running => {
             if let Some(bias_ms) = row.final_bias_ms {
                 format!("{bias_ms:+.2} ms")
             } else {
-                "Working".to_string()
+                tr("PackSync", "StatusWorking").to_string()
             }
         }
         RowDisposition::Eligible | RowDisposition::BelowThreshold => {
@@ -1013,8 +1055,8 @@ fn result_text(row: &RowState, min_confidence: f64) -> String {
         RowDisposition::Failed => row
             .error_text
             .as_deref()
-            .unwrap_or("Analysis failed")
-            .to_string(),
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| tr("PackSync", "AnalysisFailed").to_string()),
     }
 }
 

--- a/src/screens/pack_sync.rs
+++ b/src/screens/pack_sync.rs
@@ -1045,13 +1045,22 @@ fn result_text(row: &RowState, min_confidence: f64) -> String {
             }
         }
         RowDisposition::Eligible | RowDisposition::BelowThreshold => {
-            format!(
-                "{:+.2} ms\n{}% confidence",
-                row.final_bias_ms.unwrap_or(0.0),
-                confidence_pct
+            tr_fmt(
+                "PackSync",
+                "ResultConfidenceFormat",
+                &[
+                    ("bias", &format!("{:+.2}", row.final_bias_ms.unwrap_or(0.0))),
+                    ("confidence", &confidence_pct.to_string()),
+                ],
             )
+            .to_string()
         }
-        RowDisposition::NoChange => format!("0.00 ms\n{}% confidence", confidence_pct),
+        RowDisposition::NoChange => tr_fmt(
+            "PackSync",
+            "ResultNoChangeFormat",
+            &[("confidence", &confidence_pct.to_string())],
+        )
+        .to_string(),
         RowDisposition::Failed => row
             .error_text
             .as_deref()

--- a/src/screens/profile_load.rs
+++ b/src/screens/profile_load.rs
@@ -1,4 +1,5 @@
 use crate::act;
+use crate::assets::i18n::tr;
 use crate::engine::present::actors::Actor;
 use crate::engine::space::{screen_center_x, screen_center_y, screen_height, screen_width};
 use crate::game::profile;
@@ -168,7 +169,7 @@ pub fn get_actors(_: &State) -> Vec<Actor> {
         ),
         // "Common Bold" (Simply Love) -> Wendy small.
         act!(text:
-            font("wendy"): settext("Loading"):
+            font("wendy"): settext(tr("Common", "Loading")):
             align(0.5, 0.5): xy(cx, cy):
             zoom(0.6):
             diffuse(0.0, 0.0, 0.0, 1.0):

--- a/src/screens/select_color.rs
+++ b/src/screens/select_color.rs
@@ -1,4 +1,5 @@
 use crate::act;
+use crate::assets::i18n::tr;
 use crate::engine::space::{screen_center_x, screen_center_y, screen_height, screen_width};
 use crate::game::profile;
 // Screen navigation handled in app
@@ -200,8 +201,9 @@ pub fn get_actors(state: &State, alpha_multiplier: f32) -> Vec<Actor> {
 
     // 2) Bars (top + bottom)
     const FG: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
+    let title = tr("ScreenTitles", "SelectAColor");
     actors.push(screen_bar::build(screen_bar::ScreenBarParams {
-        title: "SELECT A COLOR",
+        title: &title,
         title_placement: ScreenBarTitlePlacement::Left, // big title on the left
         position: ScreenBarPosition::Top,
         transparent: false,
@@ -229,32 +231,36 @@ pub fn get_actors(state: &State, alpha_multiplier: f32) -> Vec<Actor> {
     let p1_guest = profile::is_session_side_guest(profile::PlayerSide::P1);
     let p2_guest = profile::is_session_side_guest(profile::PlayerSide::P2);
 
+    let insert_card = tr("Common", "InsertCard");
+    let press_start = tr("Common", "PressStart");
+
     let (footer_left, left_avatar) = if p1_joined {
         (
             Some(if p1_guest {
-                "INSERT CARD"
+                insert_card.as_ref()
             } else {
                 p1_profile.display_name.as_str()
             }),
             if p1_guest { None } else { p1_avatar },
         )
     } else {
-        (Some("PRESS START"), None)
+        (Some(press_start.as_ref()), None)
     };
     let (footer_right, right_avatar) = if p2_joined {
         (
             Some(if p2_guest {
-                "INSERT CARD"
+                insert_card.as_ref()
             } else {
                 p2_profile.display_name.as_str()
             }),
             if p2_guest { None } else { p2_avatar },
         )
     } else {
-        (Some("PRESS START"), None)
+        (Some(press_start.as_ref()), None)
     };
+    let event_mode = tr("Common", "EventMode");
     actors.push(screen_bar::build(screen_bar::ScreenBarParams {
-        title: "EVENT MODE",
+        title: &event_mode,
         title_placement: ScreenBarTitlePlacement::Center,
         position: ScreenBarPosition::Bottom,
         transparent: false,

--- a/src/screens/select_music/pack_sync.rs
+++ b/src/screens/select_music/pack_sync.rs
@@ -73,8 +73,8 @@ fn pack_sync_targets_for_group(
     pack_group: Option<&str>,
 ) -> Option<(String, Vec<shared_pack_sync::TargetSpec>)> {
     let pack_name = pack_group
-        .unwrap_or(shared_pack_sync::ALL_LABEL)
-        .to_string();
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| shared_pack_sync::all_label().to_string());
     let target_chart_type = profile::get_session_play_style().chart_type();
     let preferred_difficulty_index = preferred_difficulty_index(state);
     let mut current_pack_name: Option<&str> = None;


### PR DESCRIPTION
## i18n: extract profile and utility screen strings

Continues the i18n extraction work (plan step 9). Replaces hardcoded English strings with `tr()` / `tr_fmt()` calls across all profile management, utility, and loading screens.

### Changes

**manage_local_profiles.rs** — Profile menu action labels, validation/operation error messages, player assignment indicators (P1/P2/P1+P2), help panel text, delete confirmation overlay, name entry overlay, screen bar title.

**profile_boxes.rs** (select_profile) — Join/waiting prompts, guest label (4 sites), No Avatar label, song count (singular/plural via `tr_fmt`), mod summary labels (Reverse, Split, Overhead, etc.), mini indicator labels, screen bar title/footer (SELECT PROFILE, EVENT MODE, PRESS START, NOT PRESENT).

**select_color.rs** — Screen bar title (SELECT A COLOR), footer text (INSERT CARD, PRESS START, EVENT MODE).

**initials.rs** — Month abbreviations (Jan–Dec) converted from const array to `tr()` lookup function, Out of Ranking label, NO STAGE DATA AVAILABLE.

**pack_sync.rs** — Overlay titles (Syncing/Review/Complete), column headers, help text for all three phases, YES/NO labels, `All Packs` label (const → function, cross-module ref updated), row status labels, progress/confidence format strings, save prompt with format placeholders.

**profile_load.rs** — Loading text.

**init.rs** — Replaced 7 `LazyLock<Arc<str>>` statics with `tr()` calls (DEAD SYNC, Done!, Initializing, Loading songs/courses/artwork/noteskins).

**credits.rs** — Return prompt.

**en.ini** — Added `[SelectProfile]` section (22 keys), added `SelectProfile` to `[ScreenTitles]`, renamed `LocalProfilePrefix` → `LocalProfileFormat` (proper format string for i18n word order), added `ResultConfidenceFormat` and `ResultNoChangeFormat` to `[PackSync]`.