### PR TITLE
Player Options Render: extract row helpers + FrameCtx/RowCtx

### DIFF
--- a/src/screens/player_options/render.rs
+++ b/src/screens/player_options/render.rs
@@ -271,6 +271,72 @@ fn player_color_index(state: &State, player_idx: usize) -> i32 {
     }
 }
 
+/// Current animated cursor rectangle for a player (center xy + size),
+/// or `None` if the player is inactive or the cursor isn't initialised yet.
+fn cursor_for_player(state: &State, player_idx: usize) -> Option<(f32, f32, f32, f32)> {
+    if player_idx >= PLAYER_SLOTS || !state.pane().cursor_initialized[player_idx] {
+        return None;
+    }
+    let pane = state.pane();
+    let t = pane.cursor_t[player_idx].clamp(0.0, 1.0);
+    let r = CursorRect::lerp(pane.cursor_from[player_idx], pane.cursor_to[player_idx], t);
+    Some((r.x, r.y, r.w, r.h))
+}
+
+/// Draw the 4-sided cursor ring around each active player's selected
+/// option in row `item_idx`. No-ops for players whose cursor isn't on
+/// this row or hasn't been initialised yet.
+fn draw_cursor_ring(
+    actors: &mut Vec<Actor>,
+    state: &State,
+    active: [bool; PLAYER_SLOTS],
+    item_idx: usize,
+    a: f32,
+) {
+    let border_w = selection_border_width();
+    for player_idx in active_player_indices(active) {
+        if state.pane().selected_row[player_idx] != item_idx {
+            continue;
+        }
+        let Some((center_x, center_y, ring_w, ring_h)) = cursor_for_player(state, player_idx)
+        else {
+            continue;
+        };
+
+        let left = center_x - ring_w * 0.5;
+        let right = center_x + ring_w * 0.5;
+        let top = center_y - ring_h * 0.5;
+        let bottom = center_y + ring_h * 0.5;
+        let mut ring_color = color::decorative_rgba(player_color_index(state, player_idx));
+        ring_color[3] *= a;
+
+        actors.push(act!(quad:
+            align(0.5, 0.5): xy((left + right) * 0.5, top + border_w * 0.5):
+            zoomto(ring_w, border_w):
+            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+            z(Z_ROW_FOREGROUND)
+        ));
+        actors.push(act!(quad:
+            align(0.5, 0.5): xy((left + right) * 0.5, bottom - border_w * 0.5):
+            zoomto(ring_w, border_w):
+            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+            z(Z_ROW_FOREGROUND)
+        ));
+        actors.push(act!(quad:
+            align(0.5, 0.5): xy(left + border_w * 0.5, (top + bottom) * 0.5):
+            zoomto(border_w, ring_h):
+            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+            z(Z_ROW_FOREGROUND)
+        ));
+        actors.push(act!(quad:
+            align(0.5, 0.5): xy(right - border_w * 0.5, (top + bottom) * 0.5):
+            zoomto(border_w, ring_h):
+            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+            z(Z_ROW_FOREGROUND)
+        ));
+    }
+}
+
 pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     let mut actors: Vec<Actor> = Vec::with_capacity(64);
     let active = session_active_players();
@@ -398,15 +464,6 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     let title_x = row_left + title_left_pad;
     // Keep header labels bounded to the title column so they never overlap option values.
     let title_max_w = (TITLE_BG_WIDTH - title_left_pad - 5.0).max(0.0);
