### PR TITLE
Player Options NoteSkin Custom binding

### DIFF
--- a/src/screens/player_options/choice.rs
+++ b/src/screens/player_options/choice.rs
@@ -9,8 +9,8 @@ use crate::game::profile::{self as gp, PlayerSide};
 ///
 /// `pub(super)` so `CustomBinding` arms in `panes/main.rs` and
 /// `panes/advanced.rs` can drive their own apply + persist sequence inline.
-/// The typed bindings (`NumericBinding`, `ChoiceBinding<T>`, `NoteSkinBinding`)
-/// wrap this internally via their `apply_for_player` methods below, so the
+/// The typed bindings (`NumericBinding`, `ChoiceBinding<T>`) wrap this
+/// internally via their `apply_for_player` methods below, so the
 /// dispatcher itself never reads it.
 pub(super) fn persist_ctx(player_idx: usize) -> (bool, PlayerSide) {
     let play_style = gp::get_session_play_style();
@@ -61,20 +61,6 @@ impl<T: Copy + 'static> ChoiceBinding<T> {
             (self.persist_for_side)(side, value);
         }
         outcome
-    }
-}
-
-impl NoteSkinBinding {
-    #[inline]
-    pub(super) fn apply_for_player(
-        &self,
-        state: &mut State,
-        player_idx: usize,
-        choice: &str,
-    ) -> Outcome {
-        let (should_persist, side) = persist_ctx(player_idx);
-        (self.apply)(state, player_idx, choice, should_persist, side);
-        Outcome::persisted()
     }
 }
 
@@ -191,16 +177,6 @@ fn apply_cycle(
     match binding {
         CycleBinding::Bool(b) => b.apply_for_player(state, player_idx, new_index != 0),
         CycleBinding::Index(i) => i.apply_for_player(state, player_idx, new_index),
-        CycleBinding::NoteSkin(n) => {
-            let choice = state
-                .pane()
-                .row_map
-                .get(id)
-                .and_then(|r| r.choices.get(new_index))
-                .cloned()
-                .unwrap_or_default();
-            n.apply_for_player(state, player_idx, &choice)
-        }
     }
 }
 

--- a/src/screens/player_options/panes/main.rs
+++ b/src/screens/player_options/panes/main.rs
@@ -91,73 +91,133 @@ const GLOBAL_OFFSET_SHIFT: NumericBinding = NumericBinding {
     persist_for_side: gp::update_global_offset_shift_ms_for_side,
 };
 
