### PR TITLE
Introduce SpeedModType enum

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3518,20 +3518,7 @@ impl App {
             None,
         );
         po_state.music_rate = music_rate;
-        po_state.speed_mod = std::array::from_fn(|i| match scroll_speed[i] {
-            ScrollSpeedSetting::XMod(v) => player_options::SpeedMod {
-                mod_type: "X".to_string(),
-                value: v,
-            },
-            ScrollSpeedSetting::CMod(v) => player_options::SpeedMod {
-                mod_type: "C".to_string(),
-                value: v,
-            },
-            ScrollSpeedSetting::MMod(v) => player_options::SpeedMod {
-                mod_type: "M".to_string(),
-                value: v,
-            },
-        });
+        po_state.speed_mod = std::array::from_fn(|i| player_options::SpeedMod::from(scroll_speed[i]));
         self.state.screens.player_options_state = Some(po_state);
         true
     }
@@ -5527,22 +5514,20 @@ impl App {
                     |commands: &mut Vec<Command>,
                      side: profile::PlayerSide,
                      speed_mod: &player_options::SpeedMod| {
-                        let setting = match speed_mod.mod_type.as_str() {
-                            "C" => Some(ScrollSpeedSetting::CMod(speed_mod.value)),
-                            "X" => Some(ScrollSpeedSetting::XMod(speed_mod.value)),
-                            "M" => Some(ScrollSpeedSetting::MMod(speed_mod.value)),
-                            _ => None,
+                        let setting = match speed_mod.mod_type {
+                            player_options::SpeedModType::C => {
+                                ScrollSpeedSetting::CMod(speed_mod.value)
+                            }
+                            player_options::SpeedModType::X => {
+                                ScrollSpeedSetting::XMod(speed_mod.value)
+                            }
+                            player_options::SpeedModType::M => {
+                                ScrollSpeedSetting::MMod(speed_mod.value)
+                            }
                         };
 
-                        if let Some(setting) = setting {
-                            commands.push(Command::UpdateScrollSpeed { side, setting });
-                            debug!("Saved scroll speed ({side:?}): {setting}");
-                        } else {
-                            warn!(
-                                "Unsupported speed mod '{}' not saved to profile.",
-                                speed_mod.mod_type
-                            );
-                        }
+                        commands.push(Command::UpdateScrollSpeed { side, setting });
+                        debug!("Saved scroll speed ({side:?}): {setting}");
                     };
 
                 match play_style {
@@ -6106,11 +6091,16 @@ impl App {
                     }
                 }
 
-                let to_scroll_speed = |m: &player_options::SpeedMod| match m.mod_type.as_str() {
-                    "X" => crate::game::scroll::ScrollSpeedSetting::XMod(m.value),
-                    "C" => crate::game::scroll::ScrollSpeedSetting::CMod(m.value),
-                    "M" => crate::game::scroll::ScrollSpeedSetting::MMod(m.value),
-                    _ => crate::game::scroll::ScrollSpeedSetting::default(),
+                let to_scroll_speed = |m: &player_options::SpeedMod| match m.mod_type {
+                    player_options::SpeedModType::X => {
+                        crate::game::scroll::ScrollSpeedSetting::XMod(m.value)
+                    }
+                    player_options::SpeedModType::C => {
+                        crate::game::scroll::ScrollSpeedSetting::CMod(m.value)
+                    }
+                    player_options::SpeedModType::M => {
+                        crate::game::scroll::ScrollSpeedSetting::MMod(m.value)
+                    }
                 };
                 let scroll_speeds = [
                     to_scroll_speed(&po_state.speed_mod[0]),

--- a/src/screens/player_options/choice.rs
+++ b/src/screens/player_options/choice.rs
@@ -43,10 +43,9 @@ pub(super) fn change_choice_for_player(
     if id == RowId::SpeedMod {
         let speed_mod = {
             let speed_mod = &mut state.speed_mod[player_idx];
-            let (upper, increment) = match speed_mod.mod_type.as_str() {
-                "X" => (20.0, 0.05),
-                "C" | "M" => (2000.0, 5.0),
-                _ => (1.0, 0.1),
+            let (upper, increment) = match speed_mod.mod_type {
+                SpeedModType::X => (20.0, 0.05),
+                SpeedModType::C | SpeedModType::M => (2000.0, 5.0),
             };
             speed_mod.value += delta as f32 * increment;
             speed_mod.value = (speed_mod.value / increment).round() * increment;
@@ -85,15 +84,11 @@ pub(super) fn change_choice_for_player(
     }
 
     if id == RowId::TypeOfSpeedMod {
-        let new_type = match row.selected_choice_index[player_idx] {
-            0 => "X",
-            1 => "C",
-            2 => "M",
-            _ => "C",
-        };
+        let new_type =
+            SpeedModType::from_choice_index(row.selected_choice_index[player_idx]);
 
         let speed_mod = &mut state.speed_mod[player_idx];
-        let old_type = speed_mod.mod_type.clone();
+        let old_type = speed_mod.mod_type;
         let old_value = speed_mod.value;
         let reference_bpm = reference_bpm_for_song(
             &state.song,
@@ -104,13 +99,12 @@ pub(super) fn change_choice_for_player(
         } else {
             1.0
         };
-        let target_bpm: f32 = match old_type.as_str() {
-            "C" | "M" => old_value,
-            "X" => (reference_bpm * rate * old_value).round(),
-            _ => 600.0,
+        let target_bpm: f32 = match old_type {
+            SpeedModType::C | SpeedModType::M => old_value,
+            SpeedModType::X => (reference_bpm * rate * old_value).round(),
         };
         let new_value = match new_type {
-            "X" => {
+            SpeedModType::X => {
                 let denom = reference_bpm * rate;
                 let raw = if denom.is_finite() && denom > 0.0 {
                     target_bpm / denom
@@ -120,13 +114,12 @@ pub(super) fn change_choice_for_player(
                 let stepped = round_to_step(raw, 0.05);
                 stepped.clamp(0.05, 20.0)
             }
-            "C" | "M" => {
+            SpeedModType::C | SpeedModType::M => {
                 let stepped = round_to_step(target_bpm, 5.0);
                 stepped.clamp(5.0, 2000.0)
             }
-            _ => 600.0,
         };
-        speed_mod.mod_type = new_type.to_string();
+        speed_mod.mod_type = new_type;
         speed_mod.value = new_value;
         let speed_mod = speed_mod.clone();
         sync_profile_scroll_speed(&mut state.player_profiles[player_idx], &speed_mod);

--- a/src/screens/player_options/layout.rs
+++ b/src/screens/player_options/layout.rs
@@ -397,19 +397,9 @@ pub(super) fn cursor_dest_for_player(
     let display_text = if arcade_row_focuses_next_row(state, player_idx, row_idx) {
         ARCADE_NEXT_ROW_TEXT.to_string()
     } else if row.id == RowId::SpeedMod {
-        match state.speed_mod[player_idx].mod_type.as_str() {
-            "X" => format!("{:.2}x", state.speed_mod[player_idx].value),
-            "C" => format!("C{}", state.speed_mod[player_idx].value as i32),
-            "M" => format!("M{}", state.speed_mod[player_idx].value as i32),
-            _ => String::new(),
-        }
+        state.speed_mod[player_idx].display()
     } else if row.id == RowId::TypeOfSpeedMod {
-        let idx = match state.speed_mod[player_idx].mod_type.as_str() {
-            "X" => 0,
-            "C" => 1,
-            "M" => 2,
-            _ => 1,
-        };
+        let idx = state.speed_mod[player_idx].mod_type.choice_index();
         row.choices.get(idx).cloned().unwrap_or_default()
     } else {
         let idx = row.selected_choice_index[player_idx].min(row.choices.len().saturating_sub(1));

--- a/src/screens/player_options/mod.rs
+++ b/src/screens/player_options/mod.rs
@@ -73,7 +73,7 @@ use visibility::*;
 
 // --- External API ---
 pub use input::{handle_input, update};
-pub use profile::SpeedMod;
+pub use profile::{SpeedMod, SpeedModType};
 pub use render::get_actors;
 pub use row::{FixedStepchart, RowId};
 pub use state::State;
@@ -99,34 +99,8 @@ pub fn init(
     let p1_profile = crate::game::profile::get_for_side(crate::game::profile::PlayerSide::P1);
     let p2_profile = crate::game::profile::get_for_side(crate::game::profile::PlayerSide::P2);
 
-    let speed_mod_p1 = match p1_profile.scroll_speed {
-        crate::game::scroll::ScrollSpeedSetting::CMod(bpm) => SpeedMod {
-            mod_type: "C".to_string(),
-            value: bpm,
-        },
-        crate::game::scroll::ScrollSpeedSetting::XMod(mult) => SpeedMod {
-            mod_type: "X".to_string(),
-            value: mult,
-        },
-        crate::game::scroll::ScrollSpeedSetting::MMod(bpm) => SpeedMod {
-            mod_type: "M".to_string(),
-            value: bpm,
-        },
-    };
-    let speed_mod_p2 = match p2_profile.scroll_speed {
-        crate::game::scroll::ScrollSpeedSetting::CMod(bpm) => SpeedMod {
-            mod_type: "C".to_string(),
-            value: bpm,
-        },
-        crate::game::scroll::ScrollSpeedSetting::XMod(mult) => SpeedMod {
-            mod_type: "X".to_string(),
-            value: mult,
-        },
-        crate::game::scroll::ScrollSpeedSetting::MMod(bpm) => SpeedMod {
-            mod_type: "M".to_string(),
-            value: bpm,
-        },
-    };
+    let speed_mod_p1 = SpeedMod::from(p1_profile.scroll_speed);
+    let speed_mod_p2 = SpeedMod::from(p2_profile.scroll_speed);
     let chart_difficulty_index: [usize; PLAYER_SLOTS] = std::array::from_fn(|player_idx| {
         let steps_idx = chart_steps_index[player_idx];
         let mut diff_idx = preferred_difficulty_index[player_idx].min(

--- a/src/screens/player_options/profile.rs
+++ b/src/screens/player_options/profile.rs
@@ -1,28 +1,92 @@
 use super::*;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SpeedModType {
+    X,
+    C,
+    M,
+}
+
+impl SpeedModType {
+    /// Index used by the `TypeOfSpeedMod` row's `choices` vector
+    /// (`["x-mod", "c-mod", "m-mod"]`).
+    #[inline(always)]
+    pub fn choice_index(self) -> usize {
+        match self {
+            Self::X => 0,
+            Self::C => 1,
+            Self::M => 2,
+        }
+    }
+
+    #[inline(always)]
+    pub fn from_choice_index(idx: usize) -> Self {
+        match idx {
+            0 => Self::X,
+            1 => Self::C,
+            2 => Self::M,
+            _ => Self::C,
+        }
+    }
+
+    /// Single-letter prefix (`"X"` / `"C"` / `"M"`) used in HUD text.
+    #[inline(always)]
+    pub fn prefix(self) -> &'static str {
+        match self {
+            Self::X => "X",
+            Self::C => "C",
+            Self::M => "M",
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct SpeedMod {
-    pub mod_type: String, // "X", "C", "M"
+    pub mod_type: SpeedModType,
     pub value: f32,
 }
 
-#[inline(always)]
-pub(super) fn scroll_speed_for_mod(
-    speed_mod: &SpeedMod,
-) -> crate::game::scroll::ScrollSpeedSetting {
-    match speed_mod.mod_type.as_str() {
-        "C" => crate::game::scroll::ScrollSpeedSetting::CMod(speed_mod.value),
-        "X" => crate::game::scroll::ScrollSpeedSetting::XMod(speed_mod.value),
-        "M" => crate::game::scroll::ScrollSpeedSetting::MMod(speed_mod.value),
-        _ => crate::game::scroll::ScrollSpeedSetting::default(),
+impl SpeedMod {
+    /// Player-facing display string (`"1.50x"`, `"C400"`, `"M250"`).
+    pub fn display(&self) -> String {
+        match self.mod_type {
+            SpeedModType::X => format!("{:.2}x", self.value),
+            SpeedModType::C => format!("C{}", self.value as i32),
+            SpeedModType::M => format!("M{}", self.value as i32),
+        }
+    }
+}
+
+impl From<crate::game::scroll::ScrollSpeedSetting> for SpeedMod {
+    fn from(setting: crate::game::scroll::ScrollSpeedSetting) -> Self {
+        match setting {
+            crate::game::scroll::ScrollSpeedSetting::XMod(mult) => Self {
+                mod_type: SpeedModType::X,
+                value: mult,
+            },
+            crate::game::scroll::ScrollSpeedSetting::CMod(bpm) => Self {
+                mod_type: SpeedModType::C,
+                value: bpm,
+            },
+            crate::game::scroll::ScrollSpeedSetting::MMod(bpm) => Self {
+                mod_type: SpeedModType::M,
+                value: bpm,
+            },
+        }
     }
 }
 
 #[inline(always)]
-pub(super) fn sync_profile_scroll_speed(
-    profile: &mut crate::game::profile::Profile,
-    speed_mod: &SpeedMod,
-) {
+pub(super) fn scroll_speed_for_mod(speed_mod: &SpeedMod) -> crate::game::scroll::ScrollSpeedSetting {
+    match speed_mod.mod_type {
+        SpeedModType::C => crate::game::scroll::ScrollSpeedSetting::CMod(speed_mod.value),
+        SpeedModType::X => crate::game::scroll::ScrollSpeedSetting::XMod(speed_mod.value),
+        SpeedModType::M => crate::game::scroll::ScrollSpeedSetting::MMod(speed_mod.value),
+    }
+}
+
+#[inline(always)]
+pub(super) fn sync_profile_scroll_speed(profile: &mut crate::game::profile::Profile, speed_mod: &SpeedMod) {
     profile.scroll_speed = scroll_speed_for_mod(speed_mod);
 }
 
@@ -154,23 +218,22 @@ pub(super) fn speed_mod_bpm_pair(
     music_rate: f32,
 ) -> Option<(f32, f32)> {
     let (mut lo, mut hi) = display_bpm_pair_for_options(song, chart, music_rate)?;
-    match speed_mod.mod_type.as_str() {
-        "X" => {
+    match speed_mod.mod_type {
+        SpeedModType::X => {
             lo *= speed_mod.value;
             hi *= speed_mod.value;
         }
-        "M" => {
+        SpeedModType::M => {
             if hi.abs() <= f32::EPSILON {
                 return None;
             }
             lo *= speed_mod.value / hi;
             hi = speed_mod.value;
         }
-        "C" => {
+        SpeedModType::C => {
             lo = speed_mod.value;
             hi = speed_mod.value;
         }
-        _ => {}
     }
     if lo.is_finite() && hi.is_finite() {
         Some((lo, hi))
@@ -255,3 +318,4 @@ pub(super) fn round_to_step(x: f32, step: f32) -> f32 {
     }
     (x / step).round() * step
 }
+

--- a/src/screens/player_options/render.rs
+++ b/src/screens/player_options/render.rs
@@ -123,7 +123,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
             let p_chart = resolve_p1_chart(&state.song, &state.chart_steps_index);
             let main_scroll =
                 speed_mod_helper_scroll_text(&state.song, p_chart, speed_mod, state.music_rate);
-            let speed_prefix = speed_mod.mod_type.as_str();
+            let speed_prefix = speed_mod.mod_type.prefix();
             let speed_text = format!("{speed_prefix}{main_scroll}");
             // zmod uses GetWidth() from the main helper actor (unzoomed width), then +w*0.4.
             let main_draw_w = measure_wendy_text_width(asset_manager, &speed_text);
@@ -1154,18 +1154,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                         if arcade_row_focuses_next_row(state, primary_player_idx, item_idx) {
                             ARCADE_NEXT_ROW_TEXT.to_string()
                         } else if row.id == RowId::SpeedMod {
-                            match state.speed_mod[primary_player_idx].mod_type.as_str() {
-                                "X" => format!("{:.2}x", state.speed_mod[primary_player_idx].value),
-                                "C" => format!(
-                                    "C{}",
-                                    state.speed_mod[primary_player_idx].value as i32
-                                ),
-                                "M" => format!(
-                                    "M{}",
-                                    state.speed_mod[primary_player_idx].value as i32
-                                ),
-                                _ => String::new(),
-                            }
+                            state.speed_mod[primary_player_idx].display()
                         } else {
                             choice_text.clone()
                         };
@@ -1244,19 +1233,9 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                         if arcade_row_focuses_next_row(state, P2, item_idx) {
                             ARCADE_NEXT_ROW_TEXT.to_string()
                         } else if row.id == RowId::SpeedMod {
-                            match state.speed_mod[P2].mod_type.as_str() {
-                                "X" => format!("{:.2}x", state.speed_mod[P2].value),
-                                "C" => format!("C{}", state.speed_mod[P2].value as i32),
-                                "M" => format!("M{}", state.speed_mod[P2].value as i32),
-                                _ => String::new(),
-                            }
+                            state.speed_mod[P2].display()
                         } else if row.id == RowId::TypeOfSpeedMod {
-                            let idx = match state.speed_mod[P2].mod_type.as_str() {
-                                "X" => 0,
-                                "C" => 1,
-                                "M" => 2,
-                                _ => 1,
-                            };
+                            let idx = state.speed_mod[P2].mod_type.choice_index();
                             row.choices.get(idx).cloned().unwrap_or_default()
                         } else {
                             let idx = row

--- a/src/screens/player_options/rows/main.rs
+++ b/src/screens/player_options/rows/main.rs
@@ -10,12 +10,7 @@ pub(super) fn build_main_rows(
     return_screen: Screen,
     fixed_stepchart: Option<&FixedStepchart>,
 ) -> RowMap {
-    let speed_mod_value_str = match speed_mod.mod_type.as_str() {
-        "X" => format!("{:.2}x", speed_mod.value),
-        "C" => format!("C{}", speed_mod.value as i32),
-        "M" => format!("M{}", speed_mod.value as i32),
-        _ => String::new(),
-    };
+    let speed_mod_value_str = speed_mod.display();
     let (stepchart_choices, stepchart_choice_indices, initial_stepchart_choice_index) =
         if let Some(fixed) = fixed_stepchart {
             let fixed_steps_idx = chart_steps_index[session_persisted_player_idx()];
@@ -114,12 +109,7 @@ pub(super) fn build_main_rows(
             tr("PlayerOptions", "SpeedModTypeC").to_string(),
             tr("PlayerOptions", "SpeedModTypeM").to_string(),
         ],
-        selected_choice_index: [match speed_mod.mod_type.as_str() {
-            "X" => 0,
-            "C" => 1,
-            "M" => 2,
-            _ => 1, // Default to C
-        }; PLAYER_SLOTS],
+        selected_choice_index: [speed_mod.mod_type.choice_index(); PLAYER_SLOTS],
         help: tr("PlayerOptionsHelp", "TypeOfSpeedModHelp")
             .split("\\n")
             .map(|s| s.to_string())

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 pub(super) mod tests {
     use super::{
         HUD_OFFSET_MAX, HUD_OFFSET_MIN, HUD_OFFSET_ZERO_INDEX, NAV_INITIAL_HOLD_DELAY,
-        NAV_REPEAT_SCROLL_INTERVAL, P1, Row, RowId, RowMap, SpeedMod,
+        NAV_REPEAT_SCROLL_INTERVAL, P1, Row, RowBuilder, RowId, RowMap, SpeedMod, SpeedModType,
         handle_arcade_start_event, hud_offset_choices, is_row_visible, repeat_held_arcade_start,
         row_visibility, session_active_players, sync_profile_scroll_speed,
     };
@@ -56,7 +56,7 @@ pub(super) mod tests {
         sync_profile_scroll_speed(
             &mut profile,
             &SpeedMod {
-                mod_type: "X".to_string(),
+                mod_type: SpeedModType::X,
                 value: 1.5,
             },
         );
@@ -65,7 +65,7 @@ pub(super) mod tests {
         sync_profile_scroll_speed(
             &mut profile,
             &SpeedMod {
-                mod_type: "M".to_string(),
+                mod_type: SpeedModType::M,
                 value: 750.0,
             },
         );
@@ -74,7 +74,7 @@ pub(super) mod tests {
         sync_profile_scroll_speed(
             &mut profile,
             &SpeedMod {
-                mod_type: "C".to_string(),
+                mod_type: SpeedModType::C,
                 value: 600.0,
             },
         );


### PR DESCRIPTION
# refactor(player-options): introduce SpeedModType enum

## Summary

Replaces the ad-hoc `SpeedMod.mod_type: String` field with a typed `SpeedModType { X, C, M }` enum so speed-mod state is exhaustively checked at compile time. No behaviour change.

## What changed

- New `SpeedModType` enum in `player_options::profile` with helpers:
  - `prefix()` → `"X" | "C" | "M"` for rendering
  - `choice_index()` / `from_choice_index()` for the `TypeOfSpeedMod` row mapping
- New `From<ScrollSpeedSetting> for SpeedMod` so profile → UI
  conversion lives in one place.
- New `SpeedMod::display()` returning the formatted value string  (`"1.50x"` / `"C500"` / `"M500"`), used by both renderer and main
  row builder.
- All callers updated:
  - `player_options/{mod, choice, layout, render, rows/main, tests}.rs`
  - Three conversion sites in `app/mod.rs` (init,`update_scroll_speed` closure, `to_scroll_speed` closure)
- Removed the now-unreachable
  `"Unsupported speed mod '{}' not saved..."` warn arm in `update_scroll_speed`; enum exhaustiveness makes the fallback dead code.

## Why

- Eliminates a class of "stringly-typed" bugs (typos, missing arms silently falling through to `_ =>` defaults).
- Centralises the `ScrollSpeedSetting ↔ SpeedMod` mapping; previously it was duplicated in three places.