### PR TITLE
Preserve Persisted Modifier Masks at Init

### DIFF
--- a/src/screens/player_options/mod.rs
+++ b/src/screens/player_options/mod.rs
@@ -149,8 +149,19 @@ pub fn init(
         fixed_stepchart.as_ref(),
     );
     let player_profiles = [p1_profile.clone(), p2_profile.clone()];
-    // Masks are computed from the profile and are identical regardless of
-    // which pane's row_map is passed, so capture them from the Main call.
+    // `apply_profile_defaults` populates 8 of its 17 returned masks (Scroll,
+    // Insert, Remove, Holds, Accel, Effect, Appearance, EarlyDw) only when
+    // the corresponding row exists in the passed `row_map`. Those rows live
+    // on the Advanced and Uncommon panes, so we must call the function on
+    // every pane and OR the results together. Otherwise persisted profile
+    // state for those rows would silently appear empty here and get
+    // overwritten the moment the user touches any choice on those rows.
+    let p1_main = apply_profile_defaults(&mut main_row_map, &player_profiles[P1], P1);
+    let p2_main = apply_profile_defaults(&mut main_row_map, &player_profiles[P2], P2);
+    let p1_advanced = apply_profile_defaults(&mut advanced_row_map, &player_profiles[P1], P1);
+    let p2_advanced = apply_profile_defaults(&mut advanced_row_map, &player_profiles[P2], P2);
+    let p1_uncommon = apply_profile_defaults(&mut uncommon_row_map, &player_profiles[P1], P1);
+    let p2_uncommon = apply_profile_defaults(&mut uncommon_row_map, &player_profiles[P2], P2);
     let (
         scroll_active_mask_p1,
         hide_active_mask_p1,
@@ -169,7 +180,7 @@ pub fn init(
         error_bar_active_mask_p1,
         error_bar_options_active_mask_p1,
         measure_counter_options_active_mask_p1,
-    ) = apply_profile_defaults(&mut main_row_map, &player_profiles[P1], P1);
+    ) = or_active_masks(or_active_masks(p1_main, p1_advanced), p1_uncommon);
     let (
         scroll_active_mask_p2,
         hide_active_mask_p2,
@@ -188,12 +199,7 @@ pub fn init(
         error_bar_active_mask_p2,
         error_bar_options_active_mask_p2,
         measure_counter_options_active_mask_p2,
-    ) = apply_profile_defaults(&mut main_row_map, &player_profiles[P2], P2);
-    // Populate selected_choice_index for the other panes (mask returns dropped).
-    let _ = apply_profile_defaults(&mut advanced_row_map, &player_profiles[P1], P1);
-    let _ = apply_profile_defaults(&mut advanced_row_map, &player_profiles[P2], P2);
-    let _ = apply_profile_defaults(&mut uncommon_row_map, &player_profiles[P1], P1);
-    let _ = apply_profile_defaults(&mut uncommon_row_map, &player_profiles[P2], P2);
+    ) = or_active_masks(or_active_masks(p2_main, p2_advanced), p2_uncommon);
 
     let cols_per_player = noteskin_cols_per_player(crate::game::profile::get_session_play_style());
     let mut initial_noteskin_names = vec![crate::game::profile::NoteSkin::DEFAULT_NAME.to_string()];

--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -66,11 +66,7 @@ pub(super) fn build_rows(
     }
 }
 
