### PR TITLE
Menu speed adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ P1_Back=PadCode[0x00030031]@0
 
 Legacy high-level bindings like `PadDir::Up`, `PadButton::Confirm`, and `PadN::Dir::Left` are still accepted for convenience, but low-level `PadCode[...]` bindings are the most accurate and device-agnostic way to configure controllers.
 
+#### Debug shortcuts
+
+| Key | Action |
+|-----|--------|
+| `Tab` (hold) | Fast-forward menus and transitions at 4×. Disabled in gameplay. |
+| `` ` `` (hold) | Slow menus and transitions to 0.25×. Disabled in gameplay. |
+| `Tab` + `` ` `` | Halt menu animations. Disabled in gameplay. |
+
+These shortcuts mirror ITGmania's debug-loop modifiers and never affect timing-sensitive gameplay (note timing, scoring, music sync). Set `TabAcceleration=0` in `deadsync.ini` to disable them entirely.
+
 ### Profile & Online Features
 A `save` directory is created inside the data directory to store your personal data (see [Data Directories](#data-directories) for its location).
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -757,6 +757,9 @@ pub struct ShellState {
     pending_exit: bool,
     shift_held: bool,
     ctrl_held: bool,
+    tab_held: bool,
+    backquote_held: bool,
+    tab_acceleration_enabled: bool,
     window_focused: bool,
     window_occluded: bool,
     surface_active: bool,
@@ -764,6 +767,42 @@ pub struct ShellState {
     screenshot_request_side: Option<profile::PlayerSide>,
     screenshot_flash_started_at: Option<Instant>,
     screenshot_preview: Option<ScreenshotPreviewState>,
+}
+
+/// Hold-Tab fast-forward / hold-` slow-down multipliers, ITGmania parity.
+///
+/// `Tab` alone → `TAB_FAST_MULTIPLIER`× engine update rate.
+/// `` ` `` alone → `1.0 / TAB_SLOW_DIVISOR`× rate.
+/// Both held → `0.0` (halt).
+///
+/// Always returns `1.0` on `CurrentScreen::Gameplay` (timing-sensitive,
+/// per issue #174) or when `enabled` is false.
+const TAB_FAST_MULTIPLIER: f32 = 4.0;
+const TAB_SLOW_DIVISOR: f32 = 4.0;
+/// Upper bound on the post-acceleration logic dt fed to screens.
+/// Prevents catastrophic spikes (e.g. the app stalled for several seconds
+/// and the user happens to be holding Tab) from injecting absurd dt values
+/// into per-screen `update(dt)` accumulators.
+const MAX_LOGIC_DT_PER_FRAME: f32 = 0.25;
+
+#[inline]
+fn apply_tab_acceleration(
+    wall_dt: f32,
+    screen: CurrentScreen,
+    fast: bool,
+    slow: bool,
+    enabled: bool,
+) -> f32 {
+    if !enabled || matches!(screen, CurrentScreen::Gameplay) {
+        return wall_dt;
+    }
+    let scaled = match (fast, slow) {
+        (true, true) => 0.0,
+        (true, false) => wall_dt * TAB_FAST_MULTIPLIER,
+        (false, true) => wall_dt / TAB_SLOW_DIVISOR,
+        (false, false) => wall_dt,
+    };
+    scaled.clamp(0.0, MAX_LOGIC_DT_PER_FRAME)
 }
 
 #[inline(always)]
@@ -886,6 +925,9 @@ impl ShellState {
             pending_exit: false,
             shift_held: false,
             ctrl_held: false,
+            tab_held: false,
+            backquote_held: false,
+            tab_acceleration_enabled: cfg.tab_acceleration,
             window_focused: true,
             window_occluded: false,
             surface_active: cfg.display_width > 0 && cfg.display_height > 0,
@@ -2562,6 +2604,20 @@ impl App {
             .as_secs_f32();
         crate::engine::present::runtime::tick(delta_time);
 
+        // Tab/`-acceleration: scale the dt fed to non-gameplay screens and
+        // their fade transitions. Wall-clock dt (`delta_time`) is preserved
+        // for the present runtime tick above and for the gameplay step that
+        // continues running under the FadingOut→Evaluation and FadingIn
+        // transitions below, so timing-sensitive paths stay on real time.
+        // See `apply_tab_acceleration` and issue #174.
+        let logic_dt = apply_tab_acceleration(
+            delta_time,
+            self.state.screens.current_screen,
+            self.state.shell.tab_held,
+            self.state.shell.backquote_held,
+            self.state.shell.tab_acceleration_enabled,
+        );
+
         self.sync_gameplay_input_capture();
         self.state.shell.update_gamepad_overlay(redraw_started);
 
@@ -2585,7 +2641,7 @@ impl App {
                 duration,
                 target,
             } => {
-                *elapsed += delta_time;
+                *elapsed += logic_dt;
                 if *target == CurrentScreen::Evaluation
                     && self.state.screens.current_screen == CurrentScreen::Gameplay
                     && let Some(gs) = self.state.screens.gameplay_state.as_mut()
@@ -2604,13 +2660,13 @@ impl App {
                 duration,
                 target,
             } => {
-                *elapsed += delta_time;
+                *elapsed += logic_dt;
                 if *elapsed >= *duration {
                     finished_actor_fade_to = Some(*target);
                 }
             }
             TransitionState::FadingIn { elapsed, duration } => {
-                *elapsed += delta_time;
+                *elapsed += logic_dt;
                 let finished = *elapsed >= *duration;
 
                 if self.state.screens.current_screen == CurrentScreen::Gameplay
@@ -2629,7 +2685,7 @@ impl App {
                 }
             }
             TransitionState::ActorsFadeIn { elapsed } => {
-                *elapsed += delta_time;
+                *elapsed += logic_dt;
                 if *elapsed >= MENU_ACTORS_FADE_DURATION {
                     self.state.shell.transition = TransitionState::Idle;
                 }
@@ -2640,7 +2696,7 @@ impl App {
                     && self.state.gameplay_offset_save_prompt.is_some();
                 if !gameplay_prompt_active {
                     let (action, _) = self.state.screens.step_idle(
-                        delta_time,
+                        logic_dt,
                         redraw_started,
                         &self.state.session,
                         &self.asset_manager,
@@ -5151,6 +5207,12 @@ impl App {
             KeyCode::ControlLeft | KeyCode::ControlRight => {
                 self.state.shell.ctrl_held = raw_key.pressed;
             }
+            KeyCode::Tab => {
+                self.state.shell.tab_held = raw_key.pressed;
+            }
+            KeyCode::Backquote => {
+                self.state.shell.backquote_held = raw_key.pressed;
+            }
             _ => {}
         }
 
@@ -6828,6 +6890,8 @@ impl ApplicationHandler<UserEvent> for App {
                     if !focused {
                         self.state.shell.shift_held = false;
                         self.state.shell.ctrl_held = false;
+                        self.state.shell.tab_held = false;
+                        self.state.shell.backquote_held = false;
                         input::clear_debounce_state();
                         self.clear_gameplay_input_events();
                     }
@@ -7280,5 +7344,83 @@ mod tests {
             evaluation_summary_return_to(CurrentScreen::SelectCourse, true),
             CurrentScreen::Initials,
         );
+    }
+
+    // ---- Tab acceleration helper (issue #174) ----
+
+    const EPS: f32 = 1e-6;
+
+    #[test]
+    fn tab_accel_no_modifier_is_passthrough() {
+        let dt = 0.016_f32;
+        assert!(
+            (apply_tab_acceleration(dt, CurrentScreen::Menu, false, false, true) - dt).abs() < EPS
+        );
+    }
+
+    #[test]
+    fn tab_accel_fast_multiplies_by_four() {
+        let dt = 0.016_f32;
+        let out = apply_tab_acceleration(dt, CurrentScreen::Menu, true, false, true);
+        assert!((out - dt * 4.0).abs() < EPS, "got {out}");
+    }
+
+    #[test]
+    fn tab_accel_slow_divides_by_four() {
+        let dt = 0.016_f32;
+        let out = apply_tab_acceleration(dt, CurrentScreen::Menu, false, true, true);
+        assert!((out - dt / 4.0).abs() < EPS, "got {out}");
+    }
+
+    #[test]
+    fn tab_accel_both_held_halts() {
+        let dt = 0.016_f32;
+        let out = apply_tab_acceleration(dt, CurrentScreen::Menu, true, true, true);
+        assert_eq!(out, 0.0);
+    }
+
+    #[test]
+    fn tab_accel_gameplay_screen_never_scales() {
+        let dt = 0.016_f32;
+        for (fast, slow) in [(false, false), (true, false), (false, true), (true, true)] {
+            let out = apply_tab_acceleration(dt, CurrentScreen::Gameplay, fast, slow, true);
+            assert!(
+                (out - dt).abs() < EPS,
+                "Gameplay must passthrough; fast={fast} slow={slow} got={out}"
+            );
+        }
+    }
+
+    #[test]
+    fn tab_accel_disabled_never_scales() {
+        let dt = 0.016_f32;
+        for screen in [
+            CurrentScreen::Menu,
+            CurrentScreen::SelectMusic,
+            CurrentScreen::Evaluation,
+        ] {
+            for (fast, slow) in [(false, false), (true, false), (false, true), (true, true)] {
+                let out = apply_tab_acceleration(dt, screen, fast, slow, false);
+                assert!(
+                    (out - dt).abs() < EPS,
+                    "disabled must passthrough; screen={screen:?} fast={fast} slow={slow} got={out}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn tab_accel_clamps_to_max_logic_dt() {
+        // Big stall: 1s wall_dt with 4x fast-forward would yield 4s; must clamp to MAX.
+        let out = apply_tab_acceleration(1.0, CurrentScreen::Menu, true, false, true);
+        assert_eq!(out, MAX_LOGIC_DT_PER_FRAME);
+    }
+
+    #[test]
+    fn tab_accel_clamp_does_not_affect_normal_frames() {
+        let dt = 0.016_f32;
+        let out = apply_tab_acceleration(dt, CurrentScreen::Menu, true, false, true);
+        assert!(out < MAX_LOGIC_DT_PER_FRAME);
+        assert!((out - 4.0 * dt).abs() < EPS);
     }
 }

--- a/src/config/load/options.rs
+++ b/src/config/load/options.rs
@@ -296,6 +296,10 @@ fn load_audio_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
         .get("Options", "WriteCurrentScreen")
         .and_then(|v| parse_bool_str(&v))
         .unwrap_or(default.write_current_screen);
+    cfg.tab_acceleration = conf
+        .get("Options", "TabAcceleration")
+        .and_then(|v| parse_bool_str(&v))
+        .unwrap_or(default.tab_acceleration);
 }
 
 fn load_select_music_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -104,6 +104,9 @@ pub struct Config {
     pub log_to_file: bool,
     /// Write the active screen name to save/current_screen.txt on each transition.
     pub write_current_screen: bool,
+    /// Hold-Tab fast-forward (4×) for non-gameplay screens. Issue #174 / ITGmania parity.
+    /// Hold ` for slow (0.25×); both held = halt. Always disabled in Gameplay.
+    pub tab_acceleration: bool,
     /// 0=Off, 1=FPS, 2=FPS+Stutter.
     pub show_stats_mode: u8,
     pub translated_titles: bool,
@@ -265,6 +268,7 @@ impl Default for Config {
             log_level: LogLevel::Warn,
             log_to_file: true,
             write_current_screen: false,
+            tab_acceleration: true,
             show_stats_mode: 0,
             translated_titles: false,
             mine_hit_sound: true,

--- a/src/config/store/defaults.rs
+++ b/src/config/store/defaults.rs
@@ -246,6 +246,7 @@ fn push_default_options(content: &mut String, default: &Config) {
     push_line(content, "Theme", default.theme_flag.as_str());
     push_line(content, "AssistTickVolume", default.assist_tick_volume);
     push_line(content, "SFXVolume", default.sfx_volume);
+    push_bool(content, "TabAcceleration", default.tab_acceleration);
     push_bool(content, "TranslatedTitles", default.translated_titles);
     push_line(content, "VideoRenderer", default.video_renderer);
     push_bool(content, "Vsync", default.vsync);

--- a/src/config/store/save.rs
+++ b/src/config/store/save.rs
@@ -319,6 +319,7 @@ fn push_saved_options(
     push_line(content, "Theme", cfg.theme_flag.as_str());
     push_line(content, "AssistTickVolume", cfg.assist_tick_volume);
     push_line(content, "SFXVolume", cfg.sfx_volume);
+    push_bool(content, "TabAcceleration", cfg.tab_acceleration);
     push_bool(content, "TranslatedTitles", cfg.translated_titles);
     push_line(content, "VideoRenderer", cfg.video_renderer);
     push_bool(content, "Vsync", cfg.vsync);


### PR DESCRIPTION
## Summary

Adds StepMania/ITGmania-style **hold-Tab fast-forward** for non-gameplay screens. Closes #174.

| Modifier | Effect | Multiplier |
|---|---|---|
| Hold `Tab` | Fast-forward menus & fade transitions | 4x |
| Hold `` ` `` | Slow-motion menus & fade transitions | 0.25x |
| Hold both | Halt menu animations | 0x |

Always disabled on `CurrentScreen::Gameplay` so note timing, scoring, judging, and music sync are never affected — this is the explicit constraint from the issue ("as long as it is kept out of timing-sensitive gameplay") and is stricter than ITGmania, which applies its rate globally and relies on its debug-menu gate.

## What''s intentionally out of scope

- **Rebindable keys.** Tab and `` ` `` are hard-coded for v1, matching ITGmania''s defaults. The current `VirtualAction` enum is player-scoped only (no `System`/`Debug` tier), so rebinding deserves its own design pass — tracked in #206.
- **Per-actor `m_fUpdateRate` parity** (ITGmania `ActorFrame.cpp`).
- **Operator-menu UI for the toggle** — config-file only for now.
- **Lua / scripting hook** for the rate (ITGmania''s `GameLoop::SetUpdateRate`).

## Follow-ups

- #206 — make the fast/slow keys configurable through `[Keymaps]`.