### PR TITLE
Player Options Cursor Struct

### DIFF
--- a/src/screens/player_options/input.rs
+++ b/src/screens/player_options/input.rs
@@ -265,47 +265,30 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
             continue;
         };
 
+        let to_rect = CursorRect::new(to_x, to_y, to_w, to_h);
         let needs_cursor_init = !state.pane().cursor_initialized[player_idx];
         if needs_cursor_init {
-            state.pane_mut().cursor_initialized[player_idx] = true;
-            state.pane_mut().cursor_from_x[player_idx] = to_x;
-            state.pane_mut().cursor_from_y[player_idx] = to_y;
-            state.pane_mut().cursor_from_w[player_idx] = to_w;
-            state.pane_mut().cursor_from_h[player_idx] = to_h;
-            state.pane_mut().cursor_to_x[player_idx] = to_x;
-            state.pane_mut().cursor_to_y[player_idx] = to_y;
-            state.pane_mut().cursor_to_w[player_idx] = to_w;
-            state.pane_mut().cursor_to_h[player_idx] = to_h;
-            state.pane_mut().cursor_t[player_idx] = 1.0;
+            let pane = state.pane_mut();
+            pane.cursor_initialized[player_idx] = true;
+            pane.cursor_from[player_idx] = to_rect;
+            pane.cursor_to[player_idx] = to_rect;
+            pane.cursor_t[player_idx] = 1.0;
         } else {
-            let dx = (to_x - state.pane().cursor_to_x[player_idx]).abs();
-            let dy = (to_y - state.pane().cursor_to_y[player_idx]).abs();
-            let dw = (to_w - state.pane().cursor_to_w[player_idx]).abs();
-            let dh = (to_h - state.pane().cursor_to_h[player_idx]).abs();
+            let cur_to = state.pane().cursor_to[player_idx];
+            let dx = (to_rect.x - cur_to.x).abs();
+            let dy = (to_rect.y - cur_to.y).abs();
+            let dw = (to_rect.w - cur_to.w).abs();
+            let dh = (to_rect.h - cur_to.h).abs();
             if dx > 0.01 || dy > 0.01 || dw > 0.01 || dh > 0.01 {
-                let t = state.pane().cursor_t[player_idx].clamp(0.0, 1.0);
-                let cur_x = (state.pane().cursor_to_x[player_idx]
-                    - state.pane().cursor_from_x[player_idx])
-                    .mul_add(t, state.pane().cursor_from_x[player_idx]);
-                let cur_y = (state.pane().cursor_to_y[player_idx]
-                    - state.pane().cursor_from_y[player_idx])
-                    .mul_add(t, state.pane().cursor_from_y[player_idx]);
-                let cur_w = (state.pane().cursor_to_w[player_idx]
-                    - state.pane().cursor_from_w[player_idx])
-                    .mul_add(t, state.pane().cursor_from_w[player_idx]);
-                let cur_h = (state.pane().cursor_to_h[player_idx]
-                    - state.pane().cursor_from_h[player_idx])
-                    .mul_add(t, state.pane().cursor_from_h[player_idx]);
+                let pane = state.pane();
+                let t = pane.cursor_t[player_idx].clamp(0.0, 1.0);
+                let cur_rect =
+                    CursorRect::lerp(pane.cursor_from[player_idx], pane.cursor_to[player_idx], t);
 
-                state.pane_mut().cursor_from_x[player_idx] = cur_x;
-                state.pane_mut().cursor_from_y[player_idx] = cur_y;
-                state.pane_mut().cursor_from_w[player_idx] = cur_w;
-                state.pane_mut().cursor_from_h[player_idx] = cur_h;
-                state.pane_mut().cursor_to_x[player_idx] = to_x;
-                state.pane_mut().cursor_to_y[player_idx] = to_y;
-                state.pane_mut().cursor_to_w[player_idx] = to_w;
-                state.pane_mut().cursor_to_h[player_idx] = to_h;
-                state.pane_mut().cursor_t[player_idx] = 0.0;
+                let pane = state.pane_mut();
+                pane.cursor_from[player_idx] = cur_rect;
+                pane.cursor_to[player_idx] = to_rect;
+                pane.cursor_t[player_idx] = 0.0;
             }
         }
     }

--- a/src/screens/player_options/render.rs
+++ b/src/screens/player_options/render.rs
@@ -177,16 +177,10 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
         if player_idx >= PLAYER_SLOTS || !state.pane().cursor_initialized[player_idx] {
             return None;
         }
-        let t = state.pane().cursor_t[player_idx].clamp(0.0, 1.0);
-        let x = (state.pane().cursor_to_x[player_idx] - state.pane().cursor_from_x[player_idx])
-            .mul_add(t, state.pane().cursor_from_x[player_idx]);
-        let y = (state.pane().cursor_to_y[player_idx] - state.pane().cursor_from_y[player_idx])
-            .mul_add(t, state.pane().cursor_from_y[player_idx]);
-        let w = (state.pane().cursor_to_w[player_idx] - state.pane().cursor_from_w[player_idx])
-            .mul_add(t, state.pane().cursor_from_w[player_idx]);
-        let h = (state.pane().cursor_to_h[player_idx] - state.pane().cursor_from_h[player_idx])
-            .mul_add(t, state.pane().cursor_from_h[player_idx]);
-        Some((x, y, w, h))
+        let pane = state.pane();
+        let t = pane.cursor_t[player_idx].clamp(0.0, 1.0);
+        let r = CursorRect::lerp(pane.cursor_from[player_idx], pane.cursor_to[player_idx], t);
+        Some((r.x, r.y, r.w, r.h))
     };
 
     for item_idx in 0..total_rows {

--- a/src/screens/player_options/state.rs
+++ b/src/screens/player_options/state.rs
@@ -21,6 +21,34 @@ impl RowTween {
     }
 }
 
