### PR TITLE
Player Options: Consolidate Options Masks

### DIFF
--- a/src/screens/player_options/choice.rs
+++ b/src/screens/player_options/choice.rs
@@ -267,12 +267,12 @@ pub(super) fn toggle_scroll_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    state.scroll_active_mask[idx].toggle(bit);
+    state.option_masks[idx].scroll.toggle(bit);
 
     // Rebuild the ScrollOption bitmask from the active choices.
     use crate::game::profile::ScrollOption;
     let mut setting = ScrollOption::Normal;
-    let mask = state.scroll_active_mask[idx];
+    let mask = state.option_masks[idx].scroll;
     if mask.contains(ScrollMask::REVERSE) {
         setting = setting.union(ScrollOption::Reverse);
     }
@@ -335,9 +335,9 @@ pub(super) fn toggle_hide_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    state.hide_active_mask[idx].toggle(bit);
+    state.option_masks[idx].hide.toggle(bit);
 
-    let mask = state.hide_active_mask[idx];
+    let mask = state.option_masks[idx].hide;
     let hide_targets = mask.contains(HideMask::TARGETS);
     let hide_song_bg = mask.contains(HideMask::BACKGROUND);
     let hide_combo = mask.contains(HideMask::COMBO);
@@ -410,14 +410,14 @@ pub(super) fn toggle_insert_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let mut bits = state.insert_active_mask[idx].bits();
+    let mut bits = state.option_masks[idx].insert.bits();
     if (bits & bit) != 0 {
         bits &= !bit;
     } else {
         bits |= bit;
     }
     let mask = InsertMask::from_bits_truncate(bits);
-    state.insert_active_mask[idx] = mask;
+    state.option_masks[idx].insert = mask;
     state.player_profiles[idx].insert_active_mask = mask;
 
     let play_style = crate::game::profile::get_session_play_style();
@@ -466,14 +466,14 @@ pub(super) fn toggle_remove_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let mut bits = state.remove_active_mask[idx].bits();
+    let mut bits = state.option_masks[idx].remove.bits();
     if (bits & bit) != 0 {
         bits &= !bit;
     } else {
         bits |= bit;
     }
     let mask = RemoveMask::from_bits_truncate(bits);
-    state.remove_active_mask[idx] = mask;
+    state.option_masks[idx].remove = mask;
     state.player_profiles[idx].remove_active_mask = mask;
 
     let play_style = crate::game::profile::get_session_play_style();
@@ -530,14 +530,14 @@ pub(super) fn toggle_holds_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let mut bits = state.holds_active_mask[idx].bits();
+    let mut bits = state.option_masks[idx].holds.bits();
     if (bits & bit) != 0 {
         bits &= !bit;
     } else {
         bits |= bit;
     }
     let mask = HoldsMask::from_bits_truncate(bits);
-    state.holds_active_mask[idx] = mask;
+    state.option_masks[idx].holds = mask;
     state.player_profiles[idx].holds_active_mask = mask;
 
     let play_style = crate::game::profile::get_session_play_style();
@@ -594,14 +594,14 @@ pub(super) fn toggle_accel_effects_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let mut bits = state.accel_effects_active_mask[idx].bits();
+    let mut bits = state.option_masks[idx].accel_effects.bits();
     if (bits & bit) != 0 {
         bits &= !bit;
     } else {
         bits |= bit;
     }
     let mask = AccelEffectsMask::from_bits_truncate(bits);
-    state.accel_effects_active_mask[idx] = mask;
+    state.option_masks[idx].accel_effects = mask;
     state.player_profiles[idx].accel_effects_active_mask = mask;
 
     let play_style = crate::game::profile::get_session_play_style();
@@ -650,14 +650,14 @@ pub(super) fn toggle_visual_effects_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let mut bits = state.visual_effects_active_mask[idx].bits();
+    let mut bits = state.option_masks[idx].visual_effects.bits();
     if (bits & bit) != 0 {
         bits &= !bit;
     } else {
         bits |= bit;
     }
     let mask = VisualEffectsMask::from_bits_truncate(bits);
-    state.visual_effects_active_mask[idx] = mask;
+    state.option_masks[idx].visual_effects = mask;
     state.player_profiles[idx].visual_effects_active_mask = mask;
 
     let play_style = crate::game::profile::get_session_play_style();
@@ -714,14 +714,14 @@ pub(super) fn toggle_appearance_effects_row(state: &mut State, player_idx: usize
         return;
     }
 
-    let mut bits = state.appearance_effects_active_mask[idx].bits();
+    let mut bits = state.option_masks[idx].appearance_effects.bits();
     if (bits & bit) != 0 {
         bits &= !bit;
     } else {
         bits |= bit;
     }
     let mask = AppearanceEffectsMask::from_bits_truncate(bits);
-    state.appearance_effects_active_mask[idx] = mask;
+    state.option_masks[idx].appearance_effects = mask;
     state.player_profiles[idx].appearance_effects_active_mask = mask;
 
     let play_style = crate::game::profile::get_session_play_style();
@@ -770,9 +770,9 @@ pub(super) fn toggle_life_bar_options_row(state: &mut State, player_idx: usize) 
         return;
     }
 
-    state.life_bar_options_active_mask[idx].toggle(bit);
+    state.option_masks[idx].life_bar_options.toggle(bit);
 
-    let mask = state.life_bar_options_active_mask[idx];
+    let mask = state.option_masks[idx].life_bar_options;
     let rainbow_max = mask.contains(LifeBarOptionsMask::RAINBOW_MAX);
     let responsive_colors = mask.contains(LifeBarOptionsMask::RESPONSIVE_COLORS);
     let show_life_percent = mask.contains(LifeBarOptionsMask::SHOW_LIFE_PERCENT);