-pub(super) fn apply_profile_defaults(
-    row_map: &mut RowMap,
-    profile: &crate::game::profile::Profile,
-    player_idx: usize,
-) -> (
+pub(super) type ActiveMaskTuple = (
     ScrollMask,
     HideMask,
     u8,
@@ -88,7 +84,39 @@ pub(super) fn apply_profile_defaults(
     u8,
     ErrorBarOptionsMask,
     MeasureCounterOptionsMask,
-) {
+);
+
+/// OR two `ActiveMaskTuple`s element-wise. Used by `init()` to accumulate
+/// per-pane mask results, because `apply_profile_defaults` only populates
+/// some masks when the corresponding row exists in the passed `row_map`,
+/// and the rows are split across the Main/Advanced/Uncommon panes.
+pub(super) fn or_active_masks(a: ActiveMaskTuple, b: ActiveMaskTuple) -> ActiveMaskTuple {
+    (
+        a.0 | b.0,
+        a.1 | b.1,
+        a.2 | b.2,
+        a.3 | b.3,
+        a.4 | b.4,
+        a.5 | b.5,
+        a.6 | b.6,
+        a.7 | b.7,
+        a.8 | b.8,
+        a.9 | b.9,
+        a.10 | b.10,
+        a.11 | b.11,
+        a.12 | b.12,
+        a.13 | b.13,
+        a.14 | b.14,
+        a.15 | b.15,
+        a.16 | b.16,
+    )
+}
+
+pub(super) fn apply_profile_defaults(
+    row_map: &mut RowMap,
+    profile: &crate::game::profile::Profile,
+    player_idx: usize,
+) -> ActiveMaskTuple {
     let mut scroll_active_mask = ScrollMask::empty();
     let mut hide_active_mask = HideMask::empty();
     let mut insert_active_mask: u8 = 0;

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -184,6 +184,63 @@ pub(super) mod tests {
     }
 
     #[test]
+    fn init_active_masks_accumulate_across_panes() {
+        // Regression: apply_profile_defaults gates 8 of its 17 returned masks
+        // (Scroll, Insert, Remove, Holds, Accel, Effect, Appearance, EarlyDw)
+        // on the corresponding row being present in the passed row_map. Those
+        // rows live on the Advanced/Uncommon panes, so init() must call the
+        // function on all three pane row_maps and OR the resulting masks.
+        // Otherwise persisted profile state for those rows is silently lost
+        // the moment the user toggles any choice on those rows.
+        ensure_i18n();
+        let mut profile = Profile::default();
+        profile.scroll_option =
+            profile::ScrollOption::Reverse.union(profile::ScrollOption::Cross);
+
+        let mut main_rows = test_row_map(vec![test_row(
+            RowId::Exit,
+            lookup_key("PlayerOptions", "Exit"),
+            &["Exit"],
+            [0, 0],
+        )]);
+        let mut advanced_rows = test_row_map(vec![test_row(
+            RowId::Scroll,
+            lookup_key("PlayerOptions", "Scroll"),
+            &["Reverse", "Split", "Alternate", "Cross", "Centered"],
+            [0, 0],
+        )]);
+        let mut uncommon_rows = test_row_map(vec![test_row(
+            RowId::Exit,
+            lookup_key("PlayerOptions", "Exit"),
+            &["Exit"],
+            [0, 0],
+        )]);
+
+        let main =
+            super::super::panes::apply_profile_defaults(&mut main_rows, &profile, P1);
+        let adv =
+            super::super::panes::apply_profile_defaults(&mut advanced_rows, &profile, P1);
+        let unc =
+            super::super::panes::apply_profile_defaults(&mut uncommon_rows, &profile, P1);
+
+        // Main alone: Scroll row absent, mask comes back empty (the bug source).
+        assert_eq!(main.0, ScrollMask::empty());
+        // Accumulated across all three panes (the fix): Reverse + Cross preserved.
+        let combined = super::super::panes::or_active_masks(
+            super::super::panes::or_active_masks(main, adv),
+            unc,
+        );
+        assert!(
+            combined.0.contains(ScrollMask::REVERSE),
+            "Reverse bit preserved after OR-accumulation"
+        );
+        assert!(
+            combined.0.contains(ScrollMask::CROSS),
+            "Cross bit preserved after OR-accumulation"
+        );
+    }
+
+    #[test]
     fn hud_offset_choices_cover_full_range() {
         let choices = hud_offset_choices();
         assert_eq!(choices.first().map(String::as_str), Some("-250"));


### PR DESCRIPTION
## Summary

Fixes a data-loss bug in `screens::player_options::init` where persisted profile state for the `Scroll`, `Insert`, `Remove`, `Holds`, `Accel`, `Effect`, `Appearance`, and `EarlyDecentWayOffOptions` rows was silently dropped on entry to the player-options screen.

## Root cause

`panes::apply_profile_defaults` returns a 17-tuple of `*_active_mask` values derived from the profile. Eight of those masks are populated **inside** `if let Some(row) = row_map.get_mut(RowId::X)` blocks — so they are only computed when the corresponding row exists in the passed `row_map`. The other nine are populated unconditionally from profile fields.

`init()` was calling `apply_profile_defaults` six times (3 panes × 2 players) but only capturing the **Main pane** call's tuple per player; the Advanced and Uncommon results were discarded with `let _ = ...`. The Main pane's `row_map` does not contain `Scroll`, `Insert`, `Remove`, `Holds`, `Accel`, `Effect`, `Appearance`, or `EarlyDecentWayOffOptions` (those rows live on Advanced/Uncommon), so those eight `state.X_active_mask[player_idx]` fields were always initialized to empty regardless of the profile.

## User-visible effect

With, for example, `profile.scroll_option = Reverse | Cross` saved on disk:

1. Open the player-options screen. The Scroll row renders with no choices highlighted (cosmetic — `render.rs` reads `state.scroll_active_mask` for the highlight indicators).
2. Toggle any single choice on that row (say, `Alternate`). `state.scroll_active_mask[idx].toggle(ALTERNATE)` flips the in-memory mask from empty → `Alternate`.
3. The toggle handler then writes the new mask back to the profile: `state.player_profiles[idx].scroll_option = setting`. The profile is now `scroll_option = Alternate`. The previously-persisted `Reverse | Cross` is silently lost.

The same data-loss path applies to `Insert`, `Remove`, `Holds`, `Accel`, `Effect`, `Appearance`, and `EarlyDecentWayOffOptions`.

## Fix

Call `apply_profile_defaults` on all three pane `row_map`s (as before, to populate `selected_choice_index`), capture all six returned tuples, and OR them together per player via a new `or_active_masks` helper. Each mask now ends up populated by whichever pane owns the gating row. The nine unconditionally-populated masks OR with themselves and remain unchanged.
