### PR TITLE
Player Action Pane State

### DIFF
--- a/src/screens/player_options/choice.rs
+++ b/src/screens/player_options/choice.rs
@@ -27,7 +27,7 @@ pub(super) fn cycle_choice_index(
     row_id: RowId,
     delta: isize,
 ) -> Option<usize> {
-    let row = state.row_map.get_mut(row_id)?;
+    let row = state.pane_mut().row_map.get_mut(row_id)?;
     let n = row.choices.len();
     if n == 0 {
         return None;
@@ -47,15 +47,15 @@ pub(super) fn dispatch_behavior_delta(
     player_idx: usize,
     delta: isize,
 ) {
-    if state.row_map.is_empty() {
+    if state.pane().row_map.is_empty() {
         return;
     }
     let player_idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[player_idx].min(state.row_map.len().saturating_sub(1));
-    let Some(&id) = state.row_map.display_order().get(row_index) else {
+    let row_index = state.pane().selected_row[player_idx].min(state.pane().row_map.len().saturating_sub(1));
+    let Some(&id) = state.pane().row_map.display_order().get(row_index) else {
         return;
     };
-    let Some(behavior) = state.row_map.get(id).map(|r| r.behavior) else {
+    let Some(behavior) = state.pane().row_map.get(id).map(|r| r.behavior) else {
         return;
     };
 
@@ -84,7 +84,7 @@ pub(super) fn dispatch_behavior_delta(
 /// Returns true if the dispatcher handled the row (Bitmask behavior), false
 /// otherwise.
 pub(super) fn dispatch_behavior_toggle(state: &mut State, player_idx: usize, id: RowId) -> bool {
-    let Some(RowBehavior::Bitmask(b)) = state.row_map.get(id).map(|r| r.behavior) else {
+    let Some(RowBehavior::Bitmask(b)) = state.pane().row_map.get(id).map(|r| r.behavior) else {
         return false;
     };
     (b.toggle)(state, player_idx);
@@ -102,7 +102,7 @@ fn apply_numeric(
         Some(i) => i,
         None => return Outcome::NONE,
     };
-    let choice = state
+    let choice = state.pane()
         .row_map
         .get(id)
         .and_then(|r| r.choices.get(new_index))
@@ -150,7 +150,7 @@ fn apply_cycle(
             outcome
         }
         CycleBinding::NoteSkin(n) => {
-            let choice = state
+            let choice = state.pane()
                 .row_map
                 .get(id)
                 .and_then(|r| r.choices.get(new_index))
@@ -172,7 +172,7 @@ fn apply_what_comes_next_cycle(
         Some(i) => i,
         None => return Outcome::NONE,
     };
-    if let Some(row) = state.row_map.get_mut(id) {
+    if let Some(row) = state.pane_mut().row_map.get_mut(id) {
         for slot in 0..PLAYER_SLOTS {
             row.selected_choice_index[slot] = new_index;
         }
@@ -197,16 +197,16 @@ pub fn apply_choice_delta(
     player_idx: usize,
     delta: isize,
 ) {
-    if state.row_map.is_empty() {
+    if state.pane().row_map.is_empty() {
         return;
     }
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_idx = state.selected_row[idx].min(state.row_map.len().saturating_sub(1));
-    if let Some(row) = state
+    let row_idx = state.pane().selected_row[idx].min(state.pane().row_map.len().saturating_sub(1));
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_idx)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
         && row_supports_inline_nav(row)
     {
         if state.current_pane == OptionsPane::Main || row_selects_on_focus_move(row.id) {
@@ -223,12 +223,12 @@ pub fn apply_choice_delta(
 
 pub(super) fn toggle_scroll_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::Scroll {
             return;
@@ -237,9 +237,9 @@ pub(super) fn toggle_scroll_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let choice_index = state
+    let choice_index = state.pane()
         .row_map
-        .row(state.row_map.id_at(row_index))
+        .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 8 {
         1u8 << (choice_index as u8)
@@ -295,12 +295,12 @@ pub(super) fn toggle_scroll_row(state: &mut State, player_idx: usize) {
 
 pub(super) fn toggle_hide_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::Hide {
             return;
@@ -309,9 +309,9 @@ pub(super) fn toggle_hide_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let choice_index = state
+    let choice_index = state.pane()
         .row_map
-        .row(state.row_map.id_at(row_index))
+        .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 8 {
         1u8 << (choice_index as u8)
@@ -371,12 +371,12 @@ pub(super) fn toggle_hide_row(state: &mut State, player_idx: usize) {
 
 pub(super) fn toggle_insert_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::Insert {
             return;
@@ -385,9 +385,9 @@ pub(super) fn toggle_insert_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let choice_index = state
+    let choice_index = state.pane()
         .row_map
-        .row(state.row_map.id_at(row_index))
+        .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 7 {
         1u8 << (choice_index as u8)
@@ -425,12 +425,12 @@ pub(super) fn toggle_insert_row(state: &mut State, player_idx: usize) {
 
 pub(super) fn toggle_remove_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::Remove {
             return;
@@ -439,9 +439,9 @@ pub(super) fn toggle_remove_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let choice_index = state
+    let choice_index = state.pane()
         .row_map
-        .row(state.row_map.id_at(row_index))
+        .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 8 {
         1u8 << (choice_index as u8)
@@ -479,12 +479,12 @@ pub(super) fn toggle_remove_row(state: &mut State, player_idx: usize) {
 
 pub(super) fn toggle_holds_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::Holds {
             return;
@@ -493,14 +493,14 @@ pub(super) fn toggle_holds_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let choice_index = state
+    let choice_index = state.pane()
         .row_map
-        .row(state.row_map.id_at(row_index))
+        .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index
-        < state
+        < state.pane()
             .row_map
-            .row(state.row_map.id_at(row_index))
+            .row(state.pane().row_map.id_at(row_index))
             .choices
             .len()
             .min(u8::BITS as usize)
@@ -540,12 +540,12 @@ pub(super) fn toggle_holds_row(state: &mut State, player_idx: usize) {
 
 pub(super) fn toggle_accel_effects_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::Accel {
             return;
@@ -554,14 +554,14 @@ pub(super) fn toggle_accel_effects_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let choice_index = state
+    let choice_index = state.pane()
         .row_map
-        .row(state.row_map.id_at(row_index))
+        .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index
-        < state
+        < state.pane()
             .row_map
-            .row(state.row_map.id_at(row_index))
+            .row(state.pane().row_map.id_at(row_index))
             .choices
             .len()
             .min(u8::BITS as usize)
@@ -601,12 +601,12 @@ pub(super) fn toggle_accel_effects_row(state: &mut State, player_idx: usize) {
 
 pub(super) fn toggle_visual_effects_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::Effect {
             return;
@@ -615,9 +615,9 @@ pub(super) fn toggle_visual_effects_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let choice_index = state
+    let choice_index = state.pane()
         .row_map
-        .row(state.row_map.id_at(row_index))
+        .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 10 {
         1u16 << (choice_index as u16)
@@ -655,12 +655,12 @@ pub(super) fn toggle_visual_effects_row(state: &mut State, player_idx: usize) {
 
 pub(super) fn toggle_appearance_effects_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::Appearance {
             return;
@@ -669,14 +669,14 @@ pub(super) fn toggle_appearance_effects_row(state: &mut State, player_idx: usize
         return;
     }
 
-    let choice_index = state
+    let choice_index = state.pane()
         .row_map
-        .row(state.row_map.id_at(row_index))
+        .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index
-        < state
+        < state.pane()
             .row_map
-            .row(state.row_map.id_at(row_index))
+            .row(state.pane().row_map.id_at(row_index))
             .choices
             .len()
             .min(u8::BITS as usize)
@@ -718,12 +718,12 @@ pub(super) fn toggle_appearance_effects_row(state: &mut State, player_idx: usize
 
 pub(super) fn toggle_life_bar_options_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::LifeBarOptions {
             return;
@@ -732,9 +732,9 @@ pub(super) fn toggle_life_bar_options_row(state: &mut State, player_idx: usize) 
         return;
     }
 
-    let choice_index = state
+    let choice_index = state.pane()
         .row_map
-        .row(state.row_map.id_at(row_index))
+        .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 3 {
         1u8 << (choice_index as u8)
@@ -777,12 +777,12 @@ pub(super) fn toggle_life_bar_options_row(state: &mut State, player_idx: usize) 
 
 pub(super) fn toggle_fa_plus_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::FAPlusOptions {
             return;
@@ -791,14 +791,14 @@ pub(super) fn toggle_fa_plus_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let choice_index = state
+    let choice_index = state.pane()
         .row_map
-        .row(state.row_map.id_at(row_index))
+        .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index
-        < state
+        < state.pane()
             .row_map
-            .row(state.row_map.id_at(row_index))
+            .row(state.pane().row_map.id_at(row_index))
             .choices
             .len()
             .min(u8::BITS as usize)
@@ -852,12 +852,12 @@ pub(super) fn toggle_fa_plus_row(state: &mut State, player_idx: usize) {
 
 pub(super) fn toggle_results_extras_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::ResultsExtras {
             return;
@@ -866,9 +866,9 @@ pub(super) fn toggle_results_extras_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let choice_index = state
+    let choice_index = state.pane()
         .row_map
-        .row(state.row_map.id_at(row_index))
+        .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 1 {
         1u8 << (choice_index as u8)
@@ -905,12 +905,12 @@ pub(super) fn toggle_results_extras_row(state: &mut State, player_idx: usize) {
 
 pub(super) fn toggle_error_bar_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::ErrorBar {
             return;
@@ -919,9 +919,9 @@ pub(super) fn toggle_error_bar_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let choice_index = state
+    let choice_index = state.pane()
         .row_map
-        .row(state.row_map.id_at(row_index))
+        .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 5 {
         1u8 << (choice_index as u8)
@@ -963,12 +963,12 @@ pub(super) fn toggle_error_bar_row(state: &mut State, player_idx: usize) {
 
 pub(super) fn toggle_error_bar_options_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::ErrorBarOptions {
             return;
@@ -977,9 +977,9 @@ pub(super) fn toggle_error_bar_options_row(state: &mut State, player_idx: usize)
         return;
     }
 
-    let choice_index = state
+    let choice_index = state.pane()
         .row_map
-        .row(state.row_map.id_at(row_index))
+        .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 2 {
         1u8 << (choice_index as u8)
@@ -1018,12 +1018,12 @@ pub(super) fn toggle_error_bar_options_row(state: &mut State, player_idx: usize)
 
 pub(super) fn toggle_measure_counter_options_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::MeasureCounterOptions {
             return;
@@ -1032,9 +1032,9 @@ pub(super) fn toggle_measure_counter_options_row(state: &mut State, player_idx: 
         return;
     }
 
-    let choice_index = state
+    let choice_index = state.pane()
         .row_map
-        .row(state.row_map.id_at(row_index))
+        .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 5 {
         1u8 << (choice_index as u8)
@@ -1082,12 +1082,12 @@ pub(super) fn toggle_measure_counter_options_row(state: &mut State, player_idx: 
 
 pub(super) fn toggle_early_dw_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::EarlyDecentWayOffOptions {
             return;
@@ -1096,9 +1096,9 @@ pub(super) fn toggle_early_dw_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let choice_index = state
+    let choice_index = state.pane()
         .row_map
-        .row(state.row_map.id_at(row_index))
+        .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 2 {
         1u8 << (choice_index as u8)
@@ -1137,12 +1137,12 @@ pub(super) fn toggle_early_dw_row(state: &mut State, player_idx: usize) {
 
 pub(super) fn toggle_gameplay_extras_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx];
-    if let Some(row) = state
+    let row_index = state.pane().selected_row[idx];
+    if let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     {
         if row.id != RowId::GameplayExtras {
             return;
@@ -1151,7 +1151,7 @@ pub(super) fn toggle_gameplay_extras_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let row = state.row_map.row(state.row_map.id_at(row_index));
+    let row = state.pane().row_map.row(state.pane().row_map.id_at(row_index));
     let choice_index = row.selected_choice_index[idx];
     let ge_flash = tr("PlayerOptions", "GameplayExtrasFlashColumnForMiss");
     let ge_density = tr("PlayerOptions", "GameplayExtrasDensityGraphAtTop");
@@ -1223,123 +1223,31 @@ pub(super) fn toggle_gameplay_extras_row(state: &mut State, player_idx: usize) {
 }
 
 pub(super) fn apply_pane(state: &mut State, pane: OptionsPane) {
-    let speed_mod = &state.speed_mod[session_persisted_player_idx()];
-    let mut row_map = build_rows(
-        &state.song,
-        speed_mod,
-        state.chart_steps_index,
-        state.chart_difficulty_index,
-        state.music_rate,
-        pane,
-        &state.noteskin_names,
-        state.return_screen,
-        state.fixed_stepchart.as_ref(),
-    );
-    let (
-        scroll_active_mask_p1,
-        hide_active_mask_p1,
-        insert_active_mask_p1,
-        remove_active_mask_p1,
-        holds_active_mask_p1,
-        accel_effects_active_mask_p1,
-        visual_effects_active_mask_p1,
-        appearance_effects_active_mask_p1,
-        fa_plus_active_mask_p1,
-        early_dw_active_mask_p1,
-        gameplay_extras_active_mask_p1,
-        gameplay_extras_more_active_mask_p1,
-        results_extras_active_mask_p1,
-        life_bar_options_active_mask_p1,
-        error_bar_active_mask_p1,
-        error_bar_options_active_mask_p1,
-        measure_counter_options_active_mask_p1,
-    ) = apply_profile_defaults(&mut row_map, &state.player_profiles[P1], P1);
-    let (
-        scroll_active_mask_p2,
-        hide_active_mask_p2,
-        insert_active_mask_p2,
-        remove_active_mask_p2,
-        holds_active_mask_p2,
-        accel_effects_active_mask_p2,
-        visual_effects_active_mask_p2,
-        appearance_effects_active_mask_p2,
-        fa_plus_active_mask_p2,
-        early_dw_active_mask_p2,
-        gameplay_extras_active_mask_p2,
-        gameplay_extras_more_active_mask_p2,
-        results_extras_active_mask_p2,
-        life_bar_options_active_mask_p2,
-        error_bar_active_mask_p2,
-        error_bar_options_active_mask_p2,
-        measure_counter_options_active_mask_p2,
-    ) = apply_profile_defaults(&mut row_map, &state.player_profiles[P2], P2);
-    state.row_map = row_map;
-    state.scroll_active_mask = [scroll_active_mask_p1, scroll_active_mask_p2];
-    state.hide_active_mask = [hide_active_mask_p1, hide_active_mask_p2];
-    state.insert_active_mask = [insert_active_mask_p1, insert_active_mask_p2];
-    state.remove_active_mask = [remove_active_mask_p1, remove_active_mask_p2];
-    state.holds_active_mask = [holds_active_mask_p1, holds_active_mask_p2];
-    state.accel_effects_active_mask = [accel_effects_active_mask_p1, accel_effects_active_mask_p2];
-    state.visual_effects_active_mask =
-        [visual_effects_active_mask_p1, visual_effects_active_mask_p2];
-    state.appearance_effects_active_mask = [
-        appearance_effects_active_mask_p1,
-        appearance_effects_active_mask_p2,
-    ];
-    state.fa_plus_active_mask = [fa_plus_active_mask_p1, fa_plus_active_mask_p2];
-    state.early_dw_active_mask = [early_dw_active_mask_p1, early_dw_active_mask_p2];
-    state.gameplay_extras_active_mask = [
-        gameplay_extras_active_mask_p1,
-        gameplay_extras_active_mask_p2,
-    ];
-    state.gameplay_extras_more_active_mask = [
-        gameplay_extras_more_active_mask_p1,
-        gameplay_extras_more_active_mask_p2,
-    ];
-    state.results_extras_active_mask =
-        [results_extras_active_mask_p1, results_extras_active_mask_p2];
-    state.life_bar_options_active_mask = [
-        life_bar_options_active_mask_p1,
-        life_bar_options_active_mask_p2,
-    ];
-    state.error_bar_active_mask = [error_bar_active_mask_p1, error_bar_active_mask_p2];
-    state.error_bar_options_active_mask = [
-        error_bar_options_active_mask_p1,
-        error_bar_options_active_mask_p2,
-    ];
-    state.measure_counter_options_active_mask = [
-        measure_counter_options_active_mask_p1,
-        measure_counter_options_active_mask_p2,
-    ];
+    // Row_maps are pre-built at init() and live in `State::panes`, so a
+    // pane switch does not rebuild rows or recompute masks (masks are kept up
+    // to date incrementally by toggle handlers). Switching is now a structural
+    // operation: change the active pane, reset the destination pane's cursor
+    // to the top, and recompute its row tweens for the new layout.
     state.current_pane = pane;
-    state.selected_row = [0; PLAYER_SLOTS];
-    state.prev_selected_row = [0; PLAYER_SLOTS];
-    state.inline_choice_x = [f32::NAN; PLAYER_SLOTS];
-    state.arcade_row_focus = [false; PLAYER_SLOTS];
+    state.pane_mut().reset_cursor();
     state.start_held_since = [None; PLAYER_SLOTS];
     state.start_last_triggered_at = [None; PLAYER_SLOTS];
-    state.cursor_initialized = [false; PLAYER_SLOTS];
-    state.cursor_from_x = [0.0; PLAYER_SLOTS];
-    state.cursor_from_y = [0.0; PLAYER_SLOTS];
-    state.cursor_from_w = [0.0; PLAYER_SLOTS];
-    state.cursor_from_h = [0.0; PLAYER_SLOTS];
-    state.cursor_to_x = [0.0; PLAYER_SLOTS];
-    state.cursor_to_y = [0.0; PLAYER_SLOTS];
-    state.cursor_to_w = [0.0; PLAYER_SLOTS];
-    state.cursor_to_h = [0.0; PLAYER_SLOTS];
-    state.cursor_t = [1.0; PLAYER_SLOTS];
     state.help_anim_time = [0.0; PLAYER_SLOTS];
     let active = session_active_players();
-    state.row_tweens = init_row_tweens(
-        &state.row_map,
-        state.selected_row,
+    let hide = state.hide_active_mask;
+    let error_bar = state.error_bar_active_mask;
+    let allow = state.allow_per_player_global_offsets;
+    let p = state.pane_mut();
+    p.row_tweens = init_row_tweens(
+        &p.row_map,
+        p.selected_row,
         active,
-        state.hide_active_mask,
-        state.error_bar_active_mask,
-        state.allow_per_player_global_offsets,
+        hide,
+        error_bar,
+        allow,
     );
-    state.arcade_row_focus = std::array::from_fn(|player_idx| {
-        row_allows_arcade_next_row(state, state.selected_row[player_idx])
+    state.pane_mut().arcade_row_focus = std::array::from_fn(|player_idx| {
+        row_allows_arcade_next_row(state, state.pane().selected_row[player_idx])
     });
 }
 

--- a/src/screens/player_options/inline_nav.rs
+++ b/src/screens/player_options/inline_nav.rs
@@ -26,11 +26,11 @@ pub(super) fn focused_inline_choice_index(
     row_idx: usize,
 ) -> Option<usize> {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row = state
+    let row = state.pane()
         .row_map
         .display_order()
         .get(row_idx)
-        .and_then(|&id| state.row_map.get(id))?;
+        .and_then(|&id| state.pane().row_map.get(id))?;
     if !row_supports_inline_nav(row) {
         return None;
     }
@@ -43,7 +43,7 @@ pub(super) fn focused_inline_choice_index(
         return None;
     }
     let mut focus_idx = row.selected_choice_index[idx].min(centers.len().saturating_sub(1));
-    let anchor_x = state.inline_choice_x[idx];
+    let anchor_x = state.pane().inline_choice_x[idx];
     if anchor_x.is_finite() {
         let mut best_dist = f32::INFINITY;
         for (i, &center_x) in centers.iter().enumerate() {
@@ -63,16 +63,16 @@ pub(super) fn move_inline_focus(
     player_idx: usize,
     delta: isize,
 ) -> bool {
-    if state.row_map.is_empty() || delta == 0 {
+    if state.pane().row_map.is_empty() || delta == 0 {
         return false;
     }
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_idx = state.selected_row[idx].min(state.row_map.len().saturating_sub(1));
-    let Some(row) = state
+    let row_idx = state.pane().selected_row[idx].min(state.pane().row_map.len().saturating_sub(1));
+    let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_idx)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     else {
         return false;
     };
@@ -88,12 +88,12 @@ pub(super) fn move_inline_focus(
         return false;
     }
     if row_allows_arcade_next_row(state, row_idx) {
-        if state.arcade_row_focus[idx] {
+        if state.pane().arcade_row_focus[idx] {
             if delta <= 0 {
                 return false;
             }
-            state.arcade_row_focus[idx] = false;
-            state.inline_choice_x[idx] = centers[0];
+            state.pane_mut().arcade_row_focus[idx] = false;
+            state.pane_mut().inline_choice_x[idx] = centers[0];
             return true;
         }
         let Some(current_idx) = focused_inline_choice_index(state, asset_manager, idx, row_idx)
@@ -102,17 +102,17 @@ pub(super) fn move_inline_focus(
         };
         if delta < 0 {
             if current_idx == 0 {
-                state.arcade_row_focus[idx] = true;
-                state.inline_choice_x[idx] = f32::NAN;
+                state.pane_mut().arcade_row_focus[idx] = true;
+                state.pane_mut().inline_choice_x[idx] = f32::NAN;
                 return true;
             }
-            state.inline_choice_x[idx] = centers[current_idx - 1];
+            state.pane_mut().inline_choice_x[idx] = centers[current_idx - 1];
             return true;
         }
         if current_idx + 1 >= centers.len() {
             return false;
         }
-        state.inline_choice_x[idx] = centers[current_idx + 1];
+        state.pane_mut().inline_choice_x[idx] = centers[current_idx + 1];
         return true;
     }
     let Some(current_idx) = focused_inline_choice_index(state, asset_manager, idx, row_idx) else {
@@ -120,7 +120,7 @@ pub(super) fn move_inline_focus(
     };
     let n = centers.len() as isize;
     let next_idx = ((current_idx as isize + delta).rem_euclid(n)) as usize;
-    state.inline_choice_x[idx] = centers[next_idx];
+    state.pane_mut().inline_choice_x[idx] = centers[next_idx];
     true
 }
 
@@ -131,11 +131,11 @@ pub(super) fn commit_inline_focus_selection(
     row_idx: usize,
 ) -> bool {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let Some(row) = state
+    let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_idx)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     else {
         return false;
     };
@@ -146,8 +146,8 @@ pub(super) fn commit_inline_focus_selection(
         return false;
     };
     let is_shared = row_is_shared(row.id);
-    if let Some(&row_id) = state.row_map.display_order().get(row_idx) {
-        if let Some(row) = state.row_map.get_mut(row_id) {
+    if let Some(&row_id) = state.pane().row_map.display_order().get(row_idx) {
+        if let Some(row) = state.pane_mut().row_map.get_mut(row_id) {
             if is_shared {
                 let changed = row.selected_choice_index.iter().any(|&v| v != focus_idx);
                 row.selected_choice_index = [focus_idx; PLAYER_SLOTS];
@@ -168,15 +168,15 @@ pub(super) fn sync_inline_intent_from_row(
     row_idx: usize,
 ) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    if row_allows_arcade_next_row(state, row_idx) && state.arcade_row_focus[idx] {
-        state.inline_choice_x[idx] = f32::NAN;
+    if row_allows_arcade_next_row(state, row_idx) && state.pane().arcade_row_focus[idx] {
+        state.pane_mut().inline_choice_x[idx] = f32::NAN;
         return;
     }
-    let Some(row) = state
+    let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_idx)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     else {
         return;
     };
@@ -192,7 +192,7 @@ pub(super) fn sync_inline_intent_from_row(
         return;
     }
     let sel = row.selected_choice_index[idx].min(centers.len().saturating_sub(1));
-    state.inline_choice_x[idx] = centers[sel];
+    state.pane_mut().inline_choice_x[idx] = centers[sel];
 }
 
 pub(super) fn apply_inline_intent_to_row(
@@ -202,15 +202,15 @@ pub(super) fn apply_inline_intent_to_row(
     row_idx: usize,
 ) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    if row_allows_arcade_next_row(state, row_idx) && state.arcade_row_focus[idx] {
-        state.inline_choice_x[idx] = f32::NAN;
+    if row_allows_arcade_next_row(state, row_idx) && state.pane().arcade_row_focus[idx] {
+        state.pane_mut().inline_choice_x[idx] = f32::NAN;
         return;
     }
-    let Some(row) = state
+    let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_idx)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     else {
         return;
     };
@@ -227,11 +227,11 @@ pub(super) fn apply_inline_intent_to_row(
     }
     let sel = row.selected_choice_index[idx].min(centers.len().saturating_sub(1));
     if state.current_pane == OptionsPane::Main {
-        state.inline_choice_x[idx] = centers[sel];
+        state.pane_mut().inline_choice_x[idx] = centers[sel];
         return;
     }
-    if !state.inline_choice_x[idx].is_finite() {
-        state.inline_choice_x[idx] = centers[sel];
+    if !state.pane().inline_choice_x[idx].is_finite() {
+        state.pane_mut().inline_choice_x[idx] = centers[sel];
     }
 }
 
@@ -242,29 +242,29 @@ pub(super) fn move_selection_vertical(
     player_idx: usize,
     dir: NavDirection,
 ) {
-    if !matches!(dir, NavDirection::Up | NavDirection::Down) || state.row_map.is_empty() {
+    if !matches!(dir, NavDirection::Up | NavDirection::Down) || state.pane().row_map.is_empty() {
         return;
     }
     let idx = player_idx.min(PLAYER_SLOTS - 1);
     sync_selected_rows_with_visibility(state, active);
     let visibility = row_visibility(
-        &state.row_map,
+        &state.pane().row_map,
         active,
         state.hide_active_mask,
         state.error_bar_active_mask,
         state.allow_per_player_global_offsets,
     );
-    let current_row = state.selected_row[idx].min(state.row_map.len().saturating_sub(1));
-    if !state.inline_choice_x[idx].is_finite() {
+    let current_row = state.pane().selected_row[idx].min(state.pane().row_map.len().saturating_sub(1));
+    if !state.pane().inline_choice_x[idx].is_finite() {
         if let Some((anchor_x, _, _, _)) = cursor_dest_for_player(state, asset_manager, idx) {
-            state.inline_choice_x[idx] = anchor_x;
+            state.pane_mut().inline_choice_x[idx] = anchor_x;
         } else {
             sync_inline_intent_from_row(state, asset_manager, idx, current_row);
         }
     }
-    if let Some(next_row) = next_visible_row(&state.row_map, current_row, dir, visibility) {
-        state.selected_row[idx] = next_row;
-        state.arcade_row_focus[idx] = row_allows_arcade_next_row(state, next_row);
+    if let Some(next_row) = next_visible_row(&state.pane().row_map, current_row, dir, visibility) {
+        state.pane_mut().selected_row[idx] = next_row;
+        state.pane_mut().arcade_row_focus[idx] = row_allows_arcade_next_row(state, next_row);
         apply_inline_intent_to_row(state, asset_manager, idx, next_row);
     }
 }
@@ -332,8 +332,8 @@ pub(super) fn arcade_row_focuses_next_row(
 ) -> bool {
     let idx = player_idx.min(PLAYER_SLOTS - 1);
     row_allows_arcade_next_row(state, row_idx)
-        && state.arcade_row_focus[idx]
-        && state.selected_row[idx] == row_idx
+        && state.pane().arcade_row_focus[idx]
+        && state.pane().selected_row[idx] == row_idx
 }
 
 pub(super) fn arcade_next_row_layout(

--- a/src/screens/player_options/input.rs
+++ b/src/screens/player_options/input.rs
@@ -28,7 +28,7 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
             continue;
         }
 
-        if state.row_map.is_empty() {
+        if state.pane().row_map.is_empty() {
             continue;
         }
         match direction {
@@ -105,11 +105,11 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
     // If either player is on the Combo Font row, tick the preview combo once per second.
     let mut combo_row_active = false;
     for player_idx in active_player_indices(active) {
-        if let Some(row) = state
+        if let Some(row) = state.pane()
             .row_map
             .display_order()
-            .get(state.selected_row[player_idx])
-            .and_then(|&id| state.row_map.get(id))
+            .get(state.pane().selected_row[player_idx])
+            .and_then(|&id| state.pane().row_map.get(id))
             && row.id == RowId::ComboFont
         {
             combo_row_active = true;
@@ -128,14 +128,14 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
 
     // Row frame tweening: mimic ScreenOptions::PositionRows() + OptionRow::SetDestination()
     // so rows slide smoothly as the visible window scrolls.
-    let total_rows = state.row_map.len();
+    let total_rows = state.pane().row_map.len();
     let (first_row_center_y, row_step) = row_layout_params();
     if total_rows == 0 {
-        state.row_tweens.clear();
-    } else if state.row_tweens.len() != total_rows {
-        state.row_tweens = init_row_tweens(
-            &state.row_map,
-            state.selected_row,
+        state.pane_mut().row_tweens.clear();
+    } else if state.pane().row_tweens.len() != total_rows {
+        state.pane_mut().row_tweens = init_row_tweens(
+            &state.pane().row_map,
+            state.pane().selected_row,
             active,
             state.hide_active_mask,
             state.error_bar_active_mask,
@@ -143,16 +143,16 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
         );
     } else {
         let visibility = row_visibility(
-            &state.row_map,
+            &state.pane().row_map,
             active,
             state.hide_active_mask,
             state.error_bar_active_mask,
             state.allow_per_player_global_offsets,
         );
-        let visible_rows = count_visible_rows(&state.row_map, visibility);
+        let visible_rows = count_visible_rows(&state.pane().row_map, visibility);
         if visible_rows == 0 {
             let y = first_row_center_y - row_step * 0.5;
-            for tw in &mut state.row_tweens {
+            for tw in &mut state.pane_mut().row_tweens {
                 let cur_y = tw.y();
                 let cur_a = tw.a();
                 if (y - tw.to_y).abs() > 0.01 || tw.to_a != 0.0 {
@@ -172,30 +172,30 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
             }
         } else {
             let selected_visible = std::array::from_fn(|player_idx| {
-                let row_idx = state.selected_row[player_idx].min(total_rows.saturating_sub(1));
-                row_to_visible_index(&state.row_map, row_idx, visibility).unwrap_or(0)
+                let row_idx = state.pane().selected_row[player_idx].min(total_rows.saturating_sub(1));
+                row_to_visible_index(&state.pane().row_map, row_idx, visibility).unwrap_or(0)
             });
             let w = compute_row_window(visible_rows, selected_visible, active);
             let mid_pos = (VISIBLE_ROWS as f32) * 0.5 - 0.5;
             let bottom_pos = (VISIBLE_ROWS as f32) - 0.5;
             let measure_counter_anchor_visible_idx =
-                parent_anchor_visible_index(&state.row_map, RowId::MeasureCounter, visibility);
+                parent_anchor_visible_index(&state.pane().row_map, RowId::MeasureCounter, visibility);
             let judgment_tilt_anchor_visible_idx =
-                parent_anchor_visible_index(&state.row_map, RowId::JudgmentTilt, visibility);
+                parent_anchor_visible_index(&state.pane().row_map, RowId::JudgmentTilt, visibility);
             let error_bar_anchor_visible_idx =
-                parent_anchor_visible_index(&state.row_map, RowId::ErrorBar, visibility);
+                parent_anchor_visible_index(&state.pane().row_map, RowId::ErrorBar, visibility);
             let hide_anchor_visible_idx =
-                parent_anchor_visible_index(&state.row_map, RowId::Hide, visibility);
+                parent_anchor_visible_index(&state.pane().row_map, RowId::Hide, visibility);
             let mut visible_idx = 0i32;
             for i in 0..total_rows {
-                let visible = is_row_visible(&state.row_map, i, visibility);
+                let visible = is_row_visible(&state.pane().row_map, i, visibility);
                 let (f_pos, hidden) = if visible {
                     let ii = visible_idx;
                     visible_idx += 1;
                     f_pos_for_visible_idx(ii, w, mid_pos, bottom_pos)
                 } else {
                     let anchor =
-                        state.row_map.get_at(i).and_then(|row| {
+                        state.pane().row_map.get_at(i).and_then(|row| {
                             match conditional_row_parent(row.id) {
                                 Some(RowId::MeasureCounter) => measure_counter_anchor_visible_idx,
                                 Some(RowId::JudgmentTilt) => judgment_tilt_anchor_visible_idx,
@@ -216,7 +216,7 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
                 let dest_y = first_row_center_y + row_step * f_pos;
                 let dest_a = if hidden { 0.0 } else { 1.0 };
 
-                let tw = &mut state.row_tweens[i];
+                let tw = &mut state.pane_mut().row_tweens[i];
                 let cur_y = tw.y();
                 let cur_a = tw.a();
                 if (dest_y - tw.to_y).abs() > 0.01 || dest_a != tw.to_a {
@@ -239,7 +239,7 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
 
     // Reset help reveal and play SFX when a player changes rows.
     for player_idx in active_player_indices(active) {
-        if state.selected_row[player_idx] == state.prev_selected_row[player_idx] {
+        if state.pane().selected_row[player_idx] == state.pane().prev_selected_row[player_idx] {
             continue;
         }
         match state.nav_key_held_direction[player_idx] {
@@ -249,7 +249,7 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
         }
 
         state.help_anim_time[player_idx] = 0.0;
-        state.prev_selected_row[player_idx] = state.selected_row[player_idx];
+        state.pane_mut().prev_selected_row[player_idx] = state.pane().selected_row[player_idx];
     }
 
     // Retarget cursor tween destinations to match current selection and row destinations.
@@ -260,55 +260,55 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
             continue;
         };
 
-        let needs_cursor_init = !state.cursor_initialized[player_idx];
+        let needs_cursor_init = !state.pane().cursor_initialized[player_idx];
         if needs_cursor_init {
-            state.cursor_initialized[player_idx] = true;
-            state.cursor_from_x[player_idx] = to_x;
-            state.cursor_from_y[player_idx] = to_y;
-            state.cursor_from_w[player_idx] = to_w;
-            state.cursor_from_h[player_idx] = to_h;
-            state.cursor_to_x[player_idx] = to_x;
-            state.cursor_to_y[player_idx] = to_y;
-            state.cursor_to_w[player_idx] = to_w;
-            state.cursor_to_h[player_idx] = to_h;
-            state.cursor_t[player_idx] = 1.0;
+            state.pane_mut().cursor_initialized[player_idx] = true;
+            state.pane_mut().cursor_from_x[player_idx] = to_x;
+            state.pane_mut().cursor_from_y[player_idx] = to_y;
+            state.pane_mut().cursor_from_w[player_idx] = to_w;
+            state.pane_mut().cursor_from_h[player_idx] = to_h;
+            state.pane_mut().cursor_to_x[player_idx] = to_x;
+            state.pane_mut().cursor_to_y[player_idx] = to_y;
+            state.pane_mut().cursor_to_w[player_idx] = to_w;
+            state.pane_mut().cursor_to_h[player_idx] = to_h;
+            state.pane_mut().cursor_t[player_idx] = 1.0;
         } else {
-            let dx = (to_x - state.cursor_to_x[player_idx]).abs();
-            let dy = (to_y - state.cursor_to_y[player_idx]).abs();
-            let dw = (to_w - state.cursor_to_w[player_idx]).abs();
-            let dh = (to_h - state.cursor_to_h[player_idx]).abs();
+            let dx = (to_x - state.pane().cursor_to_x[player_idx]).abs();
+            let dy = (to_y - state.pane().cursor_to_y[player_idx]).abs();
+            let dw = (to_w - state.pane().cursor_to_w[player_idx]).abs();
+            let dh = (to_h - state.pane().cursor_to_h[player_idx]).abs();
             if dx > 0.01 || dy > 0.01 || dw > 0.01 || dh > 0.01 {
-                let t = state.cursor_t[player_idx].clamp(0.0, 1.0);
-                let cur_x = (state.cursor_to_x[player_idx] - state.cursor_from_x[player_idx])
-                    .mul_add(t, state.cursor_from_x[player_idx]);
-                let cur_y = (state.cursor_to_y[player_idx] - state.cursor_from_y[player_idx])
-                    .mul_add(t, state.cursor_from_y[player_idx]);
-                let cur_w = (state.cursor_to_w[player_idx] - state.cursor_from_w[player_idx])
-                    .mul_add(t, state.cursor_from_w[player_idx]);
-                let cur_h = (state.cursor_to_h[player_idx] - state.cursor_from_h[player_idx])
-                    .mul_add(t, state.cursor_from_h[player_idx]);
+                let t = state.pane().cursor_t[player_idx].clamp(0.0, 1.0);
+                let cur_x = (state.pane().cursor_to_x[player_idx] - state.pane().cursor_from_x[player_idx])
+                    .mul_add(t, state.pane().cursor_from_x[player_idx]);
+                let cur_y = (state.pane().cursor_to_y[player_idx] - state.pane().cursor_from_y[player_idx])
+                    .mul_add(t, state.pane().cursor_from_y[player_idx]);
+                let cur_w = (state.pane().cursor_to_w[player_idx] - state.pane().cursor_from_w[player_idx])
+                    .mul_add(t, state.pane().cursor_from_w[player_idx]);
+                let cur_h = (state.pane().cursor_to_h[player_idx] - state.pane().cursor_from_h[player_idx])
+                    .mul_add(t, state.pane().cursor_from_h[player_idx]);
 
-                state.cursor_from_x[player_idx] = cur_x;
-                state.cursor_from_y[player_idx] = cur_y;
-                state.cursor_from_w[player_idx] = cur_w;
-                state.cursor_from_h[player_idx] = cur_h;
-                state.cursor_to_x[player_idx] = to_x;
-                state.cursor_to_y[player_idx] = to_y;
-                state.cursor_to_w[player_idx] = to_w;
-                state.cursor_to_h[player_idx] = to_h;
-                state.cursor_t[player_idx] = 0.0;
+                state.pane_mut().cursor_from_x[player_idx] = cur_x;
+                state.pane_mut().cursor_from_y[player_idx] = cur_y;
+                state.pane_mut().cursor_from_w[player_idx] = cur_w;
+                state.pane_mut().cursor_from_h[player_idx] = cur_h;
+                state.pane_mut().cursor_to_x[player_idx] = to_x;
+                state.pane_mut().cursor_to_y[player_idx] = to_y;
+                state.pane_mut().cursor_to_w[player_idx] = to_w;
+                state.pane_mut().cursor_to_h[player_idx] = to_h;
+                state.pane_mut().cursor_t[player_idx] = 0.0;
             }
         }
     }
 
     // Advance cursor tween.
     for player_idx in [P1, P2] {
-        if state.cursor_t[player_idx] < 1.0 {
+        if state.pane().cursor_t[player_idx] < 1.0 {
             if CURSOR_TWEEN_SECONDS > 0.0 {
-                state.cursor_t[player_idx] =
-                    (state.cursor_t[player_idx] + dt / CURSOR_TWEEN_SECONDS).min(1.0);
+                state.pane_mut().cursor_t[player_idx] =
+                    (state.pane().cursor_t[player_idx] + dt / CURSOR_TWEEN_SECONDS).min(1.0);
             } else {
-                state.cursor_t[player_idx] = 1.0;
+                state.pane_mut().cursor_t[player_idx] = 1.0;
             }
         }
     }
@@ -349,12 +349,12 @@ pub(super) fn clear_start_hold(state: &mut State, player_idx: usize) {
 }
 
 pub(super) fn focus_exit_row(state: &mut State, active: [bool; PLAYER_SLOTS], player_idx: usize) {
-    if state.row_map.is_empty() {
+    if state.pane().row_map.is_empty() {
         return;
     }
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    state.selected_row[idx] = state.row_map.len().saturating_sub(1);
-    state.arcade_row_focus[idx] = row_allows_arcade_next_row(state, state.selected_row[idx]);
+    state.pane_mut().selected_row[idx] = state.pane().row_map.len().saturating_sub(1);
+    state.pane_mut().arcade_row_focus[idx] = row_allows_arcade_next_row(state, state.pane().selected_row[idx]);
     sync_selected_rows_with_visibility(state, active);
 }
 
@@ -379,7 +379,7 @@ pub(super) fn handle_nav_event(
     dir: NavDirection,
     pressed: bool,
 ) {
-    if !active[player_idx] || state.row_map.is_empty() {
+    if !active[player_idx] || state.pane().row_map.is_empty() {
         return;
     }
     if pressed {
@@ -399,7 +399,7 @@ pub(super) fn handle_nav_event(
                 if !move_arcade_horizontal_focus(state, asset_manager, player_idx, -1) {
                     apply_choice_delta(state, asset_manager, player_idx, -1);
                     if arcade_row_uses_choice_focus(state, player_idx) {
-                        state.arcade_row_focus[player_idx.min(PLAYER_SLOTS - 1)] = false;
+                        state.pane_mut().arcade_row_focus[player_idx.min(PLAYER_SLOTS - 1)] = false;
                     }
                 }
             }
@@ -407,7 +407,7 @@ pub(super) fn handle_nav_event(
                 if !move_arcade_horizontal_focus(state, asset_manager, player_idx, 1) {
                     apply_choice_delta(state, asset_manager, player_idx, 1);
                     if arcade_row_uses_choice_focus(state, player_idx) {
-                        state.arcade_row_focus[player_idx.min(PLAYER_SLOTS - 1)] = false;
+                        state.pane_mut().arcade_row_focus[player_idx.min(PLAYER_SLOTS - 1)] = false;
                     }
                 }
             }
@@ -446,10 +446,10 @@ pub(super) fn handle_arcade_start_press(
         handle_arcade_prev_event(state, asset_manager, active, player_idx);
         return None;
     }
-    if repeated && !state.row_map.is_empty() {
+    if repeated && !state.pane().row_map.is_empty() {
         let idx = player_idx.min(PLAYER_SLOTS - 1);
-        let row_idx = state.selected_row[idx].min(state.row_map.len().saturating_sub(1));
-        if row_idx + 1 == state.row_map.len() {
+        let row_idx = state.pane().selected_row[idx].min(state.pane().row_map.len().saturating_sub(1));
+        if row_idx + 1 == state.pane().row_map.len() {
             return None;
         }
     }
@@ -489,16 +489,16 @@ pub(super) fn move_arcade_horizontal_focus(
     player_idx: usize,
     delta: isize,
 ) -> bool {
-    if delta == 0 || state.row_map.is_empty() {
+    if delta == 0 || state.pane().row_map.is_empty() {
         return false;
     }
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_idx = state.selected_row[idx].min(state.row_map.len().saturating_sub(1));
-    let Some(row) = state
+    let row_idx = state.pane().selected_row[idx].min(state.pane().row_map.len().saturating_sub(1));
+    let Some(row) = state.pane()
         .row_map
         .display_order()
         .get(row_idx)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
     else {
         return false;
     };
@@ -520,11 +520,11 @@ pub(super) fn move_arcade_horizontal_focus(
     if num_choices <= 1 {
         return false;
     }
-    if state.arcade_row_focus[idx] {
+    if state.pane().arcade_row_focus[idx] {
         if delta < 0 {
             return false;
         }
-        state.arcade_row_focus[idx] = false;
+        state.pane_mut().arcade_row_focus[idx] = false;
         if current_choice == 0 {
             audio::play_sfx("assets/sounds/change_value.ogg");
         } else {
@@ -534,7 +534,7 @@ pub(super) fn move_arcade_horizontal_focus(
     }
     if delta < 0 {
         if current_choice == 0 {
-            state.arcade_row_focus[idx] = true;
+            state.pane_mut().arcade_row_focus[idx] = true;
             audio::play_sfx("assets/sounds/change_value.ogg");
             return true;
         }
@@ -554,17 +554,17 @@ pub(super) fn handle_arcade_prev_event(
     active: [bool; PLAYER_SLOTS],
     player_idx: usize,
 ) {
-    if !active[player_idx] || state.row_map.is_empty() {
+    if !active[player_idx] || state.pane().row_map.is_empty() {
         return;
     }
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let prev_row = state.selected_row[idx];
+    let prev_row = state.pane().selected_row[idx];
     clear_nav_hold(state, player_idx);
     move_selection_vertical(state, asset_manager, active, player_idx, NavDirection::Up);
-    if state.selected_row[idx] != prev_row {
+    if state.pane().selected_row[idx] != prev_row {
         audio::play_sfx("assets/sounds/prev_row.ogg");
         state.help_anim_time[idx] = 0.0;
-        state.prev_selected_row[idx] = state.selected_row[idx];
+        state.pane_mut().prev_selected_row[idx] = state.pane().selected_row[idx];
     }
 }
 
@@ -578,23 +578,23 @@ pub(super) fn handle_arcade_start_event(
         return None;
     }
     sync_selected_rows_with_visibility(state, active);
-    let num_rows = state.row_map.len();
+    let num_rows = state.pane().row_map.len();
     if num_rows == 0 {
         return None;
     }
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.selected_row[idx].min(num_rows.saturating_sub(1));
+    let row_index = state.pane().selected_row[idx].min(num_rows.saturating_sub(1));
     if row_index + 1 == num_rows {
-        state.arcade_row_focus[idx] = row_allows_arcade_next_row(state, row_index);
+        state.pane_mut().arcade_row_focus[idx] = row_allows_arcade_next_row(state, row_index);
         return handle_start_event(state, asset_manager, active, idx);
     }
-    if arcade_row_uses_choice_focus(state, idx) && !state.arcade_row_focus[idx] {
+    if arcade_row_uses_choice_focus(state, idx) && !state.pane().arcade_row_focus[idx] {
         let action = handle_start_event(state, asset_manager, active, idx);
-        state.arcade_row_focus[idx] = row_allows_arcade_next_row(state, row_index);
+        state.pane_mut().arcade_row_focus[idx] = row_allows_arcade_next_row(state, row_index);
         return action;
     }
     move_selection_vertical(state, asset_manager, active, idx, NavDirection::Down);
-    state.arcade_row_focus[idx] = row_allows_arcade_next_row(state, state.selected_row[idx]);
+    state.pane_mut().arcade_row_focus[idx] = row_allows_arcade_next_row(state, state.pane().selected_row[idx]);
     None
 }
 
@@ -608,17 +608,17 @@ pub(super) fn handle_start_event(
         return None;
     }
     sync_selected_rows_with_visibility(state, active);
-    let num_rows = state.row_map.len();
+    let num_rows = state.pane().row_map.len();
     if num_rows == 0 {
         return None;
     }
-    let row_index = state.selected_row[player_idx].min(num_rows.saturating_sub(1));
+    let row_index = state.pane().selected_row[player_idx].min(num_rows.saturating_sub(1));
     let should_focus_exit = state.current_pane == OptionsPane::Main && row_index + 1 < num_rows;
-    let row = state
+    let row = state.pane()
         .row_map
         .display_order()
         .get(row_index)
-        .and_then(|&id| state.row_map.get(id))?;
+        .and_then(|&id| state.pane().row_map.get(id))?;
     let id = row.id;
     let row_supports_inline = row_supports_inline_nav(row);
     let row_toggles = row_toggles_with_start(row);
@@ -633,11 +633,11 @@ pub(super) fn handle_start_event(
         return finish_start_without_action(state, active, player_idx, should_focus_exit);
     }
     if row_index == num_rows.saturating_sub(1)
-        && let Some(what_comes_next_row) = state
+        && let Some(what_comes_next_row) = state.pane()
             .row_map
             .display_order()
             .get(num_rows.saturating_sub(2))
-            .and_then(|&id| state.row_map.get(id))
+            .and_then(|&id| state.pane().row_map.get(id))
         && what_comes_next_row.id == RowId::WhatComesNext
     {
         let choice_idx = what_comes_next_row.selected_choice_index[player_idx];

--- a/src/screens/player_options/layout.rs
+++ b/src/screens/player_options/layout.rs
@@ -245,28 +245,28 @@ pub(super) fn cursor_dest_for_player(
     asset_manager: &AssetManager,
     player_idx: usize,
 ) -> Option<(f32, f32, f32, f32)> {
-    if state.row_map.is_empty() {
+    if state.pane().row_map.is_empty() {
         return None;
     }
     let player_idx = player_idx.min(PLAYER_SLOTS - 1);
     let visibility = row_visibility(
-        &state.row_map,
+        &state.pane().row_map,
         session_active_players(),
         state.hide_active_mask,
         state.error_bar_active_mask,
         state.allow_per_player_global_offsets,
     );
-    let mut row_idx = state.selected_row[player_idx].min(state.row_map.len().saturating_sub(1));
-    if !is_row_visible(&state.row_map, row_idx, visibility) {
-        row_idx = fallback_visible_row(&state.row_map, row_idx, visibility)?;
+    let mut row_idx = state.pane().selected_row[player_idx].min(state.pane().row_map.len().saturating_sub(1));
+    if !is_row_visible(&state.pane().row_map, row_idx, visibility) {
+        row_idx = fallback_visible_row(&state.pane().row_map, row_idx, visibility)?;
     }
-    let row = state
+    let row = state.pane()
         .row_map
         .display_order()
         .get(row_idx)
-        .and_then(|&id| state.row_map.get(id))?;
+        .and_then(|&id| state.pane().row_map.get(id))?;
 
-    let y = state
+    let y = state.pane()
         .row_tweens
         .get(row_idx)
         .map(|tw| tw.to_y)

--- a/src/screens/player_options/mod.rs
+++ b/src/screens/player_options/mod.rs
@@ -115,7 +115,7 @@ pub fn init(
     });
 
     let noteskin_names = discover_noteskin_names();
-    let mut row_map = build_rows(
+    let mut main_row_map = build_rows(
         &song,
         &speed_mod_p1,
         chart_steps_index,
@@ -126,7 +126,31 @@ pub fn init(
         return_screen,
         fixed_stepchart.as_ref(),
     );
+    let mut advanced_row_map = build_rows(
+        &song,
+        &speed_mod_p1,
+        chart_steps_index,
+        preferred_difficulty_index,
+        session_music_rate,
+        OptionsPane::Advanced,
+        &noteskin_names,
+        return_screen,
+        fixed_stepchart.as_ref(),
+    );
+    let mut uncommon_row_map = build_rows(
+        &song,
+        &speed_mod_p1,
+        chart_steps_index,
+        preferred_difficulty_index,
+        session_music_rate,
+        OptionsPane::Uncommon,
+        &noteskin_names,
+        return_screen,
+        fixed_stepchart.as_ref(),
+    );
     let player_profiles = [p1_profile.clone(), p2_profile.clone()];
+    // Masks are computed from the profile and are identical regardless of
+    // which pane's row_map is passed, so capture them from the Main call.
     let (
         scroll_active_mask_p1,
         hide_active_mask_p1,
@@ -145,7 +169,7 @@ pub fn init(
         error_bar_active_mask_p1,
         error_bar_options_active_mask_p1,
         measure_counter_options_active_mask_p1,
-    ) = apply_profile_defaults(&mut row_map, &player_profiles[P1], P1);
+    ) = apply_profile_defaults(&mut main_row_map, &player_profiles[P1], P1);
     let (
         scroll_active_mask_p2,
         hide_active_mask_p2,
@@ -164,7 +188,12 @@ pub fn init(
         error_bar_active_mask_p2,
         error_bar_options_active_mask_p2,
         measure_counter_options_active_mask_p2,
-    ) = apply_profile_defaults(&mut row_map, &player_profiles[P2], P2);
+    ) = apply_profile_defaults(&mut main_row_map, &player_profiles[P2], P2);
+    // Populate selected_choice_index for the other panes (mask returns dropped).
+    let _ = apply_profile_defaults(&mut advanced_row_map, &player_profiles[P1], P1);
+    let _ = apply_profile_defaults(&mut advanced_row_map, &player_profiles[P2], P2);
+    let _ = apply_profile_defaults(&mut uncommon_row_map, &player_profiles[P1], P1);
+    let _ = apply_profile_defaults(&mut uncommon_row_map, &player_profiles[P2], P2);
 
     let cols_per_player = noteskin_cols_per_player(crate::game::profile::get_session_play_style());
     let mut initial_noteskin_names = vec![crate::game::profile::NoteSkin::DEFAULT_NAME.to_string()];
@@ -215,23 +244,28 @@ pub fn init(
             )
         });
     let active = session_active_players();
-    let row_tweens = init_row_tweens(
-        &row_map,
+    let main_row_tweens = init_row_tweens(
+        &main_row_map,
         [0; PLAYER_SLOTS],
         active,
         [hide_active_mask_p1, hide_active_mask_p2],
         [error_bar_active_mask_p1, error_bar_active_mask_p2],
         allow_per_player_global_offsets,
     );
+    let mut panes = [
+        PaneState::new(main_row_map),
+        PaneState::new(advanced_row_map),
+        PaneState::new(uncommon_row_map),
+    ];
+    panes[OptionsPane::Main.index()].row_tweens = main_row_tweens;
+    panes[OptionsPane::Main.index()].arcade_row_focus = [true; PLAYER_SLOTS];
     State {
         song,
         return_screen,
         fixed_stepchart,
         chart_steps_index,
         chart_difficulty_index,
-        row_map,
-        selected_row: [0; PLAYER_SLOTS],
-        prev_selected_row: [0; PLAYER_SLOTS],
+        panes,
         scroll_active_mask: [scroll_active_mask_p1, scroll_active_mask_p2],
         hide_active_mask: [hide_active_mask_p1, hide_active_mask_p2],
         insert_active_mask: [insert_active_mask_p1, insert_active_mask_p2],
@@ -278,8 +312,6 @@ pub fn init(
         nav_key_last_scrolled_at: [None; PLAYER_SLOTS],
         start_held_since: [None; PLAYER_SLOTS],
         start_last_triggered_at: [None; PLAYER_SLOTS],
-        inline_choice_x: [f32::NAN; PLAYER_SLOTS],
-        arcade_row_focus: [true; PLAYER_SLOTS],
         allow_per_player_global_offsets,
         player_profiles,
         noteskin_names,
@@ -293,17 +325,6 @@ pub fn init(
         help_anim_time: [0.0; PLAYER_SLOTS],
         combo_preview_count: 0,
         combo_preview_elapsed: 0.0,
-        cursor_initialized: [false; PLAYER_SLOTS],
-        cursor_from_x: [0.0; PLAYER_SLOTS],
-        cursor_from_y: [0.0; PLAYER_SLOTS],
-        cursor_from_w: [0.0; PLAYER_SLOTS],
-        cursor_from_h: [0.0; PLAYER_SLOTS],
-        cursor_to_x: [0.0; PLAYER_SLOTS],
-        cursor_to_y: [0.0; PLAYER_SLOTS],
-        cursor_to_w: [0.0; PLAYER_SLOTS],
-        cursor_to_h: [0.0; PLAYER_SLOTS],
-        cursor_t: [1.0; PLAYER_SLOTS],
-        row_tweens,
         pane_transition: PaneTransition::None,
         menu_lr_chord: screen_input::MenuLrChordTracker::default(),
     }

--- a/src/screens/player_options/pane.rs
+++ b/src/screens/player_options/pane.rs
@@ -13,6 +13,24 @@ pub enum OptionsPane {
     Uncommon,
 }
 
+impl OptionsPane {
+    pub(super) const COUNT: usize = 3;
+
+    #[inline(always)]
+    pub(super) const fn index(self) -> usize {
+        self as usize
+    }
+
+    #[inline(always)]
+    pub(super) const fn from_index(idx: usize) -> Self {
+        match idx {
+            0 => Self::Main,
+            1 => Self::Advanced,
+            _ => Self::Uncommon,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(super) enum PaneTransition {
     None,

--- a/src/screens/player_options/panes/advanced.rs
+++ b/src/screens/player_options/panes/advanced.rs
@@ -215,7 +215,7 @@ const JUDGMENT_TILT_INTENSITY: CustomBinding = CustomBinding {
         let Some(new_index) = super::super::choice::cycle_choice_index(state, player_idx, row_id, delta) else {
             return Outcome::NONE;
         };
-        let Some(choice) = state
+        let Some(choice) = state.pane()
             .row_map
             .get(row_id)
             .and_then(|r| r.choices.get(new_index))
@@ -257,7 +257,7 @@ const CUSTOM_BLUE_FANTASTIC_WINDOW_MS: CustomBinding = CustomBinding {
         let Some(new_index) = super::super::choice::cycle_choice_index(state, player_idx, row_id, delta) else {
             return Outcome::NONE;
         };
-        let Some(choice) = state
+        let Some(choice) = state.pane()
             .row_map
             .get(row_id)
             .and_then(|r| r.choices.get(new_index))

--- a/src/screens/player_options/panes/main.rs
+++ b/src/screens/player_options/panes/main.rs
@@ -144,7 +144,7 @@ const MUSIC_RATE: CustomBinding = CustomBinding {
         state.music_rate = (state.music_rate / increment).round() * increment;
         state.music_rate = state.music_rate.clamp(0.05, 3.00);
         let formatted = fmt_music_rate(state.music_rate);
-        if let Some(row) = state.row_map.get_mut(row_id) {
+        if let Some(row) = state.pane_mut().row_map.get_mut(row_id) {
             row.choices[0] = formatted;
             for slot in 0..PLAYER_SLOTS {
                 row.selected_choice_index[slot] = 0;
@@ -225,7 +225,7 @@ const MINI: CustomBinding = CustomBinding {
         let Some(new_index) = super::super::choice::cycle_choice_index(state, player_idx, row_id, delta) else {
             return Outcome::NONE;
         };
-        let Some(choice) = state
+        let Some(choice) = state.pane()
             .row_map
             .get(row_id)
             .and_then(|r| r.choices.get(new_index))
@@ -293,7 +293,7 @@ const STEPCHART: CustomBinding = CustomBinding {
             return Outcome::NONE;
         };
         let difficulty_idx = {
-            let Some(row) = state.row_map.get(row_id) else {
+            let Some(row) = state.pane().row_map.get(row_id) else {
                 return Outcome::persisted();
             };
             let Some(diff_indices) = &row.choice_difficulty_indices else {

--- a/src/screens/player_options/render.rs
+++ b/src/screens/player_options/render.rs
@@ -159,7 +159,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     let help_box_w = widescale(614.0, 792.0);
     let help_box_x = widescale(13.0, 30.666);
     let help_box_bottom_y = screen_height() - 36.0;
-    let total_rows = state.row_map.len();
+    let total_rows = state.pane().row_map.len();
     let frame_h = ROW_HEIGHT;
     let (fallback_y0, fallback_row_step) = row_layout_params();
     let row_alpha_cutoff: f32 = 0.001;
@@ -174,23 +174,23 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     // Keep header labels bounded to the title column so they never overlap option values.
     let title_max_w = (TITLE_BG_WIDTH - title_left_pad - 5.0).max(0.0);
     let cursor_now = |player_idx: usize| -> Option<(f32, f32, f32, f32)> {
-        if player_idx >= PLAYER_SLOTS || !state.cursor_initialized[player_idx] {
+        if player_idx >= PLAYER_SLOTS || !state.pane().cursor_initialized[player_idx] {
             return None;
         }
-        let t = state.cursor_t[player_idx].clamp(0.0, 1.0);
-        let x = (state.cursor_to_x[player_idx] - state.cursor_from_x[player_idx])
-            .mul_add(t, state.cursor_from_x[player_idx]);
-        let y = (state.cursor_to_y[player_idx] - state.cursor_from_y[player_idx])
-            .mul_add(t, state.cursor_from_y[player_idx]);
-        let w = (state.cursor_to_w[player_idx] - state.cursor_from_w[player_idx])
-            .mul_add(t, state.cursor_from_w[player_idx]);
-        let h = (state.cursor_to_h[player_idx] - state.cursor_from_h[player_idx])
-            .mul_add(t, state.cursor_from_h[player_idx]);
+        let t = state.pane().cursor_t[player_idx].clamp(0.0, 1.0);
+        let x = (state.pane().cursor_to_x[player_idx] - state.pane().cursor_from_x[player_idx])
+            .mul_add(t, state.pane().cursor_from_x[player_idx]);
+        let y = (state.pane().cursor_to_y[player_idx] - state.pane().cursor_from_y[player_idx])
+            .mul_add(t, state.pane().cursor_from_y[player_idx]);
+        let w = (state.pane().cursor_to_w[player_idx] - state.pane().cursor_from_w[player_idx])
+            .mul_add(t, state.pane().cursor_from_w[player_idx]);
+        let h = (state.pane().cursor_to_h[player_idx] - state.pane().cursor_from_h[player_idx])
+            .mul_add(t, state.pane().cursor_from_h[player_idx]);
         Some((x, y, w, h))
     };
 
     for item_idx in 0..total_rows {
-        let (current_row_y, row_alpha) = state
+        let (current_row_y, row_alpha) = state.pane()
             .row_tweens
             .get(item_idx)
             .map(|tw| (tw.y(), tw.a()))
@@ -206,9 +206,9 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
         }
         let a = row_alpha;
 
-        let is_active = (active[P1] && item_idx == state.selected_row[P1])
-            || (active[P2] && item_idx == state.selected_row[P2]);
-        let row = state.row_map.row(state.row_map.id_at(item_idx));
+        let is_active = (active[P1] && item_idx == state.pane().selected_row[P1])
+            || (active[P2] && item_idx == state.pane().selected_row[P2]);
+        let row = state.pane().row_map.row(state.pane().row_map.id_at(item_idx));
         let active_bg = color::rgba_hex("#333333");
         let inactive_bg_base = color::rgba_hex("#071016");
         let bg_color = if is_active {
@@ -314,7 +314,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
             if is_active {
                 let border_w = widescale(2.0, 2.5);
                 for player_idx in active_player_indices(active) {
-                    if state.selected_row[player_idx] != item_idx {
+                    if state.pane().selected_row[player_idx] != item_idx {
                         continue;
                     }
                     let Some((center_x, center_y, ring_w, ring_h)) = cursor_now(player_idx) else {
@@ -1054,7 +1054,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
             if !widths.is_empty() {
                 let border_w = widescale(2.0, 2.5);
                 for player_idx in active_player_indices(active) {
-                    if state.selected_row[player_idx] != item_idx {
+                    if state.pane().selected_row[player_idx] != item_idx {
                         continue;
                     }
                     let Some((center_x, center_y, ring_w, ring_h)) = cursor_now(player_idx) else {
@@ -1191,7 +1191,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                         z(101)
                     ));
                     // Encircling cursor around the active option value (programmatic border)
-                    if active[primary_player_idx] && state.selected_row[primary_player_idx] == item_idx {
+                    if active[primary_player_idx] && state.pane().selected_row[primary_player_idx] == item_idx {
                         let border_w = widescale(2.0, 2.5);
                         if let Some((center_x, center_y, ring_w, ring_h)) =
                             cursor_now(primary_player_idx)
@@ -1276,7 +1276,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                             diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
                             z(101)
                         ));
-                        if active[P2] && state.selected_row[P2] == item_idx {
+                        if active[P2] && state.pane().selected_row[P2] == item_idx {
                             let border_w = widescale(2.0, 2.5);
                             if let Some((center_x, center_y, ring_w, ring_h)) = cursor_now(P2) {
                                 let left = center_x - ring_w * 0.5;
@@ -1980,12 +1980,12 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     const REVEAL_DURATION: f32 = 0.5;
     let split_help = active[P1] && active[P2];
     for player_idx in active_player_indices(active) {
-        let row_idx = state.selected_row[player_idx].min(state.row_map.len().saturating_sub(1));
-        let Some(row) = state
+        let row_idx = state.pane().selected_row[player_idx].min(state.pane().row_map.len().saturating_sub(1));
+        let Some(row) = state.pane()
             .row_map
             .display_order()
             .get(row_idx)
-            .and_then(|&id| state.row_map.get(id))
+            .and_then(|&id| state.pane().row_map.get(id))
         else {
             continue;
         };

--- a/src/screens/player_options/state.rs
+++ b/src/screens/player_options/state.rs
@@ -27,9 +27,7 @@ pub struct State {
     pub fixed_stepchart: Option<FixedStepchart>,
     pub chart_steps_index: [usize; PLAYER_SLOTS],
     pub chart_difficulty_index: [usize; PLAYER_SLOTS],
-    pub row_map: RowMap,
-    pub selected_row: [usize; PLAYER_SLOTS],
-    pub prev_selected_row: [usize; PLAYER_SLOTS],
+    pub(super) panes: [PaneState; OptionsPane::COUNT],
     // For Scroll row: bitmask of which options are enabled.
     // 0 => Normal scroll (no special modifier).
     pub scroll_active_mask: [u8; PLAYER_SLOTS],
@@ -101,8 +99,6 @@ pub struct State {
     pub nav_key_last_scrolled_at: [Option<Instant>; PLAYER_SLOTS],
     pub start_held_since: [Option<Instant>; PLAYER_SLOTS],
     pub start_last_triggered_at: [Option<Instant>; PLAYER_SLOTS],
-    pub(super) inline_choice_x: [f32; PLAYER_SLOTS],
-    pub(super) arcade_row_focus: [bool; PLAYER_SLOTS],
     pub(super) allow_per_player_global_offsets: bool,
     pub player_profiles: [crate::game::profile::Profile; PLAYER_SLOTS],
     pub(super) noteskin_names: Vec<String>,
@@ -117,6 +113,20 @@ pub struct State {
     // Combo preview state (for Combo Font row)
     pub(super) combo_preview_count: u32,
     pub(super) combo_preview_elapsed: f32,
+    pub(super) pane_transition: PaneTransition,
+    pub(super) menu_lr_chord: screen_input::MenuLrChordTracker,
+}
+
+/// Per-pane state. Each pane keeps its own row map, cursor, and tween state so
+/// switching panes never throws away rebuilt data. `current_pane` on `State`
+/// indexes into `State::panes`.
+pub struct PaneState {
+    pub row_map: RowMap,
+    pub selected_row: [usize; PLAYER_SLOTS],
+    pub prev_selected_row: [usize; PLAYER_SLOTS],
+    pub(super) inline_choice_x: [f32; PLAYER_SLOTS],
+    pub(super) arcade_row_focus: [bool; PLAYER_SLOTS],
+    pub(super) row_tweens: Vec<RowTween>,
     // Cursor ring tween (StopTweening/BeginTweening parity with ITGmania ScreenOptions::TweenCursor).
     pub(super) cursor_initialized: [bool; PLAYER_SLOTS],
     pub(super) cursor_from_x: [f32; PLAYER_SLOTS],
@@ -128,7 +138,59 @@ pub struct State {
     pub(super) cursor_to_w: [f32; PLAYER_SLOTS],
     pub(super) cursor_to_h: [f32; PLAYER_SLOTS],
     pub(super) cursor_t: [f32; PLAYER_SLOTS],
-    pub(super) row_tweens: Vec<RowTween>,
-    pub(super) pane_transition: PaneTransition,
-    pub(super) menu_lr_chord: screen_input::MenuLrChordTracker,
+}
+
+impl PaneState {
+    pub(super) fn new(row_map: RowMap) -> Self {
+        Self {
+            row_map,
+            selected_row: [0; PLAYER_SLOTS],
+            prev_selected_row: [0; PLAYER_SLOTS],
+            inline_choice_x: [f32::NAN; PLAYER_SLOTS],
+            arcade_row_focus: [false; PLAYER_SLOTS],
+            row_tweens: Vec::new(),
+            cursor_initialized: [false; PLAYER_SLOTS],
+            cursor_from_x: [0.0; PLAYER_SLOTS],
+            cursor_from_y: [0.0; PLAYER_SLOTS],
+            cursor_from_w: [0.0; PLAYER_SLOTS],
+            cursor_from_h: [0.0; PLAYER_SLOTS],
+            cursor_to_x: [0.0; PLAYER_SLOTS],
+            cursor_to_y: [0.0; PLAYER_SLOTS],
+            cursor_to_w: [0.0; PLAYER_SLOTS],
+            cursor_to_h: [0.0; PLAYER_SLOTS],
+            cursor_t: [1.0; PLAYER_SLOTS],
+        }
+    }
+
+    /// Reset cursor + per-player navigation state, keeping `row_map` intact.
+    /// Used when entering a pane: the row map persists across pane switches,
+    /// but cursor position does not.
+    pub(super) fn reset_cursor(&mut self) {
+        self.selected_row = [0; PLAYER_SLOTS];
+        self.prev_selected_row = [0; PLAYER_SLOTS];
+        self.inline_choice_x = [f32::NAN; PLAYER_SLOTS];
+        self.arcade_row_focus = [false; PLAYER_SLOTS];
+        self.cursor_initialized = [false; PLAYER_SLOTS];
+        self.cursor_from_x = [0.0; PLAYER_SLOTS];
+        self.cursor_from_y = [0.0; PLAYER_SLOTS];
+        self.cursor_from_w = [0.0; PLAYER_SLOTS];
+        self.cursor_from_h = [0.0; PLAYER_SLOTS];
+        self.cursor_to_x = [0.0; PLAYER_SLOTS];
+        self.cursor_to_y = [0.0; PLAYER_SLOTS];
+        self.cursor_to_w = [0.0; PLAYER_SLOTS];
+        self.cursor_to_h = [0.0; PLAYER_SLOTS];
+        self.cursor_t = [1.0; PLAYER_SLOTS];
+    }
+}
+
+impl State {
+    #[inline(always)]
+    pub(crate) fn pane(&self) -> &PaneState {
+        &self.panes[self.current_pane.index()]
+    }
+
+    #[inline(always)]
+    pub(crate) fn pane_mut(&mut self) -> &mut PaneState {
+        &mut self.panes[self.current_pane.index()]
+    }
 }

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -212,9 +212,9 @@ pub(super) mod tests {
 
         let mut state = super::init(song, [0; 2], [0; 2], 1, Screen::SelectMusic, None);
         let active = session_active_players();
-        let first_row = state.selected_row[P1];
+        let first_row = state.pane().selected_row[P1];
         assert!(handle_arcade_start_event(&mut state, &asset_manager, active, P1).is_none());
-        let second_row = state.selected_row[P1];
+        let second_row = state.pane().selected_row[P1];
         assert!(second_row > first_row);
 
         let now = Instant::now();
@@ -223,7 +223,7 @@ pub(super) mod tests {
             Some(now - NAV_REPEAT_SCROLL_INTERVAL - Duration::from_millis(1));
 
         assert!(repeat_held_arcade_start(&mut state, &asset_manager, active, P1, now).is_none());
-        assert!(state.selected_row[P1] > second_row);
+        assert!(state.pane().selected_row[P1] > second_row);
     }
 
     #[test]
@@ -243,9 +243,9 @@ pub(super) mod tests {
 
         let mut state = super::init(song, [0; 2], [0; 2], 1, Screen::SelectMusic, None);
         let active = session_active_players();
-        let last_row = state.row_map.len().saturating_sub(1);
-        state.selected_row[P1] = last_row;
-        state.prev_selected_row[P1] = last_row;
+        let last_row = state.pane().row_map.len().saturating_sub(1);
+        state.pane_mut().selected_row[P1] = last_row;
+        state.pane_mut().prev_selected_row[P1] = last_row;
 
         let now = Instant::now();
         state.start_held_since[P1] = Some(now - NAV_INITIAL_HOLD_DELAY - Duration::from_millis(1));
@@ -253,7 +253,7 @@ pub(super) mod tests {
             Some(now - NAV_REPEAT_SCROLL_INTERVAL - Duration::from_millis(1));
 
         assert!(repeat_held_arcade_start(&mut state, &asset_manager, active, P1, now).is_none());
-        assert_eq!(state.selected_row[P1], last_row);
+        assert_eq!(state.pane().selected_row[P1], last_row);
     }
 
     fn setup_state() -> (super::State, AssetManager) {
@@ -275,7 +275,7 @@ pub(super) mod tests {
         ensure_i18n();
         let (mut state, asset_manager) = setup_state();
 
-        let row_index = state
+        let row_index = state.pane()
             .row_map
             .display_order()
             .iter()
@@ -283,9 +283,9 @@ pub(super) mod tests {
             .expect("BackgroundFilter should be in Main pane");
 
         // Pre-set to Off (index 0) so we can detect a write
-        state.row_map.get_mut(RowId::BackgroundFilter).unwrap().selected_choice_index[P1] = 0;
+        state.pane_mut().row_map.get_mut(RowId::BackgroundFilter).unwrap().selected_choice_index[P1] = 0;
         state.player_profiles[P1].background_filter = BackgroundFilter::Darkest;
-        state.selected_row[P1] = row_index;
+        state.pane_mut().selected_row[P1] = row_index;
 
         // delta=0 should still apply the current choice
         super::change_choice_for_player(&mut state, &asset_manager, P1, 0);
@@ -302,19 +302,19 @@ pub(super) mod tests {
         ensure_i18n();
         let (mut state, asset_manager) = setup_state();
 
-        let row_index = state
+        let row_index = state.pane()
             .row_map
             .display_order()
             .iter()
             .position(|&id| id == RowId::WhatComesNext)
             .expect("WhatComesNext should be in Main pane");
 
-        state.selected_row[P1] = row_index;
-        let initial = state.row_map.get(RowId::WhatComesNext).unwrap().selected_choice_index[P1];
+        state.pane_mut().selected_row[P1] = row_index;
+        let initial = state.pane().row_map.get(RowId::WhatComesNext).unwrap().selected_choice_index[P1];
 
         super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
 
-        let row = state.row_map.get(RowId::WhatComesNext).unwrap();
+        let row = state.pane().row_map.get(RowId::WhatComesNext).unwrap();
         let n = row.choices.len();
         let expected = (initial + 1) % n;
         assert_eq!(row.selected_choice_index[0], expected, "P1 slot should advance");
@@ -341,10 +341,10 @@ pub(super) mod tests {
             help: Vec::new(),
             choice_difficulty_indices: None,
         };
-        state.row_map.display_order.push(RowId::Scroll);
-        state.row_map.insert(scroll_row);
-        let row_index = state.row_map.display_order().len() - 1;
-        state.selected_row[P1] = row_index;
+        state.pane_mut().row_map.display_order.push(RowId::Scroll);
+        state.pane_mut().row_map.insert(scroll_row);
+        let row_index = state.pane().row_map.display_order().len() - 1;
+        state.pane_mut().selected_row[P1] = row_index;
         state.scroll_active_mask[P1] = 0;
 
         let active = session_active_players();
@@ -384,23 +384,23 @@ pub(super) mod tests {
             &["1.0", "2.0"],
             [0, 0],
         );
-        state.row_map.display_order.push(RowId::JudgmentTilt);
-        state.row_map.insert(tilt_row);
-        state.row_map.display_order.push(RowId::JudgmentTiltIntensity);
-        state.row_map.insert(tilt_intensity_row);
+        state.pane_mut().row_map.display_order.push(RowId::JudgmentTilt);
+        state.pane_mut().row_map.insert(tilt_row);
+        state.pane_mut().row_map.display_order.push(RowId::JudgmentTiltIntensity);
+        state.pane_mut().row_map.insert(tilt_intensity_row);
 
-        let row_index = state
+        let row_index = state.pane()
             .row_map
             .display_order()
             .iter()
             .position(|&id| id == RowId::JudgmentTilt)
             .unwrap();
-        state.selected_row[P1] = row_index;
+        state.pane_mut().selected_row[P1] = row_index;
 
         let active = session_active_players();
         // Initially JudgmentTilt=0 (off) so JudgmentTiltIntensity should be hidden.
         assert!(
-            !judgment_tilt_intensity_visible(&state.row_map, active),
+            !judgment_tilt_intensity_visible(&state.pane().row_map, active),
             "JudgmentTiltIntensity should start hidden"
         );
 
@@ -408,7 +408,7 @@ pub(super) mod tests {
         super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
 
         assert!(
-            judgment_tilt_intensity_visible(&state.row_map, active),
+            judgment_tilt_intensity_visible(&state.pane().row_map, active),
             "JudgmentTiltIntensity should be visible after enabling JudgmentTilt"
         );
     }
@@ -418,7 +418,7 @@ pub(super) mod tests {
         ensure_i18n();
         let (mut state, asset_manager) = setup_state();
 
-        let row_index = state
+        let row_index = state.pane()
             .row_map
             .display_order()
             .iter()
@@ -426,15 +426,15 @@ pub(super) mod tests {
             .expect("BackgroundFilter should be in Main pane");
 
         // Pin both slots at index 0 so a P1 advance is unambiguously detectable.
-        let row = state.row_map.get_mut(RowId::BackgroundFilter).unwrap();
+        let row = state.pane_mut().row_map.get_mut(RowId::BackgroundFilter).unwrap();
         row.selected_choice_index = [0, 0];
         let n = row.choices.len();
         assert!(n >= 2, "BackgroundFilter should have at least 2 choices");
-        state.selected_row[P1] = row_index;
+        state.pane_mut().selected_row[P1] = row_index;
 
         super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
 
-        let row = state.row_map.get(RowId::BackgroundFilter).unwrap();
+        let row = state.pane().row_map.get(RowId::BackgroundFilter).unwrap();
         assert_eq!(row.selected_choice_index[0], 1, "P1 should have advanced");
         assert_eq!(
             row.selected_choice_index[1], 0,
@@ -447,15 +447,15 @@ pub(super) mod tests {
         ensure_i18n();
         let (mut state, asset_manager) = setup_state();
 
-        let row_index = state
+        let row_index = state.pane()
             .row_map
             .display_order()
             .iter()
             .position(|&id| id == RowId::BackgroundFilter)
             .expect("BackgroundFilter should be in Main pane");
-        state.selected_row[P1] = row_index;
+        state.pane_mut().selected_row[P1] = row_index;
 
-        let n = state
+        let n = state.pane()
             .row_map
             .get(RowId::BackgroundFilter)
             .unwrap()
@@ -464,19 +464,19 @@ pub(super) mod tests {
         assert!(n >= 2, "wrap test needs at least 2 choices");
 
         // Forward wrap: last → 0
-        state.row_map.get_mut(RowId::BackgroundFilter).unwrap().selected_choice_index[P1] = n - 1;
+        state.pane_mut().row_map.get_mut(RowId::BackgroundFilter).unwrap().selected_choice_index[P1] = n - 1;
         super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
         assert_eq!(
-            state.row_map.get(RowId::BackgroundFilter).unwrap().selected_choice_index[P1],
+            state.pane().row_map.get(RowId::BackgroundFilter).unwrap().selected_choice_index[P1],
             0,
             "delta=+1 at last index should wrap to 0"
         );
 
         // Backward wrap: 0 → last
-        state.row_map.get_mut(RowId::BackgroundFilter).unwrap().selected_choice_index[P1] = 0;
+        state.pane_mut().row_map.get_mut(RowId::BackgroundFilter).unwrap().selected_choice_index[P1] = 0;
         super::change_choice_for_player(&mut state, &asset_manager, P1, -1);
         assert_eq!(
-            state.row_map.get(RowId::BackgroundFilter).unwrap().selected_choice_index[P1],
+            state.pane().row_map.get(RowId::BackgroundFilter).unwrap().selected_choice_index[P1],
             n - 1,
             "delta=-1 at index 0 should wrap to last"
         );
@@ -487,22 +487,22 @@ pub(super) mod tests {
         ensure_i18n();
         let (mut state, asset_manager) = setup_state();
 
-        let row_index = state
+        let row_index = state.pane()
             .row_map
             .display_order()
             .iter()
             .position(|&id| id == RowId::Exit)
             .expect("Exit should be in Main pane");
-        state.selected_row[P1] = row_index;
+        state.pane_mut().selected_row[P1] = row_index;
 
-        let before = state.row_map.get(RowId::Exit).unwrap().selected_choice_index;
+        let before = state.pane().row_map.get(RowId::Exit).unwrap().selected_choice_index;
 
         // Action::Exit returns Outcome::NONE so the dispatcher must not panic,
         // mutate the row, or play SFX (which would panic — audio uninit in tests).
         super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
         super::change_choice_for_player(&mut state, &asset_manager, P1, -3);
 
-        let after = state.row_map.get(RowId::Exit).unwrap().selected_choice_index;
+        let after = state.pane().row_map.get(RowId::Exit).unwrap().selected_choice_index;
         assert_eq!(before, after, "Action::Exit must not advance its own choice index");
     }
 
@@ -527,10 +527,10 @@ pub(super) mod tests {
             help: Vec::new(),
             choice_difficulty_indices: None,
         };
-        state.row_map.display_order.push(RowId::Scroll);
-        state.row_map.insert(scroll_row);
-        let row_index = state.row_map.display_order().len() - 1;
-        state.selected_row[P1] = row_index;
+        state.pane_mut().row_map.display_order.push(RowId::Scroll);
+        state.pane_mut().row_map.insert(scroll_row);
+        let row_index = state.pane().row_map.display_order().len() - 1;
+        state.pane_mut().selected_row[P1] = row_index;
         state.scroll_active_mask = [0, 0];
 
         // L/R on a bitmask row returns Outcome::NONE — mask must not change,
@@ -544,7 +544,7 @@ pub(super) mod tests {
         );
         // selected_choice_index is also untouched (cycle_choice_index never runs)
         assert_eq!(
-            state.row_map.get(RowId::Scroll).unwrap().selected_choice_index,
+            state.pane().row_map.get(RowId::Scroll).unwrap().selected_choice_index,
             [2, 0],
             "Bitmask delta must not advance the row's selected_choice_index either"
         );

--- a/src/screens/player_options/visibility.rs
+++ b/src/screens/player_options/visibility.rs
@@ -391,28 +391,28 @@ pub(super) fn parent_anchor_visible_index(
 }
 
 pub(super) fn sync_selected_rows_with_visibility(state: &mut State, active: [bool; PLAYER_SLOTS]) {
-    if state.row_map.is_empty() {
-        state.selected_row = [0; PLAYER_SLOTS];
-        state.prev_selected_row = [0; PLAYER_SLOTS];
+    if state.pane().row_map.is_empty() {
+        state.pane_mut().selected_row = [0; PLAYER_SLOTS];
+        state.pane_mut().prev_selected_row = [0; PLAYER_SLOTS];
         return;
     }
     let visibility = row_visibility(
-        &state.row_map,
+        &state.pane().row_map,
         active,
         state.hide_active_mask,
         state.error_bar_active_mask,
         state.allow_per_player_global_offsets,
     );
     for player_idx in [P1, P2] {
-        let idx = state.selected_row[player_idx].min(state.row_map.len().saturating_sub(1));
-        if is_row_visible(&state.row_map, idx, visibility) {
-            state.selected_row[player_idx] = idx;
+        let idx = state.pane().selected_row[player_idx].min(state.pane().row_map.len().saturating_sub(1));
+        if is_row_visible(&state.pane().row_map, idx, visibility) {
+            state.pane_mut().selected_row[player_idx] = idx;
             continue;
         }
-        if let Some(fallback) = fallback_visible_row(&state.row_map, idx, visibility) {
-            state.selected_row[player_idx] = fallback;
+        if let Some(fallback) = fallback_visible_row(&state.pane().row_map, idx, visibility) {
+            state.pane_mut().selected_row[player_idx] = fallback;
             if active[player_idx] {
-                state.prev_selected_row[player_idx] = fallback;
+                state.pane_mut().prev_selected_row[player_idx] = fallback;
             }
         }
     }
@@ -422,7 +422,7 @@ pub(super) fn sync_selected_rows_with_visibility(state: &mut State, active: [boo
 pub(super) fn row_allows_arcade_next_row(state: &State, row_idx: usize) -> bool {
     arcade_options_navigation_active()
         && pane_uses_arcade_next_row(state.current_pane)
-        && state
+        && state.pane()
             .row_map
             .get_at(row_idx)
             .is_some_and(|row| row.id != RowId::Exit && row_supports_inline_nav(row))
@@ -434,11 +434,11 @@ pub(super) fn arcade_row_uses_choice_focus(state: &State, player_idx: usize) -> 
         return false;
     }
     let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_idx = state.selected_row[idx].min(state.row_map.len().saturating_sub(1));
-    state
+    let row_idx = state.pane().selected_row[idx].min(state.pane().row_map.len().saturating_sub(1));
+    state.pane()
         .row_map
         .display_order()
         .get(row_idx)
-        .and_then(|&id| state.row_map.get(id))
+        .and_then(|&id| state.pane().row_map.get(id))
         .is_some_and(row_supports_inline_nav)
 }

--- a/src/test_support/player_options_bench.rs
+++ b/src/test_support/player_options_bench.rs
@@ -37,20 +37,20 @@ pub fn fixture() -> PlayerOptionsBenchFixture {
 
     let mut state = player_options::init(song, [0; 2], [0; 2], 1, Screen::SelectMusic, None);
 
-    let perspective_row = state
+    let perspective_row = state.pane()
         .row_map
         .display_order()
         .iter()
         .position(|&id| id == RowId::Perspective)
         .unwrap_or(0);
-    let background_filter_row = state
+    let background_filter_row = state.pane()
         .row_map
         .display_order()
         .iter()
         .position(|&id| id == RowId::BackgroundFilter)
         .unwrap_or(perspective_row);
-    state.selected_row = [perspective_row, background_filter_row];
-    state.prev_selected_row = state.selected_row;
+    state.pane_mut().selected_row = [perspective_row, background_filter_row];
+    state.pane_mut().prev_selected_row = state.pane().selected_row;
     let _ = player_options::update(&mut state, 1.0, &asset_manager);
     let _ = player_options::update(&mut state, 1.0, &asset_manager);
 


### PR DESCRIPTION
# refactor(player-options): per-pane `RowMap` and cursor in `PaneState`

## Summary

Today `State` owns a single `row_map: RowMap` plus a flat set of per-pane working fields — `selected_row`, `prev_selected_row`, `inline_choice_x`, `arcade_row_focus`, `row_tweens`, and the nine `cursor_*` tween fields. Switching panes calls `apply_pane`, which throws away the current `row_map`, rebuilds it from scratch with `build_rows`, runs `apply_profile_defaults` twice (once per player) to recompute all 17 `*_active_mask` values, then resets every per-pane field. Every pane switch pays the full cost of rebuilding state that was already correct moments before.

This PR gives each pane its own working state. A new `PaneState` struct holds the row map, cursor tween, row tweens, and per-player navigation fields, and `State` stores them as `panes: [PaneState; 3]` indexed by `current_pane`. All three pane row maps are built once at `init`. The bitmask fields stay top-level on `State` and are kept in sync incrementally by the existing `toggle_*_row` handlers, so they no longer need recomputation on switch. `apply_pane` shrinks to a structural operation: change `current_pane`, reset the destination pane's cursor (preserving the existing reset-on-entry behaviour), and refresh that pane's row tweens for the new layout.

## What changes

### New `PaneState` and accessors (`state.rs`)

```rust
pub struct PaneState {
    pub row_map: RowMap,
    pub selected_row: [usize; PLAYER_SLOTS],
    pub prev_selected_row: [usize; PLAYER_SLOTS],
    pub(super) inline_choice_x: [f32; PLAYER_SLOTS],
    pub(super) arcade_row_focus: [bool; PLAYER_SLOTS],
    pub(super) row_tweens: Vec<RowTween>,
    // Cursor ring tween (StopTweening/BeginTweening parity with
    // ITGmania ScreenOptions::TweenCursor):
    pub(super) cursor_initialized: [bool; PLAYER_SLOTS],
    pub(super) cursor_from_x: [f32; PLAYER_SLOTS],
    pub(super) cursor_from_y: [f32; PLAYER_SLOTS],
    pub(super) cursor_from_w: [f32; PLAYER_SLOTS],
    pub(super) cursor_from_h: [f32; PLAYER_SLOTS],
    pub(super) cursor_to_x: [f32; PLAYER_SLOTS],
    pub(super) cursor_to_y: [f32; PLAYER_SLOTS],
    pub(super) cursor_to_w: [f32; PLAYER_SLOTS],
    pub(super) cursor_to_h: [f32; PLAYER_SLOTS],
    pub(super) cursor_t: [f32; PLAYER_SLOTS],
}

impl PaneState {
    pub(super) fn new(row_map: RowMap) -> Self { /* ... */ }
    pub(super) fn reset_cursor(&mut self) { /* selected_row, cursor_*, ... */ }
}

impl State {
    pub(crate) fn pane(&self) -> &PaneState { &self.panes[self.current_pane.index()] }
    pub(crate) fn pane_mut(&mut self) -> &mut PaneState { /* ... */ }
}
```

### `State` shrinks

The 16 per-pane fields move out of `State`. What remains on `State` is genuinely shared across panes: the 17 `*_active_mask` arrays, profile snapshots, asset previews, transition state, the `current_pane` discriminant, and the new `panes: [PaneState; 3]`. `current_pane` indexes the array; `pane()`/`pane_mut()` are the only access path used inside the screen module.

### `init` builds all three panes up front (`mod.rs`)

`init` previously built the Main pane's `row_map` and called `apply_profile_defaults` twice (once per player). It now calls `build_rows` for each pane, runs `apply_profile_defaults` against each pane's row map for both players, and constructs `panes: [PaneState; 3]` with all three populated. Bitmasks are captured from the Main call (they're computed from `Profile`, not from any specific row map, so any of the three calls would produce the same values).

### `apply_pane` is now structural (`choice.rs`)

```rust
pub(super) fn apply_pane(state: &mut State, pane: OptionsPane) {
    state.current_pane = pane;
    state.pane_mut().reset_cursor();
    state.start_held_since = [None; PLAYER_SLOTS];
    state.start_last_triggered_at = [None; PLAYER_SLOTS];
    state.help_anim_time = [0.0; PLAYER_SLOTS];

    let active = session_active_players();
    let hide = state.hide_active_mask;
    let error_bar = state.error_bar_active_mask;
    let allow = state.allow_per_player_global_offsets;
    let p = state.pane_mut();
    p.row_tweens = init_row_tweens(
        &p.row_map, p.selected_row, active, hide, error_bar, allow,
    );

    state.pane_mut().arcade_row_focus = std::array::from_fn(|player_idx| {
        row_allows_arcade_next_row(state, state.pane().selected_row[player_idx])
    });
}
```

No `build_rows` call. No `apply_profile_defaults` call. No mask recomputation. Cursor reset semantics on pane entry are preserved exactly: `reset_cursor()` zeroes `selected_row`, `prev_selected_row`, `inline_choice_x` (NaN), `arcade_row_focus`, and the cursor tween fields, matching what the old `apply_pane` did.

## Why this shape

A pane switch is now a near-zero-cost operation: change `current_pane`, reset the destination's cursor, recompute its row tweens for the new layout. The previously-unconditional `build_rows` + double `apply_profile_defaults` per switch is gone. The bitmask fields stay on top-level `State` because they're kept current incrementally by the `toggle_*_row` handlers — `apply_pane` no longer needs to recompute them, so there's no benefit to moving them into `PaneState`.

Each row's `Profile` binding is exclusive (no two rows write the same field), so a pane's `selected_choice_index` values cannot be invalidated by changes made in a different pane. Pre-built row maps remain valid across the entire screen session.