### PR TITLE
Player Options: Lift NoteskinState (cache + previews)

### DIFF
--- a/src/screens/player_options/mod.rs
+++ b/src/screens/player_options/mod.rs
@@ -202,6 +202,10 @@ pub fn init(
             ),
         }
     });
+    let noteskin = NoteskinState {
+        cache: noteskin_cache,
+        previews: noteskin_previews,
+    };
     let active = session_active_players();
     let main_row_tweens = init_row_tweens(
         &main_row_map,
@@ -234,8 +238,7 @@ pub fn init(
         start_input: [PlayerStartInput::default(); PLAYER_SLOTS],
         allow_per_player_global_offsets,
         player_profiles,
-        noteskin_cache,
-        noteskin_previews,
+        noteskin,
         preview_time: 0.0,
         preview_beat: 0.0,
         help_anim_time: [0.0; PLAYER_SLOTS],

--- a/src/screens/player_options/noteskins.rs
+++ b/src/screens/player_options/noteskins.rs
@@ -161,34 +161,36 @@ pub(super) fn resolved_tap_explosion_preview(
     resolved_noteskin_override_preview(cache, noteskin, tap_explosion_noteskin, cols_per_player)
 }
 
-pub(super) fn sync_noteskin_previews_for_player(state: &mut State, player_idx: usize) {
+pub(super) fn sync_noteskin_previews_for_player(
+    noteskin: &mut NoteskinState,
+    profile: &crate::game::profile::Profile,
+    player_idx: usize,
+) {
     let cols_per_player = noteskin_cols_per_player(crate::game::profile::get_session_play_style());
-    let noteskin_setting = state.player_profiles[player_idx].noteskin.clone();
-    let mine_noteskin_setting = state.player_profiles[player_idx].mine_noteskin.clone();
-    let receptor_noteskin_setting = state.player_profiles[player_idx].receptor_noteskin.clone();
-    let tap_explosion_noteskin_setting = state.player_profiles[player_idx]
-        .tap_explosion_noteskin
-        .clone();
-    let previews = &mut state.noteskin_previews[player_idx];
+    let noteskin_setting = profile.noteskin.clone();
+    let mine_noteskin_setting = profile.mine_noteskin.clone();
+    let receptor_noteskin_setting = profile.receptor_noteskin.clone();
+    let tap_explosion_noteskin_setting = profile.tap_explosion_noteskin.clone();
+    let previews = &mut noteskin.previews[player_idx];
     previews.base = cached_or_load_noteskin(
-        &mut state.noteskin_cache,
+        &mut noteskin.cache,
         &noteskin_setting,
         cols_per_player,
     );
     previews.mine = resolved_noteskin_override_preview(
-        &mut state.noteskin_cache,
+        &mut noteskin.cache,
         &noteskin_setting,
         mine_noteskin_setting.as_ref(),
         cols_per_player,
     );
     previews.receptor = resolved_noteskin_override_preview(
-        &mut state.noteskin_cache,
+        &mut noteskin.cache,
         &noteskin_setting,
         receptor_noteskin_setting.as_ref(),
         cols_per_player,
     );
     previews.tap_explosion = resolved_tap_explosion_preview(
-        &mut state.noteskin_cache,
+        &mut noteskin.cache,
         &noteskin_setting,
         tap_explosion_noteskin_setting.as_ref(),
         cols_per_player,

--- a/src/screens/player_options/panes/main.rs
+++ b/src/screens/player_options/panes/main.rs
@@ -138,7 +138,7 @@ const NOTE_SKIN: CustomBinding = CustomBinding {
                 if should_persist {
                     gp::update_noteskin_for_side(side, setting);
                 }
-                sync_noteskin_previews_for_player(state, player_idx);
+                sync_noteskin_previews_for_player(&mut state.noteskin, &state.player_profiles[player_idx], player_idx);
             },
         )
     },
@@ -163,7 +163,7 @@ const MINE_SKIN: CustomBinding = CustomBinding {
                 if should_persist {
                     gp::update_mine_noteskin_for_side(side, setting);
                 }
-                sync_noteskin_previews_for_player(state, player_idx);
+                sync_noteskin_previews_for_player(&mut state.noteskin, &state.player_profiles[player_idx], player_idx);
             },
         )
     },
@@ -188,7 +188,7 @@ const RECEPTOR_SKIN: CustomBinding = CustomBinding {
                 if should_persist {
                     gp::update_receptor_noteskin_for_side(side, setting);
                 }
-                sync_noteskin_previews_for_player(state, player_idx);
+                sync_noteskin_previews_for_player(&mut state.noteskin, &state.player_profiles[player_idx], player_idx);
             },
         )
     },