@@ -836,9 +836,9 @@ pub(super) fn toggle_fa_plus_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    state.fa_plus_active_mask[idx].toggle(bit);
+    state.option_masks[idx].fa_plus.toggle(bit);
 
-    let mask = state.fa_plus_active_mask[idx];
+    let mask = state.option_masks[idx].fa_plus;
     let window_enabled = mask.contains(FaPlusMask::WINDOW);
     let ex_enabled = mask.contains(FaPlusMask::EX_SCORE);
     let hard_ex_enabled = mask.contains(FaPlusMask::HARD_EX_SCORE);
@@ -902,10 +902,10 @@ pub(super) fn toggle_results_extras_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    state.results_extras_active_mask[idx].toggle(bit);
+    state.option_masks[idx].results_extras.toggle(bit);
 
     let track_early_judgments =
-        state.results_extras_active_mask[idx].contains(ResultsExtrasMask::TRACK_EARLY_JUDGMENTS);
+        state.option_masks[idx].results_extras.contains(ResultsExtrasMask::TRACK_EARLY_JUDGMENTS);
     state.player_profiles[idx].track_early_judgments = track_early_judgments;
 
     let play_style = crate::game::profile::get_session_play_style();
@@ -954,14 +954,14 @@ pub(super) fn toggle_error_bar_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    let mut bits = state.error_bar_active_mask[idx].bits();
+    let mut bits = state.option_masks[idx].error_bar.bits();
     if (bits & bit) != 0 {
         bits &= !bit;
     } else {
         bits |= bit;
     }
     let mask = ErrorBarMask::from_bits_truncate(bits);
-    state.error_bar_active_mask[idx] = mask;
+    state.option_masks[idx].error_bar = mask;
     state.player_profiles[idx].error_bar_active_mask = mask;
     state.player_profiles[idx].error_bar = crate::game::profile::error_bar_style_from_mask(mask);
     state.player_profiles[idx].error_bar_text =
@@ -1014,9 +1014,9 @@ pub(super) fn toggle_error_bar_options_row(state: &mut State, player_idx: usize)
         return;
     }
 
-    state.error_bar_options_active_mask[idx].toggle(bit);
+    state.option_masks[idx].error_bar_options.toggle(bit);
 
-    let mask = state.error_bar_options_active_mask[idx];
+    let mask = state.option_masks[idx].error_bar_options;
     let up = mask.contains(ErrorBarOptionsMask::MOVE_UP);
     let multi_tick = mask.contains(ErrorBarOptionsMask::MULTI_TICK);
     state.player_profiles[idx].error_bar_up = up;
@@ -1068,9 +1068,9 @@ pub(super) fn toggle_measure_counter_options_row(state: &mut State, player_idx: 
         return;
     }
 
-    state.measure_counter_options_active_mask[idx].toggle(bit);
+    state.option_masks[idx].measure_counter_options.toggle(bit);
 
-    let mask = state.measure_counter_options_active_mask[idx];
+    let mask = state.option_masks[idx].measure_counter_options;
     let left = mask.contains(MeasureCounterOptionsMask::MOVE_LEFT);
     let up = mask.contains(MeasureCounterOptionsMask::MOVE_UP);
     let vert = mask.contains(MeasureCounterOptionsMask::VERTICAL_LOOKAHEAD);
@@ -1131,9 +1131,9 @@ pub(super) fn toggle_early_dw_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    state.early_dw_active_mask[idx].toggle(bit);
+    state.option_masks[idx].early_dw.toggle(bit);
 
-    let mask = state.early_dw_active_mask[idx];
+    let mask = state.option_masks[idx].early_dw;
     let hide_judgments = mask.contains(EarlyDwMask::HIDE_JUDGMENTS);
     let hide_flash = mask.contains(EarlyDwMask::HIDE_FLASH);
     state.player_profiles[idx].hide_early_dw_judgments = hide_judgments;
@@ -1202,9 +1202,9 @@ pub(super) fn toggle_gameplay_extras_row(state: &mut State, player_idx: usize) {
         return;
     }
 
-    state.gameplay_extras_active_mask[idx].toggle(bit);
+    state.option_masks[idx].gameplay_extras.toggle(bit);
 
-    let mask = state.gameplay_extras_active_mask[idx];
+    let mask = state.option_masks[idx].gameplay_extras;
     let column_flash_on_miss = mask.contains(GameplayExtrasMask::FLASH_COLUMN_FOR_MISS);
     let nps_graph_at_top = mask.contains(GameplayExtrasMask::DENSITY_GRAPH_AT_TOP);
     let column_cues = mask.contains(GameplayExtrasMask::COLUMN_CUES);