-    let cursor_now = |player_idx: usize| -> Option<(f32, f32, f32, f32)> {
-        if player_idx >= PLAYER_SLOTS || !state.pane().cursor_initialized[player_idx] {
-            return None;
-        }
-        let pane = state.pane();
-        let t = pane.cursor_t[player_idx].clamp(0.0, 1.0);
-        let r = CursorRect::lerp(pane.cursor_from[player_idx], pane.cursor_to[player_idx], t);
-        Some((r.x, r.y, r.w, r.h))
-    };
 
     for item_idx in 0..total_rows {
         let (current_row_y, row_alpha) = state
@@ -537,47 +594,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
             ));
             // Draw the selection cursor for the centered "Exit" text when active
             if is_active {
-                let border_w = selection_border_width();
-                for player_idx in active_player_indices(active) {
-                    if state.pane().selected_row[player_idx] != item_idx {
-                        continue;
-                    }
-                    let Some((center_x, center_y, ring_w, ring_h)) = cursor_now(player_idx) else {
-                        continue;
-                    };
-
-                    let left = center_x - ring_w * 0.5;
-                    let right = center_x + ring_w * 0.5;
-                    let top = center_y - ring_h * 0.5;
-                    let bottom = center_y + ring_h * 0.5;
-                    let mut ring_color = color::decorative_rgba(player_color_index(state, player_idx));
-                    ring_color[3] *= a;
-
-                    actors.push(act!(quad:
-                        align(0.5, 0.5): xy((left + right) * 0.5, top + border_w * 0.5):
-                        zoomto(ring_w, border_w):
-                        diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                        z(Z_ROW_FOREGROUND)
-                    ));
-                    actors.push(act!(quad:
-                        align(0.5, 0.5): xy((left + right) * 0.5, bottom - border_w * 0.5):
-                        zoomto(ring_w, border_w):
-                        diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                        z(Z_ROW_FOREGROUND)
-                    ));
-                    actors.push(act!(quad:
-                        align(0.5, 0.5): xy(left + border_w * 0.5, (top + bottom) * 0.5):
-                        zoomto(border_w, ring_h):
-                        diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                        z(Z_ROW_FOREGROUND)
-                    ));
-                    actors.push(act!(quad:
-                        align(0.5, 0.5): xy(right - border_w * 0.5, (top + bottom) * 0.5):
-                        zoomto(border_w, ring_h):
-                        diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                        z(Z_ROW_FOREGROUND)
-                    ));
-                }
+                draw_cursor_ring(&mut actors, state, active, item_idx, a);
             }
         } else if show_all_choices_inline {
             // Render every option horizontally; when active, all options should be white.
@@ -643,46 +660,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
             }
             // Draw the 4-sided cursor ring around the selected option when this row is active.
             if !widths.is_empty() {
-                let border_w = selection_border_width();
-                for player_idx in active_player_indices(active) {
-                    if state.pane().selected_row[player_idx] != item_idx {
-                        continue;
-                    }
-                    let Some((center_x, center_y, ring_w, ring_h)) = cursor_now(player_idx) else {
-                        continue;
-                    };
-
-                    let left = center_x - ring_w * 0.5;
-                    let right = center_x + ring_w * 0.5;
-                    let top = center_y - ring_h * 0.5;
-                    let bottom = center_y + ring_h * 0.5;
-                    let mut ring_color = color::decorative_rgba(player_color_index(state, player_idx));
-                    ring_color[3] *= a;
-                    actors.push(act!(quad:
-                        align(0.5, 0.5): xy((left + right) * 0.5, top + border_w * 0.5):
-                        zoomto(ring_w, border_w):
-                        diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                        z(Z_ROW_FOREGROUND)
-                    ));
-                    actors.push(act!(quad:
-                        align(0.5, 0.5): xy((left + right) * 0.5, bottom - border_w * 0.5):
-                        zoomto(ring_w, border_w):
-                        diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                        z(Z_ROW_FOREGROUND)
-                    ));
-                    actors.push(act!(quad:
-                        align(0.5, 0.5): xy(left + border_w * 0.5, (top + bottom) * 0.5):
-                        zoomto(border_w, ring_h):
-                        diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                        z(Z_ROW_FOREGROUND)
-                    ));
-                    actors.push(act!(quad:
-                        align(0.5, 0.5): xy(right - border_w * 0.5, (top + bottom) * 0.5):
-                        zoomto(border_w, ring_h):
-                        diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                        z(Z_ROW_FOREGROUND)
-                    ));
-                }
+                draw_cursor_ring(&mut actors, state, active, item_idx, a);
             }
             // Draw each option's text (active row: all white; inactive: #808080)
             if let Some((next_row_x, _, _)) = next_row_item {
@@ -785,7 +763,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     if active[primary_player_idx] && state.pane().selected_row[primary_player_idx] == item_idx {
                         let border_w = selection_border_width();
                         if let Some((center_x, center_y, ring_w, ring_h)) =
-                            cursor_now(primary_player_idx)
+                            cursor_for_player(state, primary_player_idx)
                         {
                             let left = center_x - ring_w * 0.5;
                             let right = center_x + ring_w * 0.5;
@@ -869,7 +847,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                         ));
                         if active[P2] && state.pane().selected_row[P2] == item_idx {
                             let border_w = selection_border_width();
-                            if let Some((center_x, center_y, ring_w, ring_h)) = cursor_now(P2) {
+                            if let Some((center_x, center_y, ring_w, ring_h)) = cursor_for_player(state, P2) {
                                 let left = center_x - ring_w * 0.5;
                                 let right = center_x + ring_w * 0.5;
                                 let top = center_y - ring_h * 0.5;
@@ -1634,5 +1612,6 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     }
     actors
 }
+
 
 

--- a/src/screens/player_options/render.rs
+++ b/src/screens/player_options/render.rs
@@ -1,342 +1,5 @@
 use super::*;
 
-/// Render z-order layers for the player_options screen. Higher values
-/// draw on top of lower ones.
-const Z_ROW_BACKGROUND: i16 = 100;
-/// Row text, underlines, cursor borders, choice values, help text.
-const Z_ROW_FOREGROUND: i16 = 101;
-/// Previews drawn over a row (judgment / hold-judgment / noteskin sprites,
-/// combo and font samples).
-const Z_ROW_PREVIEW: i16 = 102;
-/// Receptor noteskin preview (drawn above the row preview layer).
-const Z_RECEPTOR_PREVIEW: i16 = 106;
-/// Tap-explosion noteskin preview, the topmost preview layer.
-const Z_EXPLOSION_PREVIEW: i16 = 107;
-/// Speed-mod overlay text, drawn on top of all preview layers.
-const Z_SPEED_MOD_TEXT: i16 = 121;
-
-/// Visual zoom for choice values rendered inline next to the row title.
-const INLINE_CHOICE_VALUE_ZOOM: f32 = 0.835;
-/// Horizontal pixel gap between consecutive inline choice values.
-const INLINE_CHOICE_SPACING: f32 = 15.75;
-
-/// Zoom factor for judgment / hold-judgment / noteskin texture previews.
-const JUDGMENT_PREVIEW_ZOOM: f32 = 0.225;
-/// Zoom factor for combo-font number previews.
-const COMBO_PREVIEW_ZOOM: f32 = 0.45;
-
-/// Pixel size of one logical noteskin arrow used to compute preview scale.
-const NOTESKIN_PREVIEW_ARROW_PIXEL_SIZE: f32 = 64.0;
-/// Scale applied to noteskin preview sprites relative to their natural size.
-const NOTESKIN_PREVIEW_SCALE: f32 = 0.45;
-
-/// Underline thickness for multi-select row indicators (16:9 / 16:10 widescale).
-fn underline_thickness() -> f32 {
-    widescale(2.0, 2.5).round().max(1.0)
-}
-
-/// Vertical pixel offset between a row's text baseline and its underline.
-fn underline_offset() -> f32 {
-    widescale(3.0, 4.0)
-}
-
-/// Border width for the cursor / selection ring drawn around a row's
-/// active choice.
-fn selection_border_width() -> f32 {
-    widescale(2.0, 2.5)
-}
-
-/// Resolved profile + session flags for one side, used by `get_actors`
-/// to populate the screen footer.
-struct PlayerCardInfo {
-    profile: crate::game::profile::Profile,
-    joined: bool,
-    guest: bool,
-}
-
-fn player_card_info(side: crate::game::profile::PlayerSide) -> PlayerCardInfo {
-    PlayerCardInfo {
-        profile: crate::game::profile::get_for_side(side),
-        joined: crate::game::profile::is_session_side_joined(side),
-        guest: crate::game::profile::is_session_side_guest(side),
-    }
-}
-
-/// Compute the footer text and optional avatar for one player side.
-///
-/// Lifetimes: the returned text borrows from either the player's
-/// `display_name` (via `card`), or from the localized `insert_card` /
-/// `press_start` strings, all of which the caller keeps alive on the
-/// stack. The optional avatar borrows the texture key directly from
-/// the profile.
-fn footer_for_card<'a>(
-    card: &'a PlayerCardInfo,
-    insert_card: &'a str,
-    press_start: &'a str,
-) -> (Option<&'a str>, Option<AvatarParams<'a>>) {
-    if !card.joined {
-        return (Some(press_start), None);
-    }
-    let text = if card.guest {
-        insert_card
-    } else {
-        card.profile.display_name.as_str()
-    };
-    let avatar = if card.guest {
-        None
-    } else {
-        card.profile
-            .avatar_texture_key
-            .as_deref()
-            .map(|texture_key| AvatarParams { texture_key })
-    };
-    (Some(text), avatar)
-}
-
-/// Resolve the texture key for a player's currently-selected choice
-/// from a fixed list of texture choices, returning `None` for "None".
-fn select_preview_texture<'a>(
-    row: &Row,
-    player_idx: usize,
-    choices: &'a [crate::assets::TextureChoice],
-) -> Option<&'a str> {
-    choices
-        .get(row.selected_choice_index[player_idx])
-        .and_then(|choice| {
-            if choice.key.eq_ignore_ascii_case("None") {
-                None
-            } else {
-                crate::assets::resolve_texture_choice(Some(choice.key.as_str()), choices)
-            }
-        })
-}
-
-/// Returns the active mask (zero-extended to u16) for a row that
-/// supports multi-select underlining, or `None` if the row uses the
-/// default single-select underline behavior.
-fn multi_select_mask(state: &State, row_id: RowId, player_idx: usize) -> Option<u16> {
-    use RowId::*;
-    Some(match row_id {
-        Scroll => state.scroll_active_mask[player_idx].bits().into(),
-        Hide => state.hide_active_mask[player_idx].bits().into(),
-        Insert => state.insert_active_mask[player_idx].bits().into(),
-        Remove => state.remove_active_mask[player_idx].bits().into(),
-        Holds => state.holds_active_mask[player_idx].bits().into(),
-        Accel => state.accel_effects_active_mask[player_idx].bits().into(),
-        Effect => state.visual_effects_active_mask[player_idx].bits(),
-        Appearance => state.appearance_effects_active_mask[player_idx].bits().into(),
-        LifeBarOptions => state.life_bar_options_active_mask[player_idx].bits().into(),
-        FAPlusOptions => state.fa_plus_active_mask[player_idx].bits().into(),
-        GameplayExtras => state.gameplay_extras_active_mask[player_idx].bits().into(),
-        GameplayExtrasMore => state.gameplay_extras_more_active_mask[player_idx].bits().into(),
-        ResultsExtras => state.results_extras_active_mask[player_idx].bits().into(),
-        MeasureCounterOptions => state.measure_counter_options_active_mask[player_idx].bits().into(),
-        ErrorBar => state.error_bar_active_mask[player_idx].bits().into(),
-        ErrorBarOptions => state.error_bar_options_active_mask[player_idx].bits().into(),
-        EarlyDecentWayOffOptions => state.early_dw_active_mask[player_idx].bits().into(),
-        _ => return None,
-    })
-}
-
-/// Whether a row uses multi-select underlining (one underline per set bit
-/// in the row's active mask) rather than the default single-select
-/// underline (one underline under the chosen value).
-fn is_multi_select_row(row_id: RowId) -> bool {
-    use RowId::*;
-    matches!(
-        row_id,
-        Scroll
-            | Hide
-            | Insert
-            | Remove
-            | Holds
-            | Accel
-            | Effect
-            | Appearance
-            | LifeBarOptions
-            | FAPlusOptions
-            | GameplayExtras
-            | GameplayExtrasMore
-            | ResultsExtras
-            | MeasureCounterOptions
-            | ErrorBar
-            | ErrorBarOptions
-            | EarlyDecentWayOffOptions
-    )
-}
-
-/// Draw multi-select underlines for one row: one underline beneath each
-/// choice whose corresponding bit is set in the per-player active mask.
-#[allow(clippy::too_many_arguments)]
-fn draw_multi_select_underlines(
-    actors: &mut Vec<Actor>,
-    state: &State,
-    row: &Row,
-    active: [bool; PLAYER_SLOTS],
-    x_positions: &[f32],
-    widths: &[f32],
-    current_row_y: f32,
-    text_h: f32,
-    a: f32,
-) {
-    let line_thickness = underline_thickness();
-    let offset = underline_offset();
-    let underline_base_y = current_row_y + text_h * 0.5 + offset;
-    let underline_y = |player_idx: usize| {
-        if active[P1] && active[P2] {
-            (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-        } else {
-            underline_base_y
-        }
-    };
-    for player_idx in active_player_indices(active) {
-        let Some(mask) = multi_select_mask(state, row.id, player_idx) else {
-            continue;
-        };
-        if mask == 0 {
-            continue;
-        }
-        let underline_y = underline_y(player_idx);
-        let mut line_color = color::decorative_rgba(player_color_index(state, player_idx));
-        line_color[3] *= a;
-        for idx in 0..row.choices.len() {
-            let bit: u16 = 1 << idx;
-            if (mask & bit) == 0 {
-                continue;
-            }
-            if let Some(sel_x) = x_positions.get(idx).copied() {
-                let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                let underline_w = draw_w.ceil();
-                actors.push(act!(quad:
-                    align(0.0, 0.5):
-                    xy(sel_x, underline_y):
-                    zoomto(underline_w, line_thickness):
-                    diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                    z(Z_ROW_FOREGROUND)
-                ));
-            }
-        }
-    }
-}
-
-/// Draw a single-select underline for one row: one underline under each
-/// active player's chosen value.
-#[allow(clippy::too_many_arguments)]
-fn draw_single_select_underline(
-    actors: &mut Vec<Actor>,
-    state: &State,
-    row: &Row,
-    active: [bool; PLAYER_SLOTS],
-    x_positions: &[f32],
-    widths: &[f32],
-    current_row_y: f32,
-    text_h: f32,
-    a: f32,
-) {
-    let line_thickness = underline_thickness();
-    let offset = underline_offset();
-    let underline_base_y = current_row_y + text_h * 0.5 + offset;
-    let underline_y = |player_idx: usize| {
-        if active[P1] && active[P2] {
-            (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-        } else {
-            underline_base_y
-        }
-    };
-    for player_idx in active_player_indices(active) {
-        let idx = row.selected_choice_index[player_idx].min(widths.len().saturating_sub(1));
-        if let Some(sel_x) = x_positions.get(idx).copied() {
-            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-            let underline_w = draw_w.ceil();
-            let underline_y = underline_y(player_idx);
-            let mut line_color = color::decorative_rgba(player_color_index(state, player_idx));
-            line_color[3] *= a;
-            actors.push(act!(quad:
-                align(0.0, 0.5):
-                xy(sel_x, underline_y):
-                zoomto(underline_w, line_thickness):
-                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                z(Z_ROW_FOREGROUND)
-            ));
-        }
-    }
-}
-
-/// Color palette index for a player's underline / cursor.
-fn player_color_index(state: &State, player_idx: usize) -> i32 {
-    if player_idx == P2 {
-        state.active_color_index - 2
-    } else {
-        state.active_color_index
-    }
-}
-
-/// Current animated cursor rectangle for a player (center xy + size),
-/// or `None` if the player is inactive or the cursor isn't initialised yet.
-fn cursor_for_player(state: &State, player_idx: usize) -> Option<(f32, f32, f32, f32)> {
-    if player_idx >= PLAYER_SLOTS || !state.pane().cursor_initialized[player_idx] {
-        return None;
-    }
-    let pane = state.pane();
-    let t = pane.cursor_t[player_idx].clamp(0.0, 1.0);
-    let r = CursorRect::lerp(pane.cursor_from[player_idx], pane.cursor_to[player_idx], t);
-    Some((r.x, r.y, r.w, r.h))
-}
-
-/// Draw the 4-sided cursor ring around each active player's selected
-/// option in row `item_idx`. No-ops for players whose cursor isn't on
-/// this row or hasn't been initialised yet.
-fn draw_cursor_ring(
-    actors: &mut Vec<Actor>,
-    state: &State,
-    active: [bool; PLAYER_SLOTS],
-    item_idx: usize,
-    a: f32,
-) {
-    let border_w = selection_border_width();
-    for player_idx in active_player_indices(active) {
-        if state.pane().selected_row[player_idx] != item_idx {
-            continue;
-        }
-        let Some((center_x, center_y, ring_w, ring_h)) = cursor_for_player(state, player_idx)
-        else {
-            continue;
-        };
-
-        let left = center_x - ring_w * 0.5;
-        let right = center_x + ring_w * 0.5;
-        let top = center_y - ring_h * 0.5;
-        let bottom = center_y + ring_h * 0.5;
-        let mut ring_color = color::decorative_rgba(player_color_index(state, player_idx));
-        ring_color[3] *= a;
-
-        actors.push(act!(quad:
-            align(0.5, 0.5): xy((left + right) * 0.5, top + border_w * 0.5):
-            zoomto(ring_w, border_w):
-            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-            z(Z_ROW_FOREGROUND)
-        ));
-        actors.push(act!(quad:
-            align(0.5, 0.5): xy((left + right) * 0.5, bottom - border_w * 0.5):
-            zoomto(ring_w, border_w):
-            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-            z(Z_ROW_FOREGROUND)
-        ));
-        actors.push(act!(quad:
-            align(0.5, 0.5): xy(left + border_w * 0.5, (top + bottom) * 0.5):
-            zoomto(border_w, ring_h):
-            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-            z(Z_ROW_FOREGROUND)
-        ));
-        actors.push(act!(quad:
-            align(0.5, 0.5): xy(right - border_w * 0.5, (top + bottom) * 0.5):
-            zoomto(border_w, ring_h):
-            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-            z(Z_ROW_FOREGROUND)
-        ));
-    }
-}
-
 pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     let mut actors: Vec<Actor> = Vec::with_capacity(64);
     let active = session_active_players();
@@ -464,6 +127,17 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     let title_x = row_left + title_left_pad;
     // Keep header labels bounded to the title column so they never overlap option values.
     let title_max_w = (TITLE_BG_WIDTH - title_left_pad - 5.0).max(0.0);
+
+    let fc = FrameCtx {
+        state,
+        asset_manager,
+        active,
+        show_p2,
+        speed_mod_x,
+        row_left,
+        row_width,
+        preview_x: [preview_x_for(P1), preview_x_for(P2)],
+    };
 
     for item_idx in 0..total_rows {
         let (current_row_y, row_alpha) = state
@@ -597,931 +271,27 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                 draw_cursor_ring(&mut actors, state, active, item_idx, a);
             }
         } else if show_all_choices_inline {
-            // Render every option horizontally; when active, all options should be white.
-            // The active option gets an underline (quad) drawn just below the text.
-            let value_zoom = INLINE_CHOICE_VALUE_ZOOM;
-            let spacing = INLINE_CHOICE_SPACING;
-            let next_row_item = show_arcade_next_row
-                .then(|| arcade_next_row_layout(state, item_idx, asset_manager, value_zoom));
-            let mut widths: Vec<f32> = Vec::with_capacity(row.choices.len());
-            let mut text_h: f32 = 16.0;
-            asset_manager.with_fonts(|all_fonts| {
-                asset_manager.with_font("miso", |metrics_font| {
-                    text_h = (metrics_font.height as f32).max(1.0) * value_zoom;
-                    for text in &row.choices {
-                        let mut w = crate::engine::present::font::measure_line_width_logical(
-                            metrics_font,
-                            text,
-                            all_fonts,
-                        ) as f32;
-                        if !w.is_finite() || w <= 0.0 {
-                            w = 1.0;
-                        }
-                        widths.push(w * value_zoom);
-                    }
-                });
-            });
-            let mut x_positions: Vec<f32> = Vec::with_capacity(widths.len());
-            {
-                let mut x = choice_inner_left;
-                for w in &widths {
-                    x_positions.push(x);
-                    x += *w + spacing;
-                }
-            }
-            // Draw underline under active options:
-            // - For normal rows: underline the currently selected choice.
-            // - For Scroll row: underline each enabled scroll mode (multi-select).
-            // - For FA+ Options row: underline each enabled FA+ toggle (multi-select).
-            if is_multi_select_row(row.id) {
-                draw_multi_select_underlines(
-                    &mut actors,
-                    state,
-                    row,
-                    active,
-                    &x_positions,
-                    &widths,
-                    current_row_y,
-                    text_h,
-                    a,
-                );
-            } else {
-                draw_single_select_underline(
-                    &mut actors,
-                    state,
-                    row,
-                    active,
-                    &x_positions,
-                    &widths,
-                    current_row_y,
-                    text_h,
-                    a,
-                );
-            }
-            // Draw the 4-sided cursor ring around the selected option when this row is active.
-            if !widths.is_empty() {
-                draw_cursor_ring(&mut actors, state, active, item_idx, a);
-            }
-            // Draw each option's text (active row: all white; inactive: #808080)
-            if let Some((next_row_x, _, _)) = next_row_item {
-                let next_row_color = if is_active {
-                    [1.0, 1.0, 1.0, a]
-                } else {
-                    sl_gray
-                };
-                actors.push(act!(text: font("miso"): settext(ARCADE_NEXT_ROW_TEXT):
-                    align(0.0, 0.5): xy(next_row_x, current_row_y): zoom(value_zoom):
-                    diffuse(
-                        next_row_color[0],
-                        next_row_color[1],
-                        next_row_color[2],
-                        next_row_color[3]
-                    ):
-                    z(Z_ROW_FOREGROUND)
-                ));
-            }
-            for (idx, text) in row.choices.iter().enumerate() {
-                let x = x_positions.get(idx).copied().unwrap_or(choice_inner_left);
-                let color_rgba = if is_active {
-                    [1.0, 1.0, 1.0, a]
-                } else {
-                    sl_gray
-                };
-                actors.push(act!(text: font("miso"): settext(text.clone()):
-                    align(0.0, 0.5): xy(x, current_row_y): zoom(value_zoom):
-                    diffuse(color_rgba[0], color_rgba[1], color_rgba[2], color_rgba[3]):
-                    z(Z_ROW_FOREGROUND)
-                ));
-            }
-        } else {
-            // Single value display (default behavior)
-            // By default, align single-value choices to the same line as Speed Mod.
-            // For Music Rate, center within the item column (to match SL parity).
-            let primary_player_idx = if active[P1] { P1 } else { P2 };
-            let mut choice_center_x = speed_mod_x;
-            if row.id == RowId::MusicRate {
-                let item_col_left = row_left + TITLE_BG_WIDTH;
-                let item_col_w = row_width - TITLE_BG_WIDTH;
-                choice_center_x = item_col_left + item_col_w * 0.5;
-            } else if primary_player_idx == P2 {
-                choice_center_x = screen_center_x().mul_add(2.0, -choice_center_x);
-            }
-            let choice_text_idx = row.selected_choice_index[primary_player_idx]
-                .min(row.choices.len().saturating_sub(1));
-            let choice_text = row
-                .choices
-                .get(choice_text_idx)
-                .unwrap_or_else(|| row.choices.first().expect("OptionRow must have choices"));
-            let choice_color = if is_active {
-                [1.0, 1.0, 1.0, a]
-            } else {
-                sl_gray
+            let rc = RowCtx {
+                fc: &fc,
+                row,
+                item_idx,
+                current_row_y,
+                a,
+                is_active,
+                sl_gray,
             };
-            asset_manager.with_fonts(|all_fonts| {
-                asset_manager.with_font("miso", |metrics_font| {
-                    let choice_display_text =
-                        if arcade_row_focuses_next_row(state, primary_player_idx, item_idx) {
-                            ARCADE_NEXT_ROW_TEXT.to_string()
-                        } else if row.id == RowId::SpeedMod {
-                            state.speed_mod[primary_player_idx].display()
-                        } else {
-                            choice_text.clone()
-                        };
-                    let mut text_w = crate::engine::present::font::measure_line_width_logical(
-                        metrics_font,
-                        &choice_display_text,
-                        all_fonts,
-                    ) as f32;
-                    if !text_w.is_finite() || text_w <= 0.0 {
-                        text_w = 1.0;
-                    }
-                    let text_h = (metrics_font.height as f32).max(1.0);
-                    let value_zoom = INLINE_CHOICE_VALUE_ZOOM;
-                    let draw_w = text_w * value_zoom;
-                    let draw_h = text_h * value_zoom;
-                    actors.push(act!(text: font("miso"): settext(choice_display_text):
-                        align(0.5, 0.5): xy(choice_center_x, current_row_y): zoom(value_zoom):
-                        diffuse(choice_color[0], choice_color[1], choice_color[2], choice_color[3]):
-                        z(Z_ROW_FOREGROUND)
-                    ));
-                    // Underline (always visible) — fixed pixel thickness for consistency
-                    let line_thickness = underline_thickness();
-                    let underline_w = draw_w.ceil(); // pixel-align for crispness
-                    let offset = underline_offset(); // place just under the baseline
-                    let underline_y = current_row_y + draw_h * 0.5 + offset;
-                    let underline_left_x = choice_center_x - draw_w * 0.5;
-                    let mut line_color = color::decorative_rgba(player_color_index(state, primary_player_idx));
-                    line_color[3] *= a;
-                    actors.push(act!(quad:
-                        align(0.0, 0.5): // start at text's left edge
-                        xy(underline_left_x, underline_y):
-                        zoomto(underline_w, line_thickness):
-                        diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                        z(Z_ROW_FOREGROUND)
-                    ));
-                    // Encircling cursor around the active option value (programmatic border)
-                    if active[primary_player_idx] && state.pane().selected_row[primary_player_idx] == item_idx {
-                        let border_w = selection_border_width();
-                        if let Some((center_x, center_y, ring_w, ring_h)) =
-                            cursor_for_player(state, primary_player_idx)
-                        {
-                            let left = center_x - ring_w * 0.5;
-                            let right = center_x + ring_w * 0.5;
-                            let top = center_y - ring_h * 0.5;
-                            let bottom = center_y + ring_h * 0.5;
-                            let mut ring_color =
-                                color::decorative_rgba(player_color_index(state, primary_player_idx));
-                            ring_color[3] *= a;
-                            actors.push(act!(quad:
-                                align(0.5, 0.5): xy(center_x, top + border_w * 0.5):
-                                zoomto(ring_w, border_w):
-                                diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                            actors.push(act!(quad:
-                                align(0.5, 0.5): xy(center_x, bottom - border_w * 0.5):
-                                zoomto(ring_w, border_w):
-                                diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                            actors.push(act!(quad:
-                                align(0.5, 0.5): xy(left + border_w * 0.5, center_y):
-                                zoomto(border_w, ring_h):
-                                diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                            actors.push(act!(quad:
-                                align(0.5, 0.5): xy(right - border_w * 0.5, center_y):
-                                zoomto(border_w, ring_h):
-                                diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                    let p2_text = if show_p2 && row.id != RowId::MusicRate {
-                        if arcade_row_focuses_next_row(state, P2, item_idx) {
-                            ARCADE_NEXT_ROW_TEXT.to_string()
-                        } else if row.id == RowId::SpeedMod {
-                            state.speed_mod[P2].display()
-                        } else if row.id == RowId::TypeOfSpeedMod {
-                            let idx = state.speed_mod[P2].mod_type.choice_index();
-                            row.choices.get(idx).cloned().unwrap_or_default()
-                        } else {
-                            let idx = row
-                                .selected_choice_index[P2]
-                                .min(row.choices.len().saturating_sub(1));
-                            row.choices.get(idx).cloned().unwrap_or_default()
-                        }
-                    } else {
-                        String::new()
-                    };
-                    if show_p2 && row.id != RowId::MusicRate {
-                        let p2_choice_center_x = screen_center_x().mul_add(2.0, -choice_center_x);
-                        let mut p2_w = crate::engine::present::font::measure_line_width_logical(
-                            metrics_font,
-                            &p2_text,
-                            all_fonts,
-                        ) as f32;
-                        if !p2_w.is_finite() || p2_w <= 0.0 {
-                            p2_w = 1.0;
-                        }
-                        let p2_draw_w = p2_w * value_zoom;
-                        actors.push(act!(text: font("miso"): settext(p2_text.clone()):
-                            align(0.5, 0.5): xy(p2_choice_center_x, current_row_y): zoom(value_zoom):
-                            diffuse(choice_color[0], choice_color[1], choice_color[2], choice_color[3]):
-                            z(Z_ROW_FOREGROUND)
-                        ));
-                        let line_thickness = underline_thickness();
-                        let underline_w = p2_draw_w.ceil();
-                        let offset = underline_offset();
-                        let underline_y = current_row_y + draw_h * 0.5 + offset;
-                        let underline_left_x = p2_choice_center_x - p2_draw_w * 0.5;
-                        let mut line_color = color::decorative_rgba(player_color_index(state, P2));
-                        line_color[3] *= a;
-                        actors.push(act!(quad:
-                            align(0.0, 0.5):
-                            xy(underline_left_x, underline_y):
-                            zoomto(underline_w, line_thickness):
-                            diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                            z(Z_ROW_FOREGROUND)
-                        ));
-                        if active[P2] && state.pane().selected_row[P2] == item_idx {
-                            let border_w = selection_border_width();
-                            if let Some((center_x, center_y, ring_w, ring_h)) = cursor_for_player(state, P2) {
-                                let left = center_x - ring_w * 0.5;
-                                let right = center_x + ring_w * 0.5;
-                                let top = center_y - ring_h * 0.5;
-                                let bottom = center_y + ring_h * 0.5;
-                                let mut ring_color = color::decorative_rgba(player_color_index(state, P2));
-                                ring_color[3] *= a;
-                                actors.push(act!(quad:
-                                    align(0.5, 0.5): xy(center_x, top + border_w * 0.5):
-                                    zoomto(ring_w, border_w):
-                                    diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                                    z(Z_ROW_FOREGROUND)
-                                ));
-                                actors.push(act!(quad:
-                                    align(0.5, 0.5): xy(center_x, bottom - border_w * 0.5):
-                                    zoomto(ring_w, border_w):
-                                    diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                                    z(Z_ROW_FOREGROUND)
-                                ));
-                                actors.push(act!(quad:
-                                    align(0.5, 0.5): xy(left + border_w * 0.5, center_y):
-                                    zoomto(border_w, ring_h):
-                                    diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                                    z(Z_ROW_FOREGROUND)
-                                ));
-                                actors.push(act!(quad:
-                                    align(0.5, 0.5): xy(right - border_w * 0.5, center_y):
-                                    zoomto(border_w, ring_h):
-                                    diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
-                                    z(Z_ROW_FOREGROUND)
-                                ));
-                            }
-                        }
-                    }
-                    // Add previews for the selected value on each side.
-                    if row.id == RowId::JudgmentFont {
-                        let texture_for = |player_idx: usize| -> Option<&str> {
-                            select_preview_texture(
-                                row,
-                                player_idx,
-                                assets::judgment_texture_choices(),
-                            )
-                        };
-                        if let Some(texture) = texture_for(primary_player_idx) {
-                            actors.push(act!(sprite(texture):
-                                align(0.5, 0.5):
-                                xy(preview_x_for(primary_player_idx), current_row_y):
-                                setstate(0):
-                                zoom(JUDGMENT_PREVIEW_ZOOM):
-                                diffuse(1.0, 1.0, 1.0, a):
-                                z(Z_ROW_PREVIEW)
-                            ));
-                        }
-                        if show_p2
-                            && primary_player_idx != P2
-                            && let Some(texture) = texture_for(P2)
-                        {
-                            actors.push(act!(sprite(texture):
-                                align(0.5, 0.5):
-                                xy(preview_x_for(P2), current_row_y):
-                                setstate(0):
-                                zoom(JUDGMENT_PREVIEW_ZOOM):
-                                diffuse(1.0, 1.0, 1.0, a):
-                                z(Z_ROW_PREVIEW)
-                            ));
-                        }
-                    }
-                    // Add hold judgment preview for "Hold Judgment" row showing both frames (Held and Let Go)
-                    if row.id == RowId::HoldJudgment {
-                        let texture_for = |player_idx: usize| -> Option<&str> {
-                            select_preview_texture(
-                                row,
-                                player_idx,
-                                assets::hold_judgment_texture_choices(),
-                            )
-                        };
-                        let draw_hold_preview = |texture: &str, center_x: f32, actors: &mut Vec<Actor>| {
-                            let zoom = JUDGMENT_PREVIEW_ZOOM;
-                            let tex_w = crate::assets::texture_dims(texture)
-                                .map_or(128.0, |meta| meta.w.max(1) as f32);
-                            let center_offset = tex_w * zoom * 0.4;
-
-                            actors.push(act!(sprite(texture):
-                                align(0.5, 0.5):
-                                xy(center_x - center_offset, current_row_y):
-                                setstate(0):
-                                zoom(zoom):
-                                diffuse(1.0, 1.0, 1.0, a):
-                                z(Z_ROW_PREVIEW)
-                            ));
-                            actors.push(act!(sprite(texture):
-                                align(0.5, 0.5):
-                                xy(center_x + center_offset, current_row_y):
-                                setstate(1):
-                                zoom(zoom):
-                                diffuse(1.0, 1.0, 1.0, a):
-                                z(Z_ROW_PREVIEW)
-                            ));
-                        };
-                        if let Some(texture) = texture_for(primary_player_idx) {
-                            draw_hold_preview(texture, preview_x_for(primary_player_idx), &mut actors);
-                        }
-                        if show_p2
-                            && primary_player_idx != P2
-                            && let Some(texture) = texture_for(P2)
-                        {
-                            draw_hold_preview(texture, preview_x_for(P2), &mut actors);
-                        }
-                    }
-                    // Match ITGmania themes that show four directional noteskin preview arrows
-                    // with explicit quant offsets: Left/Down/Up/Right and 0/1/3/2 quant indices.
-                    if row.id == RowId::NoteSkin
-                        || row.id == RowId::MineSkin
-                        || row.id == RowId::ReceptorSkin
-                        || row.id == RowId::TapExplosionSkin
-                    {
-                        const PREVIEW_ARROWS: [(usize, f32, f32); 4] = [
-                            (0, 0.0, -1.5),
-                            (1, 1.0, -0.5),
-                            (2, 3.0, 0.5),
-                            (3, 2.0, 1.5),
-                        ];
-                        let draw_noteskin_note =
-                            |ns: &Noteskin,
-                             note_idx: usize,
-                             quant_idx: f32,
-                             center_x: f32,
-                             actors: &mut Vec<Actor>| {
-                                let target_height = NOTESKIN_PREVIEW_ARROW_PIXEL_SIZE * NOTESKIN_PREVIEW_SCALE;
-                                let elapsed = state.preview_time;
-                                let beat = state.preview_beat;
-                                let note_uv_phase = ns.tap_note_uv_phase(elapsed, beat, 0.0);
-                                let tap_spacing = ns.note_display_metrics.part_texture_translate
-                                    [NoteAnimPart::Tap as usize]
-                                    .note_color_spacing;
-                                let uv_translate =
-                                    [tap_spacing[0] * quant_idx, tap_spacing[1] * quant_idx];
-                                if let Some(note_slots) = ns.note_layers.get(note_idx) {
-                                    let primary_h = note_slots
-                                        .first()
-                                        .map(|slot| slot.logical_size()[1].max(1.0))
-                                        .unwrap_or(1.0);
-                                    let note_scale = if primary_h > f32::EPSILON {
-                                        target_height / primary_h
-                                    } else {
-                                        NOTESKIN_PREVIEW_SCALE
-                                    };
-                                    for (layer_idx, note_slot) in note_slots.iter().enumerate() {
-                                        let draw = note_slot.model_draw_at(elapsed, beat);
-                                        if !draw.visible {
-                                            continue;
-                                        }
-                                        let frame = note_slot.frame_index(elapsed, beat);
-                                        let uv_elapsed = if note_slot.model.is_some() {
-                                            note_uv_phase
-                                        } else {
-                                            elapsed
-                                        };
-                                        let uv = note_slot.uv_for_frame_at(frame, uv_elapsed);
-                                        let uv = [
-                                            uv[0] + uv_translate[0],
-                                            uv[1] + uv_translate[1],
-                                            uv[2] + uv_translate[0],
-                                            uv[3] + uv_translate[1],
-                                        ];
-                                        let slot_size = note_slot.logical_size();
-                                        let base_size = [slot_size[0] * note_scale, slot_size[1] * note_scale];
-                                        let rot_rad = (-note_slot.def.rotation_deg as f32).to_radians();
-                                        let (sin_r, cos_r) = rot_rad.sin_cos();
-                                        let ox = draw.pos[0] * note_scale;
-                                        let oy = draw.pos[1] * note_scale;
-                                        let center = [
-                                            center_x + ox * cos_r - oy * sin_r,
-                                            current_row_y + ox * sin_r + oy * cos_r,
-                                        ];
-                                        let size = [
-                                            base_size[0] * draw.zoom[0].max(0.0),
-                                            base_size[1] * draw.zoom[1].max(0.0),
-                                        ];
-                                        if size[0] <= f32::EPSILON || size[1] <= f32::EPSILON {
-                                            continue;
-                                        }
-                                        let color = [draw.tint[0], draw.tint[1], draw.tint[2], draw.tint[3] * a];
-                                        let blend = if draw.blend_add {
-                                            BlendMode::Add
-                                        } else {
-                                            BlendMode::Alpha
-                                        };
-                                        let z = 102 + layer_idx as i32;
-                                        if let Some(model_actor) = noteskin_model_actor(
-                                            note_slot,
-                                            center,
-                                            size,
-                                            uv,
-                                            -note_slot.def.rotation_deg as f32,
-                                            elapsed,
-                                            beat,
-                                            color,
-                                            blend,
-                                            z as i16,
-                                        ) {
-                                            actors.push(model_actor);
-                                        } else if draw.blend_add {
-                                            actors.push(act!(sprite(note_slot.texture_key_shared()):
-                                                align(0.5, 0.5):
-                                                xy(center[0], center[1]):
-                                                setsize(size[0], size[1]):
-                                                rotationz(draw.rot[2] - note_slot.def.rotation_deg as f32):
-                                                customtexturerect(uv[0], uv[1], uv[2], uv[3]):
-                                                diffuse(color[0], color[1], color[2], color[3]):
-                                                blend(add):
-                                                z(z)
-                                            ));
-                                        } else {
-                                            actors.push(act!(sprite(note_slot.texture_key_shared()):
-                                                align(0.5, 0.5):
-                                                xy(center[0], center[1]):
-                                                setsize(size[0], size[1]):
-                                                rotationz(draw.rot[2] - note_slot.def.rotation_deg as f32):
-                                                customtexturerect(uv[0], uv[1], uv[2], uv[3]):
-                                                diffuse(color[0], color[1], color[2], color[3]):
-                                                blend(normal):
-                                                z(z)
-                                            ));
-                                        }
-                                    }
-                                    return;
-                                }
-                                let Some(note_slot) = ns.notes.get(note_idx) else {
-                                    return;
-                                };
-                                let frame = note_slot.frame_index(elapsed, beat);
-                                let uv_elapsed = if note_slot.model.is_some() {
-                                    note_uv_phase
-                                } else {
-                                    elapsed
-                                };
-                                let uv = note_slot.uv_for_frame_at(frame, uv_elapsed);
-                                let uv = [
-                                    uv[0] + uv_translate[0],
-                                    uv[1] + uv_translate[1],
-                                    uv[2] + uv_translate[0],
-                                    uv[3] + uv_translate[1],
-                                ];
-                                let size_raw = note_slot.logical_size();
-                                let width = size_raw[0].max(1.0);
-                                let height = size_raw[1].max(1.0);
-                                let scale = if height > 0.0 {
-                                    target_height / height
-                                } else {
-                                    NOTESKIN_PREVIEW_SCALE
-                                };
-                                let size = [width * scale, target_height];
-                                let center = [center_x, current_row_y];
-                                if let Some(model_actor) = noteskin_model_actor(
-                                    note_slot,
-                                    center,
-                                    size,
-                                    uv,
-                                    -note_slot.def.rotation_deg as f32,
-                                    elapsed,
-                                    beat,
-                                    [1.0, 1.0, 1.0, a],
-                                    BlendMode::Alpha,
-                                    102,
-                                ) {
-                                    actors.push(model_actor);
-                                } else {
-                                    actors.push(act!(sprite(note_slot.texture_key_shared()):
-                                        align(0.5, 0.5):
-                                        xy(center[0], center[1]):
-                                        setsize(size[0], size[1]):
-                                        rotationz(-note_slot.def.rotation_deg as f32):
-                                        customtexturerect(uv[0], uv[1], uv[2], uv[3]):
-                                        diffuse(1.0, 1.0, 1.0, a):
-                                        z(Z_ROW_PREVIEW)
-                                    ));
-                                }
-                            };
-                        let draw_noteskin_preview =
-                            |ns: &Noteskin, center_x: f32, actors: &mut Vec<Actor>| {
-                                let target_height = NOTESKIN_PREVIEW_ARROW_PIXEL_SIZE * NOTESKIN_PREVIEW_SCALE;
-                                for (col, quant_idx, x_mult) in PREVIEW_ARROWS {
-                                    let x = center_x + x_mult * target_height;
-                                    let note_idx =
-                                        col * NUM_QUANTIZATIONS + Quantization::Q4th as usize;
-                                    draw_noteskin_note(ns, note_idx, quant_idx, x, actors);
-                                }
-                            };
-                        let draw_mine_preview =
-                            |mine_ns: &Noteskin, center_x: f32, actors: &mut Vec<Actor>| {
-                                let target_height = NOTESKIN_PREVIEW_ARROW_PIXEL_SIZE * NOTESKIN_PREVIEW_SCALE;
-                                let mine_col = if mine_ns.mines.len() > 1 || mine_ns.mine_frames.len() > 1 {
-                                    1
-                                } else {
-                                    0
-                                };
-                                let fill_slot =
-                                    mine_ns.mines.get(mine_col).and_then(|slot| slot.as_ref());
-                                let frame_slot = mine_ns
-                                    .mine_frames
-                                    .get(mine_col)
-                                    .and_then(|slot| slot.as_ref());
-                                let Some(primary_slot) = frame_slot.or(fill_slot) else {
-                                    return;
-                                };
-                                let mine_phase =
-                                    mine_ns.tap_mine_uv_phase(state.preview_time, state.preview_beat, 0.0);
-                                let mine_translation =
-                                    mine_ns.part_uv_translation(NoteAnimPart::Mine, 0.0, false);
-                                let mine_center = [center_x, current_row_y];
-                                let scale_mine_slot = |slot: &SpriteSlot| {
-                                    let size = slot
-                                        .model
-                                        .as_ref()
-                                        .map(|model| model.size())
-                                        .unwrap_or_else(|| {
-                                            let logical = slot.logical_size();
-                                            [logical[0], logical[1]]
-                                        });
-                                    let width = size[0].max(1.0);
-                                    let height = size[1].max(1.0);
-                                    let scale = target_height / height;
-                                    [width * scale, target_height]
-                                };
-                                let draw_mine_slot =
-                                    |slot: &SpriteSlot, alpha: f32, z: i32, actors: &mut Vec<Actor>| {
-                                        let draw = slot.model_draw_at(state.preview_time, state.preview_beat);
-                                        if !draw.visible {
-                                            return;
-                                        }
-                                        let frame = slot.frame_index_from_phase(mine_phase);
-                                        let uv_elapsed = if slot.model.is_some() {
-                                            mine_phase
-                                        } else {
-                                            state.preview_time
-                                        };
-                                        let uv = slot.uv_for_frame_at(frame, uv_elapsed);
-                                        let uv = [
-                                            uv[0] + mine_translation[0],
-                                            uv[1] + mine_translation[1],
-                                            uv[2] + mine_translation[0],
-                                            uv[3] + mine_translation[1],
-                                        ];
-                                        let size = scale_mine_slot(slot);
-                                        if let Some(model_actor) = noteskin_model_actor(
-                                            slot,
-                                            mine_center,
-                                            size,
-                                            uv,
-                                            -slot.def.rotation_deg as f32,
-                                            state.preview_time,
-                                            state.preview_beat,
-                                            [1.0, 1.0, 1.0, alpha],
-                                            BlendMode::Alpha,
-                                            z as i16,
-                                        ) {
-                                            actors.push(model_actor);
-                                        } else {
-                                            actors.push(act!(sprite(slot.texture_key_shared()):
-                                                align(0.5, 0.5):
-                                                xy(mine_center[0], mine_center[1]):
-                                                setsize(size[0], size[1]):
-                                                rotationz(draw.rot[2] - slot.def.rotation_deg as f32):
-                                                customtexturerect(uv[0], uv[1], uv[2], uv[3]):
-                                                diffuse(1.0, 1.0, 1.0, alpha):
-                                                z(z)
-                                            ));
-                                        }
-                                    };
-                                if let Some(slot) = fill_slot {
-                                    draw_mine_slot(slot, 0.85 * a, 106, actors);
-                                }
-                                if let Some(slot) = frame_slot {
-                                    draw_mine_slot(slot, a, 107, actors);
-                                } else if fill_slot.is_none() {
-                                    draw_mine_slot(primary_slot, a, 107, actors);
-                                }
-                            };
-                        let draw_receptor_preview =
-                            |receptor_ns: &Noteskin, center_x: f32, actors: &mut Vec<Actor>| {
-                                let target_height = NOTESKIN_PREVIEW_ARROW_PIXEL_SIZE * NOTESKIN_PREVIEW_SCALE;
-                                let receptor_color =
-                                    receptor_ns.receptor_pulse.color_for_beat(state.preview_beat);
-                                let color = [
-                                    receptor_color[0],
-                                    receptor_color[1],
-                                    receptor_color[2],
-                                    receptor_color[3] * a,
-                                ];
-                                for (col, _, x_mult) in PREVIEW_ARROWS {
-                                    let Some(receptor_slot) = receptor_ns.receptor_off.get(col) else {
-                                        continue;
-                                    };
-                                    let frame = receptor_slot
-                                        .frame_index(state.preview_time, state.preview_beat);
-                                    let uv = receptor_slot
-                                        .uv_for_frame_at(frame, state.preview_time);
-                                    let logical = receptor_slot.logical_size();
-                                    let width = logical[0].max(1.0);
-                                    let height = logical[1].max(1.0);
-                                    let scale = if height > f32::EPSILON {
-                                        target_height / height
-                                    } else {
-                                        NOTESKIN_PREVIEW_SCALE
-                                    };
-                                    let size = [width * scale, target_height];
-                                    let center = [center_x + x_mult * target_height, current_row_y];
-                                    if let Some(model_actor) = noteskin_model_actor(
-                                        receptor_slot,
-                                        center,
-                                        size,
-                                        uv,
-                                        -receptor_slot.def.rotation_deg as f32,
-                                        state.preview_time,
-                                        state.preview_beat,
-                                        color,
-                                        BlendMode::Alpha,
-                                        106,
-                                    ) {
-                                        actors.push(model_actor);
-                                    } else {
-                                        actors.push(act!(sprite(receptor_slot.texture_key_shared()):
-                                            align(0.5, 0.5):
-                                            xy(center[0], center[1]):
-                                            setsize(size[0], size[1]):
-                                            rotationz(-receptor_slot.def.rotation_deg as f32):
-                                            customtexturerect(uv[0], uv[1], uv[2], uv[3]):
-                                            diffuse(color[0], color[1], color[2], color[3]):
-                                            z(Z_RECEPTOR_PREVIEW)
-                                        ));
-                                    }
-                                }
-                            };
-                        let draw_tap_explosion_preview = |explosion_ns: &Noteskin,
-                                                          receptor_ns: &Noteskin,
-                                                          center_x: f32,
-                                                          actors: &mut Vec<Actor>| {
-                            let preview_time = state.preview_time * TAP_EXPLOSION_PREVIEW_SPEED;
-                            let preview_beat = state.preview_beat * TAP_EXPLOSION_PREVIEW_SPEED;
-                            let Some(explosion) = explosion_ns
-                                .tap_explosions
-                                .get("W1")
-                                .or_else(|| explosion_ns.tap_explosions.values().next())
-                            else {
-                                return;
-                            };
-                            let duration = explosion.animation.duration();
-                            let anim_time = if duration > f32::EPSILON {
-                                preview_time.rem_euclid(duration)
-                            } else {
-                                0.0
-                            };
-                            let explosion_visual = explosion.animation.state_at(anim_time);
-                            if !explosion_visual.visible {
-                                return;
-                            }
-                            let slot = &explosion.slot;
-                            let beat_for_anim = if slot.source.is_beat_based() {
-                                anim_time.max(0.0)
-                            } else {
-                                preview_beat
-                            };
-                            let frame = slot.frame_index(anim_time, beat_for_anim);
-                            let uv_elapsed = if slot.model.is_some() {
-                                anim_time
-                            } else {
-                                preview_time
-                            };
-                            let uv = slot.uv_for_frame_at(frame, uv_elapsed);
-                            let logical = slot.logical_size();
-                            let width = logical[0].max(1.0);
-                            let height = logical[1].max(1.0);
-                            let target_height = NOTESKIN_PREVIEW_ARROW_PIXEL_SIZE * NOTESKIN_PREVIEW_SCALE;
-                            let scale = if height > f32::EPSILON {
-                                target_height / height
-                            } else {
-                                NOTESKIN_PREVIEW_SCALE
-                            };
-                            let size = [width * scale, target_height];
-                            let rotation_deg = receptor_ns
-                                .receptor_off
-                                .first()
-                                .map(|slot| slot.def.rotation_deg as f32)
-                                .unwrap_or(0.0);
-                            let color = [
-                                explosion_visual.diffuse[0],
-                                explosion_visual.diffuse[1],
-                                explosion_visual.diffuse[2],
-                                explosion_visual.diffuse[3] * a,
-                            ];
-                            let blend = if explosion.animation.blend_add {
-                                BlendMode::Add
-                            } else {
-                                BlendMode::Alpha
-                            };
-                            if let Some(model_actor) = noteskin_model_actor(
-                                slot,
-                                [center_x, current_row_y],
-                                [
-                                    size[0] * explosion_visual.zoom.max(0.0),
-                                    size[1] * explosion_visual.zoom.max(0.0),
-                                ],
-                                uv,
-                                -rotation_deg,
-                                anim_time,
-                                beat_for_anim,
-                                color,
-                                blend,
-                                107,
-                            ) {
-                                actors.push(model_actor);
-                            } else if matches!(blend, BlendMode::Add) {
-                                actors.push(act!(sprite(slot.texture_key_shared()):
-                                    align(0.5, 0.5):
-                                    xy(center_x, current_row_y):
-                                    setsize(size[0], size[1]):
-                                    zoom(explosion_visual.zoom):
-                                    rotationz(-rotation_deg):
-                                    customtexturerect(uv[0], uv[1], uv[2], uv[3]):
-                                    diffuse(color[0], color[1], color[2], color[3]):
-                                    blend(add):
-                                    z(Z_EXPLOSION_PREVIEW)
-                                ));
-                            } else {
-                                actors.push(act!(sprite(slot.texture_key_shared()):
-                                    align(0.5, 0.5):
-                                    xy(center_x, current_row_y):
-                                    setsize(size[0], size[1]):
-                                    zoom(explosion_visual.zoom):
-                                    rotationz(-rotation_deg):
-                                    customtexturerect(uv[0], uv[1], uv[2], uv[3]):
-                                    diffuse(color[0], color[1], color[2], color[3]):
-                                    blend(normal):
-                                    z(Z_EXPLOSION_PREVIEW)
-                                ));
-                            }
-                        };
-                        if row.id == RowId::NoteSkin {
-                            if let Some(ns) = state.noteskin[primary_player_idx].as_ref() {
-                                draw_noteskin_preview(
-                                    ns,
-                                    preview_x_for(primary_player_idx),
-                                    &mut actors,
-                                );
-                            }
-                            if show_p2 && primary_player_idx != P2
-                                && let Some(ns) = state.noteskin[P2].as_ref()
-                            {
-                                draw_noteskin_preview(ns, preview_x_for(P2), &mut actors);
-                            }
-                        } else if row.id == RowId::MineSkin {
-                            if let Some(mine_ns) = state.mine_noteskin[primary_player_idx]
-                                .as_deref()
-                                .or_else(|| state.noteskin[primary_player_idx].as_deref())
-                            {
-                                draw_mine_preview(
-                                    mine_ns,
-                                    preview_x_for(primary_player_idx),
-                                    &mut actors,
-                                );
-                            }
-                            if show_p2 && primary_player_idx != P2
-                                && let Some(mine_ns) = state.mine_noteskin[P2]
-                                    .as_deref()
-                                    .or_else(|| state.noteskin[P2].as_deref())
-                            {
-                                draw_mine_preview(mine_ns, preview_x_for(P2), &mut actors);
-                            }
-                        } else if row.id == RowId::ReceptorSkin {
-                            if let Some(receptor_ns) = state.receptor_noteskin[primary_player_idx]
-                                .as_deref()
-                                .or_else(|| state.noteskin[primary_player_idx].as_deref())
-                            {
-                                draw_receptor_preview(
-                                    receptor_ns,
-                                    preview_x_for(primary_player_idx),
-                                    &mut actors,
-                                );
-                            }
-                            if show_p2
-                                && primary_player_idx != P2
-                                && let Some(receptor_ns) = state.receptor_noteskin[P2]
-                                    .as_deref()
-                                    .or_else(|| state.noteskin[P2].as_deref())
-                            {
-                                draw_receptor_preview(receptor_ns, preview_x_for(P2), &mut actors);
-                            }
-                        } else if row.id == RowId::TapExplosionSkin {
-                            if !state.player_profiles[primary_player_idx]
-                                .tap_explosion_noteskin_hidden()
-                                && let Some(explosion_ns) = state.tap_explosion_noteskin
-                                    [primary_player_idx]
-                                    .as_deref()
-                                    .or_else(|| state.noteskin[primary_player_idx].as_deref())
-                            {
-                                let receptor_ns = state.receptor_noteskin[primary_player_idx]
-                                    .as_deref()
-                                    .or_else(|| state.noteskin[primary_player_idx].as_deref())
-                                    .unwrap_or(explosion_ns);
-                                draw_tap_explosion_preview(
-                                    explosion_ns,
-                                    receptor_ns,
-                                    preview_x_for(primary_player_idx),
-                                    &mut actors,
-                                );
-                            }
-                            if show_p2
-                                && primary_player_idx != P2
-                                && !state.player_profiles[P2].tap_explosion_noteskin_hidden()
-                                && let Some(explosion_ns) = state.tap_explosion_noteskin[P2]
-                                    .as_deref()
-                                    .or_else(|| state.noteskin[P2].as_deref())
-                            {
-                                let receptor_ns = state.receptor_noteskin[P2]
-                                    .as_deref()
-                                    .or_else(|| state.noteskin[P2].as_deref())
-                                    .unwrap_or(explosion_ns);
-                                draw_tap_explosion_preview(
-                                    explosion_ns,
-                                    receptor_ns,
-                                    preview_x_for(P2),
-                                    &mut actors,
-                                );
-                            }
-                        }
-                    }
-                    // Add combo preview for "Combo Font" row showing ticking numbers
-                    if row.id == RowId::ComboFont {
-                        let combo_text = state.combo_preview_count.to_string();
-                        let combo_zoom = COMBO_PREVIEW_ZOOM;
-                        // Choice indices are fixed by construction order:
-                        // 0=Wendy, 1=ArialRounded, 2=Asap, 3=BebasNeue, 4=SourceCode,
-                        // 5=Work, 6=WendyCursed, 7=None
-                        let combo_font_for = |idx: usize| -> Option<&'static str> {
-                            match idx {
-                            0 => Some("wendy_combo"),
-                            1 => Some("combo_arial_rounded"),
-                            2 => Some("combo_asap"),
-                            3 => Some("combo_bebas_neue"),
-                            4 => Some("combo_source_code"),
-                            5 => Some("combo_work"),
-                            6 => Some("combo_wendy_cursed"),
-                            _ => None,
-                            }
-                        };
-                        let p1_choice_idx = row.selected_choice_index[primary_player_idx]
-                            .min(row.choices.len().saturating_sub(1));
-                        if let Some(font_name) = combo_font_for(p1_choice_idx) {
-                            actors.push(act!(text:
-                                font(font_name): settext(combo_text.clone()):
-                                align(0.5, 0.5):
-                                xy(preview_x_for(primary_player_idx), current_row_y):
-                                zoom(combo_zoom): horizalign(center):
-                                diffuse(1.0, 1.0, 1.0, a):
-                                z(Z_ROW_PREVIEW)
-                            ));
-                        }
-                        if show_p2 && primary_player_idx != P2 {
-                            let p2_choice_idx = row.selected_choice_index[P2]
-                                .min(row.choices.len().saturating_sub(1));
-                            if let Some(font_name) = combo_font_for(p2_choice_idx) {
-                            actors.push(act!(text:
-                                font(font_name): settext(combo_text):
-                                align(0.5, 0.5):
-                                xy(preview_x_for(P2), current_row_y):
-                                zoom(combo_zoom): horizalign(center):
-                                diffuse(1.0, 1.0, 1.0, a):
-                                z(Z_ROW_PREVIEW)
-                            ));
-                            }
-                        }
-                    }
-                });
-            });
+            draw_inline_choices(&mut actors, &rc, show_arcade_next_row, choice_inner_left);
+        } else {
+            let rc = RowCtx {
+                fc: &fc,
+                row,
+                item_idx,
+                current_row_y,
+                a,
+                is_active,
+                sl_gray,
+            };
+            draw_single_value_with_preview(&mut actors, &rc);
         }
     }
     // ------------------- Description content (selected) -------------------
@@ -1612,6 +382,1336 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     }
     actors
 }
+
+/// Frame-level context: things constant across all rows in a single
+/// `get_actors` invocation. Held by reference inside `RowCtx`.
+pub(super) struct FrameCtx<'a> {
+    pub state: &'a State,
+    pub asset_manager: &'a AssetManager,
+    pub active: [bool; PLAYER_SLOTS],
+    pub show_p2: bool,
+    pub speed_mod_x: f32,
+    pub row_left: f32,
+    pub row_width: f32,
+    pub preview_x: [f32; PLAYER_SLOTS],
+}
+
+/// Per-row context: a frame ref plus everything tied to a specific row.
+pub(super) struct RowCtx<'a> {
+    pub fc: &'a FrameCtx<'a>,
+    pub row: &'a Row,
+    pub item_idx: usize,
+    pub current_row_y: f32,
+    pub a: f32,
+    pub is_active: bool,
+    pub sl_gray: [f32; 4],
+}
+
+
+/// Render z-order layers for the player_options screen. Higher values
+/// draw on top of lower ones.
+pub(super) const Z_ROW_BACKGROUND: i16 = 100;
+/// Row text, underlines, cursor borders, choice values, help text.
+pub(super) const Z_ROW_FOREGROUND: i16 = 101;
+/// Previews drawn over a row (judgment / hold-judgment / noteskin sprites,
+/// combo and font samples).
+pub(super) const Z_ROW_PREVIEW: i16 = 102;
+/// Receptor noteskin preview (drawn above the row preview layer).
+pub(super) const Z_RECEPTOR_PREVIEW: i16 = 106;
+/// Tap-explosion noteskin preview, the topmost preview layer.
+pub(super) const Z_EXPLOSION_PREVIEW: i16 = 107;
+/// Speed-mod overlay text, drawn on top of all preview layers.
+pub(super) const Z_SPEED_MOD_TEXT: i16 = 121;
+
+/// Visual zoom for choice values rendered inline next to the row title.
+pub(super) const INLINE_CHOICE_VALUE_ZOOM: f32 = 0.835;
+/// Horizontal pixel gap between consecutive inline choice values.
+pub(super) const INLINE_CHOICE_SPACING: f32 = 15.75;
+
+/// Zoom factor for judgment / hold-judgment / noteskin texture previews.
+pub(super) const JUDGMENT_PREVIEW_ZOOM: f32 = 0.225;
+/// Zoom factor for combo-font number previews.
+pub(super) const COMBO_PREVIEW_ZOOM: f32 = 0.45;
+
+/// Pixel size of one logical noteskin arrow used to compute preview scale.
+pub(super) const NOTESKIN_PREVIEW_ARROW_PIXEL_SIZE: f32 = 64.0;
+/// Scale applied to noteskin preview sprites relative to their natural size.
+pub(super) const NOTESKIN_PREVIEW_SCALE: f32 = 0.45;
+
+/// Underline thickness for multi-select row indicators (16:9 / 16:10 widescale).
+pub(super) fn underline_thickness() -> f32 {
+    widescale(2.0, 2.5).round().max(1.0)
+}
+
+/// Vertical pixel offset between a row's text baseline and its underline.
+pub(super) fn underline_offset() -> f32 {
+    widescale(3.0, 4.0)
+}
+
+/// Border width for the cursor / selection ring drawn around a row's
+/// active choice.
+pub(super) fn selection_border_width() -> f32 {
+    widescale(2.0, 2.5)
+}
+
+/// Resolved profile + session flags for one side, used by `get_actors`
+/// to populate the screen footer.
+pub(super) struct PlayerCardInfo {
+    profile: crate::game::profile::Profile,
+    joined: bool,
+    guest: bool,
+}
+
+pub(super) fn player_card_info(side: crate::game::profile::PlayerSide) -> PlayerCardInfo {
+    PlayerCardInfo {
+        profile: crate::game::profile::get_for_side(side),
+        joined: crate::game::profile::is_session_side_joined(side),
+        guest: crate::game::profile::is_session_side_guest(side),
+    }
+}
+
+/// Compute the footer text and optional avatar for one player side.
+///
+/// Lifetimes: the returned text borrows from either the player's
+/// `display_name` (via `card`), or from the localized `insert_card` /
+/// `press_start` strings, all of which the caller keeps alive on the
+/// stack. The optional avatar borrows the texture key directly from
+/// the profile.
+pub(super) fn footer_for_card<'a>(
+    card: &'a PlayerCardInfo,
+    insert_card: &'a str,
+    press_start: &'a str,
+) -> (Option<&'a str>, Option<AvatarParams<'a>>) {
+    if !card.joined {
+        return (Some(press_start), None);
+    }
+    let text = if card.guest {
+        insert_card
+    } else {
+        card.profile.display_name.as_str()
+    };
+    let avatar = if card.guest {
+        None
+    } else {
+        card.profile
+            .avatar_texture_key
+            .as_deref()
+            .map(|texture_key| AvatarParams { texture_key })
+    };
+    (Some(text), avatar)
+}
+
+/// Resolve the texture key for a player's currently-selected choice
+/// from a fixed list of texture choices, returning `None` for "None".
+pub(super) fn select_preview_texture<'a>(
+    row: &Row,
+    player_idx: usize,
+    choices: &'a [crate::assets::TextureChoice],
+) -> Option<&'a str> {
+    choices
+        .get(row.selected_choice_index[player_idx])
+        .and_then(|choice| {
+            if choice.key.eq_ignore_ascii_case("None") {
+                None
+            } else {
+                crate::assets::resolve_texture_choice(Some(choice.key.as_str()), choices)
+            }
+        })
+}
+
+/// Returns the active mask (zero-extended to u16) for a row that
+/// supports multi-select underlining, or `None` if the row uses the
+/// default single-select underline behavior.
+pub(super) fn multi_select_mask(state: &State, row_id: RowId, player_idx: usize) -> Option<u16> {
+    use RowId::*;
+    Some(match row_id {
+        Scroll => state.scroll_active_mask[player_idx].bits().into(),
+        Hide => state.hide_active_mask[player_idx].bits().into(),
+        Insert => state.insert_active_mask[player_idx].bits().into(),
+        Remove => state.remove_active_mask[player_idx].bits().into(),
+        Holds => state.holds_active_mask[player_idx].bits().into(),
+        Accel => state.accel_effects_active_mask[player_idx].bits().into(),
+        Effect => state.visual_effects_active_mask[player_idx].bits(),
+        Appearance => state.appearance_effects_active_mask[player_idx].bits().into(),
+        LifeBarOptions => state.life_bar_options_active_mask[player_idx].bits().into(),
+        FAPlusOptions => state.fa_plus_active_mask[player_idx].bits().into(),
+        GameplayExtras => state.gameplay_extras_active_mask[player_idx].bits().into(),
+        GameplayExtrasMore => state.gameplay_extras_more_active_mask[player_idx].bits().into(),
+        ResultsExtras => state.results_extras_active_mask[player_idx].bits().into(),
+        MeasureCounterOptions => state.measure_counter_options_active_mask[player_idx].bits().into(),
+        ErrorBar => state.error_bar_active_mask[player_idx].bits().into(),
+        ErrorBarOptions => state.error_bar_options_active_mask[player_idx].bits().into(),
+        EarlyDecentWayOffOptions => state.early_dw_active_mask[player_idx].bits().into(),
+        _ => return None,
+    })
+}
+
+/// Whether a row uses multi-select underlining (one underline per set bit
+/// in the row's active mask) rather than the default single-select
+/// underline (one underline under the chosen value).
+pub(super) fn is_multi_select_row(row_id: RowId) -> bool {
+    use RowId::*;
+    matches!(
+        row_id,
+        Scroll
+            | Hide
+            | Insert
+            | Remove
+            | Holds
+            | Accel
+            | Effect
+            | Appearance
+            | LifeBarOptions
+            | FAPlusOptions
+            | GameplayExtras
+            | GameplayExtrasMore
+            | ResultsExtras
+            | MeasureCounterOptions
+            | ErrorBar
+            | ErrorBarOptions
+            | EarlyDecentWayOffOptions
+    )
+}
+
+/// Draw multi-select underlines for one row: one underline beneath each
+/// choice whose corresponding bit is set in the per-player active mask.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn draw_multi_select_underlines(
+    actors: &mut Vec<Actor>,
+    state: &State,
+    row: &Row,
+    active: [bool; PLAYER_SLOTS],
+    x_positions: &[f32],
+    widths: &[f32],
+    current_row_y: f32,
+    text_h: f32,
+    a: f32,
+) {
+    let line_thickness = underline_thickness();
+    let offset = underline_offset();
+    let underline_base_y = current_row_y + text_h * 0.5 + offset;
+    let underline_y = |player_idx: usize| {
+        if active[P1] && active[P2] {
+            (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
+        } else {
+            underline_base_y
+        }
+    };
+    for player_idx in active_player_indices(active) {
+        let Some(mask) = multi_select_mask(state, row.id, player_idx) else {
+            continue;
+        };
+        if mask == 0 {
+            continue;
+        }
+        let underline_y = underline_y(player_idx);
+        let mut line_color = color::decorative_rgba(player_color_index(state, player_idx));
+        line_color[3] *= a;
+        for idx in 0..row.choices.len() {
+            let bit: u16 = 1 << idx;
+            if (mask & bit) == 0 {
+                continue;
+            }
+            if let Some(sel_x) = x_positions.get(idx).copied() {
+                let draw_w = widths.get(idx).copied().unwrap_or(40.0);
+                let underline_w = draw_w.ceil();
+                actors.push(act!(quad:
+                    align(0.0, 0.5):
+                    xy(sel_x, underline_y):
+                    zoomto(underline_w, line_thickness):
+                    diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
+                    z(Z_ROW_FOREGROUND)
+                ));
+            }
+        }
+    }
+}
+
+/// Draw a single-select underline for one row: one underline under each
+/// active player's chosen value.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn draw_single_select_underline(
+    actors: &mut Vec<Actor>,
+    state: &State,
+    row: &Row,
+    active: [bool; PLAYER_SLOTS],
+    x_positions: &[f32],
+    widths: &[f32],
+    current_row_y: f32,
+    text_h: f32,
+    a: f32,
+) {
+    let line_thickness = underline_thickness();
+    let offset = underline_offset();
+    let underline_base_y = current_row_y + text_h * 0.5 + offset;
+    let underline_y = |player_idx: usize| {
+        if active[P1] && active[P2] {
+            (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
+        } else {
+            underline_base_y
+        }
+    };
+    for player_idx in active_player_indices(active) {
+        let idx = row.selected_choice_index[player_idx].min(widths.len().saturating_sub(1));
+        if let Some(sel_x) = x_positions.get(idx).copied() {
+            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
+            let underline_w = draw_w.ceil();
+            let underline_y = underline_y(player_idx);
+            let mut line_color = color::decorative_rgba(player_color_index(state, player_idx));
+            line_color[3] *= a;
+            actors.push(act!(quad:
+                align(0.0, 0.5):
+                xy(sel_x, underline_y):
+                zoomto(underline_w, line_thickness):
+                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
+                z(Z_ROW_FOREGROUND)
+            ));
+        }
+    }
+}
+
+/// Color palette index for a player's underline / cursor.
+pub(super) fn player_color_index(state: &State, player_idx: usize) -> i32 {
+    if player_idx == P2 {
+        state.active_color_index - 2
+    } else {
+        state.active_color_index
+    }
+}
+
+/// Current animated cursor rectangle for a player (center xy + size),
+/// or `None` if the player is inactive or the cursor isn't initialised yet.
+pub(super) fn cursor_for_player(state: &State, player_idx: usize) -> Option<(f32, f32, f32, f32)> {
+    if player_idx >= PLAYER_SLOTS || !state.pane().cursor_initialized[player_idx] {
+        return None;
+    }
+    let pane = state.pane();
+    let t = pane.cursor_t[player_idx].clamp(0.0, 1.0);
+    let r = CursorRect::lerp(pane.cursor_from[player_idx], pane.cursor_to[player_idx], t);
+    Some((r.x, r.y, r.w, r.h))
+}
+
+/// Draw the 4-sided cursor ring around each active player's selected
+/// option in row `item_idx`. No-ops for players whose cursor isn't on
+/// this row or hasn't been initialised yet.
+pub(super) fn draw_cursor_ring(
+    actors: &mut Vec<Actor>,
+    state: &State,
+    active: [bool; PLAYER_SLOTS],
+    item_idx: usize,
+    a: f32,
+) {
+    let border_w = selection_border_width();
+    for player_idx in active_player_indices(active) {
+        if state.pane().selected_row[player_idx] != item_idx {
+            continue;
+        }
+        let Some((center_x, center_y, ring_w, ring_h)) = cursor_for_player(state, player_idx)
+        else {
+            continue;
+        };
+
+        let left = center_x - ring_w * 0.5;
+        let right = center_x + ring_w * 0.5;
+        let top = center_y - ring_h * 0.5;
+        let bottom = center_y + ring_h * 0.5;
+        let mut ring_color = color::decorative_rgba(player_color_index(state, player_idx));
+        ring_color[3] *= a;
+
+        actors.push(act!(quad:
+            align(0.5, 0.5): xy((left + right) * 0.5, top + border_w * 0.5):
+            zoomto(ring_w, border_w):
+            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+            z(Z_ROW_FOREGROUND)
+        ));
+        actors.push(act!(quad:
+            align(0.5, 0.5): xy((left + right) * 0.5, bottom - border_w * 0.5):
+            zoomto(ring_w, border_w):
+            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+            z(Z_ROW_FOREGROUND)
+        ));
+        actors.push(act!(quad:
+            align(0.5, 0.5): xy(left + border_w * 0.5, (top + bottom) * 0.5):
+            zoomto(border_w, ring_h):
+            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+            z(Z_ROW_FOREGROUND)
+        ));
+        actors.push(act!(quad:
+            align(0.5, 0.5): xy(right - border_w * 0.5, (top + bottom) * 0.5):
+            zoomto(border_w, ring_h):
+            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+            z(Z_ROW_FOREGROUND)
+        ));
+    }
+}
+
+
+
+/// Render the inline-choices block for one row: every choice laid out
+/// horizontally, with multi-select or single-select underline, the
+/// optional cursor ring, the optional Arcade `next row` label, and
+/// the choice texts themselves.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn draw_inline_choices(
+    actors: &mut Vec<Actor>,
+    rc: &RowCtx,
+    show_arcade_next_row: bool,
+    choice_inner_left: f32,
+) {
+    let state = rc.fc.state;
+    let asset_manager = rc.fc.asset_manager;
+    let row = rc.row;
+    let active = rc.fc.active;
+    let item_idx = rc.item_idx;
+    let current_row_y = rc.current_row_y;
+    let a = rc.a;
+    let is_active = rc.is_active;
+    let sl_gray = rc.sl_gray;
+    let value_zoom = INLINE_CHOICE_VALUE_ZOOM;
+    let spacing = INLINE_CHOICE_SPACING;
+    let next_row_item = show_arcade_next_row
+        .then(|| arcade_next_row_layout(state, item_idx, asset_manager, value_zoom));
+    let mut widths: Vec<f32> = Vec::with_capacity(row.choices.len());
+    let mut text_h: f32 = 16.0;
+    asset_manager.with_fonts(|all_fonts| {
+        asset_manager.with_font("miso", |metrics_font| {
+            text_h = (metrics_font.height as f32).max(1.0) * value_zoom;
+            for text in &row.choices {
+                let mut w = crate::engine::present::font::measure_line_width_logical(
+                    metrics_font,
+                    text,
+                    all_fonts,
+                ) as f32;
+                if !w.is_finite() || w <= 0.0 {
+                    w = 1.0;
+                }
+                widths.push(w * value_zoom);
+            }
+        });
+    });
+    let mut x_positions: Vec<f32> = Vec::with_capacity(widths.len());
+    {
+        let mut x = choice_inner_left;
+        for w in &widths {
+            x_positions.push(x);
+            x += *w + spacing;
+        }
+    }
+    // Draw underline under active options:
+    // - For normal rows: underline the currently selected choice.
+    // - For Scroll row: underline each enabled scroll mode (multi-select).
+    // - For FA+ Options row: underline each enabled FA+ toggle (multi-select).
+    if is_multi_select_row(row.id) {
+        draw_multi_select_underlines(
+            actors,
+            state,
+            row,
+            active,
+            &x_positions,
+            &widths,
+            current_row_y,
+            text_h,
+            a,
+        );
+    } else {
+        draw_single_select_underline(
+            actors,
+            state,
+            row,
+            active,
+            &x_positions,
+            &widths,
+            current_row_y,
+            text_h,
+            a,
+        );
+    }
+    // Draw the 4-sided cursor ring around the selected option when this row is active.
+    if !widths.is_empty() {
+        draw_cursor_ring(actors, state, active, item_idx, a);
+    }
+    // Draw each option's text (active row: all white; inactive: #808080)
+    if let Some((next_row_x, _, _)) = next_row_item {
+        let next_row_color = if is_active {
+            [1.0, 1.0, 1.0, a]
+        } else {
+            sl_gray
+        };
+        actors.push(act!(text: font("miso"): settext(ARCADE_NEXT_ROW_TEXT):
+            align(0.0, 0.5): xy(next_row_x, current_row_y): zoom(value_zoom):
+            diffuse(
+                next_row_color[0],
+                next_row_color[1],
+                next_row_color[2],
+                next_row_color[3]
+            ):
+            z(Z_ROW_FOREGROUND)
+        ));
+    }
+    for (idx, text) in row.choices.iter().enumerate() {
+        let x = x_positions.get(idx).copied().unwrap_or(choice_inner_left);
+        let color_rgba = if is_active {
+            [1.0, 1.0, 1.0, a]
+        } else {
+            sl_gray
+        };
+        actors.push(act!(text: font("miso"): settext(text.clone()):
+            align(0.0, 0.5): xy(x, current_row_y): zoom(value_zoom):
+            diffuse(color_rgba[0], color_rgba[1], color_rgba[2], color_rgba[3]):
+            z(Z_ROW_FOREGROUND)
+        ));
+    }
+}
+
+/// Render the single-value text + optional per-row preview block: 
+/// the chosen value text, its underline and cursor ring, the optional 
+/// P2 mirror, plus per-RowId preview sprites/text (judgment, hold, 
+/// noteskin, mineskin, receptor, explosion, combo).
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+pub(super) fn draw_single_value_with_preview(actors: &mut Vec<Actor>, rc: &RowCtx) {
+    let state = rc.fc.state;
+    let asset_manager = rc.fc.asset_manager;
+    let row = rc.row;
+    let active = rc.fc.active;
+    let item_idx = rc.item_idx;
+    let current_row_y = rc.current_row_y;
+    let a = rc.a;
+    let is_active = rc.is_active;
+    let sl_gray = rc.sl_gray;
+    let show_p2 = rc.fc.show_p2;
+    let speed_mod_x = rc.fc.speed_mod_x;
+    let row_left = rc.fc.row_left;
+    let row_width = rc.fc.row_width;
+    let preview_x = rc.fc.preview_x;
+        // Single value display (default behavior)
+        // By default, align single-value choices to the same line as Speed Mod.
+        // For Music Rate, center within the item column (to match SL parity).
+        let primary_player_idx = if active[P1] { P1 } else { P2 };
+        let mut choice_center_x = speed_mod_x;
+        if row.id == RowId::MusicRate {
+            let item_col_left = row_left + TITLE_BG_WIDTH;
+            let item_col_w = row_width - TITLE_BG_WIDTH;
+            choice_center_x = item_col_left + item_col_w * 0.5;
+        } else if primary_player_idx == P2 {
+            choice_center_x = screen_center_x().mul_add(2.0, -choice_center_x);
+        }
+        let choice_text_idx = row.selected_choice_index[primary_player_idx]
+            .min(row.choices.len().saturating_sub(1));
+        let choice_text = row
+            .choices
+            .get(choice_text_idx)
+            .unwrap_or_else(|| row.choices.first().expect("OptionRow must have choices"));
+        let choice_color = if is_active {
+            [1.0, 1.0, 1.0, a]
+        } else {
+            sl_gray
+        };
+        asset_manager.with_fonts(|all_fonts| {
+            asset_manager.with_font("miso", |metrics_font| {
+                let choice_display_text =
+                    if arcade_row_focuses_next_row(state, primary_player_idx, item_idx) {
+                        ARCADE_NEXT_ROW_TEXT.to_string()
+                    } else if row.id == RowId::SpeedMod {
+                        state.speed_mod[primary_player_idx].display()
+                    } else {
+                        choice_text.clone()
+                    };
+                let mut text_w = crate::engine::present::font::measure_line_width_logical(
+                    metrics_font,
+                    &choice_display_text,
+                    all_fonts,
+                ) as f32;
+                if !text_w.is_finite() || text_w <= 0.0 {
+                    text_w = 1.0;
+                }
+                let text_h = (metrics_font.height as f32).max(1.0);
+                let value_zoom = INLINE_CHOICE_VALUE_ZOOM;
+                let draw_w = text_w * value_zoom;
+                let draw_h = text_h * value_zoom;
+                actors.push(act!(text: font("miso"): settext(choice_display_text):
+                    align(0.5, 0.5): xy(choice_center_x, current_row_y): zoom(value_zoom):
+                    diffuse(choice_color[0], choice_color[1], choice_color[2], choice_color[3]):
+                    z(Z_ROW_FOREGROUND)
+                ));
+                // Underline (always visible) — fixed pixel thickness for consistency
+                let line_thickness = underline_thickness();
+                let underline_w = draw_w.ceil(); // pixel-align for crispness
+                let offset = underline_offset(); // place just under the baseline
+                let underline_y = current_row_y + draw_h * 0.5 + offset;
+                let underline_left_x = choice_center_x - draw_w * 0.5;
+                let mut line_color = color::decorative_rgba(player_color_index(state, primary_player_idx));
+                line_color[3] *= a;
+                actors.push(act!(quad:
+                    align(0.0, 0.5): // start at text's left edge
+                    xy(underline_left_x, underline_y):
+                    zoomto(underline_w, line_thickness):
+                    diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
+                    z(Z_ROW_FOREGROUND)
+                ));
+                // Encircling cursor around the active option value (programmatic border)
+                if active[primary_player_idx] && state.pane().selected_row[primary_player_idx] == item_idx {
+                    let border_w = selection_border_width();
+                    if let Some((center_x, center_y, ring_w, ring_h)) =
+                        cursor_for_player(state, primary_player_idx)
+                    {
+                        let left = center_x - ring_w * 0.5;
+                        let right = center_x + ring_w * 0.5;
+                        let top = center_y - ring_h * 0.5;
+                        let bottom = center_y + ring_h * 0.5;
+                        let mut ring_color =
+                            color::decorative_rgba(player_color_index(state, primary_player_idx));
+                        ring_color[3] *= a;
+                        actors.push(act!(quad:
+                            align(0.5, 0.5): xy(center_x, top + border_w * 0.5):
+                            zoomto(ring_w, border_w):
+                            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+                            z(Z_ROW_FOREGROUND)
+                        ));
+                        actors.push(act!(quad:
+                            align(0.5, 0.5): xy(center_x, bottom - border_w * 0.5):
+                            zoomto(ring_w, border_w):
+                            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+                            z(Z_ROW_FOREGROUND)
+                        ));
+                        actors.push(act!(quad:
+                            align(0.5, 0.5): xy(left + border_w * 0.5, center_y):
+                            zoomto(border_w, ring_h):
+                            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+                            z(Z_ROW_FOREGROUND)
+                        ));
+                        actors.push(act!(quad:
+                            align(0.5, 0.5): xy(right - border_w * 0.5, center_y):
+                            zoomto(border_w, ring_h):
+                            diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+                            z(Z_ROW_FOREGROUND)
+                        ));
+                    }
+                }
+                let p2_text = if show_p2 && row.id != RowId::MusicRate {
+                    if arcade_row_focuses_next_row(state, P2, item_idx) {
+                        ARCADE_NEXT_ROW_TEXT.to_string()
+                    } else if row.id == RowId::SpeedMod {
+                        state.speed_mod[P2].display()
+                    } else if row.id == RowId::TypeOfSpeedMod {
+                        let idx = state.speed_mod[P2].mod_type.choice_index();
+                        row.choices.get(idx).cloned().unwrap_or_default()
+                    } else {
+                        let idx = row
+                            .selected_choice_index[P2]
+                            .min(row.choices.len().saturating_sub(1));
+                        row.choices.get(idx).cloned().unwrap_or_default()
+                    }
+                } else {
+                    String::new()
+                };
+                if show_p2 && row.id != RowId::MusicRate {
+                    let p2_choice_center_x = screen_center_x().mul_add(2.0, -choice_center_x);
+                    let mut p2_w = crate::engine::present::font::measure_line_width_logical(
+                        metrics_font,
+                        &p2_text,
+                        all_fonts,
+                    ) as f32;
+                    if !p2_w.is_finite() || p2_w <= 0.0 {
+                        p2_w = 1.0;
+                    }
+                    let p2_draw_w = p2_w * value_zoom;
+                    actors.push(act!(text: font("miso"): settext(p2_text.clone()):
+                        align(0.5, 0.5): xy(p2_choice_center_x, current_row_y): zoom(value_zoom):
+                        diffuse(choice_color[0], choice_color[1], choice_color[2], choice_color[3]):
+                        z(Z_ROW_FOREGROUND)
+                    ));
+                    let line_thickness = underline_thickness();
+                    let underline_w = p2_draw_w.ceil();
+                    let offset = underline_offset();
+                    let underline_y = current_row_y + draw_h * 0.5 + offset;
+                    let underline_left_x = p2_choice_center_x - p2_draw_w * 0.5;
+                    let mut line_color = color::decorative_rgba(player_color_index(state, P2));
+                    line_color[3] *= a;
+                    actors.push(act!(quad:
+                        align(0.0, 0.5):
+                        xy(underline_left_x, underline_y):
+                        zoomto(underline_w, line_thickness):
+                        diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
+                        z(Z_ROW_FOREGROUND)
+                    ));
+                    if active[P2] && state.pane().selected_row[P2] == item_idx {
+                        let border_w = selection_border_width();
+                        if let Some((center_x, center_y, ring_w, ring_h)) = cursor_for_player(state, P2) {
+                            let left = center_x - ring_w * 0.5;
+                            let right = center_x + ring_w * 0.5;
+                            let top = center_y - ring_h * 0.5;
+                            let bottom = center_y + ring_h * 0.5;
+                            let mut ring_color = color::decorative_rgba(player_color_index(state, P2));
+                            ring_color[3] *= a;
+                            actors.push(act!(quad:
+                                align(0.5, 0.5): xy(center_x, top + border_w * 0.5):
+                                zoomto(ring_w, border_w):
+                                diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+                                z(Z_ROW_FOREGROUND)
+                            ));
+                            actors.push(act!(quad:
+                                align(0.5, 0.5): xy(center_x, bottom - border_w * 0.5):
+                                zoomto(ring_w, border_w):
+                                diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+                                z(Z_ROW_FOREGROUND)
+                            ));
+                            actors.push(act!(quad:
+                                align(0.5, 0.5): xy(left + border_w * 0.5, center_y):
+                                zoomto(border_w, ring_h):
+                                diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+                                z(Z_ROW_FOREGROUND)
+                            ));
+                            actors.push(act!(quad:
+                                align(0.5, 0.5): xy(right - border_w * 0.5, center_y):
+                                zoomto(border_w, ring_h):
+                                diffuse(ring_color[0], ring_color[1], ring_color[2], ring_color[3]):
+                                z(Z_ROW_FOREGROUND)
+                            ));
+                        }
+                    }
+                }
+                // Add previews for the selected value on each side.
+                if row.id == RowId::JudgmentFont {
+                    let texture_for = |player_idx: usize| -> Option<&str> {
+                        select_preview_texture(
+                            row,
+                            player_idx,
+                            assets::judgment_texture_choices(),
+                        )
+                    };
+                    if let Some(texture) = texture_for(primary_player_idx) {
+                        actors.push(act!(sprite(texture):
+                            align(0.5, 0.5):
+                            xy(preview_x[primary_player_idx], current_row_y):
+                            setstate(0):
+                            zoom(JUDGMENT_PREVIEW_ZOOM):
+                            diffuse(1.0, 1.0, 1.0, a):
+                            z(Z_ROW_PREVIEW)
+                        ));
+                    }
+                    if show_p2
+                        && primary_player_idx != P2
+                        && let Some(texture) = texture_for(P2)
+                    {
+                        actors.push(act!(sprite(texture):
+                            align(0.5, 0.5):
+                            xy(preview_x[P2], current_row_y):
+                            setstate(0):
+                            zoom(JUDGMENT_PREVIEW_ZOOM):
+                            diffuse(1.0, 1.0, 1.0, a):
+                            z(Z_ROW_PREVIEW)
+                        ));
+                    }
+                }
+                // Add hold judgment preview for "Hold Judgment" row showing both frames (Held and Let Go)
+                if row.id == RowId::HoldJudgment {
+                    let texture_for = |player_idx: usize| -> Option<&str> {
+                        select_preview_texture(
+                            row,
+                            player_idx,
+                            assets::hold_judgment_texture_choices(),
+                        )
+                    };
+                    let draw_hold_preview = |texture: &str, center_x: f32, actors: &mut Vec<Actor>| {
+                        let zoom = JUDGMENT_PREVIEW_ZOOM;
+                        let tex_w = crate::assets::texture_dims(texture)
+                            .map_or(128.0, |meta| meta.w.max(1) as f32);
+                        let center_offset = tex_w * zoom * 0.4;
+
+                        actors.push(act!(sprite(texture):
+                            align(0.5, 0.5):
+                            xy(center_x - center_offset, current_row_y):
+                            setstate(0):
+                            zoom(zoom):
+                            diffuse(1.0, 1.0, 1.0, a):
+                            z(Z_ROW_PREVIEW)
+                        ));
+                        actors.push(act!(sprite(texture):
+                            align(0.5, 0.5):
+                            xy(center_x + center_offset, current_row_y):
+                            setstate(1):
+                            zoom(zoom):
+                            diffuse(1.0, 1.0, 1.0, a):
+                            z(Z_ROW_PREVIEW)
+                        ));
+                    };
+                    if let Some(texture) = texture_for(primary_player_idx) {
+                        draw_hold_preview(texture, preview_x[primary_player_idx], &mut *actors);
+                    }
+                    if show_p2
+                        && primary_player_idx != P2
+                        && let Some(texture) = texture_for(P2)
+                    {
+                        draw_hold_preview(texture, preview_x[P2], &mut *actors);
+                    }
+                }
+                // Match ITGmania themes that show four directional noteskin preview arrows
+                // with explicit quant offsets: Left/Down/Up/Right and 0/1/3/2 quant indices.
+                if row.id == RowId::NoteSkin
+                    || row.id == RowId::MineSkin
+                    || row.id == RowId::ReceptorSkin
+                    || row.id == RowId::TapExplosionSkin
+                {
+                    const PREVIEW_ARROWS: [(usize, f32, f32); 4] = [
+                        (0, 0.0, -1.5),
+                        (1, 1.0, -0.5),
+                        (2, 3.0, 0.5),
+                        (3, 2.0, 1.5),
+                    ];
+                    let draw_noteskin_note =
+                        |ns: &Noteskin,
+                         note_idx: usize,
+                         quant_idx: f32,
+                         center_x: f32,
+                         actors: &mut Vec<Actor>| {
+                            let target_height = NOTESKIN_PREVIEW_ARROW_PIXEL_SIZE * NOTESKIN_PREVIEW_SCALE;
+                            let elapsed = state.preview_time;
+                            let beat = state.preview_beat;
+                            let note_uv_phase = ns.tap_note_uv_phase(elapsed, beat, 0.0);
+                            let tap_spacing = ns.note_display_metrics.part_texture_translate
+                                [NoteAnimPart::Tap as usize]
+                                .note_color_spacing;
+                            let uv_translate =
+                                [tap_spacing[0] * quant_idx, tap_spacing[1] * quant_idx];
+                            if let Some(note_slots) = ns.note_layers.get(note_idx) {
+                                let primary_h = note_slots
+                                    .first()
+                                    .map(|slot| slot.logical_size()[1].max(1.0))
+                                    .unwrap_or(1.0);
+                                let note_scale = if primary_h > f32::EPSILON {
+                                    target_height / primary_h
+                                } else {
+                                    NOTESKIN_PREVIEW_SCALE
+                                };
+                                for (layer_idx, note_slot) in note_slots.iter().enumerate() {
+                                    let draw = note_slot.model_draw_at(elapsed, beat);
+                                    if !draw.visible {
+                                        continue;
+                                    }
+                                    let frame = note_slot.frame_index(elapsed, beat);
+                                    let uv_elapsed = if note_slot.model.is_some() {
+                                        note_uv_phase
+                                    } else {
+                                        elapsed
+                                    };
+                                    let uv = note_slot.uv_for_frame_at(frame, uv_elapsed);
+                                    let uv = [
+                                        uv[0] + uv_translate[0],
+                                        uv[1] + uv_translate[1],
+                                        uv[2] + uv_translate[0],
+                                        uv[3] + uv_translate[1],
+                                    ];
+                                    let slot_size = note_slot.logical_size();
+                                    let base_size = [slot_size[0] * note_scale, slot_size[1] * note_scale];
+                                    let rot_rad = (-note_slot.def.rotation_deg as f32).to_radians();
+                                    let (sin_r, cos_r) = rot_rad.sin_cos();
+                                    let ox = draw.pos[0] * note_scale;
+                                    let oy = draw.pos[1] * note_scale;
+                                    let center = [
+                                        center_x + ox * cos_r - oy * sin_r,
+                                        current_row_y + ox * sin_r + oy * cos_r,
+                                    ];
+                                    let size = [
+                                        base_size[0] * draw.zoom[0].max(0.0),
+                                        base_size[1] * draw.zoom[1].max(0.0),
+                                    ];
+                                    if size[0] <= f32::EPSILON || size[1] <= f32::EPSILON {
+                                        continue;
+                                    }
+                                    let color = [draw.tint[0], draw.tint[1], draw.tint[2], draw.tint[3] * a];
+                                    let blend = if draw.blend_add {
+                                        BlendMode::Add
+                                    } else {
+                                        BlendMode::Alpha
+                                    };
+                                    let z = 102 + layer_idx as i32;
+                                    if let Some(model_actor) = noteskin_model_actor(
+                                        note_slot,
+                                        center,
+                                        size,
+                                        uv,
+                                        -note_slot.def.rotation_deg as f32,
+                                        elapsed,
+                                        beat,
+                                        color,
+                                        blend,
+                                        z as i16,
+                                    ) {
+                                        actors.push(model_actor);
+                                    } else if draw.blend_add {
+                                        actors.push(act!(sprite(note_slot.texture_key_shared()):
+                                            align(0.5, 0.5):
+                                            xy(center[0], center[1]):
+                                            setsize(size[0], size[1]):
+                                            rotationz(draw.rot[2] - note_slot.def.rotation_deg as f32):
+                                            customtexturerect(uv[0], uv[1], uv[2], uv[3]):
+                                            diffuse(color[0], color[1], color[2], color[3]):
+                                            blend(add):
+                                            z(z)
+                                        ));
+                                    } else {
+                                        actors.push(act!(sprite(note_slot.texture_key_shared()):
+                                            align(0.5, 0.5):
+                                            xy(center[0], center[1]):
+                                            setsize(size[0], size[1]):
+                                            rotationz(draw.rot[2] - note_slot.def.rotation_deg as f32):
+                                            customtexturerect(uv[0], uv[1], uv[2], uv[3]):
+                                            diffuse(color[0], color[1], color[2], color[3]):
+                                            blend(normal):
+                                            z(z)
+                                        ));
+                                    }
+                                }
+                                return;
+                            }
+                            let Some(note_slot) = ns.notes.get(note_idx) else {
+                                return;
+                            };
+                            let frame = note_slot.frame_index(elapsed, beat);
+                            let uv_elapsed = if note_slot.model.is_some() {
+                                note_uv_phase
+                            } else {
+                                elapsed
+                            };
+                            let uv = note_slot.uv_for_frame_at(frame, uv_elapsed);
+                            let uv = [
+                                uv[0] + uv_translate[0],
+                                uv[1] + uv_translate[1],
+                                uv[2] + uv_translate[0],
+                                uv[3] + uv_translate[1],
+                            ];
+                            let size_raw = note_slot.logical_size();
+                            let width = size_raw[0].max(1.0);
+                            let height = size_raw[1].max(1.0);
+                            let scale = if height > 0.0 {
+                                target_height / height
+                            } else {
+                                NOTESKIN_PREVIEW_SCALE
+                            };
+                            let size = [width * scale, target_height];
+                            let center = [center_x, current_row_y];
+                            if let Some(model_actor) = noteskin_model_actor(
+                                note_slot,
+                                center,
+                                size,
+                                uv,
+                                -note_slot.def.rotation_deg as f32,
+                                elapsed,
+                                beat,
+                                [1.0, 1.0, 1.0, a],
+                                BlendMode::Alpha,
+                                102,
+                            ) {
+                                actors.push(model_actor);
+                            } else {
+                                actors.push(act!(sprite(note_slot.texture_key_shared()):
+                                    align(0.5, 0.5):
+                                    xy(center[0], center[1]):
+                                    setsize(size[0], size[1]):
+                                    rotationz(-note_slot.def.rotation_deg as f32):
+                                    customtexturerect(uv[0], uv[1], uv[2], uv[3]):
+                                    diffuse(1.0, 1.0, 1.0, a):
+                                    z(Z_ROW_PREVIEW)
+                                ));
+                            }
+                        };
+                    let draw_noteskin_preview =
+                        |ns: &Noteskin, center_x: f32, actors: &mut Vec<Actor>| {
+                            let target_height = NOTESKIN_PREVIEW_ARROW_PIXEL_SIZE * NOTESKIN_PREVIEW_SCALE;
+                            for (col, quant_idx, x_mult) in PREVIEW_ARROWS {
+                                let x = center_x + x_mult * target_height;
+                                let note_idx =
+                                    col * NUM_QUANTIZATIONS + Quantization::Q4th as usize;
+                                draw_noteskin_note(ns, note_idx, quant_idx, x, actors);
+                            }
+                        };
+                    let draw_mine_preview =
+                        |mine_ns: &Noteskin, center_x: f32, actors: &mut Vec<Actor>| {
+                            let target_height = NOTESKIN_PREVIEW_ARROW_PIXEL_SIZE * NOTESKIN_PREVIEW_SCALE;
+                            let mine_col = if mine_ns.mines.len() > 1 || mine_ns.mine_frames.len() > 1 {
+                                1
+                            } else {
+                                0
+                            };
+                            let fill_slot =
+                                mine_ns.mines.get(mine_col).and_then(|slot| slot.as_ref());
+                            let frame_slot = mine_ns
+                                .mine_frames
+                                .get(mine_col)
+                                .and_then(|slot| slot.as_ref());
+                            let Some(primary_slot) = frame_slot.or(fill_slot) else {
+                                return;
+                            };
+                            let mine_phase =
+                                mine_ns.tap_mine_uv_phase(state.preview_time, state.preview_beat, 0.0);
+                            let mine_translation =
+                                mine_ns.part_uv_translation(NoteAnimPart::Mine, 0.0, false);
+                            let mine_center = [center_x, current_row_y];
+                            let scale_mine_slot = |slot: &SpriteSlot| {
+                                let size = slot
+                                    .model
+                                    .as_ref()
+                                    .map(|model| model.size())
+                                    .unwrap_or_else(|| {
+                                        let logical = slot.logical_size();
+                                        [logical[0], logical[1]]
+                                    });
+                                let width = size[0].max(1.0);
+                                let height = size[1].max(1.0);
+                                let scale = target_height / height;
+                                [width * scale, target_height]
+                            };
+                            let draw_mine_slot =
+                                |slot: &SpriteSlot, alpha: f32, z: i32, actors: &mut Vec<Actor>| {
+                                    let draw = slot.model_draw_at(state.preview_time, state.preview_beat);
+                                    if !draw.visible {
+                                        return;
+                                    }
+                                    let frame = slot.frame_index_from_phase(mine_phase);
+                                    let uv_elapsed = if slot.model.is_some() {
+                                        mine_phase
+                                    } else {
+                                        state.preview_time
+                                    };
+                                    let uv = slot.uv_for_frame_at(frame, uv_elapsed);
+                                    let uv = [
+                                        uv[0] + mine_translation[0],
+                                        uv[1] + mine_translation[1],
+                                        uv[2] + mine_translation[0],
+                                        uv[3] + mine_translation[1],
+                                    ];
+                                    let size = scale_mine_slot(slot);
+                                    if let Some(model_actor) = noteskin_model_actor(
+                                        slot,
+                                        mine_center,
+                                        size,
+                                        uv,
+                                        -slot.def.rotation_deg as f32,
+                                        state.preview_time,
+                                        state.preview_beat,
+                                        [1.0, 1.0, 1.0, alpha],
+                                        BlendMode::Alpha,
+                                        z as i16,
+                                    ) {
+                                        actors.push(model_actor);
+                                    } else {
+                                        actors.push(act!(sprite(slot.texture_key_shared()):
+                                            align(0.5, 0.5):
+                                            xy(mine_center[0], mine_center[1]):
+                                            setsize(size[0], size[1]):
+                                            rotationz(draw.rot[2] - slot.def.rotation_deg as f32):
+                                            customtexturerect(uv[0], uv[1], uv[2], uv[3]):
+                                            diffuse(1.0, 1.0, 1.0, alpha):
+                                            z(z)
+                                        ));
+                                    }
+                                };
+                            if let Some(slot) = fill_slot {
+                                draw_mine_slot(slot, 0.85 * a, 106, actors);
+                            }
+                            if let Some(slot) = frame_slot {
+                                draw_mine_slot(slot, a, 107, actors);
+                            } else if fill_slot.is_none() {
+                                draw_mine_slot(primary_slot, a, 107, actors);
+                            }
+                        };
+                    let draw_receptor_preview =
+                        |receptor_ns: &Noteskin, center_x: f32, actors: &mut Vec<Actor>| {
+                            let target_height = NOTESKIN_PREVIEW_ARROW_PIXEL_SIZE * NOTESKIN_PREVIEW_SCALE;
+                            let receptor_color =
+                                receptor_ns.receptor_pulse.color_for_beat(state.preview_beat);
+                            let color = [
+                                receptor_color[0],
+                                receptor_color[1],
+                                receptor_color[2],
+                                receptor_color[3] * a,
+                            ];
+                            for (col, _, x_mult) in PREVIEW_ARROWS {
+                                let Some(receptor_slot) = receptor_ns.receptor_off.get(col) else {
+                                    continue;
+                                };
+                                let frame = receptor_slot
+                                    .frame_index(state.preview_time, state.preview_beat);
+                                let uv = receptor_slot
+                                    .uv_for_frame_at(frame, state.preview_time);
+                                let logical = receptor_slot.logical_size();
+                                let width = logical[0].max(1.0);
+                                let height = logical[1].max(1.0);
+                                let scale = if height > f32::EPSILON {
+                                    target_height / height
+                                } else {
+                                    NOTESKIN_PREVIEW_SCALE
+                                };
+                                let size = [width * scale, target_height];
+                                let center = [center_x + x_mult * target_height, current_row_y];
+                                if let Some(model_actor) = noteskin_model_actor(
+                                    receptor_slot,
+                                    center,
+                                    size,
+                                    uv,
+                                    -receptor_slot.def.rotation_deg as f32,
+                                    state.preview_time,
+                                    state.preview_beat,
+                                    color,
+                                    BlendMode::Alpha,
+                                    106,
+                                ) {
+                                    actors.push(model_actor);
+                                } else {
+                                    actors.push(act!(sprite(receptor_slot.texture_key_shared()):
+                                        align(0.5, 0.5):
+                                        xy(center[0], center[1]):
+                                        setsize(size[0], size[1]):
+                                        rotationz(-receptor_slot.def.rotation_deg as f32):
+                                        customtexturerect(uv[0], uv[1], uv[2], uv[3]):
+                                        diffuse(color[0], color[1], color[2], color[3]):
+                                        z(Z_RECEPTOR_PREVIEW)
+                                    ));
+                                }
+                            }
+                        };
+                    let draw_tap_explosion_preview = |explosion_ns: &Noteskin,
+                                                      receptor_ns: &Noteskin,
+                                                      center_x: f32,
+                                                      actors: &mut Vec<Actor>| {
+                        let preview_time = state.preview_time * TAP_EXPLOSION_PREVIEW_SPEED;
+                        let preview_beat = state.preview_beat * TAP_EXPLOSION_PREVIEW_SPEED;
+                        let Some(explosion) = explosion_ns
+                            .tap_explosions
+                            .get("W1")
+                            .or_else(|| explosion_ns.tap_explosions.values().next())
+                        else {
+                            return;
+                        };
+                        let duration = explosion.animation.duration();
+                        let anim_time = if duration > f32::EPSILON {
+                            preview_time.rem_euclid(duration)
+                        } else {
+                            0.0
+                        };
+                        let explosion_visual = explosion.animation.state_at(anim_time);
+                        if !explosion_visual.visible {
+                            return;
+                        }
+                        let slot = &explosion.slot;
+                        let beat_for_anim = if slot.source.is_beat_based() {
+                            anim_time.max(0.0)
+                        } else {
+                            preview_beat
+                        };
+                        let frame = slot.frame_index(anim_time, beat_for_anim);
+                        let uv_elapsed = if slot.model.is_some() {
+                            anim_time
+                        } else {
+                            preview_time
+                        };
+                        let uv = slot.uv_for_frame_at(frame, uv_elapsed);
+                        let logical = slot.logical_size();
+                        let width = logical[0].max(1.0);
+                        let height = logical[1].max(1.0);
+                        let target_height = NOTESKIN_PREVIEW_ARROW_PIXEL_SIZE * NOTESKIN_PREVIEW_SCALE;
+                        let scale = if height > f32::EPSILON {
+                            target_height / height
+                        } else {
+                            NOTESKIN_PREVIEW_SCALE
+                        };
+                        let size = [width * scale, target_height];
+                        let rotation_deg = receptor_ns
+                            .receptor_off
+                            .first()
+                            .map(|slot| slot.def.rotation_deg as f32)
+                            .unwrap_or(0.0);
+                        let color = [
+                            explosion_visual.diffuse[0],
+                            explosion_visual.diffuse[1],
+                            explosion_visual.diffuse[2],
+                            explosion_visual.diffuse[3] * a,
+                        ];
+                        let blend = if explosion.animation.blend_add {
+                            BlendMode::Add
+                        } else {
+                            BlendMode::Alpha
+                        };
+                        if let Some(model_actor) = noteskin_model_actor(
+                            slot,
+                            [center_x, current_row_y],
+                            [
+                                size[0] * explosion_visual.zoom.max(0.0),
+                                size[1] * explosion_visual.zoom.max(0.0),
+                            ],
+                            uv,
+                            -rotation_deg,
+                            anim_time,
+                            beat_for_anim,
+                            color,
+                            blend,
+                            107,
+                        ) {
+                            actors.push(model_actor);
+                        } else if matches!(blend, BlendMode::Add) {
+                            actors.push(act!(sprite(slot.texture_key_shared()):
+                                align(0.5, 0.5):
+                                xy(center_x, current_row_y):
+                                setsize(size[0], size[1]):
+                                zoom(explosion_visual.zoom):
+                                rotationz(-rotation_deg):
+                                customtexturerect(uv[0], uv[1], uv[2], uv[3]):
+                                diffuse(color[0], color[1], color[2], color[3]):
+                                blend(add):
+                                z(Z_EXPLOSION_PREVIEW)
+                            ));
+                        } else {
+                            actors.push(act!(sprite(slot.texture_key_shared()):
+                                align(0.5, 0.5):
+                                xy(center_x, current_row_y):
+                                setsize(size[0], size[1]):
+                                zoom(explosion_visual.zoom):
+                                rotationz(-rotation_deg):
+                                customtexturerect(uv[0], uv[1], uv[2], uv[3]):
+                                diffuse(color[0], color[1], color[2], color[3]):
+                                blend(normal):
+                                z(Z_EXPLOSION_PREVIEW)
+                            ));
+                        }
+                    };
+                    if row.id == RowId::NoteSkin {
+                        if let Some(ns) = state.noteskin[primary_player_idx].as_ref() {
+                            draw_noteskin_preview(
+                                ns,
+                                preview_x[primary_player_idx],
+                                &mut *actors,
+                            );
+                        }
+                        if show_p2 && primary_player_idx != P2
+                            && let Some(ns) = state.noteskin[P2].as_ref()
+                        {
+                            draw_noteskin_preview(ns, preview_x[P2], &mut *actors);
+                        }
+                    } else if row.id == RowId::MineSkin {
+                        if let Some(mine_ns) = state.mine_noteskin[primary_player_idx]
+                            .as_deref()
+                            .or_else(|| state.noteskin[primary_player_idx].as_deref())
+                        {
+                            draw_mine_preview(
+                                mine_ns,
+                                preview_x[primary_player_idx],
+                                &mut *actors,
+                            );
+                        }
+                        if show_p2 && primary_player_idx != P2
+                            && let Some(mine_ns) = state.mine_noteskin[P2]
+                                .as_deref()
+                                .or_else(|| state.noteskin[P2].as_deref())
+                        {
+                            draw_mine_preview(mine_ns, preview_x[P2], &mut *actors);
+                        }
+                    } else if row.id == RowId::ReceptorSkin {
+                        if let Some(receptor_ns) = state.receptor_noteskin[primary_player_idx]
+                            .as_deref()
+                            .or_else(|| state.noteskin[primary_player_idx].as_deref())
+                        {
+                            draw_receptor_preview(
+                                receptor_ns,
+                                preview_x[primary_player_idx],
+                                &mut *actors,
+                            );
+                        }
+                        if show_p2
+                            && primary_player_idx != P2
+                            && let Some(receptor_ns) = state.receptor_noteskin[P2]
+                                .as_deref()
+                                .or_else(|| state.noteskin[P2].as_deref())
+                        {
+                            draw_receptor_preview(receptor_ns, preview_x[P2], &mut *actors);
+                        }
+                    } else if row.id == RowId::TapExplosionSkin {
+                        if !state.player_profiles[primary_player_idx]
+                            .tap_explosion_noteskin_hidden()
+                            && let Some(explosion_ns) = state.tap_explosion_noteskin
+                                [primary_player_idx]
+                                .as_deref()
+                                .or_else(|| state.noteskin[primary_player_idx].as_deref())
+                        {
+                            let receptor_ns = state.receptor_noteskin[primary_player_idx]
+                                .as_deref()
+                                .or_else(|| state.noteskin[primary_player_idx].as_deref())
+                                .unwrap_or(explosion_ns);
+                            draw_tap_explosion_preview(
+                                explosion_ns,
+                                receptor_ns,
+                                preview_x[primary_player_idx],
+                                &mut *actors,
+                            );
+                        }
+                        if show_p2
+                            && primary_player_idx != P2
+                            && !state.player_profiles[P2].tap_explosion_noteskin_hidden()
+                            && let Some(explosion_ns) = state.tap_explosion_noteskin[P2]
+                                .as_deref()
+                                .or_else(|| state.noteskin[P2].as_deref())
+                        {
+                            let receptor_ns = state.receptor_noteskin[P2]
+                                .as_deref()
+                                .or_else(|| state.noteskin[P2].as_deref())
+                                .unwrap_or(explosion_ns);
+                            draw_tap_explosion_preview(
+                                explosion_ns,
+                                receptor_ns,
+                                preview_x[P2],
+                                &mut *actors,
+                            );
+                        }
+                    }
+                }
+                // Add combo preview for "Combo Font" row showing ticking numbers
+                if row.id == RowId::ComboFont {
+                    let combo_text = state.combo_preview_count.to_string();
+                    let combo_zoom = COMBO_PREVIEW_ZOOM;
+                    // Choice indices are fixed by construction order:
+                    // 0=Wendy, 1=ArialRounded, 2=Asap, 3=BebasNeue, 4=SourceCode,
+                    // 5=Work, 6=WendyCursed, 7=None
+                    let combo_font_for = |idx: usize| -> Option<&'static str> {
+                        match idx {
+                        0 => Some("wendy_combo"),
+                        1 => Some("combo_arial_rounded"),
+                        2 => Some("combo_asap"),
+                        3 => Some("combo_bebas_neue"),
+                        4 => Some("combo_source_code"),
+                        5 => Some("combo_work"),
+                        6 => Some("combo_wendy_cursed"),
+                        _ => None,
+                        }
+                    };
+                    let p1_choice_idx = row.selected_choice_index[primary_player_idx]
+                        .min(row.choices.len().saturating_sub(1));
+                    if let Some(font_name) = combo_font_for(p1_choice_idx) {
+                        actors.push(act!(text:
+                            font(font_name): settext(combo_text.clone()):
+                            align(0.5, 0.5):
+                            xy(preview_x[primary_player_idx], current_row_y):
+                            zoom(combo_zoom): horizalign(center):
+                            diffuse(1.0, 1.0, 1.0, a):
+                            z(Z_ROW_PREVIEW)
+                        ));
+                    }
+                    if show_p2 && primary_player_idx != P2 {
+                        let p2_choice_idx = row.selected_choice_index[P2]
+                            .min(row.choices.len().saturating_sub(1));
+                        if let Some(font_name) = combo_font_for(p2_choice_idx) {
+                        actors.push(act!(text:
+                            font(font_name): settext(combo_text):
+                            align(0.5, 0.5):
+                            xy(preview_x[P2], current_row_y):
+                            zoom(combo_zoom): horizalign(center):
+                            diffuse(1.0, 1.0, 1.0, a):
+                            z(Z_ROW_PREVIEW)
+                        ));
+                        }
+                    }
+                }
+            });
+        });
+        }
 
 
 

--- a/src/screens/player_options/render.rs
+++ b/src/screens/player_options/render.rs
@@ -111,6 +111,166 @@ fn select_preview_texture<'a>(
         })
 }
 
