### PR TITLE
Player Options State Bitmask Types

### DIFF
--- a/src/screens/player_options/choice.rs
+++ b/src/screens/player_options/choice.rs
@@ -242,40 +242,34 @@ pub(super) fn toggle_scroll_row(state: &mut State, player_idx: usize) {
         .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 8 {
-        1u8 << (choice_index as u8)
+        ScrollMask::from_bits_truncate(1u8 << (choice_index as u8))
     } else {
-        0
+        ScrollMask::empty()
     };
-    if bit == 0 {
+    if bit.is_empty() {
         return;
     }
 
-    // Toggle this bit in the local mask.
-    if (state.scroll_active_mask[idx] & bit) != 0 {
-        state.scroll_active_mask[idx] &= !bit;
-    } else {
-        state.scroll_active_mask[idx] |= bit;
-    }
+    state.scroll_active_mask[idx].toggle(bit);
 
     // Rebuild the ScrollOption bitmask from the active choices.
     use crate::game::profile::ScrollOption;
     let mut setting = ScrollOption::Normal;
-    if state.scroll_active_mask[idx] != 0 {
-        if (state.scroll_active_mask[idx] & (1u8 << 0)) != 0 {
-            setting = setting.union(ScrollOption::Reverse);
-        }
-        if (state.scroll_active_mask[idx] & (1u8 << 1)) != 0 {
-            setting = setting.union(ScrollOption::Split);
-        }
-        if (state.scroll_active_mask[idx] & (1u8 << 2)) != 0 {
-            setting = setting.union(ScrollOption::Alternate);
-        }
-        if (state.scroll_active_mask[idx] & (1u8 << 3)) != 0 {
-            setting = setting.union(ScrollOption::Cross);
-        }
-        if (state.scroll_active_mask[idx] & (1u8 << 4)) != 0 {
-            setting = setting.union(ScrollOption::Centered);
-        }
+    let mask = state.scroll_active_mask[idx];
+    if mask.contains(ScrollMask::REVERSE) {
+        setting = setting.union(ScrollOption::Reverse);
+    }
+    if mask.contains(ScrollMask::SPLIT) {
+        setting = setting.union(ScrollOption::Split);
+    }
+    if mask.contains(ScrollMask::ALTERNATE) {
+        setting = setting.union(ScrollOption::Alternate);
+    }
+    if mask.contains(ScrollMask::CROSS) {
+        setting = setting.union(ScrollOption::Cross);
+    }
+    if mask.contains(ScrollMask::CENTERED) {
+        setting = setting.union(ScrollOption::Centered);
     }
     state.player_profiles[idx].scroll_option = setting;
     state.player_profiles[idx].reverse_scroll = setting.contains(ScrollOption::Reverse);
@@ -314,27 +308,24 @@ pub(super) fn toggle_hide_row(state: &mut State, player_idx: usize) {
         .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 8 {
-        1u8 << (choice_index as u8)
+        HideMask::from_bits_truncate(1u8 << (choice_index as u8))
     } else {
-        0
+        HideMask::empty()
     };
-    if bit == 0 {
+    if bit.is_empty() {
         return;
     }
 
-    if (state.hide_active_mask[idx] & bit) != 0 {
-        state.hide_active_mask[idx] &= !bit;
-    } else {
-        state.hide_active_mask[idx] |= bit;
-    }
+    state.hide_active_mask[idx].toggle(bit);
 
-    let hide_targets = (state.hide_active_mask[idx] & (1u8 << 0)) != 0;
-    let hide_song_bg = (state.hide_active_mask[idx] & (1u8 << 1)) != 0;
-    let hide_combo = (state.hide_active_mask[idx] & (1u8 << 2)) != 0;
-    let hide_lifebar = (state.hide_active_mask[idx] & (1u8 << 3)) != 0;
-    let hide_score = (state.hide_active_mask[idx] & (1u8 << 4)) != 0;
-    let hide_danger = (state.hide_active_mask[idx] & (1u8 << 5)) != 0;
-    let hide_combo_explosions = (state.hide_active_mask[idx] & (1u8 << 6)) != 0;
+    let mask = state.hide_active_mask[idx];
+    let hide_targets = mask.contains(HideMask::TARGETS);
+    let hide_song_bg = mask.contains(HideMask::BACKGROUND);
+    let hide_combo = mask.contains(HideMask::COMBO);
+    let hide_lifebar = mask.contains(HideMask::LIFE);
+    let hide_score = mask.contains(HideMask::SCORE);
+    let hide_danger = mask.contains(HideMask::DANGER);
+    let hide_combo_explosions = mask.contains(HideMask::COMBO_EXPLOSIONS);
 
     state.player_profiles[idx].hide_targets = hide_targets;
     state.player_profiles[idx].hide_song_bg = hide_song_bg;
@@ -737,23 +728,20 @@ pub(super) fn toggle_life_bar_options_row(state: &mut State, player_idx: usize) 
         .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 3 {
-        1u8 << (choice_index as u8)
+        LifeBarOptionsMask::from_bits_truncate(1u8 << (choice_index as u8))
     } else {
-        0
+        LifeBarOptionsMask::empty()
     };
-    if bit == 0 {
+    if bit.is_empty() {
         return;
     }
 
-    if (state.life_bar_options_active_mask[idx] & bit) != 0 {
-        state.life_bar_options_active_mask[idx] &= !bit;
-    } else {
-        state.life_bar_options_active_mask[idx] |= bit;
-    }
+    state.life_bar_options_active_mask[idx].toggle(bit);
 
-    let rainbow_max = (state.life_bar_options_active_mask[idx] & (1u8 << 0)) != 0;
-    let responsive_colors = (state.life_bar_options_active_mask[idx] & (1u8 << 1)) != 0;
-    let show_life_percent = (state.life_bar_options_active_mask[idx] & (1u8 << 2)) != 0;
+    let mask = state.life_bar_options_active_mask[idx];
+    let rainbow_max = mask.contains(LifeBarOptionsMask::RAINBOW_MAX);
+    let responsive_colors = mask.contains(LifeBarOptionsMask::RESPONSIVE_COLORS);
+    let show_life_percent = mask.contains(LifeBarOptionsMask::SHOW_LIFE_PERCENT);
     state.player_profiles[idx].rainbow_max = rainbow_max;
     state.player_profiles[idx].responsive_colors = responsive_colors;
     state.player_profiles[idx].show_life_percent = show_life_percent;
@@ -803,27 +791,23 @@ pub(super) fn toggle_fa_plus_row(state: &mut State, player_idx: usize) {
             .len()
             .min(u8::BITS as usize)
     {
-        1u8 << (choice_index as u8)
+        FaPlusMask::from_bits_truncate(1u8 << (choice_index as u8))
     } else {
-        0
+        FaPlusMask::empty()
     };
-    if bit == 0 {
+    if bit.is_empty() {
         return;
     }
 
-    // Toggle this bit in the local mask.
-    if (state.fa_plus_active_mask[idx] & bit) != 0 {
-        state.fa_plus_active_mask[idx] &= !bit;
-    } else {
-        state.fa_plus_active_mask[idx] |= bit;
-    }
+    state.fa_plus_active_mask[idx].toggle(bit);
 
-    let window_enabled = (state.fa_plus_active_mask[idx] & (1u8 << 0)) != 0;
-    let ex_enabled = (state.fa_plus_active_mask[idx] & (1u8 << 1)) != 0;
-    let hard_ex_enabled = (state.fa_plus_active_mask[idx] & (1u8 << 2)) != 0;
-    let pane_enabled = (state.fa_plus_active_mask[idx] & (1u8 << 3)) != 0;
-    let ten_ms_enabled = (state.fa_plus_active_mask[idx] & (1u8 << 4)) != 0;
-    let split_15_10ms_enabled = (state.fa_plus_active_mask[idx] & (1u8 << 5)) != 0;
+    let mask = state.fa_plus_active_mask[idx];
+    let window_enabled = mask.contains(FaPlusMask::WINDOW);
+    let ex_enabled = mask.contains(FaPlusMask::EX_SCORE);
+    let hard_ex_enabled = mask.contains(FaPlusMask::HARD_EX_SCORE);
+    let pane_enabled = mask.contains(FaPlusMask::PANE);
+    let ten_ms_enabled = mask.contains(FaPlusMask::BLUE_WINDOW_10MS);
+    let split_15_10ms_enabled = mask.contains(FaPlusMask::SPLIT_15_10MS);
     state.player_profiles[idx].show_fa_plus_window = window_enabled;
     state.player_profiles[idx].show_ex_score = ex_enabled;
     state.player_profiles[idx].show_hard_ex_score = hard_ex_enabled;
@@ -871,21 +855,19 @@ pub(super) fn toggle_results_extras_row(state: &mut State, player_idx: usize) {
         .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 1 {
-        1u8 << (choice_index as u8)
+        ResultsExtrasMask::from_bits_truncate(1u8 << (choice_index as u8))
     } else {
-        0
+        ResultsExtrasMask::empty()
     };
-    if bit == 0 {
+    if bit.is_empty() {
         return;
     }
 
-    if (state.results_extras_active_mask[idx] & bit) != 0 {
-        state.results_extras_active_mask[idx] &= !bit;
-    } else {
-        state.results_extras_active_mask[idx] |= bit;
-    }
+    state.results_extras_active_mask[idx].toggle(bit);
 
-    let track_early_judgments = (state.results_extras_active_mask[idx] & (1u8 << 0)) != 0;
+    let track_early_judgments = state
+        .results_extras_active_mask[idx]
+        .contains(ResultsExtrasMask::TRACK_EARLY_JUDGMENTS);
     state.player_profiles[idx].track_early_judgments = track_early_judgments;
 
     let play_style = crate::game::profile::get_session_play_style();
@@ -982,22 +964,19 @@ pub(super) fn toggle_error_bar_options_row(state: &mut State, player_idx: usize)
         .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 2 {
-        1u8 << (choice_index as u8)
+        ErrorBarOptionsMask::from_bits_truncate(1u8 << (choice_index as u8))
     } else {
-        0
+        ErrorBarOptionsMask::empty()
     };
-    if bit == 0 {
+    if bit.is_empty() {
         return;
     }
 
-    if (state.error_bar_options_active_mask[idx] & bit) != 0 {
-        state.error_bar_options_active_mask[idx] &= !bit;
-    } else {
-        state.error_bar_options_active_mask[idx] |= bit;
-    }
+    state.error_bar_options_active_mask[idx].toggle(bit);
 
-    let up = (state.error_bar_options_active_mask[idx] & (1u8 << 0)) != 0;
-    let multi_tick = (state.error_bar_options_active_mask[idx] & (1u8 << 1)) != 0;
+    let mask = state.error_bar_options_active_mask[idx];
+    let up = mask.contains(ErrorBarOptionsMask::MOVE_UP);
+    let multi_tick = mask.contains(ErrorBarOptionsMask::MULTI_TICK);
     state.player_profiles[idx].error_bar_up = up;
     state.player_profiles[idx].error_bar_multi_tick = multi_tick;
 
@@ -1037,25 +1016,22 @@ pub(super) fn toggle_measure_counter_options_row(state: &mut State, player_idx: 
         .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 5 {
-        1u8 << (choice_index as u8)
+        MeasureCounterOptionsMask::from_bits_truncate(1u8 << (choice_index as u8))
     } else {
-        0
+        MeasureCounterOptionsMask::empty()
     };
-    if bit == 0 {
+    if bit.is_empty() {
         return;
     }
 
-    if (state.measure_counter_options_active_mask[idx] & bit) != 0 {
-        state.measure_counter_options_active_mask[idx] &= !bit;
-    } else {
-        state.measure_counter_options_active_mask[idx] |= bit;
-    }
+    state.measure_counter_options_active_mask[idx].toggle(bit);
 
-    let left = (state.measure_counter_options_active_mask[idx] & (1u8 << 0)) != 0;
-    let up = (state.measure_counter_options_active_mask[idx] & (1u8 << 1)) != 0;
-    let vert = (state.measure_counter_options_active_mask[idx] & (1u8 << 2)) != 0;
-    let broken_run = (state.measure_counter_options_active_mask[idx] & (1u8 << 3)) != 0;
-    let run_timer = (state.measure_counter_options_active_mask[idx] & (1u8 << 4)) != 0;
+    let mask = state.measure_counter_options_active_mask[idx];
+    let left = mask.contains(MeasureCounterOptionsMask::MOVE_LEFT);
+    let up = mask.contains(MeasureCounterOptionsMask::MOVE_UP);
+    let vert = mask.contains(MeasureCounterOptionsMask::VERTICAL_LOOKAHEAD);
+    let broken_run = mask.contains(MeasureCounterOptionsMask::BROKEN_RUN_TOTAL);
+    let run_timer = mask.contains(MeasureCounterOptionsMask::RUN_TIMER);
 
     state.player_profiles[idx].measure_counter_left = left;
     state.player_profiles[idx].measure_counter_up = up;
@@ -1101,22 +1077,19 @@ pub(super) fn toggle_early_dw_row(state: &mut State, player_idx: usize) {
         .row(state.pane().row_map.id_at(row_index))
         .selected_choice_index[idx];
     let bit = if choice_index < 2 {
-        1u8 << (choice_index as u8)
+        EarlyDwMask::from_bits_truncate(1u8 << (choice_index as u8))
     } else {
-        0
+        EarlyDwMask::empty()
     };
-    if bit == 0 {
+    if bit.is_empty() {
         return;
     }
 
-    if (state.early_dw_active_mask[idx] & bit) != 0 {
-        state.early_dw_active_mask[idx] &= !bit;
-    } else {
-        state.early_dw_active_mask[idx] |= bit;
-    }
+    state.early_dw_active_mask[idx].toggle(bit);
 
-    let hide_judgments = (state.early_dw_active_mask[idx] & (1u8 << 0)) != 0;
-    let hide_flash = (state.early_dw_active_mask[idx] & (1u8 << 1)) != 0;
+    let mask = state.early_dw_active_mask[idx];
+    let hide_judgments = mask.contains(EarlyDwMask::HIDE_JUDGMENTS);
+    let hide_flash = mask.contains(EarlyDwMask::HIDE_FLASH);
     state.player_profiles[idx].hide_early_dw_judgments = hide_judgments;
     state.player_profiles[idx].hide_early_dw_flash = hide_flash;
 
@@ -1163,32 +1136,29 @@ pub(super) fn toggle_gameplay_extras_row(state: &mut State, player_idx: usize) {
         .map(|choice| {
             let choice_str = choice.as_str();
             if choice_str == ge_flash.as_ref() {
-                1u8 << 0
+                GameplayExtrasMask::FLASH_COLUMN_FOR_MISS
             } else if choice_str == ge_density.as_ref() {
-                1u8 << 1
+                GameplayExtrasMask::DENSITY_GRAPH_AT_TOP
             } else if choice_str == ge_column_cues.as_ref() {
-                1u8 << 2
+                GameplayExtrasMask::COLUMN_CUES
             } else if choice_str == ge_scorebox.as_ref() {
-                1u8 << 3
+                GameplayExtrasMask::DISPLAY_SCOREBOX
             } else {
-                0
+                GameplayExtrasMask::empty()
             }
         })
-        .unwrap_or(0);
-    if bit == 0 {
+        .unwrap_or(GameplayExtrasMask::empty());
+    if bit.is_empty() {
         return;
     }
 
-    if (state.gameplay_extras_active_mask[idx] & bit) != 0 {
-        state.gameplay_extras_active_mask[idx] &= !bit;
-    } else {
-        state.gameplay_extras_active_mask[idx] |= bit;
-    }
+    state.gameplay_extras_active_mask[idx].toggle(bit);
 
-    let column_flash_on_miss = (state.gameplay_extras_active_mask[idx] & (1u8 << 0)) != 0;
-    let nps_graph_at_top = (state.gameplay_extras_active_mask[idx] & (1u8 << 1)) != 0;
-    let column_cues = (state.gameplay_extras_active_mask[idx] & (1u8 << 2)) != 0;
-    let display_scorebox = (state.gameplay_extras_active_mask[idx] & (1u8 << 3)) != 0;
+    let mask = state.gameplay_extras_active_mask[idx];
+    let column_flash_on_miss = mask.contains(GameplayExtrasMask::FLASH_COLUMN_FOR_MISS);
+    let nps_graph_at_top = mask.contains(GameplayExtrasMask::DENSITY_GRAPH_AT_TOP);
+    let column_cues = mask.contains(GameplayExtrasMask::COLUMN_CUES);
+    let display_scorebox = mask.contains(GameplayExtrasMask::DISPLAY_SCOREBOX);
     let subtractive_scoring = state.player_profiles[idx].subtractive_scoring;
     let pacemaker = state.player_profiles[idx].pacemaker;
 
@@ -1196,8 +1166,14 @@ pub(super) fn toggle_gameplay_extras_row(state: &mut State, player_idx: usize) {
     state.player_profiles[idx].nps_graph_at_top = nps_graph_at_top;
     state.player_profiles[idx].column_cues = column_cues;
     state.player_profiles[idx].display_scorebox = display_scorebox;
-    state.gameplay_extras_more_active_mask[idx] =
-        (column_cues as u8) | ((display_scorebox as u8) << 1);
+    let mut more = GameplayExtrasMoreMask::empty();
+    if column_cues {
+        more.insert(GameplayExtrasMoreMask::COLUMN_CUES);
+    }
+    if display_scorebox {
+        more.insert(GameplayExtrasMoreMask::DISPLAY_SCOREBOX);
+    }
+    state.gameplay_extras_more_active_mask[idx] = more;
 
     let play_style = crate::game::profile::get_session_play_style();
     let should_persist = play_style == crate::game::profile::PlayStyle::Versus

--- a/src/screens/player_options/layout.rs
+++ b/src/screens/player_options/layout.rs
@@ -118,7 +118,7 @@ pub(super) fn init_row_tweens(
     row_map: &RowMap,
     selected_row: [usize; PLAYER_SLOTS],
     active: [bool; PLAYER_SLOTS],
-    hide_active_mask: [u8; PLAYER_SLOTS],
+    hide_active_mask: [HideMask; PLAYER_SLOTS],
     error_bar_active_mask: [u8; PLAYER_SLOTS],
     allow_per_player_global_offsets: bool,
 ) -> Vec<RowTween> {

--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -71,38 +71,38 @@ pub(super) fn apply_profile_defaults(
     profile: &crate::game::profile::Profile,
     player_idx: usize,
 ) -> (
-    u8,
-    u8,
+    ScrollMask,
+    HideMask,
     u8,
     u8,
     u8,
     u8,
     u16,
     u8,
+    FaPlusMask,
+    EarlyDwMask,
+    GameplayExtrasMask,
+    GameplayExtrasMoreMask,
+    ResultsExtrasMask,
+    LifeBarOptionsMask,
     u8,
-    u8,
-    u8,
-    u8,
-    u8,
-    u8,
-    u8,
-    u8,
-    u8,
+    ErrorBarOptionsMask,
+    MeasureCounterOptionsMask,
 ) {
-    let mut scroll_active_mask: u8 = 0;
-    let mut hide_active_mask: u8 = 0;
+    let mut scroll_active_mask = ScrollMask::empty();
+    let mut hide_active_mask = HideMask::empty();
     let mut insert_active_mask: u8 = 0;
     let mut remove_active_mask: u8 = 0;
     let mut holds_active_mask: u8 = 0;
     let mut accel_effects_active_mask: u8 = 0;
     let mut visual_effects_active_mask: u16 = 0;
     let mut appearance_effects_active_mask: u8 = 0;
-    let mut fa_plus_active_mask: u8 = 0;
-    let mut early_dw_active_mask: u8 = 0;
-    let mut gameplay_extras_active_mask: u8 = 0;
-    let mut gameplay_extras_more_active_mask: u8 = 0;
-    let mut results_extras_active_mask: u8 = 0;
-    let mut life_bar_options_active_mask: u8 = 0;
+    let mut fa_plus_active_mask = FaPlusMask::empty();
+    let mut early_dw_active_mask = EarlyDwMask::empty();
+    let mut gameplay_extras_active_mask = GameplayExtrasMask::empty();
+    let mut gameplay_extras_more_active_mask = GameplayExtrasMoreMask::empty();
+    let mut results_extras_active_mask = ResultsExtrasMask::empty();
+    let mut life_bar_options_active_mask = LifeBarOptionsMask::empty();
     let mut error_bar_active_mask: u8 =
         crate::game::profile::normalize_error_bar_mask(profile.error_bar_active_mask);
     if error_bar_active_mask == 0 {
@@ -111,8 +111,8 @@ pub(super) fn apply_profile_defaults(
             profile.error_bar_text,
         );
     }
-    let mut error_bar_options_active_mask: u8 = 0;
-    let mut measure_counter_options_active_mask: u8 = 0;
+    let mut error_bar_options_active_mask = ErrorBarOptionsMask::empty();
+    let mut measure_counter_options_active_mask = MeasureCounterOptionsMask::empty();
     let match_ns_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
     let no_tap_label = tr("PlayerOptions", NO_TAP_EXPLOSION_LABEL);
     // Initialize Background Filter row from profile setting (Off, Dark, Darker, Darkest)
@@ -423,20 +423,20 @@ pub(super) fn apply_profile_defaults(
             .min(row.choices.len().saturating_sub(1));
     }
     if profile.rainbow_max {
-        life_bar_options_active_mask |= 1u8 << 0;
+        life_bar_options_active_mask.insert(LifeBarOptionsMask::RAINBOW_MAX);
     }
     if profile.responsive_colors {
-        life_bar_options_active_mask |= 1u8 << 1;
+        life_bar_options_active_mask.insert(LifeBarOptionsMask::RESPONSIVE_COLORS);
     }
     if profile.show_life_percent {
-        life_bar_options_active_mask |= 1u8 << 2;
+        life_bar_options_active_mask.insert(LifeBarOptionsMask::SHOW_LIFE_PERCENT);
     }
     if let Some(row) = row_map.get_mut(RowId::LifeBarOptions) {
-        if life_bar_options_active_mask != 0 {
+        if !life_bar_options_active_mask.is_empty() {
             let first_idx = (0..row.choices.len())
                 .find(|i| {
                     let bit = 1u8 << (*i as u8);
-                    (life_bar_options_active_mask & bit) != 0
+                    (life_bar_options_active_mask.bits() & bit) != 0
                 })
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;
@@ -452,17 +452,17 @@ pub(super) fn apply_profile_defaults(
             .min(row.choices.len().saturating_sub(1));
     }
     if profile.error_bar_up {
-        error_bar_options_active_mask |= 1u8 << 0;
+        error_bar_options_active_mask.insert(ErrorBarOptionsMask::MOVE_UP);
     }
     if profile.error_bar_multi_tick {
-        error_bar_options_active_mask |= 1u8 << 1;
+        error_bar_options_active_mask.insert(ErrorBarOptionsMask::MULTI_TICK);
     }
     if let Some(row) = row_map.get_mut(RowId::ErrorBarOptions) {
-        if error_bar_options_active_mask != 0 {
+        if !error_bar_options_active_mask.is_empty() {
             let first_idx = (0..row.choices.len())
                 .find(|i| {
                     let bit = 1u8 << (*i as u8);
-                    (error_bar_options_active_mask & bit) != 0
+                    (error_bar_options_active_mask.bits() & bit) != 0
                 })
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;
@@ -483,26 +483,26 @@ pub(super) fn apply_profile_defaults(
             .min(row.choices.len().saturating_sub(1));
     }
     if profile.measure_counter_left {
-        measure_counter_options_active_mask |= 1u8 << 0;
+        measure_counter_options_active_mask.insert(MeasureCounterOptionsMask::MOVE_LEFT);
     }
     if profile.measure_counter_up {
-        measure_counter_options_active_mask |= 1u8 << 1;
+        measure_counter_options_active_mask.insert(MeasureCounterOptionsMask::MOVE_UP);
     }
     if profile.measure_counter_vert {
-        measure_counter_options_active_mask |= 1u8 << 2;
+        measure_counter_options_active_mask.insert(MeasureCounterOptionsMask::VERTICAL_LOOKAHEAD);
     }
     if profile.broken_run {
-        measure_counter_options_active_mask |= 1u8 << 3;
+        measure_counter_options_active_mask.insert(MeasureCounterOptionsMask::BROKEN_RUN_TOTAL);
     }
     if profile.run_timer {
-        measure_counter_options_active_mask |= 1u8 << 4;
+        measure_counter_options_active_mask.insert(MeasureCounterOptionsMask::RUN_TIMER);
     }
     if let Some(row) = row_map.get_mut(RowId::MeasureCounterOptions) {
-        if measure_counter_options_active_mask != 0 {
+        if !measure_counter_options_active_mask.is_empty() {
             let first_idx = (0..row.choices.len())
                 .find(|i| {
                     let bit = 1u8 << (*i as u8);
-                    (measure_counter_options_active_mask & bit) != 0
+                    (measure_counter_options_active_mask.bits() & bit) != 0
                 })
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;
@@ -536,14 +536,14 @@ pub(super) fn apply_profile_defaults(
             .min(row.choices.len().saturating_sub(1));
     }
     if profile.track_early_judgments {
-        results_extras_active_mask |= 1u8 << 0;
+        results_extras_active_mask.insert(ResultsExtrasMask::TRACK_EARLY_JUDGMENTS);
     }
     if let Some(row) = row_map.get_mut(RowId::ResultsExtras) {
-        if results_extras_active_mask != 0 {
+        if !results_extras_active_mask.is_empty() {
             let first_idx = (0..row.choices.len())
                 .find(|i| {
                     let bit = 1u8 << (*i as u8);
-                    (results_extras_active_mask & bit) != 0
+                    (results_extras_active_mask.bits() & bit) != 0
                 })
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;
@@ -567,17 +567,17 @@ pub(super) fn apply_profile_defaults(
     }
     if let Some(row) = row_map.get_mut(RowId::EarlyDecentWayOffOptions) {
         if profile.hide_early_dw_judgments {
-            early_dw_active_mask |= 1u8 << 0;
+            early_dw_active_mask.insert(EarlyDwMask::HIDE_JUDGMENTS);
         }
         if profile.hide_early_dw_flash {
-            early_dw_active_mask |= 1u8 << 1;
+            early_dw_active_mask.insert(EarlyDwMask::HIDE_FLASH);
         }
 
-        if early_dw_active_mask != 0 {
+        if !early_dw_active_mask.is_empty() {
             let first_idx = (0..row.choices.len())
                 .find(|i| {
                     let bit = 1u8 << (*i as u8);
-                    (early_dw_active_mask & bit) != 0
+                    (early_dw_active_mask.bits() & bit) != 0
                 })
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;
@@ -591,22 +591,22 @@ pub(super) fn apply_profile_defaults(
         row.selected_choice_index[player_idx] = 0;
     }
     if profile.show_fa_plus_window {
-        fa_plus_active_mask |= 1u8 << 0;
+        fa_plus_active_mask.insert(FaPlusMask::WINDOW);
     }
     if profile.show_ex_score {
-        fa_plus_active_mask |= 1u8 << 1;
+        fa_plus_active_mask.insert(FaPlusMask::EX_SCORE);
     }
     if profile.show_hard_ex_score {
-        fa_plus_active_mask |= 1u8 << 2;
+        fa_plus_active_mask.insert(FaPlusMask::HARD_EX_SCORE);
     }
     if profile.show_fa_plus_pane {
-        fa_plus_active_mask |= 1u8 << 3;
+        fa_plus_active_mask.insert(FaPlusMask::PANE);
     }
     if profile.fa_plus_10ms_blue_window {
-        fa_plus_active_mask |= 1u8 << 4;
+        fa_plus_active_mask.insert(FaPlusMask::BLUE_WINDOW_10MS);
     }
     if profile.split_15_10ms {
-        fa_plus_active_mask |= 1u8 << 5;
+        fa_plus_active_mask.insert(FaPlusMask::SPLIT_15_10MS);
     }
     if let Some(row) = row_map.get_mut(RowId::CustomBlueFantasticWindow) {
         row.selected_choice_index[player_idx] = if profile.custom_fantastic_window {
@@ -627,25 +627,25 @@ pub(super) fn apply_profile_defaults(
 
     // Initialize Gameplay Extras row from profile (multi-choice toggle group).
     if profile.column_flash_on_miss {
-        gameplay_extras_active_mask |= 1u8 << 0;
+        gameplay_extras_active_mask.insert(GameplayExtrasMask::FLASH_COLUMN_FOR_MISS);
     }
     if profile.nps_graph_at_top {
-        gameplay_extras_active_mask |= 1u8 << 1;
+        gameplay_extras_active_mask.insert(GameplayExtrasMask::DENSITY_GRAPH_AT_TOP);
     }
     if profile.column_cues {
-        gameplay_extras_active_mask |= 1u8 << 2;
-        gameplay_extras_more_active_mask |= 1u8 << 0;
+        gameplay_extras_active_mask.insert(GameplayExtrasMask::COLUMN_CUES);
+        gameplay_extras_more_active_mask.insert(GameplayExtrasMoreMask::COLUMN_CUES);
     }
     if profile.display_scorebox {
-        gameplay_extras_active_mask |= 1u8 << 3;
-        gameplay_extras_more_active_mask |= 1u8 << 1;
+        gameplay_extras_active_mask.insert(GameplayExtrasMask::DISPLAY_SCOREBOX);
+        gameplay_extras_more_active_mask.insert(GameplayExtrasMoreMask::DISPLAY_SCOREBOX);
     }
     if let Some(row) = row_map.get_mut(RowId::GameplayExtras) {
-        if gameplay_extras_active_mask != 0 {
+        if !gameplay_extras_active_mask.is_empty() {
             let first_idx = (0..row.choices.len())
                 .find(|i| {
                     let bit = 1u8 << (*i as u8);
-                    (gameplay_extras_active_mask & bit) != 0
+                    (gameplay_extras_active_mask.bits() & bit) != 0
                 })
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;
@@ -663,11 +663,11 @@ pub(super) fn apply_profile_defaults(
 
     // Initialize Gameplay Extras (More) row from profile (multi-choice toggle group).
     if let Some(row) = row_map.get_mut(RowId::GameplayExtrasMore) {
-        if gameplay_extras_more_active_mask != 0 {
+        if !gameplay_extras_more_active_mask.is_empty() {
             let first_idx = (0..row.choices.len())
                 .find(|i| {
                     let bit = 1u8 << (*i as u8);
-                    (gameplay_extras_more_active_mask & bit) != 0
+                    (gameplay_extras_more_active_mask.bits() & bit) != 0
                 })
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;
@@ -678,32 +678,32 @@ pub(super) fn apply_profile_defaults(
 
     // Initialize Hide row from profile (multi-choice toggle group).
     if profile.hide_targets {
-        hide_active_mask |= 1u8 << 0;
+        hide_active_mask.insert(HideMask::TARGETS);
     }
     if profile.hide_song_bg {
-        hide_active_mask |= 1u8 << 1;
+        hide_active_mask.insert(HideMask::BACKGROUND);
     }
     if profile.hide_combo {
-        hide_active_mask |= 1u8 << 2;
+        hide_active_mask.insert(HideMask::COMBO);
     }
     if profile.hide_lifebar {
-        hide_active_mask |= 1u8 << 3;
+        hide_active_mask.insert(HideMask::LIFE);
     }
     if profile.hide_score {
-        hide_active_mask |= 1u8 << 4;
+        hide_active_mask.insert(HideMask::SCORE);
     }
     if profile.hide_danger {
-        hide_active_mask |= 1u8 << 5;
+        hide_active_mask.insert(HideMask::DANGER);
     }
     if profile.hide_combo_explosions {
-        hide_active_mask |= 1u8 << 6;
+        hide_active_mask.insert(HideMask::COMBO_EXPLOSIONS);
     }
     if let Some(row) = row_map.get_mut(RowId::Hide) {
-        if hide_active_mask != 0 {
+        if !hide_active_mask.is_empty() {
             let first_idx = (0..row.choices.len())
                 .find(|i| {
                     let bit = 1u8 << (*i as u8);
-                    (hide_active_mask & bit) != 0
+                    (hide_active_mask.bits() & bit) != 0
                 })
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;
@@ -731,16 +731,17 @@ pub(super) fn apply_profile_defaults(
         ];
         for &(flag, idx) in flags {
             if profile.scroll_option.contains(flag) && idx < row.choices.len() && idx < 8 {
-                scroll_active_mask |= 1u8 << (idx as u8);
+                scroll_active_mask
+                    .insert(ScrollMask::from_bits_truncate(1u8 << (idx as u8)));
             }
         }
 
         // Cursor starts at the first active choice if any, otherwise at the first option.
-        if scroll_active_mask != 0 {
+        if !scroll_active_mask.is_empty() {
             let first_idx = (0..row.choices.len())
                 .find(|i| {
                     let bit = 1u8 << (*i as u8);
-                    (scroll_active_mask & bit) != 0
+                    (scroll_active_mask.bits() & bit) != 0
                 })
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;

--- a/src/screens/player_options/render.rs
+++ b/src/screens/player_options/render.rs
@@ -403,7 +403,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.scroll_active_mask[player_idx];
+                    let mask = state.scroll_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }
@@ -440,7 +440,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.hide_active_mask[player_idx];
+                    let mask = state.hide_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }
@@ -699,7 +699,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.life_bar_options_active_mask[player_idx];
+                    let mask = state.life_bar_options_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }
@@ -736,7 +736,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.fa_plus_active_mask[player_idx];
+                    let mask = state.fa_plus_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }
@@ -773,7 +773,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.gameplay_extras_active_mask[player_idx];
+                    let mask = state.gameplay_extras_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }
@@ -810,7 +810,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.gameplay_extras_more_active_mask[player_idx];
+                    let mask = state.gameplay_extras_more_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }
@@ -847,7 +847,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.results_extras_active_mask[player_idx];
+                    let mask = state.results_extras_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }
@@ -884,7 +884,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.measure_counter_options_active_mask[player_idx];
+                    let mask = state.measure_counter_options_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }
@@ -958,7 +958,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.error_bar_options_active_mask[player_idx];
+                    let mask = state.error_bar_options_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }
@@ -995,7 +995,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.early_dw_active_mask[player_idx];
+                    let mask = state.early_dw_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }

--- a/src/screens/player_options/state.rs
+++ b/src/screens/player_options/state.rs
@@ -1,4 +1,112 @@
 use super::*;
+use bitflags::bitflags;
+
+bitflags! {
+    /// Active modifiers for the Scroll row.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct ScrollMask: u8 {
+        const REVERSE   = 1 << 0;
+        const SPLIT     = 1 << 1;
+        const ALTERNATE = 1 << 2;
+        const CROSS     = 1 << 3;
+        const CENTERED  = 1 << 4;
+    }
+}
+
+bitflags! {
+    /// Active toggles for the Hide row.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct HideMask: u8 {
+        const TARGETS          = 1 << 0;
+        const BACKGROUND       = 1 << 1;
+        const COMBO            = 1 << 2;
+        const LIFE             = 1 << 3;
+        const SCORE            = 1 << 4;
+        const DANGER           = 1 << 5;
+        const COMBO_EXPLOSIONS = 1 << 6;
+    }
+}
+
+bitflags! {
+    /// Active toggles for the FA+ Options row.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct FaPlusMask: u8 {
+        const WINDOW           = 1 << 0;
+        const EX_SCORE         = 1 << 1;
+        const HARD_EX_SCORE    = 1 << 2;
+        const PANE             = 1 << 3;
+        const BLUE_WINDOW_10MS = 1 << 4;
+        const SPLIT_15_10MS    = 1 << 5;
+    }
+}
+
+bitflags! {
+    /// Active toggles for the Early Decent / Way Off Options row.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct EarlyDwMask: u8 {
+        const HIDE_JUDGMENTS = 1 << 0;
+        const HIDE_FLASH     = 1 << 1;
+    }
+}
+
+bitflags! {
+    /// Active toggles for the Gameplay Extras row.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct GameplayExtrasMask: u8 {
+        const FLASH_COLUMN_FOR_MISS = 1 << 0;
+        const DENSITY_GRAPH_AT_TOP  = 1 << 1;
+        const COLUMN_CUES           = 1 << 2;
+        const DISPLAY_SCOREBOX      = 1 << 3;
+    }
+}
+
+bitflags! {
+    /// Active toggles for the Gameplay Extras (More) row.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct GameplayExtrasMoreMask: u8 {
+        const COLUMN_CUES      = 1 << 0;
+        const DISPLAY_SCOREBOX = 1 << 1;
+    }
+}
+
+bitflags! {
+    /// Active toggles for the Results Extras row.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct ResultsExtrasMask: u8 {
+        const TRACK_EARLY_JUDGMENTS = 1 << 0;
+    }
+}
+
+bitflags! {
+    /// Active toggles for the Life Bar Options row.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct LifeBarOptionsMask: u8 {
+        const RAINBOW_MAX       = 1 << 0;
+        const RESPONSIVE_COLORS = 1 << 1;
+        const SHOW_LIFE_PERCENT = 1 << 2;
+    }
+}
+
+bitflags! {
+    /// Active toggles for the Error Bar Options row.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct ErrorBarOptionsMask: u8 {
+        const MOVE_UP    = 1 << 0;
+        const MULTI_TICK = 1 << 1;
+    }
+}
+
+bitflags! {
+    /// Active toggles for the Measure Counter Options row.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct MeasureCounterOptionsMask: u8 {
+        const MOVE_LEFT          = 1 << 0;
+        const MOVE_UP            = 1 << 1;
+        const VERTICAL_LOOKAHEAD = 1 << 2;
+        const BROKEN_RUN_TOTAL   = 1 << 3;
+        const RUN_TIMER          = 1 << 4;
+    }
+}
 
 #[derive(Clone, Copy, Debug)]
 pub(super) struct RowTween {
@@ -28,43 +136,19 @@ pub struct State {
     pub chart_steps_index: [usize; PLAYER_SLOTS],
     pub chart_difficulty_index: [usize; PLAYER_SLOTS],
     pub(super) panes: [PaneState; OptionsPane::COUNT],
-    // For Scroll row: bitmask of which options are enabled.
-    // 0 => Normal scroll (no special modifier).
-    pub scroll_active_mask: [u8; PLAYER_SLOTS],
-    // For Hide row: bitmask of which options are enabled.
-    // bit0 = Targets, bit1 = Background, bit2 = Combo, bit3 = Life,
-    // bit4 = Score, bit5 = Danger, bit6 = Combo Explosions.
-    pub hide_active_mask: [u8; PLAYER_SLOTS],
-    // For FA+ Options row: bitmask of which options are enabled.
-    // bit0 = Display FA+ Window, bit1 = Display EX Score, bit2 = Display H.EX Score,
-    // bit3 = Display FA+ Pane, bit4 = 10ms Blue Window, bit5 = 15/10ms Split.
-    pub fa_plus_active_mask: [u8; PLAYER_SLOTS],
-    // For Early Decent/Way Off Options row: bitmask of which options are enabled.
-    // bit0 = Hide Judgments, bit1 = Hide NoteField Flash.
-    pub early_dw_active_mask: [u8; PLAYER_SLOTS],
-    // For Gameplay Extras row: bitmask of which options are enabled.
-    // bit0 = Flash Column for Miss, bit1 = Density Graph at Top,
-    // bit2 = Column Cues, bit3 = Display Scorebox.
-    pub gameplay_extras_active_mask: [u8; PLAYER_SLOTS],
-    // For Gameplay Extras (More) row: bitmask of which options are enabled.
-    // bit0 = Column Cues, bit1 = Display Scorebox.
-    pub gameplay_extras_more_active_mask: [u8; PLAYER_SLOTS],
-    // For Results Extras row: bitmask of which options are enabled.
-    // bit0 = Track Early Judgments.
-    pub results_extras_active_mask: [u8; PLAYER_SLOTS],
-    // For Life Bar Options row: bitmask of which options are enabled.
-    // bit0 = Rainbow Max, bit1 = Responsive Colors, bit2 = Show Life Percentage.
-    pub life_bar_options_active_mask: [u8; PLAYER_SLOTS],
+    pub scroll_active_mask: [ScrollMask; PLAYER_SLOTS],
+    pub hide_active_mask: [HideMask; PLAYER_SLOTS],
+    pub fa_plus_active_mask: [FaPlusMask; PLAYER_SLOTS],
+    pub early_dw_active_mask: [EarlyDwMask; PLAYER_SLOTS],
+    pub gameplay_extras_active_mask: [GameplayExtrasMask; PLAYER_SLOTS],
+    pub gameplay_extras_more_active_mask: [GameplayExtrasMoreMask; PLAYER_SLOTS],
+    pub results_extras_active_mask: [ResultsExtrasMask; PLAYER_SLOTS],
+    pub life_bar_options_active_mask: [LifeBarOptionsMask; PLAYER_SLOTS],
     // For Error Bar row: bitmask of which options are enabled.
     // bit0 = Colorful, bit1 = Monochrome, bit2 = Text, bit3 = Highlight, bit4 = Average.
     pub error_bar_active_mask: [u8; PLAYER_SLOTS],
-    // For Error Bar Options row: bitmask of which options are enabled.
-    // bit0 = Move Up, bit1 = Multi-Tick (Simply Love semantics).
-    pub error_bar_options_active_mask: [u8; PLAYER_SLOTS],
-    // For Measure Counter Options row: bitmask of which options are enabled.
-    // bit0 = Move Left, bit1 = Move Up, bit2 = Vertical Lookahead,
-    // bit3 = Broken Run Total, bit4 = Run Timer.
-    pub measure_counter_options_active_mask: [u8; PLAYER_SLOTS],
+    pub error_bar_options_active_mask: [ErrorBarOptionsMask; PLAYER_SLOTS],
+    pub measure_counter_options_active_mask: [MeasureCounterOptionsMask; PLAYER_SLOTS],
     // For Insert row: bitmask of enabled chart insert transforms.
     // bit0 = Wide, bit1 = Big, bit2 = Quick, bit3 = BMRize,
     // bit4 = Skippy, bit5 = Echo, bit6 = Stomp.

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -3,11 +3,11 @@ use super::*;
 #[cfg(test)]
 pub(super) mod tests {
     use super::{
-        HUD_OFFSET_MAX, HUD_OFFSET_MIN, HUD_OFFSET_ZERO_INDEX, NAV_INITIAL_HOLD_DELAY,
-        NAV_REPEAT_SCROLL_INTERVAL, P1, Row, RowId, RowMap, SpeedMod, SpeedModType,
+        HUD_OFFSET_MAX, HUD_OFFSET_MIN, HUD_OFFSET_ZERO_INDEX, HideMask, NAV_INITIAL_HOLD_DELAY,
+        NAV_REPEAT_SCROLL_INTERVAL, P1, Row, RowId, RowMap, ScrollMask, SpeedMod, SpeedModType,
         handle_arcade_start_event, handle_start_event, hud_offset_choices, is_row_visible,
-        judgment_tilt_intensity_visible, repeat_held_arcade_start,
-        row_visibility, session_active_players, sync_profile_scroll_speed,
+        judgment_tilt_intensity_visible, repeat_held_arcade_start, row_visibility,
+        session_active_players, sync_profile_scroll_speed,
     };
     use crate::assets::AssetManager;
     use crate::assets::i18n::{LookupKey, lookup_key};
@@ -100,10 +100,10 @@ pub(super) mod tests {
                 [0, 0],
             ),
         ]);
-        let visibility = row_visibility(&row_map, [true, false], [0, 0], [0, 0], false);
+        let visibility = row_visibility(&row_map, [true, false], [HideMask::empty(), HideMask::empty()], [0, 0], false);
         assert!(!is_row_visible(&row_map, 1, visibility));
 
-        let visibility = row_visibility(&row_map, [true, false], [0, 0], [1, 0], false);
+        let visibility = row_visibility(&row_map, [true, false], [HideMask::empty(), HideMask::empty()], [1, 0], false);
         assert!(is_row_visible(&row_map, 1, visibility));
     }
 
@@ -124,7 +124,7 @@ pub(super) mod tests {
                 [0, 0],
             ),
         ]);
-        let visibility = row_visibility(&row_map, [true, false], [0, 0], [0, 0], false);
+        let visibility = row_visibility(&row_map, [true, false], [HideMask::empty(), HideMask::empty()], [0, 0], false);
         assert!(!is_row_visible(&row_map, 1, visibility));
 
         let row_map = test_row_map(vec![
@@ -141,7 +141,7 @@ pub(super) mod tests {
                 [0, 0],
             ),
         ]);
-        let visibility = row_visibility(&row_map, [true, false], [0, 0], [0, 0], false);
+        let visibility = row_visibility(&row_map, [true, false], [HideMask::empty(), HideMask::empty()], [0, 0], false);
         assert!(is_row_visible(&row_map, 1, visibility));
     }
 
@@ -162,7 +162,7 @@ pub(super) mod tests {
                 [0, 0],
             ),
         ]);
-        let visibility = row_visibility(&row_map, [true, true], [0, 0], [0, 0], false);
+        let visibility = row_visibility(&row_map, [true, true], [HideMask::empty(), HideMask::empty()], [0, 0], false);
         assert!(!is_row_visible(&row_map, 1, visibility));
 
         let row_map = test_row_map(vec![
@@ -179,7 +179,7 @@ pub(super) mod tests {
                 [0, 0],
             ),
         ]);
-        let visibility = row_visibility(&row_map, [true, true], [0, 0], [0, 0], false);
+        let visibility = row_visibility(&row_map, [true, true], [HideMask::empty(), HideMask::empty()], [0, 0], false);
         assert!(is_row_visible(&row_map, 1, visibility));
     }
 
@@ -345,13 +345,13 @@ pub(super) mod tests {
         state.pane_mut().row_map.insert(scroll_row);
         let row_index = state.pane().row_map.display_order().len() - 1;
         state.pane_mut().selected_row[P1] = row_index;
-        state.scroll_active_mask[P1] = 0;
+        state.scroll_active_mask[P1] = ScrollMask::empty();
 
         let active = session_active_players();
         handle_start_event(&mut state, &asset_manager, active, P1);
 
         assert_ne!(
-            state.scroll_active_mask[P1], 0,
+            state.scroll_active_mask[P1], ScrollMask::empty(),
             "Scroll bitmask should have been toggled"
         );
     }
@@ -531,7 +531,7 @@ pub(super) mod tests {
         state.pane_mut().row_map.insert(scroll_row);
         let row_index = state.pane().row_map.display_order().len() - 1;
         state.pane_mut().selected_row[P1] = row_index;
-        state.scroll_active_mask = [0, 0];
+        state.scroll_active_mask = [ScrollMask::empty(), ScrollMask::empty()];
 
         // L/R on a bitmask row returns Outcome::NONE — mask must not change,
         // and no SFX should be played (audio uninit in tests would panic).
@@ -539,7 +539,7 @@ pub(super) mod tests {
         super::change_choice_for_player(&mut state, &asset_manager, P1, -1);
 
         assert_eq!(
-            state.scroll_active_mask, [0, 0],
+            state.scroll_active_mask, [ScrollMask::empty(), ScrollMask::empty()],
             "delta on Bitmask row must not toggle the mask"
         );
         // selected_choice_index is also untouched (cycle_choice_index never runs)

--- a/src/screens/player_options/visibility.rs
+++ b/src/screens/player_options/visibility.rs
@@ -225,12 +225,12 @@ pub(super) fn density_graph_background_visible(
 
 pub(super) fn combo_rows_visible(
     active: [bool; PLAYER_SLOTS],
-    hide_active_mask: [u8; PLAYER_SLOTS],
+    hide_active_mask: [HideMask; PLAYER_SLOTS],
 ) -> bool {
     let mut any_active = false;
     for player_idx in active_player_indices(active) {
         any_active = true;
-        let hide_combo = (hide_active_mask[player_idx] & (1u8 << 2)) != 0;
+        let hide_combo = hide_active_mask[player_idx].contains(HideMask::COMBO);
         if !hide_combo {
             return true;
         }
@@ -240,12 +240,12 @@ pub(super) fn combo_rows_visible(
 
 pub(super) fn lifebar_rows_visible(
     active: [bool; PLAYER_SLOTS],
-    hide_active_mask: [u8; PLAYER_SLOTS],
+    hide_active_mask: [HideMask; PLAYER_SLOTS],
 ) -> bool {
     let mut any_active = false;
     for player_idx in active_player_indices(active) {
         any_active = true;
-        let hide_lifebar = (hide_active_mask[player_idx] & (1u8 << 3)) != 0;
+        let hide_lifebar = hide_active_mask[player_idx].contains(HideMask::LIFE);
         if !hide_lifebar {
             return true;
         }
@@ -274,7 +274,7 @@ pub(super) fn indicator_score_type_visible(row_map: &RowMap, active: [bool; PLAY
 pub(super) fn row_visibility(
     row_map: &RowMap,
     active: [bool; PLAYER_SLOTS],
-    hide_active_mask: [u8; PLAYER_SLOTS],
+    hide_active_mask: [HideMask; PLAYER_SLOTS],
     error_bar_active_mask: [u8; PLAYER_SLOTS],
     allow_per_player_global_offsets: bool,
 ) -> RowVisibility {


### PR DESCRIPTION
# refactor(player-options): typed bitflags for state-only row masks

## Summary

`State` carries seventeen `*_active_mask` arrays, one per player, that drive the multi-toggle "bitmask" rows on the player-options screen. Today every one of them is a raw `[u8; PLAYER_SLOTS]` (or `[u16; PLAYER_SLOTS]` for visual effects), and bit positions are encoded in `// bit0 = …` comment blocks above the field. Bit math is repeated by hand in three places per row — the `toggle_*_row` handler in `choice.rs`, `apply_profile_defaults` in `panes/mod.rs`, and the underline pass in `render.rs` — as `1u8 << N` shifts, `mask & bit` reads, and `mask |= bit` / `mask &= !bit` writes. There is nothing in the type system stopping a Hide bit from being toggled into a Scroll mask, and the only documentation of which bit means what is the comment on the field declaration.

This PR introduces ten typed `bitflags!` structs — one per row whose mask is not persisted to `Profile` — and changes the corresponding `State` fields to carry them by type. Bit positions are now named constants (`HideMask::COMBO`, `ScrollMask::REVERSE`, …) defined alongside the struct in `state.rs`. Reads become `mask.contains(Mask::FOO)`, writes become `mask.insert(Mask::FOO)` / `mask.toggle(bit)`, and the previously-required bounds guard on `1u8 << choice_index` is preserved so we never construct a flag from an out-of-range shift.

The seven masks that round-trip through `Profile` (insert, remove, holds, accel_effects, visual_effects, appearance_effects, error_bar) are deliberately left as raw integers in this PR — they touch persisted wire format and a sharp edge around `INSERT_MASK_BIT_MINES`, so they will be migrated in a separate change.

## Why this shape

One typed mask per row, defined alongside `State` in `state.rs`, keeps the "what does bit 3 of the Hide row mean?" question answerable in a single place — the `bitflags!` block — and lets the compiler reject toggling a `HideMask` value into a `ScrollMask` field. 