+/// Position + size for the cursor ring tween. Used as both the `from` and
+/// `to` endpoints of the cursor's per-player tween.
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct CursorRect {
+    pub(super) x: f32,
+    pub(super) y: f32,
+    pub(super) w: f32,
+    pub(super) h: f32,
+}
+
+impl CursorRect {
+    #[inline(always)]
+    pub(super) fn new(x: f32, y: f32, w: f32, h: f32) -> Self {
+        Self { x, y, w, h }
+    }
+
+    /// Linearly interpolate between `from` and `to` by `t` (component-wise).
+    #[inline(always)]
+    pub(super) fn lerp(from: Self, to: Self, t: f32) -> Self {
+        Self {
+            x: (to.x - from.x).mul_add(t, from.x),
+            y: (to.y - from.y).mul_add(t, from.y),
+            w: (to.w - from.w).mul_add(t, from.w),
+            h: (to.h - from.h).mul_add(t, from.h),
+        }
+    }
+}
+
 pub struct State {
     pub song: Arc<SongData>,
     pub return_screen: Screen,
@@ -128,14 +156,8 @@ pub struct PaneState {
     pub(super) row_tweens: Vec<RowTween>,
     // Cursor ring tween (StopTweening/BeginTweening parity with ITGmania ScreenOptions::TweenCursor).
     pub(super) cursor_initialized: [bool; PLAYER_SLOTS],
-    pub(super) cursor_from_x: [f32; PLAYER_SLOTS],
-    pub(super) cursor_from_y: [f32; PLAYER_SLOTS],
-    pub(super) cursor_from_w: [f32; PLAYER_SLOTS],
-    pub(super) cursor_from_h: [f32; PLAYER_SLOTS],
-    pub(super) cursor_to_x: [f32; PLAYER_SLOTS],
-    pub(super) cursor_to_y: [f32; PLAYER_SLOTS],
-    pub(super) cursor_to_w: [f32; PLAYER_SLOTS],
-    pub(super) cursor_to_h: [f32; PLAYER_SLOTS],
+    pub(super) cursor_from: [CursorRect; PLAYER_SLOTS],
+    pub(super) cursor_to: [CursorRect; PLAYER_SLOTS],
     pub(super) cursor_t: [f32; PLAYER_SLOTS],
 }
 
@@ -149,14 +171,8 @@ impl PaneState {
             arcade_row_focus: [false; PLAYER_SLOTS],
             row_tweens: Vec::new(),
             cursor_initialized: [false; PLAYER_SLOTS],
-            cursor_from_x: [0.0; PLAYER_SLOTS],
-            cursor_from_y: [0.0; PLAYER_SLOTS],
-            cursor_from_w: [0.0; PLAYER_SLOTS],
-            cursor_from_h: [0.0; PLAYER_SLOTS],
-            cursor_to_x: [0.0; PLAYER_SLOTS],
-            cursor_to_y: [0.0; PLAYER_SLOTS],
-            cursor_to_w: [0.0; PLAYER_SLOTS],
-            cursor_to_h: [0.0; PLAYER_SLOTS],
+            cursor_from: [CursorRect::default(); PLAYER_SLOTS],
+            cursor_to: [CursorRect::default(); PLAYER_SLOTS],
             cursor_t: [1.0; PLAYER_SLOTS],
         }
     }
@@ -170,14 +186,8 @@ impl PaneState {
         self.inline_choice_x = [f32::NAN; PLAYER_SLOTS];
         self.arcade_row_focus = [false; PLAYER_SLOTS];
         self.cursor_initialized = [false; PLAYER_SLOTS];
-        self.cursor_from_x = [0.0; PLAYER_SLOTS];
-        self.cursor_from_y = [0.0; PLAYER_SLOTS];
-        self.cursor_from_w = [0.0; PLAYER_SLOTS];
-        self.cursor_from_h = [0.0; PLAYER_SLOTS];
-        self.cursor_to_x = [0.0; PLAYER_SLOTS];
-        self.cursor_to_y = [0.0; PLAYER_SLOTS];
-        self.cursor_to_w = [0.0; PLAYER_SLOTS];
-        self.cursor_to_h = [0.0; PLAYER_SLOTS];
+        self.cursor_from = [CursorRect::default(); PLAYER_SLOTS];
+        self.cursor_to = [CursorRect::default(); PLAYER_SLOTS];
         self.cursor_t = [1.0; PLAYER_SLOTS];
     }
 }


### PR DESCRIPTION
## refactor(player-options): wrap cursor tween endpoints in `CursorRect`

## Summary

The cursor ring tween on `PaneState` previously stored its endpoints as eight separate per-player arrays — `cursor_from_x/y/w/h` and `cursor_to_x/y/w/h` — plus `cursor_t` and `cursor_initialized`. Every read/write site touched the components individually, so retargeting the cursor was 8 lines of assignments and computing the in-flight position was 4 `mul_add` expressions repeated in two places.

This PR groups the four components into a small `CursorRect` value type and reduces every cursor site to whole-rect operations.

## Why this shape

Pure refactor — no behavior change. The four cursor components always move together (StopTweening/BeginTweening parity with ITGmania `ScreenOptions::TweenCursor`), so storing them as eight parallel arrays leaked an internal layout choice into every call site. Wrapping them lets the lerp live in one place and makes the intent (`from → to` over `t`) read directly off the field names.

`cursor_t` and `cursor_initialized` stay separate because they are scalar/flag state, not part of the rect.