+/// Returns the active mask (zero-extended to u16) for a row that
+/// supports multi-select underlining, or `None` if the row uses the
+/// default single-select underline behavior.
+fn multi_select_mask(state: &State, row_id: RowId, player_idx: usize) -> Option<u16> {
+    use RowId::*;
+    Some(match row_id {
+        Scroll => state.scroll_active_mask[player_idx].bits().into(),
+        Hide => state.hide_active_mask[player_idx].bits().into(),
+        Insert => state.insert_active_mask[player_idx].bits().into(),
+        Remove => state.remove_active_mask[player_idx].bits().into(),
+        Holds => state.holds_active_mask[player_idx].bits().into(),
+        Accel => state.accel_effects_active_mask[player_idx].bits().into(),
+        Effect => state.visual_effects_active_mask[player_idx].bits(),
+        Appearance => state.appearance_effects_active_mask[player_idx].bits().into(),
+        LifeBarOptions => state.life_bar_options_active_mask[player_idx].bits().into(),
+        FAPlusOptions => state.fa_plus_active_mask[player_idx].bits().into(),
+        GameplayExtras => state.gameplay_extras_active_mask[player_idx].bits().into(),
+        GameplayExtrasMore => state.gameplay_extras_more_active_mask[player_idx].bits().into(),
+        ResultsExtras => state.results_extras_active_mask[player_idx].bits().into(),
+        MeasureCounterOptions => state.measure_counter_options_active_mask[player_idx].bits().into(),
+        ErrorBar => state.error_bar_active_mask[player_idx].bits().into(),
+        ErrorBarOptions => state.error_bar_options_active_mask[player_idx].bits().into(),
+        EarlyDecentWayOffOptions => state.early_dw_active_mask[player_idx].bits().into(),
+        _ => return None,
+    })
+}
+
+/// Whether a row uses multi-select underlining (one underline per set bit
+/// in the row's active mask) rather than the default single-select
+/// underline (one underline under the chosen value).
+fn is_multi_select_row(row_id: RowId) -> bool {
+    use RowId::*;
+    matches!(
+        row_id,
+        Scroll
+            | Hide
+            | Insert
+            | Remove
+            | Holds
+            | Accel
+            | Effect
+            | Appearance
+            | LifeBarOptions
+            | FAPlusOptions
+            | GameplayExtras
+            | GameplayExtrasMore
+            | ResultsExtras
+            | MeasureCounterOptions
+            | ErrorBar
+            | ErrorBarOptions
+            | EarlyDecentWayOffOptions
+    )
+}
+
+/// Draw multi-select underlines for one row: one underline beneath each
+/// choice whose corresponding bit is set in the per-player active mask.
+#[allow(clippy::too_many_arguments)]
+fn draw_multi_select_underlines(
+    actors: &mut Vec<Actor>,
+    state: &State,
+    row: &Row,
+    active: [bool; PLAYER_SLOTS],
+    x_positions: &[f32],
+    widths: &[f32],
+    current_row_y: f32,
+    text_h: f32,
+    a: f32,
+) {
+    let line_thickness = underline_thickness();
+    let offset = underline_offset();
+    let underline_base_y = current_row_y + text_h * 0.5 + offset;
+    let underline_y = |player_idx: usize| {
+        if active[P1] && active[P2] {
+            (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
+        } else {
+            underline_base_y
+        }
+    };
+    for player_idx in active_player_indices(active) {
+        let Some(mask) = multi_select_mask(state, row.id, player_idx) else {
+            continue;
+        };
+        if mask == 0 {
+            continue;
+        }
+        let underline_y = underline_y(player_idx);
+        let mut line_color = color::decorative_rgba(player_color_index(state, player_idx));
+        line_color[3] *= a;
+        for idx in 0..row.choices.len() {
+            let bit: u16 = 1 << idx;
+            if (mask & bit) == 0 {
+                continue;
+            }
+            if let Some(sel_x) = x_positions.get(idx).copied() {
+                let draw_w = widths.get(idx).copied().unwrap_or(40.0);
+                let underline_w = draw_w.ceil();
+                actors.push(act!(quad:
+                    align(0.0, 0.5):
+                    xy(sel_x, underline_y):
+                    zoomto(underline_w, line_thickness):
+                    diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
+                    z(Z_ROW_FOREGROUND)
+                ));
+            }
+        }
+    }
+}
+
+/// Draw a single-select underline for one row: one underline under each
+/// active player's chosen value.
+#[allow(clippy::too_many_arguments)]
+fn draw_single_select_underline(
+    actors: &mut Vec<Actor>,
+    state: &State,
+    row: &Row,
+    active: [bool; PLAYER_SLOTS],
+    x_positions: &[f32],
+    widths: &[f32],
+    current_row_y: f32,
+    text_h: f32,
+    a: f32,
+) {
+    let line_thickness = underline_thickness();
+    let offset = underline_offset();
+    let underline_base_y = current_row_y + text_h * 0.5 + offset;
+    let underline_y = |player_idx: usize| {
+        if active[P1] && active[P2] {
+            (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
+        } else {
+            underline_base_y
+        }
+    };
+    for player_idx in active_player_indices(active) {
+        let idx = row.selected_choice_index[player_idx].min(widths.len().saturating_sub(1));
+        if let Some(sel_x) = x_positions.get(idx).copied() {
+            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
+            let underline_w = draw_w.ceil();
+            let underline_y = underline_y(player_idx);
+            let mut line_color = color::decorative_rgba(player_color_index(state, player_idx));
+            line_color[3] *= a;
+            actors.push(act!(quad:
+                align(0.0, 0.5):
+                xy(sel_x, underline_y):
+                zoomto(underline_w, line_thickness):
+                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
+                z(Z_ROW_FOREGROUND)
+            ));
+        }
+    }
+}
+
+/// Color palette index for a player's underline / cursor.
+fn player_color_index(state: &State, player_idx: usize) -> i32 {
+    if player_idx == P2 {
+        state.active_color_index - 2
+    } else {
+        state.active_color_index
+    }
+}
+
 pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     let mut actors: Vec<Actor> = Vec::with_capacity(64);
     let active = session_active_players();
@@ -171,13 +331,6 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     let preview_center_x =
         speed_mod_x_p1 + widescale(PREVIEW_CENTER_OFFSET_NORMAL, PREVIEW_CENTER_OFFSET_WIDE);
 
-    let player_color_index = |player_idx: usize| {
-        if player_idx == P2 {
-            state.active_color_index - 2
-        } else {
-            state.active_color_index
-        }
-    };
     let speed_x_for = |player_idx: usize| {
         if player_idx == P2 {
             speed_mod_x_p2
@@ -191,7 +344,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     if state.current_pane == OptionsPane::Main {
         for player_idx in active_player_indices(active) {
             let speed_mod = &state.speed_mod[player_idx];
-            let speed_color = color::simply_love_rgba(player_color_index(player_idx));
+            let speed_color = color::simply_love_rgba(player_color_index(state, player_idx));
             let p_chart = resolve_p1_chart(&state.song, &state.chart_steps_index);
             let main_scroll =
                 speed_mod_helper_scroll_text(&state.song, p_chart, speed_mod, state.music_rate);
@@ -397,7 +550,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     let right = center_x + ring_w * 0.5;
                     let top = center_y - ring_h * 0.5;
                     let bottom = center_y + ring_h * 0.5;
-                    let mut ring_color = color::decorative_rgba(player_color_index(player_idx));
+                    let mut ring_color = color::decorative_rgba(player_color_index(state, player_idx));
                     ring_color[3] *= a;
 
                     actors.push(act!(quad:
@@ -463,664 +616,30 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
             // - For normal rows: underline the currently selected choice.
             // - For Scroll row: underline each enabled scroll mode (multi-select).
             // - For FA+ Options row: underline each enabled FA+ toggle (multi-select).
-            if row.id == RowId::Scroll {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.scroll_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::Hide {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.hide_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::Insert {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.insert_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::Remove {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.remove_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::Holds {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.holds_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::Accel {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.accel_effects_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::Effect {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.visual_effects_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u16 << (idx as u16);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::Appearance {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.appearance_effects_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::LifeBarOptions {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.life_bar_options_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::FAPlusOptions {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.fa_plus_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::GameplayExtras {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.gameplay_extras_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::GameplayExtrasMore {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.gameplay_extras_more_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::ResultsExtras {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.results_extras_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::MeasureCounterOptions {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.measure_counter_options_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::ErrorBar {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.error_bar_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::ErrorBarOptions {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.error_bar_options_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
-            } else if row.id == RowId::EarlyDecentWayOffOptions {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let mask = state.early_dw_active_mask[player_idx].bits();
-                    if mask == 0 {
-                        continue;
-                    }
-                    let underline_y = underline_y_for(player_idx);
-                    let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                    line_color[3] *= a;
-                    for idx in 0..row.choices.len() {
-                        let bit = 1u8 << (idx as u8);
-                        if (mask & bit) == 0 {
-                            continue;
-                        }
-                        if let Some(sel_x) = x_positions.get(idx).copied() {
-                            let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                            let underline_w = draw_w.ceil();
-                            actors.push(act!(quad:
-                                align(0.0, 0.5):
-                                xy(sel_x, underline_y):
-                                zoomto(underline_w, line_thickness):
-                                diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                                z(Z_ROW_FOREGROUND)
-                            ));
-                        }
-                    }
-                }
+            if is_multi_select_row(row.id) {
+                draw_multi_select_underlines(
+                    &mut actors,
+                    state,
+                    row,
+                    active,
+                    &x_positions,
+                    &widths,
+                    current_row_y,
+                    text_h,
+                    a,
+                );
             } else {
-                let line_thickness = underline_thickness();
-                let offset = underline_offset();
-                let underline_base_y = current_row_y + text_h * 0.5 + offset;
-                let underline_y_for = |player_idx: usize| {
-                    if active[P1] && active[P2] {
-                        (player_idx as f32).mul_add(line_thickness + 1.0, underline_base_y)
-                    } else {
-                        underline_base_y
-                    }
-                };
-                for player_idx in active_player_indices(active) {
-                    let idx =
-                        row.selected_choice_index[player_idx].min(widths.len().saturating_sub(1));
-                    if let Some(sel_x) = x_positions.get(idx).copied() {
-                        let draw_w = widths.get(idx).copied().unwrap_or(40.0);
-                        let underline_w = draw_w.ceil();
-                        let underline_y = underline_y_for(player_idx);
-                        let mut line_color = color::decorative_rgba(player_color_index(player_idx));
-                        line_color[3] *= a;
-                        actors.push(act!(quad:
-                            align(0.0, 0.5):
-                            xy(sel_x, underline_y):
-                            zoomto(underline_w, line_thickness):
-                            diffuse(line_color[0], line_color[1], line_color[2], line_color[3]):
-                            z(Z_ROW_FOREGROUND)
-                        ));
-                    }
-                }
+                draw_single_select_underline(
+                    &mut actors,
+                    state,
+                    row,
+                    active,
+                    &x_positions,
+                    &widths,
+                    current_row_y,
+                    text_h,
+                    a,
+                );
             }
             // Draw the 4-sided cursor ring around the selected option when this row is active.
             if !widths.is_empty() {
@@ -1137,7 +656,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     let right = center_x + ring_w * 0.5;
                     let top = center_y - ring_h * 0.5;
                     let bottom = center_y + ring_h * 0.5;
-                    let mut ring_color = color::decorative_rgba(player_color_index(player_idx));
+                    let mut ring_color = color::decorative_rgba(player_color_index(state, player_idx));
                     ring_color[3] *= a;
                     actors.push(act!(quad:
                         align(0.5, 0.5): xy((left + right) * 0.5, top + border_w * 0.5):
@@ -1253,7 +772,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     let offset = underline_offset(); // place just under the baseline
                     let underline_y = current_row_y + draw_h * 0.5 + offset;
                     let underline_left_x = choice_center_x - draw_w * 0.5;
-                    let mut line_color = color::decorative_rgba(player_color_index(primary_player_idx));
+                    let mut line_color = color::decorative_rgba(player_color_index(state, primary_player_idx));
                     line_color[3] *= a;
                     actors.push(act!(quad:
                         align(0.0, 0.5): // start at text's left edge
@@ -1273,7 +792,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                             let top = center_y - ring_h * 0.5;
                             let bottom = center_y + ring_h * 0.5;
                             let mut ring_color =
-                                color::decorative_rgba(player_color_index(primary_player_idx));
+                                color::decorative_rgba(player_color_index(state, primary_player_idx));
                             ring_color[3] *= a;
                             actors.push(act!(quad:
                                 align(0.5, 0.5): xy(center_x, top + border_w * 0.5):
@@ -1339,7 +858,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                         let offset = underline_offset();
                         let underline_y = current_row_y + draw_h * 0.5 + offset;
                         let underline_left_x = p2_choice_center_x - p2_draw_w * 0.5;
-                        let mut line_color = color::decorative_rgba(player_color_index(P2));
+                        let mut line_color = color::decorative_rgba(player_color_index(state, P2));
                         line_color[3] *= a;
                         actors.push(act!(quad:
                             align(0.0, 0.5):
@@ -1355,7 +874,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                                 let right = center_x + ring_w * 0.5;
                                 let top = center_y - ring_h * 0.5;
                                 let bottom = center_y + ring_h * 0.5;
-                                let mut ring_color = color::decorative_rgba(player_color_index(P2));
+                                let mut ring_color = color::decorative_rgba(player_color_index(state, P2));
                                 ring_color[3] *= a;
                                 actors.push(act!(quad:
                                     align(0.5, 0.5): xy(center_x, top + border_w * 0.5):
@@ -2047,7 +1566,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
         else {
             continue;
         };
-        let help_text_color = color::simply_love_rgba(player_color_index(player_idx));
+        let help_text_color = color::simply_love_rgba(player_color_index(state, player_idx));
         let wrap_width = if split_help || player_idx == P2 {
             (help_box_w * 0.5) - 30.0
         } else {
@@ -2115,3 +1634,5 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
     }
     actors
 }
+
+


### PR DESCRIPTION
# Player Options Render: extract row helpers + FrameCtx/RowCtx

## What changes

Pulls the two large per-row branches out of `get_actors`:

- **`draw_inline_choices`** — ~96-line block for rows that show every choice horizontally with multi/single-select underlines and a cursor ring.
- **`draw_single_value_with_preview`** — ~830-line block for default rows that render the chosen value text, P2 mirror, cursor rings, and per-`RowId` preview sprites/text (judgment, hold, noteskin family, combo).

Bundles the long argument lists threaded through these helpers into two context structs:

- **`FrameCtx`** — `state`, `asset_manager`, `active`, plus frame-constant layout values (`show_p2`, `speed_mod_x`, `row_left`, `row_width`, `preview_x`).
- **`RowCtx`** — borrows `FrameCtx` and adds per-row data (`row`, `item_idx`, `current_row_y`, `a`, `is_active`, `sl_gray`).

## Dependency

Stacked on top of:
- #229 — dedup multi-select underline blocks
- #230 — lift cursor_for_player; dedup ring blocks

Please merge those first; this PR's diff assumes those helpers and free functions are in place.
