### PR TITLE
Player Options Noteskin Init Helper

### DIFF
--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -66,6 +66,30 @@ pub(super) fn build_rows(
     }
 }
 
+fn find_noteskin_choice_index(
+    profile_value: Option<&crate::game::profile::NoteSkin>,
+    choices: &[String],
+    match_label: &str,
+    none_label: Option<&str>,
+) -> usize {
+    let position_eq = |label: &str| choices.iter().position(|c| c.as_str() == label);
+    match profile_value {
+        None => position_eq(match_label).unwrap_or(0),
+        Some(skin) => {
+            if let Some(none_label) = none_label {
+                if skin.is_none_choice() {
+                    return position_eq(none_label).unwrap_or(0);
+                }
+            }
+            choices
+                .iter()
+                .position(|c| c.eq_ignore_ascii_case(skin.as_str()))
+                .or_else(|| position_eq(match_label))
+                .unwrap_or(0)
+        }
+    }
+}
+
 pub(super) fn apply_profile_defaults(
     row_map: &mut RowMap,
     profile: &crate::game::profile::Profile,
@@ -148,75 +172,28 @@ pub(super) fn apply_profile_defaults(
             .unwrap_or(0);
     }
     if let Some(row) = row_map.get_mut(RowId::MineSkin) {
-        row.selected_choice_index[player_idx] = profile.mine_noteskin.as_ref().map_or_else(
-            || {
-                row.choices
-                    .iter()
-                    .position(|c| c.as_str() == match_ns_label.as_ref())
-                    .unwrap_or(0)
-            },
-            |mine_noteskin| {
-                row.choices
-                    .iter()
-                    .position(|c| c.eq_ignore_ascii_case(mine_noteskin.as_str()))
-                    .or_else(|| {
-                        row.choices
-                            .iter()
-                            .position(|c| c.as_str() == match_ns_label.as_ref())
-                    })
-                    .unwrap_or(0)
-            },
+        row.selected_choice_index[player_idx] = find_noteskin_choice_index(
+            profile.mine_noteskin.as_ref(),
+            &row.choices,
+            match_ns_label.as_ref(),
+            None,
         );
     }
     if let Some(row) = row_map.get_mut(RowId::ReceptorSkin) {
-        row.selected_choice_index[player_idx] = profile.receptor_noteskin.as_ref().map_or_else(
-            || {
-                row.choices
-                    .iter()
-                    .position(|c| c.as_str() == match_ns_label.as_ref())
-                    .unwrap_or(0)
-            },
-            |receptor_noteskin| {
-                row.choices
-                    .iter()
-                    .position(|c| c.eq_ignore_ascii_case(receptor_noteskin.as_str()))
-                    .or_else(|| {
-                        row.choices
-                            .iter()
-                            .position(|c| c.as_str() == match_ns_label.as_ref())
-                    })
-                    .unwrap_or(0)
-            },
+        row.selected_choice_index[player_idx] = find_noteskin_choice_index(
+            profile.receptor_noteskin.as_ref(),
+            &row.choices,
+            match_ns_label.as_ref(),
+            None,
         );
     }
     if let Some(row) = row_map.get_mut(RowId::TapExplosionSkin) {
-        row.selected_choice_index[player_idx] =
-            profile.tap_explosion_noteskin.as_ref().map_or_else(
-                || {
-                    row.choices
-                        .iter()
-                        .position(|c| c.as_str() == match_ns_label.as_ref())
-                        .unwrap_or(0)
-                },
-                |tap_explosion_noteskin| {
-                    if tap_explosion_noteskin.is_none_choice() {
-                        row.choices
-                            .iter()
-                            .position(|c| c.as_str() == no_tap_label.as_ref())
-                            .unwrap_or(0)
-                    } else {
-                        row.choices
-                            .iter()
-                            .position(|c| c.eq_ignore_ascii_case(tap_explosion_noteskin.as_str()))
-                            .or_else(|| {
-                                row.choices
-                                    .iter()
-                                    .position(|c| c.as_str() == match_ns_label.as_ref())
-                            })
-                            .unwrap_or(0)
-                    }
-                },
-            );
+        row.selected_choice_index[player_idx] = find_noteskin_choice_index(
+            profile.tap_explosion_noteskin.as_ref(),
+            &row.choices,
+            match_ns_label.as_ref(),
+            Some(no_tap_label.as_ref()),
+        );
     }
     // Initialize Combo Font row from profile setting
     if let Some(row) = row_map.get_mut(RowId::ComboFont) {


### PR DESCRIPTION
# Player Options Noteskin Init Helper

## Summary

Extract a single helper for the noteskin-row profile-defaults logic. Three near-identical blocks in `panes::apply_profile_defaults` collapse into one helper plus three short call sites. Pure refactor, no behavior change.

## Background

`apply_profile_defaults` initializes one row's `selected_choice_index` from the player's profile. For three rows — `MineSkin`, `ReceptorSkin`, and `TapExplosionSkin` — the logic was nearly identical:

1. If the profile value is `None`, look up the "match note skin" label
in the row's choices (fall back to index 0).
2. Otherwise, search choices for the skin's name (case-insensitive),
falling back to the "match" label, falling back to 0.

`TapExplosionSkin` had one extra wrinkle: when the profile value is the explicit none-choice (`is_none_choice()`), it should select the "no tap explosion" label instead.

Each row repeated this as an inline `map_or_else` — ~20 lines apiece, 70 total.

## Change

New private helper in `panes/mod.rs`:

```rust
fn find_noteskin_choice_index(
    profile_value: Option<&NoteSkin>,
    choices: &[String],
    match_label: &str,
    none_label: Option<&str>,
) -> usize
```

`MineSkin` and `ReceptorSkin` pass `none_label: None`; `TapExplosionSkin` passes `Some(no_tap_label.as_ref())`. The three call sites now read uniformly and the search/fallback policy lives in one place.

## Behavior

No behavior change. The match-label lookup, case-insensitivity, none-choice short-circuit (TapExplosion only), and 0 fallback are all preserved.

## Verification

- `cargo build --lib` clean.
- `cargo test --lib -- --test-threads=1` — all 623 tests pass.

## Diff

Single file: `src/screens/player_options/panes/mod.rs` **+40 / −63** (net −23 lines).
