### PR TITLE
fix(dynamic_media): restore PreparedBannerVideo.path and fix borrow in clear_gameplay_backgrounds

### DIFF
--- a/src/app/dynamic_media.rs
+++ b/src/app/dynamic_media.rs
@@ -23,6 +23,7 @@ struct DynamicVideoState {
 
 struct PreparedBannerVideo {
     key: String,
+    path: PathBuf,
     poster: RgbaImage,
     player: video::Player,
 }
@@ -761,10 +762,10 @@ impl DynamicMedia {
         backend: &mut Backend,
     ) {
         self.destroy_current_dynamic_background(assets, backend);
-        for key in self.active_song_lua_videos.drain().map(|(key, _)| key) {
+        for key in std::mem::take(&mut self.active_song_lua_videos).into_keys() {
             self.release_texture_key(assets, backend, key);
         }
-        for key in self.failed_song_lua_video_keys.drain() {
+        for key in std::mem::take(&mut self.failed_song_lua_video_keys) {
             self.release_texture_key(assets, backend, key);
         }
         self.reset_pending_gameplay_background();
@@ -1090,6 +1091,7 @@ fn prepare_banner_video(key: String, path: PathBuf) -> BannerVideoPrepResult {
         return match video::open(&path, true) {
             Ok(video) => BannerVideoPrepResult::Ready(PreparedBannerVideo {
                 key,
+                path,
                 poster: video.poster,
                 player: video.player,
             }),
@@ -1111,6 +1113,7 @@ fn prepare_banner_video(key: String, path: PathBuf) -> BannerVideoPrepResult {
     };
     BannerVideoPrepResult::Ready(PreparedBannerVideo {
         key,
+        path,
         poster,
         player,
     })


### PR DESCRIPTION
# fix(dynamic_media): restore `PreparedBannerVideo.path` and fix borrow in `clear_gameplay_backgrounds`

Fix missing updates in `dynamic_media.rs`‎ to fix the build.
