### PR TITLE
Translation Status Workflow Dependency Fix

### DIFF
--- a/.github/workflows/update-translation-status.yml
+++ b/.github/workflows/update-translation-status.yml
@@ -18,6 +18,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            pkg-config \
+            libasound2-dev \
+            libx11-dev \
+            libx11-xcb-dev \
+            libxi-dev \
+            libxcursor-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libwayland-dev \
+            libxkbcommon-dev \
+            libvulkan-dev \
+            libudev-dev \
+            libgl1-mesa-dev \
+            libxcb1-dev \
+            libxcb-randr0-dev
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 


### PR DESCRIPTION
The lang_coverage binary depends on the deadsync crate, which transitively requires alsa, x11, wayland, vulkan, etc. Without these system libraries the alsa-sys build script fails with 'Package alsa was not found in the pkg-config search path'.