### PR TITLE
Add instructions for MacOS Input Monitoring permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,12 @@ Follow these steps to get the game running:
         ```sh
         .\target\release\deadsync.exe
         ```
-    *   **On Linux or macOS:**
+    *   **On Linux:**
+        ```sh
+        ./target/release/deadsync
+        ```
+     *  **On macOS:**
+        Before the first run, grant Input Monitoring permissions to `Terminal.app` in `System Settings > Privacy & Security > Input Monitoring`. Without this, deadsync will not receive any keystrokes. Then, run: 
         ```sh
         ./target/release/deadsync
         ```


### PR DESCRIPTION
Tried out DS on MacOS Sequoia, ran into the problem where DS saw no inputs from any devices. Closer to the release, this should be handled by adding `NSInputMonitoringUsageDescription` into `Info.plist`, so that the app can show a dialog if the permission is missing. For now, this is how to get it working when building from source.