### PR TITLE
fix(song-lua): seed placeholder player actors with default screen position

### DIFF
--- a/src/app/dynamic_media.rs
+++ b/src/app/dynamic_media.rs
@@ -23,6 +23,7 @@ struct DynamicVideoState {
 
 struct PreparedBannerVideo {
     key: String,
+    path: PathBuf,
     poster: RgbaImage,
     player: video::Player,
 }
@@ -761,10 +762,10 @@ impl DynamicMedia {
         backend: &mut Backend,
     ) {
         self.destroy_current_dynamic_background(assets, backend);
-        for key in self.active_song_lua_videos.drain().map(|(key, _)| key) {
+        for key in std::mem::take(&mut self.active_song_lua_videos).into_keys() {
             self.release_texture_key(assets, backend, key);
         }
-        for key in self.failed_song_lua_video_keys.drain() {
+        for key in std::mem::take(&mut self.failed_song_lua_video_keys) {
             self.release_texture_key(assets, backend, key);
         }
         self.reset_pending_gameplay_background();
@@ -1090,6 +1091,7 @@ fn prepare_banner_video(key: String, path: PathBuf) -> BannerVideoPrepResult {
         return match video::open(&path, true) {
             Ok(video) => BannerVideoPrepResult::Ready(PreparedBannerVideo {
                 key,
+                path,
                 poster: video.poster,
                 player: video.player,
             }),
@@ -1111,6 +1113,7 @@ fn prepare_banner_video(key: String, path: PathBuf) -> BannerVideoPrepResult {
     };
     BannerVideoPrepResult::Ready(PreparedBannerVideo {
         key,
+        path,
         poster,
         player,
     })

--- a/src/game/gameplay/attacks.rs
+++ b/src/game/gameplay/attacks.rs
@@ -4,8 +4,8 @@ use crate::game::note::Note;
 use crate::game::parsing::song_lua::{
     CompiledSongLua, SongLuaCapturedActor, SongLuaCompileContext, SongLuaDifficulty,
     SongLuaEaseTarget, SongLuaEaseWindow, SongLuaMessageEvent, SongLuaModWindow,
-    SongLuaOverlayActor, SongLuaOverlayEase, SongLuaOverlayMessageCommand, SongLuaPlayerContext,
-    SongLuaSpanMode, SongLuaSpeedMod, SongLuaTimeUnit, compile_song_lua,
+    SongLuaOverlayActor, SongLuaOverlayEase, SongLuaOverlayMessageCommand, SongLuaOverlayState,
+    SongLuaPlayerContext, SongLuaSpanMode, SongLuaSpeedMod, SongLuaTimeUnit, compile_song_lua,
 };
 use crate::game::profile;
 use crate::game::scroll::ScrollSpeedSetting;
@@ -1952,8 +1952,35 @@ pub(super) fn build_song_lua_runtime_windows(
     let mut overlay_eases = Vec::new();
     let mut overlay_ease_ranges = Vec::new();
     let mut overlay_events = Vec::new();
+    let play_style = profile::get_session_play_style();
+    let player_side = profile::get_session_player_side();
+    let center_1player_notefield = crate::config::get().center_1player_notefield;
+    // Default player actor x/y must match StepMania's (SCREEN_CENTER_X, SCREEN_CENTER_Y)
+    // origin so that, when no song.lua override is present, the gameplay player
+    // transform path produces a zero translation. Without this, every non-lua song
+    // would translate the playfield by (-playfield_center_x, +screen_center_y),
+    // shoving it up and to the left.
+    let default_player_actor = |player_index: usize| SongLuaCapturedActor {
+        initial_state: SongLuaOverlayState {
+            x: if player_index < num_players {
+                song_lua_compile_player_screen_x(
+                    num_players,
+                    player_index,
+                    &player_profiles[player_index],
+                    play_style,
+                    player_side,
+                    center_1player_notefield,
+                )
+            } else {
+                screen_center_x()
+            },
+            y: screen_center_y(),
+            ..SongLuaOverlayState::default()
+        },
+        message_commands: Vec::new(),
+    };
     let mut player_actors: [SongLuaCapturedActor; MAX_PLAYERS] =
-        std::array::from_fn(|_| SongLuaCapturedActor::default());
+        std::array::from_fn(default_player_actor);
     let mut player_events: [Vec<SongLuaOverlayMessageRuntime>; MAX_PLAYERS] =
         std::array::from_fn(|_| Vec::new());
     let mut song_foreground = SongLuaCapturedActor::default();
@@ -2006,7 +2033,7 @@ pub(super) fn build_song_lua_runtime_windows(
     } else {
         1.0
     };
-    context.style_name = match profile::get_session_play_style() {
+    context.style_name = match play_style {
         profile::PlayStyle::Single => "single",
         profile::PlayStyle::Versus => "versus",
         profile::PlayStyle::Double => "double",
@@ -2018,9 +2045,6 @@ pub(super) fn build_song_lua_runtime_windows(
     context.confusion_offset_available = true;
     context.confusion_available = true;
     context.amod_available = false;
-    let play_style = profile::get_session_play_style();
-    let player_side = profile::get_session_player_side();
-    let center_1player_notefield = crate::config::get().center_1player_notefield;
     context.players = std::array::from_fn(|player| SongLuaPlayerContext {
         enabled: player < num_players,
         difficulty: if player < num_players {


### PR DESCRIPTION
## Summary

Songs without a foreground/player `song.lua` actor render with the playfield shifted roughly (−640, +360) on a 1280×720 logical screen — up and off to the left, with the receptors out of view.

## Root cause

`5dc38f6` (`fix(song-lua): restore direct player transforms and foreground layering`) added a transform driven by the captured player actor's initial state:

```
translate_x = target_x - playfield_center_x
translate_y = screen_center_y()  - target_y
```

For songs that ship a `song.lua`, `create_player_state_table` seeds `__songlua_state_x = player.screen_x` at compile time, so `target_x` ends up at the natural playfield center and the translate is zero.

For songs **without** a player/foreground lua actor, `build_song_lua_runtime_windows` builds a placeholder `player_actors` array using `SongLuaCapturedActor::default()`, whose `initial_state.x/y` are `0.0`. Those zeros flow in as `target_x/target_y` and produce the offscreen translate.

## Fix

Build the placeholder array via a small `default_player_actor` closure that seeds:

- `initial_state.x` ← `song_lua_compile_player_screen_x(...)` (same helper the compile path uses; honors `num_players`, `play_style`, `player_side`, `center_1player_notefield`, `note_field_offset_x`)
- `initial_state.y` ← `screen_center_y()`

so the no-lua case feeds the natural rendering position into the new transform and yields a zero translate. The lua-overlay path is untouched — it overrides via `__songlua_state_x` as before, so direct player transforms from `song.lua` continue to work.

`play_style`, `player_side`, and `center_1player_notefield` lookups are hoisted to the top of the function so the closure and the existing downstream code share them.
