### PR TITLE
Build Asset Copy For Custom Profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,7 +937,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deadsync"
-version = "0.3.543"
+version = "0.3.545"
 dependencies = [
  "alsa",
  "ash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deadsync"
-version = "0.3.543"
+version = "0.3.545"
 authors = ["Patrik Nilsson <perfecttaste@pm.me>"]
 edition = "2024"
 description = "A competitive SM/ITG engine focused on perfect sync and performance."

--- a/build.rs
+++ b/build.rs
@@ -187,11 +187,23 @@ fn compile_vulkan_shaders(compiler: &mut Compiler, out_dir: &Path) -> Result<(),
 }
 
 fn compute_target_dir() -> Result<PathBuf, Box<dyn Error>> {
-    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?);
-    let profile = std::env::var("PROFILE")?;
-    let base = std::env::var("CARGO_TARGET_DIR")
-        .map_or_else(|_| manifest_dir.join("target"), PathBuf::from);
-    Ok(base.join(profile))
+    // Cargo's `PROFILE` env var only ever takes the values `debug` or
+    // `release` (it reflects the inherited base profile, not the actual
+    // profile name). For custom profiles like `[profile.local]` that inherit
+    // from `release`, joining `target/<PROFILE>` would copy assets into
+    // `target/release` while the binary is built into `target/local`,
+    // leaving the runtime without its bundled assets.
+    //
+    // Instead, derive the real per-profile output directory from `OUT_DIR`,
+    // which Cargo sets to `target/<profile>/build/<crate-hash>/out`. Walking
+    // up three parents lands on `target/<profile>` for every profile name.
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR")?);
+    let target_dir = out_dir
+        .ancestors()
+        .nth(3)
+        .ok_or("OUT_DIR did not have the expected target/<profile>/build/<hash>/out shape")?
+        .to_path_buf();
+    Ok(target_dir)
 }
 
 fn copy_assets(target_dir: &Path) -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
## Summary

Fix `build.rs` so that bundled assets are copied next to the actual binary for **every** Cargo profile, not just `debug` and `release`.