@@ -1223,7 +1223,7 @@ pub(super) fn toggle_gameplay_extras_row(state: &mut State, player_idx: usize) {
     if display_scorebox {
         more.insert(GameplayExtrasMoreMask::DISPLAY_SCOREBOX);
     }
-    state.gameplay_extras_more_active_mask[idx] = more;
+    state.option_masks[idx].gameplay_extras_more = more;
 
     let play_style = crate::game::profile::get_session_play_style();
     let should_persist = play_style == crate::game::profile::PlayStyle::Versus
@@ -1260,11 +1260,10 @@ pub(super) fn apply_pane(state: &mut State, pane: OptionsPane) {
     state.start_last_triggered_at = [None; PLAYER_SLOTS];
     state.help_anim_time = [0.0; PLAYER_SLOTS];
     let active = session_active_players();
-    let hide = state.hide_active_mask;
-    let error_bar = state.error_bar_active_mask;
     let allow = state.allow_per_player_global_offsets;
+    let option_masks = state.option_masks;
     let p = state.pane_mut();
-    p.row_tweens = init_row_tweens(&p.row_map, p.selected_row, active, hide, error_bar, allow);
+    p.row_tweens = init_row_tweens(&p.row_map, p.selected_row, active, option_masks, allow);
     state.pane_mut().arcade_row_focus = std::array::from_fn(|player_idx| {
         row_allows_arcade_next_row(state, state.pane().selected_row[player_idx])
     });

--- a/src/screens/player_options/inline_nav.rs
+++ b/src/screens/player_options/inline_nav.rs
@@ -218,8 +218,7 @@ pub(super) fn move_selection_vertical(
     let visibility = row_visibility(
         &state.pane().row_map,
         active,
-        state.hide_active_mask,
-        state.error_bar_active_mask,
+        state.option_masks,
         state.allow_per_player_global_offsets,
     );
     let current_row =

--- a/src/screens/player_options/input.rs
+++ b/src/screens/player_options/input.rs
@@ -138,16 +138,14 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
             &state.pane().row_map,
             state.pane().selected_row,
             active,
-            state.hide_active_mask,
-            state.error_bar_active_mask,
+            state.option_masks,
             state.allow_per_player_global_offsets,
         );
     } else {
         let visibility = row_visibility(
             &state.pane().row_map,
             active,
-            state.hide_active_mask,
-            state.error_bar_active_mask,
+            state.option_masks,
             state.allow_per_player_global_offsets,
         );
         let visible_rows = count_visible_rows(&state.pane().row_map, visibility);

--- a/src/screens/player_options/layout.rs
+++ b/src/screens/player_options/layout.rs
@@ -118,8 +118,7 @@ pub(super) fn init_row_tweens(
     row_map: &RowMap,
     selected_row: [usize; PLAYER_SLOTS],
     active: [bool; PLAYER_SLOTS],
-    hide_active_mask: [HideMask; PLAYER_SLOTS],
-    error_bar_active_mask: [ErrorBarMask; PLAYER_SLOTS],
+    option_masks: [PlayerOptionMasks; PLAYER_SLOTS],
     allow_per_player_global_offsets: bool,
 ) -> Vec<RowTween> {
     let total_rows = row_map.display_order().len();
@@ -131,8 +130,7 @@ pub(super) fn init_row_tweens(
     let visibility = row_visibility(
         row_map,
         active,
-        hide_active_mask,
-        error_bar_active_mask,
+        option_masks,
         allow_per_player_global_offsets,
     );
     let visible_rows = count_visible_rows(row_map, visibility);
@@ -252,8 +250,7 @@ pub(super) fn cursor_dest_for_player(
     let visibility = row_visibility(
         &state.pane().row_map,
         session_active_players(),
-        state.hide_active_mask,
-        state.error_bar_active_mask,
+        state.option_masks,
         state.allow_per_player_global_offsets,
     );
     let mut row_idx =

--- a/src/screens/player_options/mod.rs
+++ b/src/screens/player_options/mod.rs
@@ -160,44 +160,8 @@ pub fn init(
     let p2_advanced = apply_profile_defaults(&mut advanced_row_map, &player_profiles[P2], P2);
     let p1_uncommon = apply_profile_defaults(&mut uncommon_row_map, &player_profiles[P1], P1);
     let p2_uncommon = apply_profile_defaults(&mut uncommon_row_map, &player_profiles[P2], P2);
-    let (
-        scroll_active_mask_p1,
-        hide_active_mask_p1,
-        insert_active_mask_p1,
-        remove_active_mask_p1,
-        holds_active_mask_p1,
-        accel_effects_active_mask_p1,
-        visual_effects_active_mask_p1,
-        appearance_effects_active_mask_p1,
-        fa_plus_active_mask_p1,
-        early_dw_active_mask_p1,
-        gameplay_extras_active_mask_p1,
-        gameplay_extras_more_active_mask_p1,
-        results_extras_active_mask_p1,
-        life_bar_options_active_mask_p1,
-        error_bar_active_mask_p1,
-        error_bar_options_active_mask_p1,
-        measure_counter_options_active_mask_p1,
-    ) = or_active_masks(or_active_masks(p1_main, p1_advanced), p1_uncommon);
-    let (
-        scroll_active_mask_p2,
-        hide_active_mask_p2,
-        insert_active_mask_p2,
-        remove_active_mask_p2,
-        holds_active_mask_p2,
-        accel_effects_active_mask_p2,
-        visual_effects_active_mask_p2,
-        appearance_effects_active_mask_p2,
-        fa_plus_active_mask_p2,
-        early_dw_active_mask_p2,
-        gameplay_extras_active_mask_p2,
-        gameplay_extras_more_active_mask_p2,
-        results_extras_active_mask_p2,
-        life_bar_options_active_mask_p2,
-        error_bar_active_mask_p2,
-        error_bar_options_active_mask_p2,
-        measure_counter_options_active_mask_p2,
-    ) = or_active_masks(or_active_masks(p2_main, p2_advanced), p2_uncommon);
+    let p1_masks = p1_main.merge(p1_advanced).merge(p1_uncommon);
+    let p2_masks = p2_main.merge(p2_advanced).merge(p2_uncommon);
 
     let cols_per_player = noteskin_cols_per_player(crate::game::profile::get_session_play_style());
     let mut initial_noteskin_names = vec![crate::game::profile::NoteSkin::DEFAULT_NAME.to_string()];
@@ -252,8 +216,7 @@ pub fn init(
         &main_row_map,
         [0; PLAYER_SLOTS],
         active,
-        [hide_active_mask_p1, hide_active_mask_p2],
-        [error_bar_active_mask_p1, error_bar_active_mask_p2],
+        [p1_masks, p2_masks],
         allow_per_player_global_offsets,
     );
     let mut panes = [
@@ -270,41 +233,7 @@ pub fn init(
         chart_steps_index,
         chart_difficulty_index,
         panes,
-        scroll_active_mask: [scroll_active_mask_p1, scroll_active_mask_p2],
-        hide_active_mask: [hide_active_mask_p1, hide_active_mask_p2],
-        insert_active_mask: [insert_active_mask_p1, insert_active_mask_p2],
-        remove_active_mask: [remove_active_mask_p1, remove_active_mask_p2],
-        holds_active_mask: [holds_active_mask_p1, holds_active_mask_p2],
-        accel_effects_active_mask: [accel_effects_active_mask_p1, accel_effects_active_mask_p2],
-        visual_effects_active_mask: [visual_effects_active_mask_p1, visual_effects_active_mask_p2],
-        appearance_effects_active_mask: [
-            appearance_effects_active_mask_p1,
-            appearance_effects_active_mask_p2,
-        ],
-        fa_plus_active_mask: [fa_plus_active_mask_p1, fa_plus_active_mask_p2],
-        early_dw_active_mask: [early_dw_active_mask_p1, early_dw_active_mask_p2],
-        gameplay_extras_active_mask: [
-            gameplay_extras_active_mask_p1,
-            gameplay_extras_active_mask_p2,
-        ],
-        gameplay_extras_more_active_mask: [
-            gameplay_extras_more_active_mask_p1,
-            gameplay_extras_more_active_mask_p2,
-        ],
-        results_extras_active_mask: [results_extras_active_mask_p1, results_extras_active_mask_p2],
-        life_bar_options_active_mask: [
-            life_bar_options_active_mask_p1,
-            life_bar_options_active_mask_p2,
-        ],
-        error_bar_active_mask: [error_bar_active_mask_p1, error_bar_active_mask_p2],
-        error_bar_options_active_mask: [
-            error_bar_options_active_mask_p1,
-            error_bar_options_active_mask_p2,
-        ],
-        measure_counter_options_active_mask: [
-            measure_counter_options_active_mask_p1,
-            measure_counter_options_active_mask_p2,
-        ],
+        option_masks: [p1_masks, p2_masks],
         active_color_index,
         speed_mod: [speed_mod_p1, speed_mod_p2],
         music_rate: session_music_rate,

--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -108,57 +108,11 @@ fn find_noteskin_choice_index(
     }
 }
 
-type ActiveMaskTuple = (
-    ScrollMask,
-    HideMask,
-    InsertMask,
-    RemoveMask,
-    HoldsMask,
-    AccelEffectsMask,
-    VisualEffectsMask,
-    AppearanceEffectsMask,
-    FaPlusMask,
-    EarlyDwMask,
-    GameplayExtrasMask,
-    GameplayExtrasMoreMask,
-    ResultsExtrasMask,
-    LifeBarOptionsMask,
-    ErrorBarMask,
-    ErrorBarOptionsMask,
-    MeasureCounterOptionsMask,
-);
-
-/// OR two `ActiveMaskTuple`s element-wise. Used by `init()` to accumulate
-/// per-pane mask results, because `apply_profile_defaults` only populates
-/// some masks when the corresponding row exists in the passed `row_map`,
-/// and the rows are split across the Main/Advanced/Uncommon panes.
-pub(super) fn or_active_masks(a: ActiveMaskTuple, b: ActiveMaskTuple) -> ActiveMaskTuple {
-    (
-        a.0 | b.0,
-        a.1 | b.1,
-        a.2 | b.2,
-        a.3 | b.3,
-        a.4 | b.4,
-        a.5 | b.5,
-        a.6 | b.6,
-        a.7 | b.7,
-        a.8 | b.8,
-        a.9 | b.9,
-        a.10 | b.10,
-        a.11 | b.11,
-        a.12 | b.12,
-        a.13 | b.13,
-        a.14 | b.14,
-        a.15 | b.15,
-        a.16 | b.16,
-    )
-}
-
 pub(super) fn apply_profile_defaults(
     row_map: &mut RowMap,
     profile: &crate::game::profile::Profile,
     player_idx: usize,
-) -> ActiveMaskTuple {
+) -> PlayerOptionMasks {
     let mut scroll_active_mask = ScrollMask::empty();
     let mut hide_active_mask = HideMask::empty();
     let mut insert_active_mask = InsertMask::empty();
@@ -857,23 +811,23 @@ pub(super) fn apply_profile_defaults(
             .unwrap_or(0)
             .min(row.choices.len().saturating_sub(1));
     }
-    (
-        scroll_active_mask,
-        hide_active_mask,
-        insert_active_mask,
-        remove_active_mask,
-        holds_active_mask,
-        accel_effects_active_mask,
-        visual_effects_active_mask,
-        appearance_effects_active_mask,
-        fa_plus_active_mask,
-        early_dw_active_mask,
-        gameplay_extras_active_mask,
-        gameplay_extras_more_active_mask,
-        results_extras_active_mask,
-        life_bar_options_active_mask,
-        error_bar_active_mask,
-        error_bar_options_active_mask,
-        measure_counter_options_active_mask,
-    )
+    PlayerOptionMasks {
+        scroll: scroll_active_mask,
+        hide: hide_active_mask,
+        insert: insert_active_mask,
+        remove: remove_active_mask,
+        holds: holds_active_mask,
+        accel_effects: accel_effects_active_mask,
+        visual_effects: visual_effects_active_mask,
+        appearance_effects: appearance_effects_active_mask,
+        fa_plus: fa_plus_active_mask,
+        early_dw: early_dw_active_mask,
+        gameplay_extras: gameplay_extras_active_mask,
+        gameplay_extras_more: gameplay_extras_more_active_mask,
+        results_extras: results_extras_active_mask,
+        life_bar_options: life_bar_options_active_mask,
+        error_bar: error_bar_active_mask,
+        error_bar_options: error_bar_options_active_mask,
+        measure_counter_options: measure_counter_options_active_mask,
+    }
 }

--- a/src/screens/player_options/render.rs
+++ b/src/screens/player_options/render.rs
@@ -524,31 +524,31 @@ pub(super) fn select_preview_texture<'a>(
 pub(super) fn multi_select_mask(state: &State, row_id: RowId, player_idx: usize) -> Option<u16> {
     use RowId::*;
     Some(match row_id {
-        Scroll => state.scroll_active_mask[player_idx].bits().into(),
-        Hide => state.hide_active_mask[player_idx].bits().into(),
-        Insert => state.insert_active_mask[player_idx].bits().into(),
-        Remove => state.remove_active_mask[player_idx].bits().into(),
-        Holds => state.holds_active_mask[player_idx].bits().into(),
-        Accel => state.accel_effects_active_mask[player_idx].bits().into(),
-        Effect => state.visual_effects_active_mask[player_idx].bits(),
-        Appearance => state.appearance_effects_active_mask[player_idx]
+        Scroll => state.option_masks[player_idx].scroll.bits().into(),
+        Hide => state.option_masks[player_idx].hide.bits().into(),
+        Insert => state.option_masks[player_idx].insert.bits().into(),
+        Remove => state.option_masks[player_idx].remove.bits().into(),
+        Holds => state.option_masks[player_idx].holds.bits().into(),
+        Accel => state.option_masks[player_idx].accel_effects.bits().into(),
+        Effect => state.option_masks[player_idx].visual_effects.bits(),
+        Appearance => state.option_masks[player_idx].appearance_effects
             .bits()
             .into(),
-        LifeBarOptions => state.life_bar_options_active_mask[player_idx].bits().into(),
-        FAPlusOptions => state.fa_plus_active_mask[player_idx].bits().into(),
-        GameplayExtras => state.gameplay_extras_active_mask[player_idx].bits().into(),
-        GameplayExtrasMore => state.gameplay_extras_more_active_mask[player_idx]
+        LifeBarOptions => state.option_masks[player_idx].life_bar_options.bits().into(),
+        FAPlusOptions => state.option_masks[player_idx].fa_plus.bits().into(),
+        GameplayExtras => state.option_masks[player_idx].gameplay_extras.bits().into(),
+        GameplayExtrasMore => state.option_masks[player_idx].gameplay_extras_more
             .bits()
             .into(),
-        ResultsExtras => state.results_extras_active_mask[player_idx].bits().into(),
-        MeasureCounterOptions => state.measure_counter_options_active_mask[player_idx]
+        ResultsExtras => state.option_masks[player_idx].results_extras.bits().into(),
+        MeasureCounterOptions => state.option_masks[player_idx].measure_counter_options
             .bits()
             .into(),
-        ErrorBar => state.error_bar_active_mask[player_idx].bits().into(),
-        ErrorBarOptions => state.error_bar_options_active_mask[player_idx]
+        ErrorBar => state.option_masks[player_idx].error_bar.bits().into(),
+        ErrorBarOptions => state.option_masks[player_idx].error_bar_options
             .bits()
             .into(),
-        EarlyDecentWayOffOptions => state.early_dw_active_mask[player_idx].bits().into(),
+        EarlyDecentWayOffOptions => state.option_masks[player_idx].early_dw.bits().into(),
         _ => return None,
     })
 }

--- a/src/screens/player_options/state.rs
+++ b/src/screens/player_options/state.rs
@@ -112,6 +112,60 @@ bitflags! {
     }
 }
 
+/// All per-player active bitmasks for option rows.
+///
+/// Stored as `[PlayerOptionMasks; PLAYER_SLOTS]` on `State` (one entry per
+/// player slot). Adding a new mask row only requires adding one field here.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PlayerOptionMasks {
+    pub scroll: ScrollMask,
+    pub hide: HideMask,
+    pub insert: InsertMask,
+    pub remove: RemoveMask,
+    pub holds: HoldsMask,
+    pub accel_effects: AccelEffectsMask,
+    pub visual_effects: VisualEffectsMask,
+    pub appearance_effects: AppearanceEffectsMask,
+    pub fa_plus: FaPlusMask,
+    pub early_dw: EarlyDwMask,
+    pub gameplay_extras: GameplayExtrasMask,
+    pub gameplay_extras_more: GameplayExtrasMoreMask,
+    pub results_extras: ResultsExtrasMask,
+    pub life_bar_options: LifeBarOptionsMask,
+    pub error_bar: ErrorBarMask,
+    pub error_bar_options: ErrorBarOptionsMask,
+    pub measure_counter_options: MeasureCounterOptionsMask,
+}
+
+impl PlayerOptionMasks {
+    /// Field-wise bitwise OR of two mask sets. Used to accumulate the partial
+    /// results of `apply_profile_defaults` across the Main/Advanced/Uncommon
+    /// panes (each pane only populates the masks for rows it contains; the
+    /// rest are left at `Default::default()` and are identity under OR).
+    #[inline]
+    pub fn merge(self, other: Self) -> Self {
+        Self {
+            scroll: self.scroll | other.scroll,
+            hide: self.hide | other.hide,
+            insert: self.insert | other.insert,
+            remove: self.remove | other.remove,
+            holds: self.holds | other.holds,
+            accel_effects: self.accel_effects | other.accel_effects,
+            visual_effects: self.visual_effects | other.visual_effects,
+            appearance_effects: self.appearance_effects | other.appearance_effects,
+            fa_plus: self.fa_plus | other.fa_plus,
+            early_dw: self.early_dw | other.early_dw,
+            gameplay_extras: self.gameplay_extras | other.gameplay_extras,
+            gameplay_extras_more: self.gameplay_extras_more | other.gameplay_extras_more,
+            results_extras: self.results_extras | other.results_extras,
+            life_bar_options: self.life_bar_options | other.life_bar_options,
+            error_bar: self.error_bar | other.error_bar,
+            error_bar_options: self.error_bar_options | other.error_bar_options,
+            measure_counter_options: self.measure_counter_options | other.measure_counter_options,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(super) struct RowTween {
     pub(super) from_y: f32,
@@ -168,42 +222,8 @@ pub struct State {
     pub chart_steps_index: [usize; PLAYER_SLOTS],
     pub chart_difficulty_index: [usize; PLAYER_SLOTS],
     pub(super) panes: [PaneState; OptionsPane::COUNT],
-    pub scroll_active_mask: [ScrollMask; PLAYER_SLOTS],
-    pub hide_active_mask: [HideMask; PLAYER_SLOTS],
-    pub fa_plus_active_mask: [FaPlusMask; PLAYER_SLOTS],
-    pub early_dw_active_mask: [EarlyDwMask; PLAYER_SLOTS],
-    pub gameplay_extras_active_mask: [GameplayExtrasMask; PLAYER_SLOTS],
-    pub gameplay_extras_more_active_mask: [GameplayExtrasMoreMask; PLAYER_SLOTS],
-    pub results_extras_active_mask: [ResultsExtrasMask; PLAYER_SLOTS],
-    pub life_bar_options_active_mask: [LifeBarOptionsMask; PLAYER_SLOTS],
-    // For Error Bar row: bitmask of which options are enabled.
-    // bit0 = Colorful, bit1 = Monochrome, bit2 = Text, bit3 = Highlight, bit4 = Average.
-    pub error_bar_active_mask: [ErrorBarMask; PLAYER_SLOTS],
-    pub error_bar_options_active_mask: [ErrorBarOptionsMask; PLAYER_SLOTS],
-    pub measure_counter_options_active_mask: [MeasureCounterOptionsMask; PLAYER_SLOTS],
-    // For Insert row: bitmask of enabled chart insert transforms.
-    // bit0 = Wide, bit1 = Big, bit2 = Quick, bit3 = BMRize,
-    // bit4 = Skippy, bit5 = Echo, bit6 = Stomp.
-    pub insert_active_mask: [InsertMask; PLAYER_SLOTS],
-    // For Remove row: bitmask of enabled chart removal transforms.
-    // bit0 = Little, bit1 = No Mines, bit2 = No Holds, bit3 = No Jumps,
-    // bit4 = No Hands, bit5 = No Quads, bit6 = No Lifts, bit7 = No Fakes.
-    pub remove_active_mask: [RemoveMask; PLAYER_SLOTS],
-    // For Holds row: bitmask of enabled hold transforms.
-    // bit0 = Planted, bit1 = Floored, bit2 = Twister,
-    // bit3 = No Rolls, bit4 = Holds To Rolls.
-    pub holds_active_mask: [HoldsMask; PLAYER_SLOTS],
-    // For Accel Effects row: bitmask of enabled acceleration transforms.
-    // bit0 = Boost, bit1 = Brake, bit2 = Wave, bit3 = Expand, bit4 = Boomerang.
-    pub accel_effects_active_mask: [AccelEffectsMask; PLAYER_SLOTS],
-    // For Visual Effects row: bitmask of enabled visual transforms.
-    // bit0 = Drunk, bit1 = Dizzy, bit2 = Confusion, bit3 = Big,
-    // bit4 = Flip, bit5 = Invert, bit6 = Tornado, bit7 = Tipsy,
-    // bit8 = Bumpy, bit9 = Beat.
-    pub visual_effects_active_mask: [VisualEffectsMask; PLAYER_SLOTS],
-    // For Appearance Effects row: bitmask of enabled appearance transforms.
-    // bit0 = Hidden, bit1 = Sudden, bit2 = Stealth, bit3 = Blink, bit4 = R.Vanish.
-    pub appearance_effects_active_mask: [AppearanceEffectsMask; PLAYER_SLOTS],
+    /// All per-player option bitmasks. See `PlayerOptionMasks` for field meanings.
+    pub option_masks: [PlayerOptionMasks; PLAYER_SLOTS],
     pub active_color_index: i32,
     pub speed_mod: [SpeedMod; PLAYER_SLOTS],
     pub music_rate: f32,

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -4,10 +4,10 @@ use super::*;
 pub(super) mod tests {
     use super::{
         ErrorBarMask, HUD_OFFSET_MAX, HUD_OFFSET_MIN, HUD_OFFSET_ZERO_INDEX, HideMask,
-        NAV_INITIAL_HOLD_DELAY, NAV_REPEAT_SCROLL_INTERVAL, P1, P2, Row, RowId, RowMap, ScrollMask,
-        SpeedMod, SpeedModType, handle_arcade_start_event, handle_start_event, hud_offset_choices,
-        is_row_visible, judgment_tilt_intensity_visible, repeat_held_arcade_start, row_visibility,
-        session_active_players, sync_profile_scroll_speed,
+        NAV_INITIAL_HOLD_DELAY, NAV_REPEAT_SCROLL_INTERVAL, P1, P2, PlayerOptionMasks, Row, RowId,
+        RowMap, ScrollMask, SpeedMod, SpeedModType, handle_arcade_start_event, handle_start_event,
+        hud_offset_choices, is_row_visible, judgment_tilt_intensity_visible,
+        repeat_held_arcade_start, row_visibility, session_active_players, sync_profile_scroll_speed,
     };
     use crate::assets::AssetManager;
     use crate::assets::i18n::{LookupKey, lookup_key};
@@ -104,8 +104,10 @@ pub(super) mod tests {
         let visibility = row_visibility(
             &row_map,
             [true, false],
-            [HideMask::empty(), HideMask::empty()],
-            [ErrorBarMask::empty(), ErrorBarMask::empty()],
+            [
+                PlayerOptionMasks { hide: HideMask::empty(), error_bar: ErrorBarMask::empty(), ..Default::default() },
+                PlayerOptionMasks { hide: HideMask::empty(), error_bar: ErrorBarMask::empty(), ..Default::default() },
+            ],
             false,
         );
         assert!(!is_row_visible(&row_map, 1, visibility));
@@ -113,8 +115,10 @@ pub(super) mod tests {
         let visibility = row_visibility(
             &row_map,
             [true, false],
-            [HideMask::empty(), HideMask::empty()],
-            [ErrorBarMask::COLORFUL, ErrorBarMask::empty()],
+            [
+                PlayerOptionMasks { hide: HideMask::empty(), error_bar: ErrorBarMask::COLORFUL, ..Default::default() },
+                PlayerOptionMasks { hide: HideMask::empty(), error_bar: ErrorBarMask::empty(), ..Default::default() },
+            ],
             false,
         );
         assert!(is_row_visible(&row_map, 1, visibility));
@@ -140,8 +144,10 @@ pub(super) mod tests {
         let visibility = row_visibility(
             &row_map,
             [true, false],
-            [HideMask::empty(), HideMask::empty()],
-            [ErrorBarMask::empty(), ErrorBarMask::empty()],
+            [
+                PlayerOptionMasks { hide: HideMask::empty(), error_bar: ErrorBarMask::empty(), ..Default::default() },
+                PlayerOptionMasks { hide: HideMask::empty(), error_bar: ErrorBarMask::empty(), ..Default::default() },
+            ],
             false,
         );
         assert!(!is_row_visible(&row_map, 1, visibility));
@@ -163,8 +169,10 @@ pub(super) mod tests {
         let visibility = row_visibility(
             &row_map,
             [true, false],
-            [HideMask::empty(), HideMask::empty()],
-            [ErrorBarMask::empty(), ErrorBarMask::empty()],
+            [
+                PlayerOptionMasks { hide: HideMask::empty(), error_bar: ErrorBarMask::empty(), ..Default::default() },
+                PlayerOptionMasks { hide: HideMask::empty(), error_bar: ErrorBarMask::empty(), ..Default::default() },
+            ],
             false,
         );
         assert!(is_row_visible(&row_map, 1, visibility));
@@ -190,8 +198,10 @@ pub(super) mod tests {
         let visibility = row_visibility(
             &row_map,
             [true, true],
-            [HideMask::empty(), HideMask::empty()],
-            [ErrorBarMask::empty(), ErrorBarMask::empty()],
+            [
+                PlayerOptionMasks { hide: HideMask::empty(), error_bar: ErrorBarMask::empty(), ..Default::default() },
+                PlayerOptionMasks { hide: HideMask::empty(), error_bar: ErrorBarMask::empty(), ..Default::default() },
+            ],
             false,
         );
         assert!(!is_row_visible(&row_map, 1, visibility));
@@ -213,8 +223,10 @@ pub(super) mod tests {
         let visibility = row_visibility(
             &row_map,
             [true, true],
-            [HideMask::empty(), HideMask::empty()],
-            [ErrorBarMask::empty(), ErrorBarMask::empty()],
+            [
+                PlayerOptionMasks { hide: HideMask::empty(), error_bar: ErrorBarMask::empty(), ..Default::default() },
+                PlayerOptionMasks { hide: HideMask::empty(), error_bar: ErrorBarMask::empty(), ..Default::default() },
+            ],
             false,
         );
         assert!(is_row_visible(&row_map, 1, visibility));
@@ -257,18 +269,15 @@ pub(super) mod tests {
         let unc = super::super::panes::apply_profile_defaults(&mut uncommon_rows, &profile, P1);
 
         // Main alone: Scroll row absent, mask comes back empty (the bug source).
-        assert_eq!(main.0, ScrollMask::empty());
+        assert_eq!(main.scroll, ScrollMask::empty());
         // Accumulated across all three panes (the fix): Reverse + Cross preserved.
-        let combined = super::super::panes::or_active_masks(
-            super::super::panes::or_active_masks(main, adv),
-            unc,
-        );
+        let combined = main.merge(adv).merge(unc);
         assert!(
-            combined.0.contains(ScrollMask::REVERSE),
+            combined.scroll.contains(ScrollMask::REVERSE),
             "Reverse bit preserved after OR-accumulation"
         );
         assert!(
-            combined.0.contains(ScrollMask::CROSS),
+            combined.scroll.contains(ScrollMask::CROSS),
             "Cross bit preserved after OR-accumulation"
         );
     }
@@ -468,13 +477,13 @@ pub(super) mod tests {
         state.pane_mut().row_map.insert(scroll_row);
         let row_index = state.pane().row_map.display_order().len() - 1;
         state.pane_mut().selected_row[P1] = row_index;
-        state.scroll_active_mask[P1] = ScrollMask::empty();
+        state.option_masks[P1].scroll = ScrollMask::empty();
 
         let active = session_active_players();
         handle_start_event(&mut state, &asset_manager, active, P1);
 
         assert_ne!(
-            state.scroll_active_mask[P1],
+            state.option_masks[P1].scroll,
             ScrollMask::empty(),
             "Scroll bitmask should have been toggled"
         );
@@ -762,7 +771,8 @@ pub(super) mod tests {
         state.pane_mut().row_map.insert(scroll_row);
         let row_index = state.pane().row_map.display_order().len() - 1;
         state.pane_mut().selected_row[P1] = row_index;
-        state.scroll_active_mask = [ScrollMask::empty(), ScrollMask::empty()];
+        state.option_masks[P1].scroll = ScrollMask::empty();
+        state.option_masks[P2].scroll = ScrollMask::empty();
 
         // L/R on a bitmask row returns Outcome::NONE — mask must not change,
         // and no SFX should be played (audio uninit in tests would panic).
@@ -770,7 +780,7 @@ pub(super) mod tests {
         super::change_choice_for_player(&mut state, &asset_manager, P1, -1);
 
         assert_eq!(
-            state.scroll_active_mask,
+            [state.option_masks[P1].scroll, state.option_masks[P2].scroll],
             [ScrollMask::empty(), ScrollMask::empty()],
             "delta on Bitmask row must not toggle the mask"
         );

--- a/src/screens/player_options/visibility.rs
+++ b/src/screens/player_options/visibility.rs
@@ -173,12 +173,12 @@ pub(super) fn combo_offsets_visible(row_map: &RowMap, active: [bool; PLAYER_SLOT
 
 pub(super) fn error_bar_children_visible(
     active: [bool; PLAYER_SLOTS],
-    error_bar_active_mask: [ErrorBarMask; PLAYER_SLOTS],
+    option_masks: [PlayerOptionMasks; PLAYER_SLOTS],
 ) -> bool {
     let mut any_active = false;
     for player_idx in active_player_indices(active) {
         any_active = true;
-        if !error_bar_active_mask[player_idx].is_empty() {
+        if !option_masks[player_idx].error_bar.is_empty() {
             return true;
         }
     }
@@ -225,12 +225,12 @@ pub(super) fn density_graph_background_visible(
 
 pub(super) fn combo_rows_visible(
     active: [bool; PLAYER_SLOTS],
-    hide_active_mask: [HideMask; PLAYER_SLOTS],
+    option_masks: [PlayerOptionMasks; PLAYER_SLOTS],
 ) -> bool {
     let mut any_active = false;
     for player_idx in active_player_indices(active) {
         any_active = true;
-        let hide_combo = hide_active_mask[player_idx].contains(HideMask::COMBO);
+        let hide_combo = option_masks[player_idx].hide.contains(HideMask::COMBO);
         if !hide_combo {
             return true;
         }
@@ -240,12 +240,12 @@ pub(super) fn combo_rows_visible(
 
 pub(super) fn lifebar_rows_visible(
     active: [bool; PLAYER_SLOTS],
-    hide_active_mask: [HideMask; PLAYER_SLOTS],
+    option_masks: [PlayerOptionMasks; PLAYER_SLOTS],
 ) -> bool {
     let mut any_active = false;
     for player_idx in active_player_indices(active) {
         any_active = true;
-        let hide_lifebar = hide_active_mask[player_idx].contains(HideMask::LIFE);
+        let hide_lifebar = option_masks[player_idx].hide.contains(HideMask::LIFE);
         if !hide_lifebar {
             return true;
         }
@@ -274,8 +274,7 @@ pub(super) fn indicator_score_type_visible(row_map: &RowMap, active: [bool; PLAY
 pub(super) fn row_visibility(
     row_map: &RowMap,
     active: [bool; PLAYER_SLOTS],
-    hide_active_mask: [HideMask; PLAYER_SLOTS],
-    error_bar_active_mask: [ErrorBarMask; PLAYER_SLOTS],
+    option_masks: [PlayerOptionMasks; PLAYER_SLOTS],
     allow_per_player_global_offsets: bool,
 ) -> RowVisibility {
     RowVisibility {
@@ -283,11 +282,11 @@ pub(super) fn row_visibility(
         show_judgment_offsets: judgment_offsets_visible(row_map, active),
         show_judgment_tilt_intensity: judgment_tilt_intensity_visible(row_map, active),
         show_combo_offsets: combo_offsets_visible(row_map, active),
-        show_error_bar_children: error_bar_children_visible(active, error_bar_active_mask),
+        show_error_bar_children: error_bar_children_visible(active, option_masks),
         show_custom_fantastic_window_ms: custom_fantastic_window_ms_visible(row_map, active),
         show_density_graph_background: density_graph_background_visible(row_map, active),
-        show_combo_rows: combo_rows_visible(active, hide_active_mask),
-        show_lifebar_rows: lifebar_rows_visible(active, hide_active_mask),
+        show_combo_rows: combo_rows_visible(active, option_masks),
+        show_lifebar_rows: lifebar_rows_visible(active, option_masks),
         show_indicator_score_type: indicator_score_type_visible(row_map, active),
         show_global_offset_shift: allow_per_player_global_offsets,
     }
@@ -399,8 +398,7 @@ pub(super) fn sync_selected_rows_with_visibility(state: &mut State, active: [boo
     let visibility = row_visibility(
         &state.pane().row_map,
         active,
-        state.hide_active_mask,
-        state.error_bar_active_mask,
+        state.option_masks,
         state.allow_per_player_global_offsets,
     );
     for player_idx in [P1, P2] {


### PR DESCRIPTION
# Player Options: Consolidate Options Masks

## What changes

`State` carried a flat collection of per-option active mask arrays, one per toggle row. Adding a new row meant touching the state struct, the pane defaults plumbing, and every consumer that threaded those masks around. This PR groups them into a single `PlayerOptionMasks` struct held per player slot, and updates the helpers and call sites to pass that one value instead.

Mechanical refactor; no behavior change.
