### PR TITLE
Player Options Typed Bitflags For Profile Row Masks

### DIFF
--- a/src/game/gameplay.rs
+++ b/src/game/gameplay.rs
@@ -700,7 +700,7 @@ fn effective_mini_value_with_visual_mask(
 
 #[inline(always)]
 fn effective_mini_value(profile: &profile::Profile) -> f32 {
-    let visual_mask = profile::normalize_visual_effects_mask(profile.visual_effects_active_mask);
+    let visual_mask = profile.visual_effects_active_mask.bits();
     effective_mini_value_with_visual_mask(profile, visual_mask, profile.mini_percent as f32)
 }
 
@@ -731,7 +731,7 @@ fn player_draw_scale_with_visual_mask(
 
 #[inline(always)]
 fn player_draw_scale(profile: &profile::Profile) -> f32 {
-    let visual_mask = profile::normalize_visual_effects_mask(profile.visual_effects_active_mask);
+    let visual_mask = profile.visual_effects_active_mask.bits();
     player_draw_scale_with_visual_mask(profile, visual_mask, 0.0)
 }
 
@@ -2545,9 +2545,9 @@ fn apply_uncommon_masks_for_player(
 ) {
     apply_uncommon_masks_with_masks(
         notes,
-        profile::normalize_insert_mask(player_profile.insert_active_mask),
-        profile::normalize_remove_mask(player_profile.remove_active_mask),
-        profile::normalize_holds_mask(player_profile.holds_active_mask),
+        player_profile.insert_active_mask.bits(),
+        player_profile.remove_active_mask.bits(),
+        player_profile.holds_active_mask.bits(),
         timing_player,
         col_offset,
         cols,
@@ -2559,9 +2559,9 @@ fn apply_uncommon_masks_for_player(
 
 #[inline(always)]
 fn has_uncommon_masks(profile: &profile::Profile) -> bool {
-    profile::normalize_insert_mask(profile.insert_active_mask) != 0
-        || profile::normalize_remove_mask(profile.remove_active_mask) != 0
-        || profile::normalize_holds_mask(profile.holds_active_mask) != 0
+    !profile.insert_active_mask.is_empty()
+        || !profile.remove_active_mask.is_empty()
+        || !profile.holds_active_mask.is_empty()
 }
 
 fn apply_uncommon_chart_transforms(
@@ -6433,15 +6433,15 @@ fn error_bar_register_tap(
     tap_music_time_s: f32,
 ) {
     let prof = &state.player_profiles[player];
-    let mut error_bar_mask = profile::normalize_error_bar_mask(prof.error_bar_active_mask);
-    if error_bar_mask == 0 {
+    let mut error_bar_mask = prof.error_bar_active_mask;
+    if error_bar_mask.is_empty() {
         error_bar_mask = profile::error_bar_mask_from_style(prof.error_bar, prof.error_bar_text);
     }
-    let show_text = (error_bar_mask & profile::ERROR_BAR_BIT_TEXT) != 0;
-    let show_monochrome = (error_bar_mask & profile::ERROR_BAR_BIT_MONOCHROME) != 0;
-    let show_colorful = (error_bar_mask & profile::ERROR_BAR_BIT_COLORFUL) != 0;
-    let show_highlight = (error_bar_mask & profile::ERROR_BAR_BIT_HIGHLIGHT) != 0;
-    let show_average = (error_bar_mask & profile::ERROR_BAR_BIT_AVERAGE) != 0;
+    let show_text = error_bar_mask.contains(profile::ErrorBarMask::TEXT);
+    let show_monochrome = error_bar_mask.contains(profile::ErrorBarMask::MONOCHROME);
+    let show_colorful = error_bar_mask.contains(profile::ErrorBarMask::COLORFUL);
+    let show_highlight = error_bar_mask.contains(profile::ErrorBarMask::HIGHLIGHT);
+    let show_average = error_bar_mask.contains(profile::ErrorBarMask::AVERAGE);
     let show_fa_plus_window = prof.show_fa_plus_window;
     let fa_plus_window_s = player_fa_plus_window_s(state, player);
     let error_bar_trim = prof.error_bar_trim;
@@ -9452,7 +9452,7 @@ mod tests {
     #[test]
     fn score_valid_rejects_nohands_when_chart_has_hands() {
         let mut profile = profile::Profile::default();
-        profile.remove_active_mask = super::REMOVE_MASK_BIT_NO_HANDS;
+        profile.remove_active_mask = profile::RemoveMask::from_bits_truncate(super::REMOVE_MASK_BIT_NO_HANDS);
         let chart = test_chart(
             ArrowStats {
                 hands: 4,

--- a/src/game/gameplay/attacks.rs
+++ b/src/game/gameplay/attacks.rs
@@ -2810,9 +2810,7 @@ pub(super) fn apply_chart_attacks_transforms(
 
 #[inline(always)]
 pub(super) fn base_appearance_effects(profile: &profile::Profile) -> AppearanceEffects {
-    AppearanceEffects::from_mask(profile::normalize_appearance_effects_mask(
-        profile.appearance_effects_active_mask,
-    ))
+    AppearanceEffects::from_mask(profile.appearance_effects_active_mask.bits())
 }
 
 #[inline(always)]
@@ -3098,9 +3096,7 @@ pub fn effective_accel_effects_for_player(state: &State, player_idx: usize) -> A
     let base = if player_attack_base_cleared(state, player_idx) {
         AccelEffects::default()
     } else {
-        AccelEffects::from_mask(profile::normalize_accel_effects_mask(
-            state.player_profiles[player_idx].accel_effects_active_mask,
-        ))
+        AccelEffects::from_mask(state.player_profiles[player_idx].accel_effects_active_mask.bits())
     };
     let attack = state.active_attack_accel[player_idx];
     AccelEffects {
@@ -3120,9 +3116,7 @@ pub fn effective_visual_effects_for_player(state: &State, player_idx: usize) -> 
     let base = if player_attack_base_cleared(state, player_idx) {
         VisualEffects::default()
     } else {
-        VisualEffects::from_mask(profile::normalize_visual_effects_mask(
-            state.player_profiles[player_idx].visual_effects_active_mask,
-        ))
+        VisualEffects::from_mask(state.player_profiles[player_idx].visual_effects_active_mask.bits())
     };
     let attack = state.active_attack_visual[player_idx];
     VisualEffects {

--- a/src/game/gameplay/stats.rs
+++ b/src/game/gameplay/stats.rs
@@ -179,7 +179,7 @@ pub fn score_invalid_reason_lines_for_chart(
         reasons.push("music rate is below 1.0x");
     }
 
-    let remove_mask = profile::normalize_remove_mask(profile.remove_active_mask);
+    let remove_mask = profile.remove_active_mask.bits();
     if (remove_mask & REMOVE_MASK_BIT_NO_HOLDS) != 0 && chart.stats.holds > 0 {
         reasons.push("No Holds is enabled on a chart with holds");
     }
@@ -202,7 +202,7 @@ pub fn score_invalid_reason_lines_for_chart(
         reasons.push("No Fakes is enabled on a chart with fakes");
     }
 
-    let holds_mask = profile::normalize_holds_mask(profile.holds_active_mask);
+    let holds_mask = profile.holds_active_mask.bits();
     if (holds_mask & HOLDS_MASK_BIT_NO_ROLLS) != 0 && chart.stats.rolls > 0 {
         reasons.push("No Rolls is enabled on a chart with rolls");
     }
@@ -211,7 +211,7 @@ pub fn score_invalid_reason_lines_for_chart(
         reasons.push("Little is enabled");
     }
 
-    let insert_mask = profile::normalize_insert_mask(profile.insert_active_mask);
+    let insert_mask = profile.insert_active_mask.bits();
     if (insert_mask & INSERT_MASK_BIT_ECHO) != 0 {
         reasons.push("Echo is enabled");
     }

--- a/src/game/profile.rs
+++ b/src/game/profile.rs
@@ -1,6 +1,7 @@
 pub use super::scroll::ScrollSpeedSetting;
 use crate::config::{self, SimpleIni, dirs};
 use bincode::{Decode, Encode};
+use bitflags::bitflags;
 use chrono::{Datelike, Local};
 use log::{debug, info, warn};
 use std::collections::HashSet;
@@ -319,41 +320,106 @@ impl core::fmt::Display for ScrollOption {
     }
 }
 
-pub const INSERT_ACTIVE_BITS: u8 = (1 << 7) - 1;
-pub const REMOVE_ACTIVE_BITS: u8 = u8::MAX;
-pub const HOLDS_ACTIVE_BITS: u8 = (1 << 5) - 1;
-pub const ACCEL_EFFECTS_ACTIVE_BITS: u8 = (1 << 5) - 1;
-pub const VISUAL_EFFECTS_ACTIVE_BITS: u16 = (1 << 10) - 1;
-pub const APPEARANCE_EFFECTS_ACTIVE_BITS: u8 = (1 << 5) - 1;
-
-#[inline(always)]
-pub const fn normalize_insert_mask(mask: u8) -> u8 {
-    mask & INSERT_ACTIVE_BITS
+bitflags! {
+    /// Persisted bitmask of enabled chart insert transforms.
+    ///
+    /// Bit layout matches the runtime `INSERT_MASK_BIT_*` constants in
+    /// `game::gameplay`, except bit 7 (Mines) is runtime/attack-only and is
+    /// deliberately not represented here. The boundary that fuses the
+    /// two — `profile.insert_active_mask.bits() | chart_attack.insert_mask` —
+    /// lives in `screens::components::gameplay::notefield`.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+    pub struct InsertMask: u8 {
+        const WIDE   = 1 << 0;
+        const BIG    = 1 << 1;
+        const QUICK  = 1 << 2;
+        const BMRIZE = 1 << 3;
+        const SKIPPY = 1 << 4;
+        const ECHO   = 1 << 5;
+        const STOMP  = 1 << 6;
+    }
 }
 
-#[inline(always)]
-pub const fn normalize_remove_mask(mask: u8) -> u8 {
-    mask & REMOVE_ACTIVE_BITS
+bitflags! {
+    /// Persisted bitmask of enabled chart removal transforms.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+    pub struct RemoveMask: u8 {
+        const LITTLE   = 1 << 0;
+        const NO_MINES = 1 << 1;
+        const NO_HOLDS = 1 << 2;
+        const NO_JUMPS = 1 << 3;
+        const NO_HANDS = 1 << 4;
+        const NO_QUADS = 1 << 5;
+        const NO_LIFTS = 1 << 6;
+        const NO_FAKES = 1 << 7;
+    }
 }
 
-#[inline(always)]
-pub const fn normalize_holds_mask(mask: u8) -> u8 {
-    mask & HOLDS_ACTIVE_BITS
+bitflags! {
+    /// Persisted bitmask of enabled hold transforms.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+    pub struct HoldsMask: u8 {
+        const PLANTED        = 1 << 0;
+        const FLOORED        = 1 << 1;
+        const TWISTER        = 1 << 2;
+        const NO_ROLLS       = 1 << 3;
+        const HOLDS_TO_ROLLS = 1 << 4;
+    }
 }
 
-#[inline(always)]
-pub const fn normalize_accel_effects_mask(mask: u8) -> u8 {
-    mask & ACCEL_EFFECTS_ACTIVE_BITS
+bitflags! {
+    /// Persisted bitmask of enabled acceleration transforms.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+    pub struct AccelEffectsMask: u8 {
+        const BOOST     = 1 << 0;
+        const BRAKE     = 1 << 1;
+        const WAVE      = 1 << 2;
+        const EXPAND    = 1 << 3;
+        const BOOMERANG = 1 << 4;
+    }
 }
 
-#[inline(always)]
-pub const fn normalize_visual_effects_mask(mask: u16) -> u16 {
-    mask & VISUAL_EFFECTS_ACTIVE_BITS
+bitflags! {
+    /// Persisted bitmask of enabled visual transforms.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+    pub struct VisualEffectsMask: u16 {
+        const DRUNK     = 1 << 0;
+        const DIZZY     = 1 << 1;
+        const CONFUSION = 1 << 2;
+        const BIG       = 1 << 3;
+        const FLIP      = 1 << 4;
+        const INVERT    = 1 << 5;
+        const TORNADO   = 1 << 6;
+        const TIPSY     = 1 << 7;
+        const BUMPY     = 1 << 8;
+        const BEAT      = 1 << 9;
+    }
 }
 
-#[inline(always)]
-pub const fn normalize_appearance_effects_mask(mask: u8) -> u8 {
-    mask & APPEARANCE_EFFECTS_ACTIVE_BITS
+bitflags! {
+    /// Persisted bitmask of enabled appearance transforms.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+    pub struct AppearanceEffectsMask: u8 {
+        const HIDDEN         = 1 << 0;
+        const SUDDEN         = 1 << 1;
+        const STEALTH        = 1 << 2;
+        const BLINK          = 1 << 3;
+        const RANDOM_VANISH  = 1 << 4;
+    }
+}
+
+bitflags! {
+    /// Persisted bitmask for the Error Bar SelectMultiple row. Each bit
+    /// toggles one rendering submodule (Colorful / Monochrome / Text /
+    /// Highlight / Average).
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+    pub struct ErrorBarMask: u8 {
+        const COLORFUL   = 1 << 0;
+        const MONOCHROME = 1 << 1;
+        const TEXT       = 1 << 2;
+        const HIGHLIGHT  = 1 << 3;
+        const AVERAGE    = 1 << 4;
+    }
 }
 
 // --- Profile Data ---
@@ -440,20 +506,29 @@ fn write_player_options(content: &mut String, section: &str, options: &PlayerOpt
     content.push_str(&format!("ScrollSpeed={}\n", options.scroll_speed));
     content.push_str(&format!("Scroll={}\n", options.scroll_option));
     content.push_str(&format!("Turn={}\n", options.turn_option));
-    content.push_str(&format!("InsertMask={}\n", options.insert_active_mask));
-    content.push_str(&format!("RemoveMask={}\n", options.remove_active_mask));
-    content.push_str(&format!("HoldsMask={}\n", options.holds_active_mask));
+    content.push_str(&format!(
+        "InsertMask={}\n",
+        options.insert_active_mask.bits()
+    ));
+    content.push_str(&format!(
+        "RemoveMask={}\n",
+        options.remove_active_mask.bits()
+    ));
+    content.push_str(&format!(
+        "HoldsMask={}\n",
+        options.holds_active_mask.bits()
+    ));
     content.push_str(&format!(
         "AccelEffectsMask={}\n",
-        options.accel_effects_active_mask
+        options.accel_effects_active_mask.bits()
     ));
     content.push_str(&format!(
         "VisualEffectsMask={}\n",
-        options.visual_effects_active_mask
+        options.visual_effects_active_mask.bits()
     ));
     content.push_str(&format!(
         "AppearanceEffectsMask={}\n",
-        options.appearance_effects_active_mask
+        options.appearance_effects_active_mask.bits()
     ));
     content.push_str(&format!("AttackMode={}\n", options.attack_mode));
     content.push_str(&format!("HideLightType={}\n", options.hide_light_type));
@@ -580,26 +655,29 @@ fn write_player_options(content: &mut String, section: &str, options: &PlayerOpt
         "ErrorBarText={}\n",
         i32::from(options.error_bar_text)
     ));
-    content.push_str(&format!("ErrorBarMask={}\n", options.error_bar_active_mask));
+    content.push_str(&format!(
+        "ErrorBarMask={}\n",
+        options.error_bar_active_mask.bits()
+    ));
     content.push_str(&format!(
         "Colorful={}\n",
-        i32::from((options.error_bar_active_mask & ERROR_BAR_BIT_COLORFUL) != 0)
+        i32::from(options.error_bar_active_mask.contains(ErrorBarMask::COLORFUL))
     ));
     content.push_str(&format!(
         "Monochrome={}\n",
-        i32::from((options.error_bar_active_mask & ERROR_BAR_BIT_MONOCHROME) != 0)
+        i32::from(options.error_bar_active_mask.contains(ErrorBarMask::MONOCHROME))
     ));
     content.push_str(&format!(
         "Text={}\n",
-        i32::from((options.error_bar_active_mask & ERROR_BAR_BIT_TEXT) != 0)
+        i32::from(options.error_bar_active_mask.contains(ErrorBarMask::TEXT))
     ));
     content.push_str(&format!(
         "Highlight={}\n",
-        i32::from((options.error_bar_active_mask & ERROR_BAR_BIT_HIGHLIGHT) != 0)
+        i32::from(options.error_bar_active_mask.contains(ErrorBarMask::HIGHLIGHT))
     ));
     content.push_str(&format!(
         "Average={}\n",
-        i32::from((options.error_bar_active_mask & ERROR_BAR_BIT_AVERAGE) != 0)
+        i32::from(options.error_bar_active_mask.contains(ErrorBarMask::AVERAGE))
     ));
     content.push_str(&format!("ErrorBarUp={}\n", i32::from(options.error_bar_up)));
     content.push_str(&format!(
@@ -879,7 +957,7 @@ fn load_player_options(
     let mask_from_key = profile_conf
         .get(section, "ErrorBarMask")
         .and_then(|s| s.parse::<u8>().ok())
-        .map(normalize_error_bar_mask);
+        .map(ErrorBarMask::from_bits_truncate);
     let colorful = profile_conf
         .get(section, "Colorful")
         .and_then(|s| s.parse::<u8>().ok())
@@ -906,23 +984,23 @@ fn load_player_options(
         || highlight.is_some()
         || average.is_some()
     {
-        let mut mask: u8 = 0;
+        let mut mask = ErrorBarMask::empty();
         if colorful.unwrap_or(false) {
-            mask |= ERROR_BAR_BIT_COLORFUL;
+            mask |= ErrorBarMask::COLORFUL;
         }
         if monochrome.unwrap_or(false) {
-            mask |= ERROR_BAR_BIT_MONOCHROME;
+            mask |= ErrorBarMask::MONOCHROME;
         }
         if text.unwrap_or(false) {
-            mask |= ERROR_BAR_BIT_TEXT;
+            mask |= ErrorBarMask::TEXT;
         }
         if highlight.unwrap_or(false) {
-            mask |= ERROR_BAR_BIT_HIGHLIGHT;
+            mask |= ErrorBarMask::HIGHLIGHT;
         }
         if average.unwrap_or(false) {
-            mask |= ERROR_BAR_BIT_AVERAGE;
+            mask |= ErrorBarMask::AVERAGE;
         }
-        Some(normalize_error_bar_mask(mask))
+        Some(mask)
     } else {
         None
     };
@@ -999,32 +1077,32 @@ fn load_player_options(
     options.insert_active_mask = profile_conf
         .get(section, "InsertMask")
         .and_then(|s| s.parse::<u8>().ok())
-        .map(normalize_insert_mask)
+        .map(InsertMask::from_bits_truncate)
         .unwrap_or(options.insert_active_mask);
     options.remove_active_mask = profile_conf
         .get(section, "RemoveMask")
         .and_then(|s| s.parse::<u8>().ok())
-        .map(normalize_remove_mask)
+        .map(RemoveMask::from_bits_truncate)
         .unwrap_or(options.remove_active_mask);
     options.holds_active_mask = profile_conf
         .get(section, "HoldsMask")
         .and_then(|s| s.parse::<u8>().ok())
-        .map(normalize_holds_mask)
+        .map(HoldsMask::from_bits_truncate)
         .unwrap_or(options.holds_active_mask);
     options.accel_effects_active_mask = profile_conf
         .get(section, "AccelEffectsMask")
         .and_then(|s| s.parse::<u8>().ok())
-        .map(normalize_accel_effects_mask)
+        .map(AccelEffectsMask::from_bits_truncate)
         .unwrap_or(options.accel_effects_active_mask);
     options.visual_effects_active_mask = profile_conf
         .get(section, "VisualEffectsMask")
         .and_then(|s| s.parse::<u16>().ok())
-        .map(normalize_visual_effects_mask)
+        .map(VisualEffectsMask::from_bits_truncate)
         .unwrap_or(options.visual_effects_active_mask);
     options.appearance_effects_active_mask = profile_conf
         .get(section, "AppearanceEffectsMask")
         .and_then(|s| s.parse::<u8>().ok())
-        .map(normalize_appearance_effects_mask)
+        .map(AppearanceEffectsMask::from_bits_truncate)
         .unwrap_or(options.appearance_effects_active_mask);
     options.attack_mode = profile_conf
         .get(section, "AttackMode")
@@ -1630,46 +1708,39 @@ impl core::fmt::Display for ErrorBarStyle {
     }
 }
 
-pub const ERROR_BAR_BIT_COLORFUL: u8 = 1 << 0;
-pub const ERROR_BAR_BIT_MONOCHROME: u8 = 1 << 1;
-pub const ERROR_BAR_BIT_TEXT: u8 = 1 << 2;
-pub const ERROR_BAR_BIT_HIGHLIGHT: u8 = 1 << 3;
-pub const ERROR_BAR_BIT_AVERAGE: u8 = 1 << 4;
-pub const ERROR_BAR_ACTIVE_BITS: u8 = ERROR_BAR_BIT_COLORFUL
-    | ERROR_BAR_BIT_MONOCHROME
-    | ERROR_BAR_BIT_TEXT
-    | ERROR_BAR_BIT_HIGHLIGHT
-    | ERROR_BAR_BIT_AVERAGE;
+pub const ERROR_BAR_BIT_COLORFUL: ErrorBarMask = ErrorBarMask::COLORFUL;
+pub const ERROR_BAR_BIT_MONOCHROME: ErrorBarMask = ErrorBarMask::MONOCHROME;
+pub const ERROR_BAR_BIT_TEXT: ErrorBarMask = ErrorBarMask::TEXT;
+pub const ERROR_BAR_BIT_HIGHLIGHT: ErrorBarMask = ErrorBarMask::HIGHLIGHT;
+pub const ERROR_BAR_BIT_AVERAGE: ErrorBarMask = ErrorBarMask::AVERAGE;
 
 #[inline(always)]
-pub const fn normalize_error_bar_mask(mask: u8) -> u8 {
-    mask & ERROR_BAR_ACTIVE_BITS
-}
-
-#[inline(always)]
-pub const fn error_bar_mask_from_style(style: ErrorBarStyle, text: bool) -> u8 {
-    let mut mask = if text { ERROR_BAR_BIT_TEXT } else { 0 };
-    mask |= match style {
-        ErrorBarStyle::None => 0,
-        ErrorBarStyle::Colorful => ERROR_BAR_BIT_COLORFUL,
-        ErrorBarStyle::Monochrome => ERROR_BAR_BIT_MONOCHROME,
-        ErrorBarStyle::Text => ERROR_BAR_BIT_TEXT,
-        ErrorBarStyle::Highlight => ERROR_BAR_BIT_HIGHLIGHT,
-        ErrorBarStyle::Average => ERROR_BAR_BIT_AVERAGE,
+pub const fn error_bar_mask_from_style(style: ErrorBarStyle, text: bool) -> ErrorBarMask {
+    let text_bits = if text {
+        ErrorBarMask::TEXT.bits()
+    } else {
+        0
     };
-    normalize_error_bar_mask(mask)
+    let style_bits = match style {
+        ErrorBarStyle::None => 0,
+        ErrorBarStyle::Colorful => ErrorBarMask::COLORFUL.bits(),
+        ErrorBarStyle::Monochrome => ErrorBarMask::MONOCHROME.bits(),
+        ErrorBarStyle::Text => ErrorBarMask::TEXT.bits(),
+        ErrorBarStyle::Highlight => ErrorBarMask::HIGHLIGHT.bits(),
+        ErrorBarStyle::Average => ErrorBarMask::AVERAGE.bits(),
+    };
+    ErrorBarMask::from_bits_truncate(text_bits | style_bits)
 }
 
 #[inline(always)]
-pub const fn error_bar_style_from_mask(mask: u8) -> ErrorBarStyle {
-    let mask = normalize_error_bar_mask(mask);
-    if (mask & ERROR_BAR_BIT_COLORFUL) != 0 {
+pub const fn error_bar_style_from_mask(mask: ErrorBarMask) -> ErrorBarStyle {
+    if mask.contains(ErrorBarMask::COLORFUL) {
         ErrorBarStyle::Colorful
-    } else if (mask & ERROR_BAR_BIT_MONOCHROME) != 0 {
+    } else if mask.contains(ErrorBarMask::MONOCHROME) {
         ErrorBarStyle::Monochrome
-    } else if (mask & ERROR_BAR_BIT_HIGHLIGHT) != 0 {
+    } else if mask.contains(ErrorBarMask::HIGHLIGHT) {
         ErrorBarStyle::Highlight
-    } else if (mask & ERROR_BAR_BIT_AVERAGE) != 0 {
+    } else if mask.contains(ErrorBarMask::AVERAGE) {
         ErrorBarStyle::Average
     } else {
         ErrorBarStyle::None
@@ -1677,8 +1748,8 @@ pub const fn error_bar_style_from_mask(mask: u8) -> ErrorBarStyle {
 }
 
 #[inline(always)]
-pub const fn error_bar_text_from_mask(mask: u8) -> bool {
-    (normalize_error_bar_mask(mask) & ERROR_BAR_BIT_TEXT) != 0
+pub const fn error_bar_text_from_mask(mask: ErrorBarMask) -> bool {
+    mask.contains(ErrorBarMask::TEXT)
 }
 
 pub const CUSTOM_FANTASTIC_WINDOW_MIN_MS: u8 = 1;
@@ -2308,12 +2379,12 @@ pub struct PlayerOptionsData {
     pub scroll_option: ScrollOption,
     pub reverse_scroll: bool,
     pub turn_option: TurnOption,
-    pub insert_active_mask: u8,
-    pub remove_active_mask: u8,
-    pub holds_active_mask: u8,
-    pub accel_effects_active_mask: u8,
-    pub visual_effects_active_mask: u16,
-    pub appearance_effects_active_mask: u8,
+    pub insert_active_mask: InsertMask,
+    pub remove_active_mask: RemoveMask,
+    pub holds_active_mask: HoldsMask,
+    pub accel_effects_active_mask: AccelEffectsMask,
+    pub visual_effects_active_mask: VisualEffectsMask,
+    pub appearance_effects_active_mask: AppearanceEffectsMask,
     pub attack_mode: AttackMode,
     pub hide_light_type: HideLightType,
     pub rescore_early_hits: bool,
@@ -2338,7 +2409,7 @@ pub struct PlayerOptionsData {
     pub responsive_colors: bool,
     pub show_life_percent: bool,
     pub tilt_multiplier: f32,
-    pub error_bar_active_mask: u8,
+    pub error_bar_active_mask: ErrorBarMask,
     pub error_bar: ErrorBarStyle,
     pub error_bar_text: bool,
     pub error_bar_up: bool,
@@ -2400,12 +2471,12 @@ fn default_player_options() -> PlayerOptionsData {
         scroll_option: ScrollOption::default(),
         reverse_scroll: false,
         turn_option: TurnOption::default(),
-        insert_active_mask: 0,
-        remove_active_mask: 0,
-        holds_active_mask: 0,
-        accel_effects_active_mask: 0,
-        visual_effects_active_mask: 0,
-        appearance_effects_active_mask: 0,
+        insert_active_mask: InsertMask::empty(),
+        remove_active_mask: RemoveMask::empty(),
+        holds_active_mask: HoldsMask::empty(),
+        accel_effects_active_mask: AccelEffectsMask::empty(),
+        visual_effects_active_mask: VisualEffectsMask::empty(),
+        appearance_effects_active_mask: AppearanceEffectsMask::empty(),
         attack_mode: AttackMode::default(),
         hide_light_type: HideLightType::default(),
         rescore_early_hits: true,
@@ -2521,12 +2592,12 @@ pub struct Profile {
     pub turn_option: TurnOption,
     // zmod uncommon modifiers (ScreenPlayerOptions3).
     // Bit order mirrors row choice order in metrics.ini.
-    pub insert_active_mask: u8,
-    pub remove_active_mask: u8,
-    pub holds_active_mask: u8,
-    pub accel_effects_active_mask: u8,
-    pub visual_effects_active_mask: u16,
-    pub appearance_effects_active_mask: u8,
+    pub insert_active_mask: InsertMask,
+    pub remove_active_mask: RemoveMask,
+    pub holds_active_mask: HoldsMask,
+    pub accel_effects_active_mask: AccelEffectsMask,
+    pub visual_effects_active_mask: VisualEffectsMask,
+    pub appearance_effects_active_mask: AppearanceEffectsMask,
     pub attack_mode: AttackMode,
     pub hide_light_type: HideLightType,
     // Allow early Decent/WayOff hits to be rescored to better judgments.
@@ -2566,8 +2637,7 @@ pub struct Profile {
     pub tilt_multiplier: f32,
     // Error bar (zmod semantics): each bit toggles one submodule in the
     // SelectMultiple row (Colorful/Monochrome/Text/Highlight/Average).
-    pub error_bar_active_mask: u8,
-    // Backward-compatible primary style string written to profile.ini.
+    pub error_bar_active_mask: ErrorBarMask,
     pub error_bar: ErrorBarStyle,
     // Backward-compatible text flag written to profile.ini.
     pub error_bar_text: bool,
@@ -4739,5 +4809,128 @@ mod tests {
 
         assert!(profile.tap_explosion_noteskin_hidden());
         assert_eq!(profile.resolved_tap_explosion_noteskin(), None);
+    }
+
+    #[test]
+    fn persisted_row_mask_bit_layouts_are_stable() {
+        use super::{
+            AccelEffectsMask, AppearanceEffectsMask, ErrorBarMask, HoldsMask, InsertMask,
+            RemoveMask, VisualEffectsMask,
+        };
+
+        // InsertMask: persisted bits 0..=6 (Mines is runtime-only and
+        // intentionally not represented here).
+        assert_eq!(InsertMask::WIDE.bits(), 1 << 0);
+        assert_eq!(InsertMask::BIG.bits(), 1 << 1);
+        assert_eq!(InsertMask::QUICK.bits(), 1 << 2);
+        assert_eq!(InsertMask::BMRIZE.bits(), 1 << 3);
+        assert_eq!(InsertMask::SKIPPY.bits(), 1 << 4);
+        assert_eq!(InsertMask::ECHO.bits(), 1 << 5);
+        assert_eq!(InsertMask::STOMP.bits(), 1 << 6);
+        assert_eq!(InsertMask::all().bits(), 0b0111_1111);
+
+        // RemoveMask: bits 0..=7
+        assert_eq!(RemoveMask::LITTLE.bits(), 1 << 0);
+        assert_eq!(RemoveMask::NO_MINES.bits(), 1 << 1);
+        assert_eq!(RemoveMask::NO_HOLDS.bits(), 1 << 2);
+        assert_eq!(RemoveMask::NO_JUMPS.bits(), 1 << 3);
+        assert_eq!(RemoveMask::NO_HANDS.bits(), 1 << 4);
+        assert_eq!(RemoveMask::NO_QUADS.bits(), 1 << 5);
+        assert_eq!(RemoveMask::NO_LIFTS.bits(), 1 << 6);
+        assert_eq!(RemoveMask::NO_FAKES.bits(), 1 << 7);
+        assert_eq!(RemoveMask::all().bits(), 0xFF);
+
+        assert_eq!(HoldsMask::PLANTED.bits(), 1 << 0);
+        assert_eq!(HoldsMask::FLOORED.bits(), 1 << 1);
+        assert_eq!(HoldsMask::TWISTER.bits(), 1 << 2);
+        assert_eq!(HoldsMask::NO_ROLLS.bits(), 1 << 3);
+        assert_eq!(HoldsMask::HOLDS_TO_ROLLS.bits(), 1 << 4);
+        assert_eq!(HoldsMask::all().bits(), 0b0001_1111);
+
+        assert_eq!(AccelEffectsMask::BOOST.bits(), 1 << 0);
+        assert_eq!(AccelEffectsMask::BRAKE.bits(), 1 << 1);
+        assert_eq!(AccelEffectsMask::WAVE.bits(), 1 << 2);
+        assert_eq!(AccelEffectsMask::EXPAND.bits(), 1 << 3);
+        assert_eq!(AccelEffectsMask::BOOMERANG.bits(), 1 << 4);
+        assert_eq!(AccelEffectsMask::all().bits(), 0b0001_1111);
+
+        assert_eq!(VisualEffectsMask::DRUNK.bits(), 1 << 0);
+        assert_eq!(VisualEffectsMask::DIZZY.bits(), 1 << 1);
+        assert_eq!(VisualEffectsMask::CONFUSION.bits(), 1 << 2);
+        assert_eq!(VisualEffectsMask::BIG.bits(), 1 << 3);
+        assert_eq!(VisualEffectsMask::FLIP.bits(), 1 << 4);
+        assert_eq!(VisualEffectsMask::INVERT.bits(), 1 << 5);
+        assert_eq!(VisualEffectsMask::TORNADO.bits(), 1 << 6);
+        assert_eq!(VisualEffectsMask::TIPSY.bits(), 1 << 7);
+        assert_eq!(VisualEffectsMask::BUMPY.bits(), 1 << 8);
+        assert_eq!(VisualEffectsMask::BEAT.bits(), 1 << 9);
+        assert_eq!(VisualEffectsMask::all().bits(), 0b11_1111_1111);
+
+        assert_eq!(AppearanceEffectsMask::HIDDEN.bits(), 1 << 0);
+        assert_eq!(AppearanceEffectsMask::SUDDEN.bits(), 1 << 1);
+        assert_eq!(AppearanceEffectsMask::STEALTH.bits(), 1 << 2);
+        assert_eq!(AppearanceEffectsMask::BLINK.bits(), 1 << 3);
+        assert_eq!(AppearanceEffectsMask::RANDOM_VANISH.bits(), 1 << 4);
+        assert_eq!(AppearanceEffectsMask::all().bits(), 0b0001_1111);
+
+        assert_eq!(ErrorBarMask::COLORFUL.bits(), 1 << 0);
+        assert_eq!(ErrorBarMask::MONOCHROME.bits(), 1 << 1);
+        assert_eq!(ErrorBarMask::TEXT.bits(), 1 << 2);
+        assert_eq!(ErrorBarMask::HIGHLIGHT.bits(), 1 << 3);
+        assert_eq!(ErrorBarMask::AVERAGE.bits(), 1 << 4);
+        assert_eq!(ErrorBarMask::all().bits(), 0b0001_1111);
+    }
+
+    #[test]
+    fn from_bits_truncate_drops_unrepresented_bits() {
+        use super::{InsertMask, VisualEffectsMask};
+
+        // InsertMask only persists 7 bits; bit 7 (Mines) belongs to runtime.
+        assert_eq!(
+            InsertMask::from_bits_truncate(0xFF),
+            InsertMask::all()
+        );
+        assert_eq!(InsertMask::from_bits_truncate(0xFF).bits(), 0b0111_1111);
+
+        // VisualEffectsMask is 10 bits in a u16.
+        assert_eq!(
+            VisualEffectsMask::from_bits_truncate(u16::MAX),
+            VisualEffectsMask::all()
+        );
+        assert_eq!(
+            VisualEffectsMask::from_bits_truncate(u16::MAX).bits(),
+            0b11_1111_1111
+        );
+    }
+
+    #[test]
+    fn error_bar_helpers_roundtrip_through_mask() {
+        use super::{ErrorBarMask, ErrorBarStyle, error_bar_mask_from_style,
+            error_bar_style_from_mask, error_bar_text_from_mask};
+
+        // Style + text combine into mask bits.
+        let mask = error_bar_mask_from_style(ErrorBarStyle::Colorful, true);
+        assert!(mask.contains(ErrorBarMask::COLORFUL));
+        assert!(mask.contains(ErrorBarMask::TEXT));
+        assert_eq!(error_bar_style_from_mask(mask), ErrorBarStyle::Colorful);
+        assert!(error_bar_text_from_mask(mask));
+
+        // Style precedence: Colorful > Monochrome > Highlight > Average > None.
+        let mask = ErrorBarMask::COLORFUL | ErrorBarMask::MONOCHROME;
+        assert_eq!(error_bar_style_from_mask(mask), ErrorBarStyle::Colorful);
+
+        // Text-only mask round-trips to (Style::None, text=true) — the legacy
+        // canonicalization quirk preserved by the typed helpers.
+        let mask = error_bar_mask_from_style(ErrorBarStyle::Text, false);
+        assert!(mask.contains(ErrorBarMask::TEXT));
+        assert!(!mask.contains(ErrorBarMask::COLORFUL));
+        assert_eq!(error_bar_style_from_mask(mask), ErrorBarStyle::None);
+        assert!(error_bar_text_from_mask(mask));
+
+        // Empty mask means no error bar at all.
+        let mask = error_bar_mask_from_style(ErrorBarStyle::None, false);
+        assert!(mask.is_empty());
+        assert_eq!(error_bar_style_from_mask(mask), ErrorBarStyle::None);
+        assert!(!error_bar_text_from_mask(mask));
     }
 }

--- a/src/game/profile/update.rs
+++ b/src/game/profile/update.rs
@@ -1,14 +1,13 @@
 use super::{
-    AttackMode, BackgroundFilter, ComboColors, ComboFont, ComboMode, DataVisualizations,
-    ErrorBarTrim, HUD_OFFSET_MAX, HUD_OFFSET_MIN, HideLightType, HoldJudgmentGraphic,
-    JudgmentGraphic, LifeMeterType, MeasureCounter, MeasureLines, MiniIndicator,
-    MiniIndicatorScoreType, NoteSkin, Perspective, PlayStyle, PlayerSide, ScrollOption,
-    ScrollSpeedSetting, TargetScoreSetting, TimingWindowsOption, TurnOption,
-    clamp_custom_fantastic_window_ms, error_bar_style_from_mask, error_bar_text_from_mask,
-    lock_profiles, normalize_accel_effects_mask, normalize_appearance_effects_mask,
-    normalize_error_bar_mask, normalize_holds_mask, normalize_insert_mask, normalize_remove_mask,
-    normalize_visual_effects_mask, sanitize_player_initials, save_profile_ini_for_side,
-    save_profile_stats_for_side, session_side_is_guest, side_ix,
+    AccelEffectsMask, AppearanceEffectsMask, AttackMode, BackgroundFilter, ComboColors, ComboFont,
+    ComboMode, DataVisualizations, ErrorBarMask, ErrorBarTrim, HUD_OFFSET_MAX, HUD_OFFSET_MIN,
+    HideLightType, HoldJudgmentGraphic, HoldsMask, InsertMask, JudgmentGraphic, LifeMeterType,
+    MeasureCounter, MeasureLines, MiniIndicator, MiniIndicatorScoreType, NoteSkin, Perspective,
+    PlayStyle, PlayerSide, RemoveMask, ScrollOption, ScrollSpeedSetting, TargetScoreSetting,
+    TimingWindowsOption, TurnOption, VisualEffectsMask, clamp_custom_fantastic_window_ms,
+    error_bar_style_from_mask, error_bar_text_from_mask, lock_profiles,
+    sanitize_player_initials, save_profile_ini_for_side, save_profile_stats_for_side,
+    session_side_is_guest, side_ix,
 };
 use chrono::Local;
 use std::path::Path;
@@ -229,8 +228,7 @@ pub fn update_turn_option_for_side(side: PlayerSide, setting: TurnOption) {
     save_profile_ini_for_side(side);
 }
 
-pub fn update_insert_mask_for_side(side: PlayerSide, mask: u8) {
-    let mask = normalize_insert_mask(mask);
+pub fn update_insert_mask_for_side(side: PlayerSide, mask: InsertMask) {
     {
         let mut profiles = lock_profiles();
         let profile = &mut profiles[side_ix(side)];
@@ -242,8 +240,7 @@ pub fn update_insert_mask_for_side(side: PlayerSide, mask: u8) {
     save_profile_ini_for_side(side);
 }
 
-pub fn update_remove_mask_for_side(side: PlayerSide, mask: u8) {
-    let mask = normalize_remove_mask(mask);
+pub fn update_remove_mask_for_side(side: PlayerSide, mask: RemoveMask) {
     {
         let mut profiles = lock_profiles();
         let profile = &mut profiles[side_ix(side)];
@@ -255,8 +252,7 @@ pub fn update_remove_mask_for_side(side: PlayerSide, mask: u8) {
     save_profile_ini_for_side(side);
 }
 
-pub fn update_holds_mask_for_side(side: PlayerSide, mask: u8) {
-    let mask = normalize_holds_mask(mask);
+pub fn update_holds_mask_for_side(side: PlayerSide, mask: HoldsMask) {
     {
         let mut profiles = lock_profiles();
         let profile = &mut profiles[side_ix(side)];
@@ -268,8 +264,7 @@ pub fn update_holds_mask_for_side(side: PlayerSide, mask: u8) {
     save_profile_ini_for_side(side);
 }
 
-pub fn update_accel_effects_mask_for_side(side: PlayerSide, mask: u8) {
-    let mask = normalize_accel_effects_mask(mask);
+pub fn update_accel_effects_mask_for_side(side: PlayerSide, mask: AccelEffectsMask) {
     {
         let mut profiles = lock_profiles();
         let profile = &mut profiles[side_ix(side)];
@@ -281,8 +276,7 @@ pub fn update_accel_effects_mask_for_side(side: PlayerSide, mask: u8) {
     save_profile_ini_for_side(side);
 }
 
-pub fn update_visual_effects_mask_for_side(side: PlayerSide, mask: u16) {
-    let mask = normalize_visual_effects_mask(mask);
+pub fn update_visual_effects_mask_for_side(side: PlayerSide, mask: VisualEffectsMask) {
     {
         let mut profiles = lock_profiles();
         let profile = &mut profiles[side_ix(side)];
@@ -294,8 +288,7 @@ pub fn update_visual_effects_mask_for_side(side: PlayerSide, mask: u16) {
     save_profile_ini_for_side(side);
 }
 
-pub fn update_appearance_effects_mask_for_side(side: PlayerSide, mask: u8) {
-    let mask = normalize_appearance_effects_mask(mask);
+pub fn update_appearance_effects_mask_for_side(side: PlayerSide, mask: AppearanceEffectsMask) {
     {
         let mut profiles = lock_profiles();
         let profile = &mut profiles[side_ix(side)];
@@ -904,8 +897,7 @@ pub fn update_tilt_multiplier_for_side(side: PlayerSide, multiplier: f32) {
     save_profile_ini_for_side(side);
 }
 
-pub fn update_error_bar_mask_for_side(side: PlayerSide, mask: u8) {
-    let mask = normalize_error_bar_mask(mask);
+pub fn update_error_bar_mask_for_side(side: PlayerSide, mask: ErrorBarMask) {
     let style = error_bar_style_from_mask(mask);
     let text = error_bar_text_from_mask(mask);
     {

--- a/src/game/scores/arrowcloud.rs
+++ b/src/game/scores/arrowcloud.rs
@@ -413,15 +413,15 @@ fn arrowcloud_modifiers(profile: &Profile) -> ArrowCloudModifiers {
     ArrowCloudModifiers {
         visual_delay: profile.visual_delay_ms,
         acceleration: arrowcloud_mask_labels_u8(
-            profile::normalize_accel_effects_mask(profile.accel_effects_active_mask),
+            profile.accel_effects_active_mask.bits(),
             &ARROWCLOUD_ACCEL_NAMES,
         ),
         appearance: arrowcloud_mask_labels_u8(
-            profile::normalize_appearance_effects_mask(profile.appearance_effects_active_mask),
+            profile.appearance_effects_active_mask.bits(),
             &ARROWCLOUD_APPEARANCE_NAMES,
         ),
         effect: arrowcloud_mask_labels_u16(
-            profile::normalize_visual_effects_mask(profile.visual_effects_active_mask),
+            profile.visual_effects_active_mask.bits(),
             &ARROWCLOUD_EFFECT_NAMES,
         ),
         mini: profile.mini_percent.clamp(-100, 150),

--- a/src/game/scores/groovestats.rs
+++ b/src/game/scores/groovestats.rs
@@ -517,9 +517,9 @@ fn groovestats_eval_state(
     } else {
         1.0
     };
-    let remove_mask = profile::normalize_remove_mask(profile.remove_active_mask);
-    let insert_mask = profile::normalize_insert_mask(profile.insert_active_mask);
-    let holds_mask = profile::normalize_holds_mask(profile.holds_active_mask);
+    let remove_mask = profile.remove_active_mask.bits();
+    let insert_mask = profile.insert_active_mask.bits();
+    let holds_mask = profile.holds_active_mask.bits();
     let fail_type_ok = matches!(
         crate::config::get().default_fail_type,
         crate::config::DefaultFailType::Immediate
@@ -1455,7 +1455,7 @@ mod tests {
     fn groovestats_validity_allows_cmod_and_no_mines() {
         let mut profile = Profile::default();
         profile.scroll_speed = ScrollSpeedSetting::CMod(650.0);
-        profile.remove_active_mask = 1u8 << 1;
+        profile.remove_active_mask = crate::game::profile::RemoveMask::from_bits_truncate(1u8 << 1);
 
         assert_eq!(
             groovestats_submit_invalid_reason(&sample_chart("dance-single"), false, &profile, 1.5),

--- a/src/game/scores/itl.rs
+++ b/src/game/scores/itl.rs
@@ -1303,8 +1303,7 @@ fn itl_eval_state(gs: &gameplay::State, player_idx: usize, data: &ItlFileData) -
     } else {
         1.0
     };
-    let remove_mask =
-        profile::normalize_remove_mask(gs.player_profiles[player_idx].remove_active_mask);
+    let remove_mask = gs.player_profiles[player_idx].remove_active_mask.bits();
     let mines_enabled = (remove_mask & (1u8 << 1)) == 0;
     let passed = gameplay_run_passed(
         gs.song_completed_naturally,

--- a/src/screens/components/gameplay/notefield.rs
+++ b/src/screens/components/gameplay/notefield.rs
@@ -573,11 +573,11 @@ fn gameplay_mods_text_key(state: &State, player_idx: usize) -> GameplayModsTextK
         speed_tag,
         speed_bits,
         noteskin_hash: noteskin_hasher.finish(),
-        insert_mask: profile::normalize_insert_mask(profile.insert_active_mask)
+        insert_mask: profile.insert_active_mask.bits()
             | chart_attack.insert_mask,
-        remove_mask: profile::normalize_remove_mask(profile.remove_active_mask)
+        remove_mask: profile.remove_active_mask.bits()
             | chart_attack.remove_mask,
-        holds_mask: profile::normalize_holds_mask(profile.holds_active_mask)
+        holds_mask: profile.holds_active_mask.bits()
             | chart_attack.holds_mask,
         turn_bits: turn_option_bits(profile.turn_option) | chart_attack.turn_bits,
         attack_mode: profile.attack_mode as u8,
@@ -1684,12 +1684,12 @@ fn zmod_layout_ys(
     let mut bottom_y = judgment_y + ERROR_BAR_JUDGMENT_HEIGHT * 0.5;
 
     // Zmod SL-Layout.lua: hasErrorBar checks multiple flags.
-    let mut error_bar_mask = profile::normalize_error_bar_mask(profile.error_bar_active_mask);
-    if error_bar_mask == 0 {
+    let mut error_bar_mask = profile.error_bar_active_mask;
+    if error_bar_mask.is_empty() {
         error_bar_mask =
             profile::error_bar_mask_from_style(profile.error_bar, profile.error_bar_text);
     }
-    let has_error_bar = error_bar_mask != 0;
+    let has_error_bar = !error_bar_mask.is_empty();
     if has_error_bar {
         if resolved_judgment_texture(profile).is_none() {
             // Error bar replaces judgment; no top/bottom adjustment.
@@ -2945,8 +2945,8 @@ pub fn build_bundles(
         return BuiltNotefield::empty(screen_center_x());
     }
     let error_bar_mask = {
-        let mut mask = profile::normalize_error_bar_mask(profile.error_bar_active_mask);
-        if mask == 0 {
+        let mut mask = profile.error_bar_active_mask;
+        if mask.is_empty() {
             mask = profile::error_bar_mask_from_style(profile.error_bar, profile.error_bar_text);
         }
         mask
@@ -2960,11 +2960,11 @@ pub fn build_bundles(
     let actor_cap = (num_cols * 10).max(28)
         + measure_line_extra
         + if profile.column_cues { num_cols + 4 } else { 0 }
-        + if error_bar_mask != 0 { 18 } else { 0 };
+        + if !error_bar_mask.is_empty() { 18 } else { 0 };
     let hud_cap = 8
         + if profile.column_cues { 1 } else { 0 }
         + if profile.hide_combo { 0 } else { 2 }
-        + if (error_bar_mask & profile::ERROR_BAR_BIT_TEXT) != 0 {
+        + if error_bar_mask.contains(profile::ErrorBarMask::TEXT) {
             1
         } else {
             0
@@ -6389,12 +6389,12 @@ pub fn build_bundles(
         }
     }
 
-    let show_error_bar_colorful = (error_bar_mask & profile::ERROR_BAR_BIT_COLORFUL) != 0;
-    let show_error_bar_monochrome = (error_bar_mask & profile::ERROR_BAR_BIT_MONOCHROME) != 0;
-    let show_error_bar_text = (error_bar_mask & profile::ERROR_BAR_BIT_TEXT) != 0;
-    let show_error_bar_highlight = (error_bar_mask & profile::ERROR_BAR_BIT_HIGHLIGHT) != 0;
-    let show_error_bar_average = (error_bar_mask & profile::ERROR_BAR_BIT_AVERAGE) != 0;
-    let show_error_bar = error_bar_mask != 0;
+    let show_error_bar_colorful = error_bar_mask.contains(profile::ErrorBarMask::COLORFUL);
+    let show_error_bar_monochrome = error_bar_mask.contains(profile::ErrorBarMask::MONOCHROME);
+    let show_error_bar_text = error_bar_mask.contains(profile::ErrorBarMask::TEXT);
+    let show_error_bar_highlight = error_bar_mask.contains(profile::ErrorBarMask::HIGHLIGHT);
+    let show_error_bar_average = error_bar_mask.contains(profile::ErrorBarMask::AVERAGE);
+    let show_error_bar = !error_bar_mask.is_empty();
     let error_bar_y = hud_layout.error_bar_y;
     let error_bar_max_h = hud_layout.error_bar_max_h;
     let error_bar_x = playfield_center_x + error_bar_extra_x;

--- a/src/screens/player_options/choice.rs
+++ b/src/screens/player_options/choice.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::engine::audio;
-use crate::game::profile::{self as gp, PlayerSide};
+use crate::game::profile::{
+    self as gp, AccelEffectsMask, AppearanceEffectsMask, ErrorBarMask, HoldsMask, InsertMask,
+    PlayerSide, RemoveMask, VisualEffectsMask,
+};
 
 // ============================ Dispatchers ============================
 // Dispatch reads `row.behavior` to decide how to apply input.
@@ -436,14 +439,14 @@ pub(super) fn toggle_insert_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    if (state.insert_active_mask[idx] & bit) != 0 {
-        state.insert_active_mask[idx] &= !bit;
+    let mut bits = state.insert_active_mask[idx].bits();
+    if (bits & bit) != 0 {
+        bits &= !bit;
     } else {
-        state.insert_active_mask[idx] |= bit;
+        bits |= bit;
     }
-    state.insert_active_mask[idx] =
-        crate::game::profile::normalize_insert_mask(state.insert_active_mask[idx]);
-    let mask = state.insert_active_mask[idx];
+    let mask = InsertMask::from_bits_truncate(bits);
+    state.insert_active_mask[idx] = mask;
     state.player_profiles[idx].insert_active_mask = mask;
 
     let play_style = crate::game::profile::get_session_play_style();
@@ -492,14 +495,14 @@ pub(super) fn toggle_remove_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    if (state.remove_active_mask[idx] & bit) != 0 {
-        state.remove_active_mask[idx] &= !bit;
+    let mut bits = state.remove_active_mask[idx].bits();
+    if (bits & bit) != 0 {
+        bits &= !bit;
     } else {
-        state.remove_active_mask[idx] |= bit;
+        bits |= bit;
     }
-    state.remove_active_mask[idx] =
-        crate::game::profile::normalize_remove_mask(state.remove_active_mask[idx]);
-    let mask = state.remove_active_mask[idx];
+    let mask = RemoveMask::from_bits_truncate(bits);
+    state.remove_active_mask[idx] = mask;
     state.player_profiles[idx].remove_active_mask = mask;
 
     let play_style = crate::game::profile::get_session_play_style();
@@ -556,14 +559,14 @@ pub(super) fn toggle_holds_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    if (state.holds_active_mask[idx] & bit) != 0 {
-        state.holds_active_mask[idx] &= !bit;
+    let mut bits = state.holds_active_mask[idx].bits();
+    if (bits & bit) != 0 {
+        bits &= !bit;
     } else {
-        state.holds_active_mask[idx] |= bit;
+        bits |= bit;
     }
-    state.holds_active_mask[idx] =
-        crate::game::profile::normalize_holds_mask(state.holds_active_mask[idx]);
-    let mask = state.holds_active_mask[idx];
+    let mask = HoldsMask::from_bits_truncate(bits);
+    state.holds_active_mask[idx] = mask;
     state.player_profiles[idx].holds_active_mask = mask;
 
     let play_style = crate::game::profile::get_session_play_style();
@@ -620,14 +623,14 @@ pub(super) fn toggle_accel_effects_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    if (state.accel_effects_active_mask[idx] & bit) != 0 {
-        state.accel_effects_active_mask[idx] &= !bit;
+    let mut bits = state.accel_effects_active_mask[idx].bits();
+    if (bits & bit) != 0 {
+        bits &= !bit;
     } else {
-        state.accel_effects_active_mask[idx] |= bit;
+        bits |= bit;
     }
-    state.accel_effects_active_mask[idx] =
-        crate::game::profile::normalize_accel_effects_mask(state.accel_effects_active_mask[idx]);
-    let mask = state.accel_effects_active_mask[idx];
+    let mask = AccelEffectsMask::from_bits_truncate(bits);
+    state.accel_effects_active_mask[idx] = mask;
     state.player_profiles[idx].accel_effects_active_mask = mask;
 
     let play_style = crate::game::profile::get_session_play_style();
@@ -676,14 +679,14 @@ pub(super) fn toggle_visual_effects_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    if (state.visual_effects_active_mask[idx] & bit) != 0 {
-        state.visual_effects_active_mask[idx] &= !bit;
+    let mut bits = state.visual_effects_active_mask[idx].bits();
+    if (bits & bit) != 0 {
+        bits &= !bit;
     } else {
-        state.visual_effects_active_mask[idx] |= bit;
+        bits |= bit;
     }
-    state.visual_effects_active_mask[idx] =
-        crate::game::profile::normalize_visual_effects_mask(state.visual_effects_active_mask[idx]);
-    let mask = state.visual_effects_active_mask[idx];
+    let mask = VisualEffectsMask::from_bits_truncate(bits);
+    state.visual_effects_active_mask[idx] = mask;
     state.player_profiles[idx].visual_effects_active_mask = mask;
 
     let play_style = crate::game::profile::get_session_play_style();
@@ -740,16 +743,14 @@ pub(super) fn toggle_appearance_effects_row(state: &mut State, player_idx: usize
         return;
     }
 
-    if (state.appearance_effects_active_mask[idx] & bit) != 0 {
-        state.appearance_effects_active_mask[idx] &= !bit;
+    let mut bits = state.appearance_effects_active_mask[idx].bits();
+    if (bits & bit) != 0 {
+        bits &= !bit;
     } else {
-        state.appearance_effects_active_mask[idx] |= bit;
+        bits |= bit;
     }
-    state.appearance_effects_active_mask[idx] =
-        crate::game::profile::normalize_appearance_effects_mask(
-            state.appearance_effects_active_mask[idx],
-        );
-    let mask = state.appearance_effects_active_mask[idx];
+    let mask = AppearanceEffectsMask::from_bits_truncate(bits);
+    state.appearance_effects_active_mask[idx] = mask;
     state.player_profiles[idx].appearance_effects_active_mask = mask;
 
     let play_style = crate::game::profile::get_session_play_style();
@@ -981,14 +982,14 @@ pub(super) fn toggle_error_bar_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    if (state.error_bar_active_mask[idx] & bit) != 0 {
-        state.error_bar_active_mask[idx] &= !bit;
+    let mut bits = state.error_bar_active_mask[idx].bits();
+    if (bits & bit) != 0 {
+        bits &= !bit;
     } else {
-        state.error_bar_active_mask[idx] |= bit;
+        bits |= bit;
     }
-    state.error_bar_active_mask[idx] =
-        crate::game::profile::normalize_error_bar_mask(state.error_bar_active_mask[idx]);
-    let mask = state.error_bar_active_mask[idx];
+    let mask = ErrorBarMask::from_bits_truncate(bits);
+    state.error_bar_active_mask[idx] = mask;
     state.player_profiles[idx].error_bar_active_mask = mask;
     state.player_profiles[idx].error_bar = crate::game::profile::error_bar_style_from_mask(mask);
     state.player_profiles[idx].error_bar_text =

--- a/src/screens/player_options/layout.rs
+++ b/src/screens/player_options/layout.rs
@@ -119,7 +119,7 @@ pub(super) fn init_row_tweens(
     selected_row: [usize; PLAYER_SLOTS],
     active: [bool; PLAYER_SLOTS],
     hide_active_mask: [HideMask; PLAYER_SLOTS],
-    error_bar_active_mask: [u8; PLAYER_SLOTS],
+    error_bar_active_mask: [ErrorBarMask; PLAYER_SLOTS],
     allow_per_player_global_offsets: bool,
 ) -> Vec<RowTween> {
     let total_rows = row_map.display_order().len();

--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -73,39 +73,38 @@ pub(super) fn apply_profile_defaults(
 ) -> (
     ScrollMask,
     HideMask,
-    u8,
-    u8,
-    u8,
-    u8,
-    u16,
-    u8,
+    InsertMask,
+    RemoveMask,
+    HoldsMask,
+    AccelEffectsMask,
+    VisualEffectsMask,
+    AppearanceEffectsMask,
     FaPlusMask,
     EarlyDwMask,
     GameplayExtrasMask,
     GameplayExtrasMoreMask,
     ResultsExtrasMask,
     LifeBarOptionsMask,
-    u8,
+    ErrorBarMask,
     ErrorBarOptionsMask,
     MeasureCounterOptionsMask,
 ) {
     let mut scroll_active_mask = ScrollMask::empty();
     let mut hide_active_mask = HideMask::empty();
-    let mut insert_active_mask: u8 = 0;
-    let mut remove_active_mask: u8 = 0;
-    let mut holds_active_mask: u8 = 0;
-    let mut accel_effects_active_mask: u8 = 0;
-    let mut visual_effects_active_mask: u16 = 0;
-    let mut appearance_effects_active_mask: u8 = 0;
+    let mut insert_active_mask = InsertMask::empty();
+    let mut remove_active_mask = RemoveMask::empty();
+    let mut holds_active_mask = HoldsMask::empty();
+    let mut accel_effects_active_mask = AccelEffectsMask::empty();
+    let mut visual_effects_active_mask = VisualEffectsMask::empty();
+    let mut appearance_effects_active_mask = AppearanceEffectsMask::empty();
     let mut fa_plus_active_mask = FaPlusMask::empty();
     let mut early_dw_active_mask = EarlyDwMask::empty();
     let mut gameplay_extras_active_mask = GameplayExtrasMask::empty();
     let mut gameplay_extras_more_active_mask = GameplayExtrasMoreMask::empty();
     let mut results_extras_active_mask = ResultsExtrasMask::empty();
     let mut life_bar_options_active_mask = LifeBarOptionsMask::empty();
-    let mut error_bar_active_mask: u8 =
-        crate::game::profile::normalize_error_bar_mask(profile.error_bar_active_mask);
-    if error_bar_active_mask == 0 {
+    let mut error_bar_active_mask = profile.error_bar_active_mask;
+    if error_bar_active_mask.is_empty() {
         error_bar_active_mask = crate::game::profile::error_bar_mask_from_style(
             profile.error_bar,
             profile.error_bar_text,
@@ -389,11 +388,12 @@ pub(super) fn apply_profile_defaults(
         row.selected_choice_index[player_idx] = if profile.error_ms_display { 1 } else { 0 };
     }
     if let Some(row) = row_map.get_mut(RowId::ErrorBar) {
-        if error_bar_active_mask != 0 {
+        if !error_bar_active_mask.is_empty() {
+            let bits = error_bar_active_mask.bits();
             let first_idx = (0..row.choices.len())
                 .find(|i| {
                     let bit = 1u8 << (*i as u8);
-                    (error_bar_active_mask & bit) != 0
+                    (bits & bit) != 0
                 })
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;
@@ -750,14 +750,11 @@ pub(super) fn apply_profile_defaults(
         }
     }
     if let Some(row) = row_map.get_mut(RowId::Insert) {
-        insert_active_mask =
-            crate::game::profile::normalize_insert_mask(profile.insert_active_mask);
-        if insert_active_mask != 0 {
+        insert_active_mask = profile.insert_active_mask;
+        let bits = insert_active_mask.bits();
+        if bits != 0 {
             let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u8 << (*i as u8);
-                    (insert_active_mask & bit) != 0
-                })
+                .find(|i| (bits & (1u8 << (*i as u8))) != 0)
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;
         } else {
@@ -765,14 +762,11 @@ pub(super) fn apply_profile_defaults(
         }
     }
     if let Some(row) = row_map.get_mut(RowId::Remove) {
-        remove_active_mask =
-            crate::game::profile::normalize_remove_mask(profile.remove_active_mask);
-        if remove_active_mask != 0 {
+        remove_active_mask = profile.remove_active_mask;
+        let bits = remove_active_mask.bits();
+        if bits != 0 {
             let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u8 << (*i as u8);
-                    (remove_active_mask & bit) != 0
-                })
+                .find(|i| (bits & (1u8 << (*i as u8))) != 0)
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;
         } else {
@@ -780,13 +774,11 @@ pub(super) fn apply_profile_defaults(
         }
     }
     if let Some(row) = row_map.get_mut(RowId::Holds) {
-        holds_active_mask = crate::game::profile::normalize_holds_mask(profile.holds_active_mask);
-        if holds_active_mask != 0 {
+        holds_active_mask = profile.holds_active_mask;
+        let bits = holds_active_mask.bits();
+        if bits != 0 {
             let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u8 << (*i as u8);
-                    (holds_active_mask & bit) != 0
-                })
+                .find(|i| (bits & (1u8 << (*i as u8))) != 0)
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;
         } else {
@@ -794,14 +786,11 @@ pub(super) fn apply_profile_defaults(
         }
     }
     if let Some(row) = row_map.get_mut(RowId::Accel) {
-        accel_effects_active_mask =
-            crate::game::profile::normalize_accel_effects_mask(profile.accel_effects_active_mask);
-        if accel_effects_active_mask != 0 {
+        accel_effects_active_mask = profile.accel_effects_active_mask;
+        let bits = accel_effects_active_mask.bits();
+        if bits != 0 {
             let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u8 << (*i as u8);
-                    (accel_effects_active_mask & bit) != 0
-                })
+                .find(|i| (bits & (1u8 << (*i as u8))) != 0)
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;
         } else {
@@ -809,14 +798,11 @@ pub(super) fn apply_profile_defaults(
         }
     }
     if let Some(row) = row_map.get_mut(RowId::Effect) {
-        visual_effects_active_mask =
-            crate::game::profile::normalize_visual_effects_mask(profile.visual_effects_active_mask);
-        if visual_effects_active_mask != 0 {
+        visual_effects_active_mask = profile.visual_effects_active_mask;
+        let bits = visual_effects_active_mask.bits();
+        if bits != 0 {
             let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u16 << (*i as u16);
-                    (visual_effects_active_mask & bit) != 0
-                })
+                .find(|i| (bits & (1u16 << (*i as u16))) != 0)
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;
         } else {
@@ -824,15 +810,11 @@ pub(super) fn apply_profile_defaults(
         }
     }
     if let Some(row) = row_map.get_mut(RowId::Appearance) {
-        appearance_effects_active_mask = crate::game::profile::normalize_appearance_effects_mask(
-            profile.appearance_effects_active_mask,
-        );
-        if appearance_effects_active_mask != 0 {
+        appearance_effects_active_mask = profile.appearance_effects_active_mask;
+        let bits = appearance_effects_active_mask.bits();
+        if bits != 0 {
             let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u8 << (*i as u8);
-                    (appearance_effects_active_mask & bit) != 0
-                })
+                .find(|i| (bits & (1u8 << (*i as u8))) != 0)
                 .unwrap_or(0);
             row.selected_choice_index[player_idx] = first_idx;
         } else {

--- a/src/screens/player_options/render.rs
+++ b/src/screens/player_options/render.rs
@@ -475,7 +475,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.insert_active_mask[player_idx];
+                    let mask = state.insert_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }
@@ -512,7 +512,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.remove_active_mask[player_idx];
+                    let mask = state.remove_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }
@@ -549,7 +549,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.holds_active_mask[player_idx];
+                    let mask = state.holds_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }
@@ -586,7 +586,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.accel_effects_active_mask[player_idx];
+                    let mask = state.accel_effects_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }
@@ -623,7 +623,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.visual_effects_active_mask[player_idx];
+                    let mask = state.visual_effects_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }
@@ -660,7 +660,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.appearance_effects_active_mask[player_idx];
+                    let mask = state.appearance_effects_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }
@@ -919,7 +919,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     }
                 };
                 for player_idx in active_player_indices(active) {
-                    let mask = state.error_bar_active_mask[player_idx];
+                    let mask = state.error_bar_active_mask[player_idx].bits();
                     if mask == 0 {
                         continue;
                     }

--- a/src/screens/player_options/state.rs
+++ b/src/screens/player_options/state.rs
@@ -1,4 +1,8 @@
 use super::*;
+pub use crate::game::profile::{
+    AccelEffectsMask, AppearanceEffectsMask, ErrorBarMask, HoldsMask, InsertMask, RemoveMask,
+    VisualEffectsMask,
+};
 use bitflags::bitflags;
 
 bitflags! {
@@ -174,32 +178,32 @@ pub struct State {
     pub life_bar_options_active_mask: [LifeBarOptionsMask; PLAYER_SLOTS],
     // For Error Bar row: bitmask of which options are enabled.
     // bit0 = Colorful, bit1 = Monochrome, bit2 = Text, bit3 = Highlight, bit4 = Average.
-    pub error_bar_active_mask: [u8; PLAYER_SLOTS],
+    pub error_bar_active_mask: [ErrorBarMask; PLAYER_SLOTS],
     pub error_bar_options_active_mask: [ErrorBarOptionsMask; PLAYER_SLOTS],
     pub measure_counter_options_active_mask: [MeasureCounterOptionsMask; PLAYER_SLOTS],
     // For Insert row: bitmask of enabled chart insert transforms.
     // bit0 = Wide, bit1 = Big, bit2 = Quick, bit3 = BMRize,
     // bit4 = Skippy, bit5 = Echo, bit6 = Stomp.
-    pub insert_active_mask: [u8; PLAYER_SLOTS],
+    pub insert_active_mask: [InsertMask; PLAYER_SLOTS],
     // For Remove row: bitmask of enabled chart removal transforms.
     // bit0 = Little, bit1 = No Mines, bit2 = No Holds, bit3 = No Jumps,
     // bit4 = No Hands, bit5 = No Quads, bit6 = No Lifts, bit7 = No Fakes.
-    pub remove_active_mask: [u8; PLAYER_SLOTS],
+    pub remove_active_mask: [RemoveMask; PLAYER_SLOTS],
     // For Holds row: bitmask of enabled hold transforms.
     // bit0 = Planted, bit1 = Floored, bit2 = Twister,
     // bit3 = No Rolls, bit4 = Holds To Rolls.
-    pub holds_active_mask: [u8; PLAYER_SLOTS],
+    pub holds_active_mask: [HoldsMask; PLAYER_SLOTS],
     // For Accel Effects row: bitmask of enabled acceleration transforms.
     // bit0 = Boost, bit1 = Brake, bit2 = Wave, bit3 = Expand, bit4 = Boomerang.
-    pub accel_effects_active_mask: [u8; PLAYER_SLOTS],
+    pub accel_effects_active_mask: [AccelEffectsMask; PLAYER_SLOTS],
     // For Visual Effects row: bitmask of enabled visual transforms.
     // bit0 = Drunk, bit1 = Dizzy, bit2 = Confusion, bit3 = Big,
     // bit4 = Flip, bit5 = Invert, bit6 = Tornado, bit7 = Tipsy,
     // bit8 = Bumpy, bit9 = Beat.
-    pub visual_effects_active_mask: [u16; PLAYER_SLOTS],
+    pub visual_effects_active_mask: [VisualEffectsMask; PLAYER_SLOTS],
     // For Appearance Effects row: bitmask of enabled appearance transforms.
     // bit0 = Hidden, bit1 = Sudden, bit2 = Stealth, bit3 = Blink, bit4 = R.Vanish.
-    pub appearance_effects_active_mask: [u8; PLAYER_SLOTS],
+    pub appearance_effects_active_mask: [AppearanceEffectsMask; PLAYER_SLOTS],
     pub active_color_index: i32,
     pub speed_mod: [SpeedMod; PLAYER_SLOTS],
     pub music_rate: f32,

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -3,10 +3,10 @@ use super::*;
 #[cfg(test)]
 pub(super) mod tests {
     use super::{
-        HUD_OFFSET_MAX, HUD_OFFSET_MIN, HUD_OFFSET_ZERO_INDEX, HideMask, NAV_INITIAL_HOLD_DELAY,
-        NAV_REPEAT_SCROLL_INTERVAL, P1, Row, RowId, RowMap, ScrollMask, SpeedMod, SpeedModType,
-        handle_arcade_start_event, handle_start_event, hud_offset_choices, is_row_visible,
-        judgment_tilt_intensity_visible, repeat_held_arcade_start, row_visibility,
+        ErrorBarMask, HUD_OFFSET_MAX, HUD_OFFSET_MIN, HUD_OFFSET_ZERO_INDEX, HideMask,
+        NAV_INITIAL_HOLD_DELAY, NAV_REPEAT_SCROLL_INTERVAL, P1, Row, RowId, RowMap, ScrollMask,
+        SpeedMod, SpeedModType, handle_arcade_start_event, handle_start_event, hud_offset_choices,
+        is_row_visible, judgment_tilt_intensity_visible, repeat_held_arcade_start, row_visibility,
         session_active_players, sync_profile_scroll_speed,
     };
     use crate::assets::AssetManager;
@@ -100,10 +100,10 @@ pub(super) mod tests {
                 [0, 0],
             ),
         ]);
-        let visibility = row_visibility(&row_map, [true, false], [HideMask::empty(), HideMask::empty()], [0, 0], false);
+        let visibility = row_visibility(&row_map, [true, false], [HideMask::empty(), HideMask::empty()], [ErrorBarMask::empty(), ErrorBarMask::empty()], false);
         assert!(!is_row_visible(&row_map, 1, visibility));
 
-        let visibility = row_visibility(&row_map, [true, false], [HideMask::empty(), HideMask::empty()], [1, 0], false);
+        let visibility = row_visibility(&row_map, [true, false], [HideMask::empty(), HideMask::empty()], [ErrorBarMask::COLORFUL, ErrorBarMask::empty()], false);
         assert!(is_row_visible(&row_map, 1, visibility));
     }
 
@@ -124,7 +124,7 @@ pub(super) mod tests {
                 [0, 0],
             ),
         ]);
-        let visibility = row_visibility(&row_map, [true, false], [HideMask::empty(), HideMask::empty()], [0, 0], false);
+        let visibility = row_visibility(&row_map, [true, false], [HideMask::empty(), HideMask::empty()], [ErrorBarMask::empty(), ErrorBarMask::empty()], false);
         assert!(!is_row_visible(&row_map, 1, visibility));
 
         let row_map = test_row_map(vec![
@@ -141,7 +141,7 @@ pub(super) mod tests {
                 [0, 0],
             ),
         ]);
-        let visibility = row_visibility(&row_map, [true, false], [HideMask::empty(), HideMask::empty()], [0, 0], false);
+        let visibility = row_visibility(&row_map, [true, false], [HideMask::empty(), HideMask::empty()], [ErrorBarMask::empty(), ErrorBarMask::empty()], false);
         assert!(is_row_visible(&row_map, 1, visibility));
     }
 
@@ -162,7 +162,7 @@ pub(super) mod tests {
                 [0, 0],
             ),
         ]);
-        let visibility = row_visibility(&row_map, [true, true], [HideMask::empty(), HideMask::empty()], [0, 0], false);
+        let visibility = row_visibility(&row_map, [true, true], [HideMask::empty(), HideMask::empty()], [ErrorBarMask::empty(), ErrorBarMask::empty()], false);
         assert!(!is_row_visible(&row_map, 1, visibility));
 
         let row_map = test_row_map(vec![
@@ -179,7 +179,7 @@ pub(super) mod tests {
                 [0, 0],
             ),
         ]);
-        let visibility = row_visibility(&row_map, [true, true], [HideMask::empty(), HideMask::empty()], [0, 0], false);
+        let visibility = row_visibility(&row_map, [true, true], [HideMask::empty(), HideMask::empty()], [ErrorBarMask::empty(), ErrorBarMask::empty()], false);
         assert!(is_row_visible(&row_map, 1, visibility));
     }
 

--- a/src/screens/player_options/visibility.rs
+++ b/src/screens/player_options/visibility.rs
@@ -173,12 +173,12 @@ pub(super) fn combo_offsets_visible(row_map: &RowMap, active: [bool; PLAYER_SLOT
 
 pub(super) fn error_bar_children_visible(
     active: [bool; PLAYER_SLOTS],
-    error_bar_active_mask: [u8; PLAYER_SLOTS],
+    error_bar_active_mask: [ErrorBarMask; PLAYER_SLOTS],
 ) -> bool {
     let mut any_active = false;
     for player_idx in active_player_indices(active) {
         any_active = true;
-        if crate::game::profile::normalize_error_bar_mask(error_bar_active_mask[player_idx]) != 0 {
+        if !error_bar_active_mask[player_idx].is_empty() {
             return true;
         }
     }
@@ -275,7 +275,7 @@ pub(super) fn row_visibility(
     row_map: &RowMap,
     active: [bool; PLAYER_SLOTS],
     hide_active_mask: [HideMask; PLAYER_SLOTS],
-    error_bar_active_mask: [u8; PLAYER_SLOTS],
+    error_bar_active_mask: [ErrorBarMask; PLAYER_SLOTS],
     allow_per_player_global_offsets: bool,
 ) -> RowVisibility {
     RowVisibility {


### PR DESCRIPTION
# Player options: typed Bitflags for persisted Profile row masks

## Summary

Convert the seven Profile-persisted row masks (Insert, Remove, Holds, AccelEffects, VisualEffects, AppearanceEffects, ErrorBar) from raw `u8`/`u16` to `bitflags!` structs defined alongside the existing constants in `game::profile`.

`State`, `Profile` and `PlayerOptionsData` now share these typed surfaces, and the seven `profile::normalize_*_mask` validation helpers are dropped — the `from_bits_truncate` constructor used at the load boundary delivers the same truncation guarantee with no extra hop.

This is the persisted-mask companion to PR #209 (which typed the 10 State-only masks). Together they remove the last raw-int row mask in the player-options stack.

## Wire format

Unchanged. Profile.ini stores these masks as decimal numbers (`mask.bits()`); the `bitflags` `Display` impl is symbolic and is intentionally **not** used for serialization.