@@ -216,7 +216,7 @@ const TAP_EXPLOSION_SKIN: CustomBinding = CustomBinding {
                 if should_persist {
                     gp::update_tap_explosion_noteskin_for_side(side, setting);
                 }
-                sync_noteskin_previews_for_player(state, player_idx);
+                sync_noteskin_previews_for_player(&mut state.noteskin, &state.player_profiles[player_idx], player_idx);
             },
         )
     },

--- a/src/screens/player_options/render.rs
+++ b/src/screens/player_options/render.rs
@@ -1644,85 +1644,59 @@ fn draw_tap_explosion_preview(
 }
 
 fn draw_noteskin_row_preview(actors: &mut Vec<Actor>, rc: &RowCtx, primary_player_idx: usize) {
-    if let Some(ns) = rc.fc.state.noteskin_previews[primary_player_idx]
-        .base
-        .as_ref()
-    {
+    if let Some(ns) = rc.fc.state.noteskin.previews[primary_player_idx].base.as_ref() {
         draw_noteskin_preview(actors, rc, ns, rc.fc.preview_x[primary_player_idx]);
     }
-    if rc.fc.show_p2
-        && primary_player_idx != P2
-        && let Some(ns) = rc.fc.state.noteskin_previews[P2].base.as_ref()
+    if rc.fc.show_p2 && primary_player_idx != P2
+        && let Some(ns) = rc.fc.state.noteskin.previews[P2].base.as_ref()
     {
         draw_noteskin_preview(actors, rc, ns, rc.fc.preview_x[P2]);
     }
 }
 
 fn draw_mineskin_row_preview(actors: &mut Vec<Actor>, rc: &RowCtx, primary_player_idx: usize) {
-    if let Some(mine_ns) = rc.fc.state.noteskin_previews[primary_player_idx]
-        .mine
+    if let Some(mine_ns) = rc.fc.state.noteskin.previews[primary_player_idx].mine
         .as_deref()
-        .or_else(|| {
-            rc.fc.state.noteskin_previews[primary_player_idx]
-                .base
-                .as_deref()
-        })
+        .or_else(|| rc.fc.state.noteskin.previews[primary_player_idx].base.as_deref())
     {
         draw_mine_preview(actors, rc, mine_ns, rc.fc.preview_x[primary_player_idx]);
     }
-    if rc.fc.show_p2
-        && primary_player_idx != P2
-        && let Some(mine_ns) = rc.fc.state.noteskin_previews[P2]
-            .mine
+    if rc.fc.show_p2 && primary_player_idx != P2
+        && let Some(mine_ns) = rc.fc.state.noteskin.previews[P2].mine
             .as_deref()
-            .or_else(|| rc.fc.state.noteskin_previews[P2].base.as_deref())
+            .or_else(|| rc.fc.state.noteskin.previews[P2].base.as_deref())
     {
         draw_mine_preview(actors, rc, mine_ns, rc.fc.preview_x[P2]);
     }
 }
 
 fn draw_receptorskin_row_preview(actors: &mut Vec<Actor>, rc: &RowCtx, primary_player_idx: usize) {
-    if let Some(receptor_ns) = rc.fc.state.noteskin_previews[primary_player_idx]
-        .receptor
+    if let Some(receptor_ns) = rc.fc.state.noteskin.previews[primary_player_idx].receptor
         .as_deref()
-        .or_else(|| {
-            rc.fc.state.noteskin_previews[primary_player_idx]
-                .base
-                .as_deref()
-        })
+        .or_else(|| rc.fc.state.noteskin.previews[primary_player_idx].base.as_deref())
     {
         draw_receptor_preview(actors, rc, receptor_ns, rc.fc.preview_x[primary_player_idx]);
     }
     if rc.fc.show_p2
         && primary_player_idx != P2
-        && let Some(receptor_ns) = rc.fc.state.noteskin_previews[P2]
-            .receptor
+        && let Some(receptor_ns) = rc.fc.state.noteskin.previews[P2].receptor
             .as_deref()
-            .or_else(|| rc.fc.state.noteskin_previews[P2].base.as_deref())
+            .or_else(|| rc.fc.state.noteskin.previews[P2].base.as_deref())
     {
         draw_receptor_preview(actors, rc, receptor_ns, rc.fc.preview_x[P2]);
     }
 }
 
 fn draw_tap_explosion_row_preview(actors: &mut Vec<Actor>, rc: &RowCtx, primary_player_idx: usize) {
-    if !rc.fc.state.player_profiles[primary_player_idx].tap_explosion_noteskin_hidden()
-        && let Some(explosion_ns) = rc.fc.state.noteskin_previews[primary_player_idx]
-            .tap_explosion
+    if !rc.fc.state.player_profiles[primary_player_idx]
+        .tap_explosion_noteskin_hidden()
+        && let Some(explosion_ns) = rc.fc.state.noteskin.previews[primary_player_idx].tap_explosion
             .as_deref()
-            .or_else(|| {
-                rc.fc.state.noteskin_previews[primary_player_idx]
-                    .base
-                    .as_deref()
-            })
+            .or_else(|| rc.fc.state.noteskin.previews[primary_player_idx].base.as_deref())
     {
-        let receptor_ns = rc.fc.state.noteskin_previews[primary_player_idx]
-            .receptor
+        let receptor_ns = rc.fc.state.noteskin.previews[primary_player_idx].receptor
             .as_deref()
-            .or_else(|| {
-                rc.fc.state.noteskin_previews[primary_player_idx]
-                    .base
-                    .as_deref()
-            })
+            .or_else(|| rc.fc.state.noteskin.previews[primary_player_idx].base.as_deref())
             .unwrap_or(explosion_ns);
         draw_tap_explosion_preview(
             actors,
@@ -1735,15 +1709,13 @@ fn draw_tap_explosion_row_preview(actors: &mut Vec<Actor>, rc: &RowCtx, primary_
     if rc.fc.show_p2
         && primary_player_idx != P2
         && !rc.fc.state.player_profiles[P2].tap_explosion_noteskin_hidden()
-        && let Some(explosion_ns) = rc.fc.state.noteskin_previews[P2]
-            .tap_explosion
+        && let Some(explosion_ns) = rc.fc.state.noteskin.previews[P2].tap_explosion
             .as_deref()
-            .or_else(|| rc.fc.state.noteskin_previews[P2].base.as_deref())
+            .or_else(|| rc.fc.state.noteskin.previews[P2].base.as_deref())
     {
-        let receptor_ns = rc.fc.state.noteskin_previews[P2]
-            .receptor
+        let receptor_ns = rc.fc.state.noteskin.previews[P2].receptor
             .as_deref()
-            .or_else(|| rc.fc.state.noteskin_previews[P2].base.as_deref())
+            .or_else(|| rc.fc.state.noteskin.previews[P2].base.as_deref())
             .unwrap_or(explosion_ns);
         draw_tap_explosion_preview(actors, rc, explosion_ns, receptor_ns, rc.fc.preview_x[P2]);
     }

--- a/src/screens/player_options/state.rs
+++ b/src/screens/player_options/state.rs
@@ -168,14 +168,21 @@ impl PlayerOptionMasks {
 
 /// Loaded noteskin previews for a single player slot.
 ///
-/// Stored as `[PlayerNoteskinPreviews; PLAYER_SLOTS]` on `State` (one entry
-/// per player slot).
+/// Stored as `[PlayerNoteskinPreviews; PLAYER_SLOTS]` on `NoteskinState` (one
+/// entry per player slot).
 #[derive(Clone, Default)]
 pub(super) struct PlayerNoteskinPreviews {
     pub(super) base: Option<Arc<Noteskin>>,
     pub(super) mine: Option<Arc<Noteskin>>,
     pub(super) receptor: Option<Arc<Noteskin>>,
     pub(super) tap_explosion: Option<Arc<Noteskin>>,
+}
+
+/// Owns the noteskin loading subsystem: the shared cache and the per-player
+/// resolved previews.
+pub(super) struct NoteskinState {
+    pub(super) cache: HashMap<String, Arc<Noteskin>>,
+    pub(super) previews: [PlayerNoteskinPreviews; PLAYER_SLOTS],
 }
 
 /// Per-player navigation key hold/repeat timing.
@@ -264,8 +271,7 @@ pub struct State {
     pub start_input: [PlayerStartInput; PLAYER_SLOTS],
     pub(super) allow_per_player_global_offsets: bool,
     pub player_profiles: [crate::game::profile::Profile; PLAYER_SLOTS],
-    pub(super) noteskin_cache: HashMap<String, Arc<Noteskin>>,
-    pub(super) noteskin_previews: [PlayerNoteskinPreviews; PLAYER_SLOTS],
+    pub(super) noteskin: NoteskinState,
     pub(super) preview_time: f32,
     pub(super) preview_beat: f32,
     pub(super) help_anim_time: [f32; PLAYER_SLOTS],


### PR DESCRIPTION
Group `noteskin_cache` and `noteskin_previews` on `State` into a `NoteskinState` sub-struct. 