### PR TITLE
Player Options Row Mirror Accross Players Flag

### DIFF
--- a/src/screens/player_options/choice.rs
+++ b/src/screens/player_options/choice.rs
@@ -115,7 +115,12 @@ pub(super) fn dispatch_behavior_delta(
     let Some(&id) = state.pane().row_map.display_order().get(row_index) else {
         return;
     };
-    let Some(behavior) = state.pane().row_map.get(id).map(|r| r.behavior) else {
+    let Some((behavior, mirror_across_players)) = state
+        .pane()
+        .row_map
+        .get(id)
+        .map(|r| (r.behavior, r.mirror_across_players))
+    else {
         return;
     };
 
@@ -124,11 +129,17 @@ pub(super) fn dispatch_behavior_delta(
         RowBehavior::Cycle(b) => apply_cycle(state, player_idx, id, delta, &b),
         RowBehavior::Custom(b) => (b.apply)(state, player_idx, id, delta),
         RowBehavior::Bitmask(_) => Outcome::NONE,
-        RowBehavior::Action(ActionRow::Exit) => Outcome::NONE,
-        RowBehavior::Action(ActionRow::WhatComesNext) => {
-            apply_what_comes_next_cycle(state, player_idx, id, delta)
-        }
+        RowBehavior::Exit => Outcome::NONE,
     };
+
+    if outcome.persisted && mirror_across_players {
+        if let Some(row) = state.pane_mut().row_map.get_mut(id) {
+            let v = row.selected_choice_index[player_idx];
+            for slot in 0..PLAYER_SLOTS {
+                row.selected_choice_index[slot] = v;
+            }
+        }
+    }
 
     if outcome.persisted {
         super::sync_inline_intent_from_row(state, asset_manager, player_idx, row_index);
@@ -202,24 +213,6 @@ fn apply_cycle(
             n.apply_for_player(state, player_idx, &choice)
         }
     }
-}
-
-fn apply_what_comes_next_cycle(
-    state: &mut State,
-    player_idx: usize,
-    id: RowId,
-    delta: isize,
-) -> Outcome {
-    let new_index = match cycle_choice_index(state, player_idx, id, delta) {
-        Some(i) => i,
-        None => return Outcome::NONE,
-    };
-    if let Some(row) = state.pane_mut().row_map.get_mut(id) {
-        for slot in 0..PLAYER_SLOTS {
-            row.selected_choice_index[slot] = new_index;
-        }
-    }
-    Outcome::persisted()
 }
 
 // ========================= Original choice.rs ==========================

--- a/src/screens/player_options/inline_nav.rs
+++ b/src/screens/player_options/inline_nav.rs
@@ -148,7 +148,7 @@ pub(super) fn commit_inline_focus_selection(
     let Some(focus_idx) = focused_inline_choice_index(state, asset_manager, idx, row_idx) else {
         return false;
     };
-    let is_shared = row_is_shared(row.id);
+    let is_shared = row.mirror_across_players;
     if let Some(&row_id) = state.pane().row_map.display_order().get(row_idx) {
         if let Some(row) = state.pane_mut().row_map.get_mut(row_id) {
             if is_shared {

--- a/src/screens/player_options/panes/advanced.rs
+++ b/src/screens/player_options/panes/advanced.rs
@@ -328,6 +328,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "TurnHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::Scroll,
@@ -343,6 +344,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "ScrollHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::Hide,
@@ -360,6 +362,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "HideHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::LifeMeterType,
@@ -373,6 +376,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "LifeMeterTypeHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::LifeBarOptions,
@@ -386,6 +390,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "LifeBarOptionsHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::DataVisualizations,
@@ -399,6 +404,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "DataVisualizationsHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::DensityGraphBackground,
@@ -411,6 +417,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "DensityGraphBackgroundHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::TargetScore,
@@ -435,6 +442,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [10; PLAYER_SLOTS], // S by default
         help: vec![tr("PlayerOptionsHelp", "TargetScoreHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::ActionOnMissedTarget,
@@ -448,6 +456,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "TargetScoreMissPolicyHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::MiniIndicator,
@@ -465,6 +474,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "MiniIndicatorHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::IndicatorScoreType,
@@ -478,6 +488,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "IndicatorScoreTypeHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::GameplayExtras,
@@ -487,6 +498,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "GameplayExtrasHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::ComboColors,
@@ -502,6 +514,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "ComboColorsHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::ComboColorMode,
@@ -514,6 +527,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "ComboColorModeHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::CarryCombo,
@@ -526,6 +540,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "CarryComboHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::JudgmentTilt,
@@ -538,6 +553,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "JudgmentTiltHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::JudgmentTiltIntensity,
@@ -547,6 +563,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "JudgmentTiltIntensityHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::JudgmentBehindArrows,
@@ -559,6 +576,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "JudgmentBehindArrowsHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::OffsetIndicator,
@@ -571,6 +589,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "OffsetIndicatorHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::ErrorBar,
@@ -586,6 +605,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "ErrorBarHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::ErrorBarTrim,
@@ -600,6 +620,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "ErrorBarTrimHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::ErrorBarOptions,
@@ -612,6 +633,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "ErrorBarOptionsHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::ErrorBarOffsetX,
@@ -621,6 +643,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [HUD_OFFSET_ZERO_INDEX; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "ErrorBarOffsetXHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::ErrorBarOffsetY,
@@ -630,6 +653,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [HUD_OFFSET_ZERO_INDEX; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "ErrorBarOffsetYHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::MeasureCounter,
@@ -646,6 +670,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "MeasureCounterHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::MeasureCounterLookahead,
@@ -661,6 +686,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "MeasureCounterLookaheadHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::MeasureCounterOptions,
@@ -676,6 +702,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "MeasureCounterOptionsHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::MeasureLines,
@@ -690,6 +717,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "MeasureLinesHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::RescoreEarlyHits,
@@ -702,6 +730,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "RescoreEarlyHitsHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::EarlyDecentWayOffOptions,
@@ -718,6 +747,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "EarlyDecentWayOffOptionsHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::ResultsExtras,
@@ -727,6 +757,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "ResultsExtrasHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::TimingWindows,
@@ -741,6 +772,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "TimingWindowsHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::FAPlusOptions,
@@ -757,6 +789,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "FAPlusOptionsHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::CustomBlueFantasticWindow,
@@ -769,6 +802,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "CustomBlueFantasticWindowHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::CustomBlueFantasticWindowMs,
@@ -778,24 +812,27 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "CustomBlueFantasticWindowMsHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::WhatComesNext,
-        behavior: RowBehavior::Action(ActionRow::WhatComesNext),
+        behavior: RowBehavior::Custom(super::WHAT_COMES_NEXT),
         name: lookup_key("PlayerOptions", "WhatComesNext"),
         choices: what_comes_next_choices(OptionsPane::Advanced, return_screen),
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "WhatComesNextAdvancedHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: true,
     });
     b.push(Row {
         id: RowId::Exit,
-        behavior: RowBehavior::Action(ActionRow::Exit),
+        behavior: RowBehavior::Exit,
         name: lookup_key("Common", "Exit"),
         choices: vec![tr("Common", "Exit").to_string()],
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![String::new()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.finish()
 }

--- a/src/screens/player_options/panes/main.rs
+++ b/src/screens/player_options/panes/main.rs
@@ -465,6 +465,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::SpeedMod,
@@ -477,6 +478,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::Mini,
@@ -489,6 +491,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::Perspective,
@@ -507,6 +510,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::NoteSkin,
@@ -523,6 +527,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::MineSkin,
@@ -535,6 +540,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::ReceptorSkin,
@@ -547,6 +553,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::TapExplosionSkin,
@@ -559,6 +566,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::JudgmentFont,
@@ -574,6 +582,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::JudgmentOffsetX,
@@ -586,6 +595,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::JudgmentOffsetY,
@@ -598,6 +608,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::ComboFont,
@@ -619,6 +630,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::ComboOffsetX,
@@ -631,6 +643,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::ComboOffsetY,
@@ -643,6 +656,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::HoldJudgment,
@@ -658,6 +672,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::BackgroundFilter,
@@ -675,6 +690,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::NoteFieldOffsetX,
@@ -687,6 +703,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::NoteFieldOffsetY,
@@ -699,6 +716,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::VisualDelay,
@@ -711,6 +729,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::GlobalOffsetShift,
@@ -723,6 +742,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::MusicRate,
@@ -735,6 +755,7 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::Stepchart,
@@ -747,10 +768,11 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: Some(stepchart_choice_indices),
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::WhatComesNext,
-        behavior: RowBehavior::Action(ActionRow::WhatComesNext),
+        behavior: RowBehavior::Custom(super::WHAT_COMES_NEXT),
         name: lookup_key("PlayerOptions", "WhatComesNext"),
         choices: what_comes_next_choices(OptionsPane::Main, return_screen),
         selected_choice_index: [0; PLAYER_SLOTS],
@@ -759,15 +781,17 @@ pub(super) fn build_main_rows(
             .map(|s| s.to_string())
             .collect(),
         choice_difficulty_indices: None,
+        mirror_across_players: true,
     });
     b.push(Row {
         id: RowId::Exit,
-        behavior: RowBehavior::Action(ActionRow::Exit),
+        behavior: RowBehavior::Exit,
         name: lookup_key("Common", "Exit"),
         choices: vec![tr("Common", "Exit").to_string()],
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![String::new()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.finish()
 }

--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -7,6 +7,24 @@ use advanced::*;
 use main::*;
 use uncommon::*;
 
+/// Cycle binding for the "What Comes Next" row. Mirroring across players is
+/// handled by the dispatcher via `Row::mirror_across_players`, not here.
+pub(super) const WHAT_COMES_NEXT: CustomBinding = CustomBinding {
+    apply: apply_what_comes_next_cycle,
+};
+
+fn apply_what_comes_next_cycle(
+    state: &mut State,
+    player_idx: usize,
+    id: RowId,
+    delta: isize,
+) -> Outcome {
+    match super::choice::cycle_choice_index(state, player_idx, id, delta) {
+        Some(_) => Outcome::persisted(),
+        None => Outcome::NONE,
+    }
+}
+
 #[inline(always)]
 pub(super) fn choose_different_screen_label(return_screen: Screen) -> String {
     match return_screen {

--- a/src/screens/player_options/panes/uncommon.rs
+++ b/src/screens/player_options/panes/uncommon.rs
@@ -54,6 +54,7 @@ pub(super) fn build_uncommon_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "InsertHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::Remove,
@@ -72,6 +73,7 @@ pub(super) fn build_uncommon_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "RemoveHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::Holds,
@@ -87,6 +89,7 @@ pub(super) fn build_uncommon_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "HoldsHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::Accel,
@@ -102,6 +105,7 @@ pub(super) fn build_uncommon_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "AccelHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::Effect,
@@ -122,6 +126,7 @@ pub(super) fn build_uncommon_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "EffectHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::Appearance,
@@ -137,6 +142,7 @@ pub(super) fn build_uncommon_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "AppearanceHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::Attacks,
@@ -150,6 +156,7 @@ pub(super) fn build_uncommon_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "AttacksHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::HideLightType,
@@ -164,10 +171,11 @@ pub(super) fn build_uncommon_rows(return_screen: Screen) -> RowMap {
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![tr("PlayerOptionsHelp", "HideLightTypeHelp").to_string()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.push(Row {
         id: RowId::WhatComesNext,
-        behavior: RowBehavior::Action(ActionRow::WhatComesNext),
+        behavior: RowBehavior::Custom(super::WHAT_COMES_NEXT),
         name: lookup_key("PlayerOptions", "WhatComesNext"),
         choices: what_comes_next_choices(OptionsPane::Uncommon, return_screen),
         selected_choice_index: [0; PLAYER_SLOTS],
@@ -176,15 +184,17 @@ pub(super) fn build_uncommon_rows(return_screen: Screen) -> RowMap {
             tr("PlayerOptionsHelp", "WhatComesNextHelp2").to_string(),
         ],
         choice_difficulty_indices: None,
+        mirror_across_players: true,
     });
     b.push(Row {
         id: RowId::Exit,
-        behavior: RowBehavior::Action(ActionRow::Exit),
+        behavior: RowBehavior::Exit,
         name: lookup_key("Common", "Exit"),
         choices: vec![tr("Common", "Exit").to_string()],
         selected_choice_index: [0; PLAYER_SLOTS],
         help: vec![String::new()],
         choice_difficulty_indices: None,
+        mirror_across_players: false,
     });
     b.finish()
 }

--- a/src/screens/player_options/row.rs
+++ b/src/screens/player_options/row.rs
@@ -164,19 +164,13 @@ pub struct CustomBinding {
     pub apply: fn(&mut State, usize, RowId, isize) -> Outcome,
 }
 
-#[derive(Clone, Copy, Debug)]
-pub enum ActionRow {
-    Exit,
-    WhatComesNext,
-}
-
 /// What kind of row this is, and any state owned by the row's behaviour.
 #[derive(Clone, Copy, Debug)]
 pub enum RowBehavior {
     Numeric(NumericBinding),
     Cycle(CycleBinding),
     Bitmask(BitmaskBinding),
-    Action(ActionRow),
+    Exit,
     Custom(CustomBinding),
 }
 
@@ -313,16 +307,16 @@ pub struct Row {
     pub selected_choice_index: [usize; PLAYER_SLOTS],
     pub help: Vec<String>,
     pub choice_difficulty_indices: Option<Vec<usize>>,
+    /// When `true`, after a delta apply that persisted the row, the
+    /// dispatcher copies `selected_choice_index[player_idx]` to every other
+    /// slot. Also consulted by inline-nav focus commit. Use for rows whose
+    /// state is conceptually shared across players (e.g. `WhatComesNext`).
+    pub mirror_across_players: bool,
 }
 
 #[derive(Clone, Debug)]
 pub struct FixedStepchart {
     pub label: String,
-}
-
-#[inline(always)]
-pub(super) fn row_is_shared(id: RowId) -> bool {
-    id == RowId::Exit || id == RowId::WhatComesNext || id == RowId::MusicRate
 }
 
 #[inline(always)]

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -33,12 +33,13 @@ pub(super) mod tests {
     ) -> Row {
         Row {
             id,
-            behavior: super::RowBehavior::Action(super::ActionRow::Exit),
+            behavior: super::RowBehavior::Exit,
             name,
             choices: choices.iter().map(ToString::to_string).collect(),
             selected_choice_index,
             help: Vec::new(),
             choice_difficulty_indices: None,
+            mirror_across_players: false,
         }
     }
 
@@ -358,6 +359,7 @@ pub(super) mod tests {
             selected_choice_index: [0, 0],
             help: Vec::new(),
             choice_difficulty_indices: None,
+            mirror_across_players: false,
         };
         state.pane_mut().row_map.display_order.push(RowId::Scroll);
         state.pane_mut().row_map.insert(scroll_row);
@@ -395,6 +397,7 @@ pub(super) mod tests {
             selected_choice_index: [0, 0],
             help: Vec::new(),
             choice_difficulty_indices: None,
+            mirror_across_players: false,
         };
         let tilt_intensity_row = test_row(
             RowId::JudgmentTiltIntensity,
@@ -557,7 +560,7 @@ pub(super) mod tests {
             .unwrap()
             .selected_choice_index;
 
-        // Action::Exit returns Outcome::NONE so the dispatcher must not panic,
+        // RowBehavior::Exit returns Outcome::NONE so the dispatcher must not panic,
         // mutate the row, or play SFX (which would panic — audio uninit in tests).
         super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
         super::change_choice_for_player(&mut state, &asset_manager, P1, -3);
@@ -570,7 +573,7 @@ pub(super) mod tests {
             .selected_choice_index;
         assert_eq!(
             before, after,
-            "Action::Exit must not advance its own choice index"
+            "RowBehavior::Exit must not advance its own choice index"
         );
     }
 
@@ -594,6 +597,7 @@ pub(super) mod tests {
             selected_choice_index: [2, 0],
             help: Vec::new(),
             choice_difficulty_indices: None,
+            mirror_across_players: false,
         };
         state.pane_mut().row_map.display_order.push(RowId::Scroll);
         state.pane_mut().row_map.insert(scroll_row);
@@ -703,5 +707,136 @@ pub(super) mod tests {
                 "{id:?} is defined as a RowId but no pane builder constructs a Row for it",
             );
         }
+    }
+
+    #[test]
+    fn dispatch_mirror_flag_off_keeps_per_player_index() {
+        ensure_i18n();
+        let (mut state, asset_manager) = setup_state();
+
+        // BackgroundFilter is a Cycle row with mirror_across_players: false.
+        let row_index = state
+            .pane()
+            .row_map
+            .display_order()
+            .iter()
+            .position(|&id| id == RowId::BackgroundFilter)
+            .expect("BackgroundFilter should be in Main pane");
+        state.pane_mut().selected_row[P1] = row_index;
+
+        let row = state.pane().row_map.get(RowId::BackgroundFilter).unwrap();
+        assert!(
+            !row.mirror_across_players,
+            "BackgroundFilter should default to per-player choice"
+        );
+        let p2_before = row.selected_choice_index[1];
+
+        super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
+
+        let row = state.pane().row_map.get(RowId::BackgroundFilter).unwrap();
+        assert_eq!(
+            row.selected_choice_index[1], p2_before,
+            "P2 slot must not move when mirror_across_players is false"
+        );
+    }
+
+    #[test]
+    fn dispatch_mirror_skipped_when_apply_returns_none() {
+        ensure_i18n();
+        let (mut state, asset_manager) = setup_state();
+
+        // Insert a fixture Custom row whose apply always returns Outcome::NONE,
+        // even though mirror_across_players is true. The dispatcher must NOT
+        // overwrite P2 in that case.
+        let custom = super::CustomBinding {
+            apply: |_state, _player_idx, _id, _delta| super::Outcome::NONE,
+        };
+        let mirror_row = Row {
+            id: RowId::Hide,
+            behavior: super::RowBehavior::Custom(custom),
+            name: lookup_key("PlayerOptions", "Hide"),
+            choices: vec!["A".into(), "B".into(), "C".into()],
+            selected_choice_index: [0, 0],
+            help: Vec::new(),
+            choice_difficulty_indices: None,
+            mirror_across_players: true,
+        };
+        state.pane_mut().row_map.display_order.push(RowId::Hide);
+        state.pane_mut().row_map.insert(mirror_row);
+        let row_index = state.pane().row_map.display_order().len() - 1;
+        state.pane_mut().selected_row[P1] = row_index;
+
+        // Pre-set P2 to a distinct value to detect any incorrect overwrite.
+        state
+            .pane_mut()
+            .row_map
+            .get_mut(RowId::Hide)
+            .unwrap()
+            .selected_choice_index[1] = 2;
+
+        super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
+
+        let row = state.pane().row_map.get(RowId::Hide).unwrap();
+        assert_eq!(
+            row.selected_choice_index[1], 2,
+            "P2 must keep its prior value when the Custom apply returns Outcome::NONE"
+        );
+    }
+
+    #[test]
+    fn inline_nav_what_comes_next_syncs_both_players_on_focus_commit() {
+        ensure_i18n();
+        let (mut state, asset_manager) = setup_state();
+
+        let row_index = state
+            .pane()
+            .row_map
+            .display_order()
+            .iter()
+            .position(|&id| id == RowId::WhatComesNext)
+            .expect("WhatComesNext should be in Main pane");
+        state.pane_mut().selected_row[P1] = row_index;
+
+        let n = state
+            .pane()
+            .row_map
+            .get(RowId::WhatComesNext)
+            .unwrap()
+            .choices
+            .len();
+        assert!(
+            n >= 2,
+            "WhatComesNext needs at least 2 choices for this test"
+        );
+
+        // Reset both slots to a known starting choice and target a different one.
+        state
+            .pane_mut()
+            .row_map
+            .get_mut(RowId::WhatComesNext)
+            .unwrap()
+            .selected_choice_index = [0, 0];
+        let row = state.pane().row_map.get(RowId::WhatComesNext).unwrap();
+        let left_x = super::inline_nav::inline_choice_left_x_for_row(&state, row_index);
+        let centers =
+            super::inline_nav::inline_choice_centers(&row.choices, &asset_manager, left_x);
+        assert_eq!(centers.len(), n);
+        let target = 1usize;
+        state.pane_mut().inline_choice_x[P1] = centers[target];
+
+        let changed = super::inline_nav::commit_inline_focus_selection(
+            &mut state,
+            &asset_manager,
+            P1,
+            row_index,
+        );
+        assert!(changed, "commit should report a change");
+
+        let row = state.pane().row_map.get(RowId::WhatComesNext).unwrap();
+        assert_eq!(
+            row.selected_choice_index,
+            [target, target],
+            "WhatComesNext (mirror_across_players=true) must sync both player slots on inline focus commit"
+        );
     }
 }


### PR DESCRIPTION
# Player options: introduce `Row::mirror_across_players` flag; collapse `Action`

## Summary

Replace the row-kind-based "is this row shared across players?" predicate with a single per-row data flag, and collapse the `RowBehavior::Action` enum into the two variants it actually represented.

Behavior is unchanged. The PR is a refactor that turns implicit, scattered knowledge ("`WhatComesNext` mirrors", "`row_is_shared` lists three IDs", "`apply_what_comes_next_cycle` writes both slots") into one explicit property on the `Row` itself.