-const NOTE_SKIN: NoteSkinBinding = NoteSkinBinding {
-    apply: |state, player_idx, choice, should_persist, side| {
-        let name = if choice.is_empty() {
-            gp::NoteSkin::DEFAULT_NAME.to_string()
-        } else {
-            choice.to_string()
-        };
-        let setting = gp::NoteSkin::new(&name);
-        state.player_profiles[player_idx].noteskin = setting.clone();
-        if should_persist {
-            gp::update_noteskin_for_side(side, setting);
-        }
-        sync_noteskin_previews_for_player(state, player_idx);
+/// Shared boilerplate for a noteskin-style cycle row implemented via
+/// `CustomBinding`: advance the choice index, look up the chosen string, then
+/// hand off to a row-specific `apply` closure that knows how to turn that
+/// string into the right Profile/State write.
+fn apply_noteskin_delta(
+    state: &mut State,
+    player_idx: usize,
+    row_id: RowId,
+    delta: isize,
+    apply: fn(&mut State, usize, &str, bool, gp::PlayerSide),
+) -> Outcome {
+    let Some(new_index) =
+        super::super::choice::cycle_choice_index(state, player_idx, row_id, delta)
+    else {
+        return Outcome::NONE;
+    };
+    let choice = state
+        .pane()
+        .row_map
+        .get(row_id)
+        .and_then(|r| r.choices.get(new_index))
+        .cloned()
+        .unwrap_or_default();
+    let (should_persist, side) = super::super::choice::persist_ctx(player_idx);
+    apply(state, player_idx, &choice, should_persist, side);
+    Outcome::persisted()
+}
+
+const NOTE_SKIN: CustomBinding = CustomBinding {
+    apply: |state, player_idx, row_id, delta| {
+        apply_noteskin_delta(
+            state,
+            player_idx,
+            row_id,
+            delta,
+            |state, player_idx, choice, should_persist, side| {
+                let name = if choice.is_empty() {
+                    gp::NoteSkin::DEFAULT_NAME.to_string()
+                } else {
+                    choice.to_string()
+                };
+                let setting = gp::NoteSkin::new(&name);
+                state.player_profiles[player_idx].noteskin = setting.clone();
+                if should_persist {
+                    gp::update_noteskin_for_side(side, setting);
+                }
+                sync_noteskin_previews_for_player(state, player_idx);
+            },
+        )
     },
 };
-const MINE_SKIN: NoteSkinBinding = NoteSkinBinding {
-    apply: |state, player_idx, choice, should_persist, side| {
-        let match_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
-        let setting = if choice == match_label.as_ref() {
-            None
-        } else {
-            Some(gp::NoteSkin::new(choice))
-        };
-        state.player_profiles[player_idx]
-            .mine_noteskin
-            .clone_from(&setting);
-        if should_persist {
-            gp::update_mine_noteskin_for_side(side, setting);
-        }
-        sync_noteskin_previews_for_player(state, player_idx);
+const MINE_SKIN: CustomBinding = CustomBinding {
+    apply: |state, player_idx, row_id, delta| {
+        apply_noteskin_delta(
+            state,
+            player_idx,
+            row_id,
+            delta,
+            |state, player_idx, choice, should_persist, side| {
+                let match_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
+                let setting = if choice == match_label.as_ref() {
+                    None
+                } else {
+                    Some(gp::NoteSkin::new(choice))
+                };
+                state.player_profiles[player_idx]
+                    .mine_noteskin
+                    .clone_from(&setting);
+                if should_persist {
+                    gp::update_mine_noteskin_for_side(side, setting);
+                }
+                sync_noteskin_previews_for_player(state, player_idx);
+            },
+        )
     },
 };
-const RECEPTOR_SKIN: NoteSkinBinding = NoteSkinBinding {
-    apply: |state, player_idx, choice, should_persist, side| {
-        let match_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
-        let setting = if choice == match_label.as_ref() {
-            None
-        } else {
-            Some(gp::NoteSkin::new(choice))
-        };
-        state.player_profiles[player_idx]
-            .receptor_noteskin
-            .clone_from(&setting);
-        if should_persist {
-            gp::update_receptor_noteskin_for_side(side, setting);
-        }
-        sync_noteskin_previews_for_player(state, player_idx);
+const RECEPTOR_SKIN: CustomBinding = CustomBinding {
+    apply: |state, player_idx, row_id, delta| {
+        apply_noteskin_delta(
+            state,
+            player_idx,
+            row_id,
+            delta,
+            |state, player_idx, choice, should_persist, side| {
+                let match_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
+                let setting = if choice == match_label.as_ref() {
+                    None
+                } else {
+                    Some(gp::NoteSkin::new(choice))
+                };
+                state.player_profiles[player_idx]
+                    .receptor_noteskin
+                    .clone_from(&setting);
+                if should_persist {
+                    gp::update_receptor_noteskin_for_side(side, setting);
+                }
+                sync_noteskin_previews_for_player(state, player_idx);
+            },
+        )
     },
 };
-const TAP_EXPLOSION_SKIN: NoteSkinBinding = NoteSkinBinding {
-    apply: |state, player_idx, choice, should_persist, side| {
-        let match_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
-        let no_tap_label = tr("PlayerOptions", NO_TAP_EXPLOSION_LABEL);
-        let setting = if choice == match_label.as_ref() {
-            None
-        } else if choice == no_tap_label.as_ref() {
-            Some(gp::NoteSkin::none_choice())
-        } else {
-            Some(gp::NoteSkin::new(choice))
-        };
-        state.player_profiles[player_idx]
-            .tap_explosion_noteskin
-            .clone_from(&setting);
-        if should_persist {
-            gp::update_tap_explosion_noteskin_for_side(side, setting);
-        }
-        sync_noteskin_previews_for_player(state, player_idx);
+const TAP_EXPLOSION_SKIN: CustomBinding = CustomBinding {
+    apply: |state, player_idx, row_id, delta| {
+        apply_noteskin_delta(
+            state,
+            player_idx,
+            row_id,
+            delta,
+            |state, player_idx, choice, should_persist, side| {
+                let match_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
+                let no_tap_label = tr("PlayerOptions", NO_TAP_EXPLOSION_LABEL);
+                let setting = if choice == match_label.as_ref() {
+                    None
+                } else if choice == no_tap_label.as_ref() {
+                    Some(gp::NoteSkin::none_choice())
+                } else {
+                    Some(gp::NoteSkin::new(choice))
+                };
+                state.player_profiles[player_idx]
+                    .tap_explosion_noteskin
+                    .clone_from(&setting);
+                if should_persist {
+                    gp::update_tap_explosion_noteskin_for_side(side, setting);
+                }
+                sync_noteskin_previews_for_player(state, player_idx);
+            },
+        )
     },
 };
 
@@ -510,7 +570,7 @@ pub(super) fn build_main_rows(
     });
     b.push(Row {
         id: RowId::NoteSkin,
-        behavior: RowBehavior::Cycle(CycleBinding::NoteSkin(NOTE_SKIN)),
+        behavior: RowBehavior::Custom(NOTE_SKIN),
         name: lookup_key("PlayerOptions", "NoteSkin"),
         choices: if noteskin_names.is_empty() {
             vec![crate::game::profile::NoteSkin::DEFAULT_NAME.to_string()]
@@ -526,7 +586,7 @@ pub(super) fn build_main_rows(
     });
     b.push(Row {
         id: RowId::MineSkin,
-        behavior: RowBehavior::Cycle(CycleBinding::NoteSkin(MINE_SKIN)),
+        behavior: RowBehavior::Custom(MINE_SKIN),
         name: lookup_key("PlayerOptions", "MineSkin"),
         choices: build_noteskin_override_choices(noteskin_names),
         selected_choice_index: [0; PLAYER_SLOTS],
@@ -538,7 +598,7 @@ pub(super) fn build_main_rows(
     });
     b.push(Row {
         id: RowId::ReceptorSkin,
-        behavior: RowBehavior::Cycle(CycleBinding::NoteSkin(RECEPTOR_SKIN)),
+        behavior: RowBehavior::Custom(RECEPTOR_SKIN),
         name: lookup_key("PlayerOptions", "ReceptorSkin"),
         choices: build_noteskin_override_choices(noteskin_names),
         selected_choice_index: [0; PLAYER_SLOTS],
@@ -550,7 +610,7 @@ pub(super) fn build_main_rows(
     });
     b.push(Row {
         id: RowId::TapExplosionSkin,
-        behavior: RowBehavior::Cycle(CycleBinding::NoteSkin(TAP_EXPLOSION_SKIN)),
+        behavior: RowBehavior::Custom(TAP_EXPLOSION_SKIN),
         name: lookup_key("PlayerOptions", "TapExplosionSkin"),
         choices: build_tap_explosion_noteskin_choices(noteskin_names),
         selected_choice_index: [0; PLAYER_SLOTS],

--- a/src/screens/player_options/row.rs
+++ b/src/screens/player_options/row.rs
@@ -136,7 +136,6 @@ pub struct NumericBinding {
 pub enum CycleBinding {
     Bool(ChoiceBinding<bool>),
     Index(ChoiceBinding<usize>),
-    NoteSkin(NoteSkinBinding),
 }
 
 /// A typed cycle binding. `apply` writes the new value into the profile and
@@ -147,11 +146,6 @@ pub enum CycleBinding {
 pub struct ChoiceBinding<T: Copy + 'static> {
     pub apply: fn(&mut Profile, T) -> Outcome,
     pub persist_for_side: fn(PlayerSide, T),
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct NoteSkinBinding {
-    pub apply: fn(&mut State, usize, &str, bool, PlayerSide),
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
NoteSkin rows previously masqueraded as a Cycle variant, but their apply signature took (&mut State, usize, &str, bool, PlayerSide) — touching State, not Profile, and not fitting the ChoiceBinding<T> shape.

Fold them into RowBehavior::Custom via a small apply_noteskin_delta helper that factors the cycle_choice_index + persist_ctx + apply boilerplate. The four binding constants (NOTE_SKIN, MINE_SKIN, RECEPTOR_SKIN, TAP_EXPLOSION_SKIN) become CustomBindings; their per-row logic is preserved verbatim inside the inner closure.

No behavior change. CycleBinding now contains only Bool/Index variants — both genuine ChoiceBinding<T> wrappers, so the typed-binding family is internally consistent.