### PR TITLE
Player Options: Data-drive mask-row init via BitmaskBinding

### DIFF
--- a/src/screens/player_options/mod.rs
+++ b/src/screens/player_options/mod.rs
@@ -202,6 +202,10 @@ pub fn init(
             ),
         }
     });
+    let noteskin = NoteskinState {
+        cache: noteskin_cache,
+        previews: noteskin_previews,
+    };
     let active = session_active_players();
     let main_row_tweens = init_row_tweens(
         &main_row_map,
@@ -234,8 +238,7 @@ pub fn init(
         start_input: [PlayerStartInput::default(); PLAYER_SLOTS],
         allow_per_player_global_offsets,
         player_profiles,
-        noteskin_cache,
-        noteskin_previews,
+        noteskin,
         preview_time: 0.0,
         preview_beat: 0.0,
         help_anim_time: [0.0; PLAYER_SLOTS],

--- a/src/screens/player_options/mod.rs
+++ b/src/screens/player_options/mod.rs
@@ -147,21 +147,19 @@ pub fn init(
         fixed_stepchart.as_ref(),
     );
     let player_profiles = [p1_profile.clone(), p2_profile.clone()];
-    // `apply_profile_defaults` populates 8 of its 17 returned masks (Scroll,
-    // Insert, Remove, Holds, Accel, Effect, Appearance, EarlyDw) only when
-    // the corresponding row exists in the passed `row_map`. Those rows live
-    // on the Advanced and Uncommon panes, so we must call the function on
-    // every pane and OR the results together. Otherwise persisted profile
-    // state for those rows would silently appear empty here and get
-    // overwritten the moment the user touches any choice on those rows.
-    let p1_main = apply_profile_defaults(&mut main_row_map, &player_profiles[P1], P1);
-    let p2_main = apply_profile_defaults(&mut main_row_map, &player_profiles[P2], P2);
-    let p1_advanced = apply_profile_defaults(&mut advanced_row_map, &player_profiles[P1], P1);
-    let p2_advanced = apply_profile_defaults(&mut advanced_row_map, &player_profiles[P2], P2);
-    let p1_uncommon = apply_profile_defaults(&mut uncommon_row_map, &player_profiles[P1], P1);
-    let p2_uncommon = apply_profile_defaults(&mut uncommon_row_map, &player_profiles[P2], P2);
-    let p1_masks = p1_main.merge(p1_advanced).merge(p1_uncommon);
-    let p2_masks = p2_main.merge(p2_advanced).merge(p2_uncommon);
+    // Each `BitmaskBinding` lives on exactly one pane's row, and
+    // `apply_derived_masks` is a pure function of `profile`, so calling
+    // `apply_profile_defaults` once per (pane, player) with the same
+    // `&mut PlayerOptionMasks` accumulates writes safely without needing
+    // a per-pane merge step.
+    let mut p1_masks = PlayerOptionMasks::default();
+    let mut p2_masks = PlayerOptionMasks::default();
+    apply_profile_defaults(&mut main_row_map, &player_profiles[P1], P1, &mut p1_masks);
+    apply_profile_defaults(&mut main_row_map, &player_profiles[P2], P2, &mut p2_masks);
+    apply_profile_defaults(&mut advanced_row_map, &player_profiles[P1], P1, &mut p1_masks);
+    apply_profile_defaults(&mut advanced_row_map, &player_profiles[P2], P2, &mut p2_masks);
+    apply_profile_defaults(&mut uncommon_row_map, &player_profiles[P1], P1, &mut p1_masks);
+    apply_profile_defaults(&mut uncommon_row_map, &player_profiles[P2], P2, &mut p2_masks);
 
     let cols_per_player = noteskin_cols_per_player(crate::game::profile::get_session_play_style());
     let mut initial_noteskin_names = vec![crate::game::profile::NoteSkin::DEFAULT_NAME.to_string()];

--- a/src/screens/player_options/noteskins.rs
+++ b/src/screens/player_options/noteskins.rs
@@ -161,34 +161,36 @@ pub(super) fn resolved_tap_explosion_preview(
     resolved_noteskin_override_preview(cache, noteskin, tap_explosion_noteskin, cols_per_player)
 }
 
-pub(super) fn sync_noteskin_previews_for_player(state: &mut State, player_idx: usize) {
+pub(super) fn sync_noteskin_previews_for_player(
+    noteskin: &mut NoteskinState,
+    profile: &crate::game::profile::Profile,
+    player_idx: usize,
+) {
     let cols_per_player = noteskin_cols_per_player(crate::game::profile::get_session_play_style());
-    let noteskin_setting = state.player_profiles[player_idx].noteskin.clone();
-    let mine_noteskin_setting = state.player_profiles[player_idx].mine_noteskin.clone();
-    let receptor_noteskin_setting = state.player_profiles[player_idx].receptor_noteskin.clone();
-    let tap_explosion_noteskin_setting = state.player_profiles[player_idx]
-        .tap_explosion_noteskin
-        .clone();
-    let previews = &mut state.noteskin_previews[player_idx];
+    let noteskin_setting = profile.noteskin.clone();
+    let mine_noteskin_setting = profile.mine_noteskin.clone();
+    let receptor_noteskin_setting = profile.receptor_noteskin.clone();
+    let tap_explosion_noteskin_setting = profile.tap_explosion_noteskin.clone();
+    let previews = &mut noteskin.previews[player_idx];
     previews.base = cached_or_load_noteskin(
-        &mut state.noteskin_cache,
+        &mut noteskin.cache,
         &noteskin_setting,
         cols_per_player,
     );
     previews.mine = resolved_noteskin_override_preview(
-        &mut state.noteskin_cache,
+        &mut noteskin.cache,
         &noteskin_setting,
         mine_noteskin_setting.as_ref(),
         cols_per_player,
     );
     previews.receptor = resolved_noteskin_override_preview(
-        &mut state.noteskin_cache,
+        &mut noteskin.cache,
         &noteskin_setting,
         receptor_noteskin_setting.as_ref(),
         cols_per_player,
     );
     previews.tap_explosion = resolved_tap_explosion_preview(
-        &mut state.noteskin_cache,
+        &mut noteskin.cache,
         &noteskin_setting,
         tap_explosion_noteskin_setting.as_ref(),
         cols_per_player,

--- a/src/screens/player_options/panes/advanced.rs
+++ b/src/screens/player_options/panes/advanced.rs
@@ -153,7 +153,40 @@ const ERROR_BAR_OFFSET_Y: NumericBinding = NumericBinding {
 
 const SCROLL: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_scroll_row,
-    init: None,
+    init: Some(BitmaskInit {
+        from_profile: |p| {
+            // The Scroll row's choice indices are fixed by build order
+            // (0=Reverse, 1=Split, 2=Alternate, 3=Cross, 4=Centered) and the
+            // ScrollOption bit positions match. The order assertion in
+            // ``scroll_choice_order_matches_scroll_option_bits`` guards the
+            // invariant. We translate per-flag rather than copying ``.0`` so
+            // any future divergence is caught here.
+            use crate::game::profile::ScrollOption;
+            let mut bits = super::super::state::ScrollMask::empty();
+            if p.scroll_option.contains(ScrollOption::Reverse) {
+                bits.insert(super::super::state::ScrollMask::from_bits_retain(1u8 << 0));
+            }
+            if p.scroll_option.contains(ScrollOption::Split) {
+                bits.insert(super::super::state::ScrollMask::from_bits_retain(1u8 << 1));
+            }
+            if p.scroll_option.contains(ScrollOption::Alternate) {
+                bits.insert(super::super::state::ScrollMask::from_bits_retain(1u8 << 2));
+            }
+            if p.scroll_option.contains(ScrollOption::Cross) {
+                bits.insert(super::super::state::ScrollMask::from_bits_retain(1u8 << 3));
+            }
+            if p.scroll_option.contains(ScrollOption::Centered) {
+                bits.insert(super::super::state::ScrollMask::from_bits_retain(1u8 << 4));
+            }
+            bits.bits() as u32
+        },
+        get_active: |m| m.scroll.bits() as u32,
+        set_active: |m, b| {
+            debug_assert_eq!(b & !(u8::MAX as u32), 0, "ScrollMask init bits exceed u8 width");
+            m.scroll = super::super::state::ScrollMask::from_bits_retain(b as u8);
+        },
+        cursor: CursorInit::FirstActiveBit,
+    }),
 };
 const HIDE: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_hide_row,
@@ -224,7 +257,25 @@ const GAMEPLAY_EXTRAS: BitmaskBinding = BitmaskBinding {
 };
 const ERROR_BAR: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_error_bar_row,
-    init: None,
+    init: Some(BitmaskInit {
+        from_profile: |p| {
+            // Profile already stores the desired mask; if it's empty (e.g.
+            // legacy profile or unset) fall back to the canonical mapping
+            // from the visual style + text-mode pair.
+            let mask = if p.error_bar_active_mask.is_empty() {
+                crate::game::profile::error_bar_mask_from_style(p.error_bar, p.error_bar_text)
+            } else {
+                p.error_bar_active_mask
+            };
+            mask.bits() as u32
+        },
+        get_active: |m| m.error_bar.bits() as u32,
+        set_active: |m, b| {
+            debug_assert_eq!(b & !(u8::MAX as u32), 0, "ErrorBarMask init bits exceed u8 width");
+            m.error_bar = crate::game::profile::ErrorBarMask::from_bits_retain(b as u8);
+        },
+        cursor: CursorInit::FirstActiveBit,
+    }),
 };
 const ERROR_BAR_OPTIONS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_error_bar_options_row,
@@ -1114,16 +1165,53 @@ mod bitmask_binding_init_tests {
     fn binding_without_init_is_noop() {
         ensure_i18n();
         let mut row = make_bitmask_row(
-            RowId::Scroll,
-            lookup_key("PlayerOptions", "Scroll"),
-            &["Reverse", "Split", "Alternate", "Cross", "Centered"],
+            RowId::GameplayExtras,
+            lookup_key("PlayerOptions", "GameplayExtras"),
+            &["FlashMiss", "DensityTop", "ColumnCues", "Scorebox"],
         );
         row.selected_choice_index = [3, 4];
         let mut masks = PlayerOptionMasks::default();
         let profile = Profile::default();
-        let applied = init_bitmask_row_from_binding(&mut row, &SCROLL, &profile, &mut masks, 0);
-        assert!(!applied, "SCROLL binding has no init contract yet");
+        let applied = init_bitmask_row_from_binding(&mut row, &GAMEPLAY_EXTRAS, &profile, &mut masks, 0);
+        assert!(!applied, "GAMEPLAY_EXTRAS binding has no init contract yet");
         assert_eq!(row.selected_choice_index, [3, 4], "row untouched");
         assert_eq!(masks, PlayerOptionMasks::default(), "masks untouched");
+    }
+
+    /// Order assertion: Scroll choice index N maps to ScrollMask bit (1 << N)
+    /// maps to ScrollOption variant N. The SCROLL binding's from_profile
+    /// closure relies on this 1:1 ordering; if any of the three orderings
+    /// drifts, this test must fail before reaching production.
+    #[test]
+    fn scroll_choice_order_matches_scroll_option_bits() {
+        use crate::game::profile::ScrollOption;
+        let cases = [
+            (0u8, ScrollOption::Reverse),
+            (1, ScrollOption::Split),
+            (2, ScrollOption::Alternate),
+            (3, ScrollOption::Cross),
+            (4, ScrollOption::Centered),
+        ];
+        for (idx, opt) in cases {
+            let mut profile = Profile::default();
+            profile.scroll_option = opt;
+            let mut row = make_bitmask_row(
+                RowId::Scroll,
+                lookup_key("PlayerOptions", "Scroll"),
+                &["Reverse", "Split", "Alternate", "Cross", "Centered"],
+            );
+            let mut masks = PlayerOptionMasks::default();
+            let applied = init_bitmask_row_from_binding(&mut row, &SCROLL, &profile, &mut masks, 0);
+            assert!(applied, "SCROLL binding has init contract");
+            assert_eq!(
+                masks.scroll.bits(),
+                1u8 << idx,
+                "ScrollOption variant at choice index {idx} must set bit (1 << {idx})",
+            );
+            assert_eq!(
+                row.selected_choice_index[0], idx as usize,
+                "FirstActiveBit cursor lands on choice index {idx}",
+            );
+        }
     }
 }

--- a/src/screens/player_options/panes/advanced.rs
+++ b/src/screens/player_options/panes/advanced.rs
@@ -185,7 +185,8 @@ const HIDE: BitmaskBinding = BitmaskBinding {
         },
         get_active: |m| m.hide.bits() as u32,
         set_active: |m, b| {
-            m.hide = super::super::state::HideMask::from_bits_truncate(b as u8);
+            debug_assert_eq!(b & !(u8::MAX as u32), 0, "HideMask init bits exceed u8 width");
+            m.hide = super::super::state::HideMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::FirstActiveBit,
     }),
@@ -237,7 +238,8 @@ const FA_PLUS_OPTIONS: BitmaskBinding = BitmaskBinding {
         },
         get_active: |m| m.fa_plus.bits() as u32,
         set_active: |m, b| {
-            m.fa_plus = super::super::state::FaPlusMask::from_bits_truncate(b as u8);
+            debug_assert_eq!(b & !(u8::MAX as u32), 0, "FaPlusMask init bits exceed u8 width");
+            m.fa_plus = super::super::state::FaPlusMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::Fixed(0),
     }),

--- a/src/screens/player_options/panes/advanced.rs
+++ b/src/screens/player_options/panes/advanced.rs
@@ -193,7 +193,30 @@ const HIDE: BitmaskBinding = BitmaskBinding {
 };
 const LIFE_BAR_OPTIONS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_life_bar_options_row,
-    init: None,
+    init: Some(BitmaskInit {
+        from_profile: |p| {
+            let mut bits = super::super::state::LifeBarOptionsMask::empty();
+            if p.rainbow_max {
+                bits.insert(super::super::state::LifeBarOptionsMask::RAINBOW_MAX);
+            }
+            if p.responsive_colors {
+                bits.insert(super::super::state::LifeBarOptionsMask::RESPONSIVE_COLORS);
+            }
+            if p.show_life_percent {
+                bits.insert(super::super::state::LifeBarOptionsMask::SHOW_LIFE_PERCENT);
+            }
+            bits.bits() as u32
+        },
+        get_active: |m| m.life_bar_options.bits() as u32,
+        set_active: |m, b| {
+            debug_assert_eq!(
+                b & !(u8::MAX as u32), 0,
+                "LifeBarOptionsMask init bits exceed u8 width",
+            );
+            m.life_bar_options = super::super::state::LifeBarOptionsMask::from_bits_retain(b as u8);
+        },
+        cursor: CursorInit::FirstActiveBit,
+    }),
 };
 const GAMEPLAY_EXTRAS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_gameplay_extras_row,
@@ -205,11 +228,62 @@ const ERROR_BAR: BitmaskBinding = BitmaskBinding {
 };
 const ERROR_BAR_OPTIONS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_error_bar_options_row,
-    init: None,
+    init: Some(BitmaskInit {
+        from_profile: |p| {
+            let mut bits = super::super::state::ErrorBarOptionsMask::empty();
+            if p.error_bar_up {
+                bits.insert(super::super::state::ErrorBarOptionsMask::MOVE_UP);
+            }
+            if p.error_bar_multi_tick {
+                bits.insert(super::super::state::ErrorBarOptionsMask::MULTI_TICK);
+            }
+            bits.bits() as u32
+        },
+        get_active: |m| m.error_bar_options.bits() as u32,
+        set_active: |m, b| {
+            debug_assert_eq!(
+                b & !(u8::MAX as u32), 0,
+                "ErrorBarOptionsMask init bits exceed u8 width",
+            );
+            m.error_bar_options =
+                super::super::state::ErrorBarOptionsMask::from_bits_retain(b as u8);
+        },
+        cursor: CursorInit::FirstActiveBit,
+    }),
 };
 const MEASURE_COUNTER_OPTIONS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_measure_counter_options_row,
-    init: None,
+    init: Some(BitmaskInit {
+        from_profile: |p| {
+            let mut bits = super::super::state::MeasureCounterOptionsMask::empty();
+            if p.measure_counter_left {
+                bits.insert(super::super::state::MeasureCounterOptionsMask::MOVE_LEFT);
+            }
+            if p.measure_counter_up {
+                bits.insert(super::super::state::MeasureCounterOptionsMask::MOVE_UP);
+            }
+            if p.measure_counter_vert {
+                bits.insert(super::super::state::MeasureCounterOptionsMask::VERTICAL_LOOKAHEAD);
+            }
+            if p.broken_run {
+                bits.insert(super::super::state::MeasureCounterOptionsMask::BROKEN_RUN_TOTAL);
+            }
+            if p.run_timer {
+                bits.insert(super::super::state::MeasureCounterOptionsMask::RUN_TIMER);
+            }
+            bits.bits() as u32
+        },
+        get_active: |m| m.measure_counter_options.bits() as u32,
+        set_active: |m, b| {
+            debug_assert_eq!(
+                b & !(u8::MAX as u32), 0,
+                "MeasureCounterOptionsMask init bits exceed u8 width",
+            );
+            m.measure_counter_options =
+                super::super::state::MeasureCounterOptionsMask::from_bits_retain(b as u8);
+        },
+        cursor: CursorInit::FirstActiveBit,
+    }),
 };
 const FA_PLUS_OPTIONS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_fa_plus_row,
@@ -246,11 +320,45 @@ const FA_PLUS_OPTIONS: BitmaskBinding = BitmaskBinding {
 };
 const EARLY_DW_OPTIONS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_early_dw_row,
-    init: None,
+    init: Some(BitmaskInit {
+        from_profile: |p| {
+            let mut bits = super::super::state::EarlyDwMask::empty();
+            if p.hide_early_dw_judgments {
+                bits.insert(super::super::state::EarlyDwMask::HIDE_JUDGMENTS);
+            }
+            if p.hide_early_dw_flash {
+                bits.insert(super::super::state::EarlyDwMask::HIDE_FLASH);
+            }
+            bits.bits() as u32
+        },
+        get_active: |m| m.early_dw.bits() as u32,
+        set_active: |m, b| {
+            debug_assert_eq!(b & !(u8::MAX as u32), 0, "EarlyDwMask init bits exceed u8 width");
+            m.early_dw = super::super::state::EarlyDwMask::from_bits_retain(b as u8);
+        },
+        cursor: CursorInit::FirstActiveBit,
+    }),
 };
 const RESULTS_EXTRAS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_results_extras_row,
-    init: None,
+    init: Some(BitmaskInit {
+        from_profile: |p| {
+            let mut bits = super::super::state::ResultsExtrasMask::empty();
+            if p.track_early_judgments {
+                bits.insert(super::super::state::ResultsExtrasMask::TRACK_EARLY_JUDGMENTS);
+            }
+            bits.bits() as u32
+        },
+        get_active: |m| m.results_extras.bits() as u32,
+        set_active: |m, b| {
+            debug_assert_eq!(
+                b & !(u8::MAX as u32), 0,
+                "ResultsExtrasMask init bits exceed u8 width",
+            );
+            m.results_extras = super::super::state::ResultsExtrasMask::from_bits_retain(b as u8);
+        },
+        cursor: CursorInit::FirstActiveBit,
+    }),
 };
 
 const ACTION_ON_MISSED_TARGET: CustomBinding = CustomBinding {

--- a/src/screens/player_options/panes/advanced.rs
+++ b/src/screens/player_options/panes/advanced.rs
@@ -1,3 +1,4 @@
+use super::super::row::{BitmaskInit, CursorInit};
 use super::super::constants::MINI_INDICATOR_VARIANTS;
 use super::super::row::index_binding;
 use super::*;
@@ -152,33 +153,102 @@ const ERROR_BAR_OFFSET_Y: NumericBinding = NumericBinding {
 
 const SCROLL: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_scroll_row,
+    init: None,
 };
 const HIDE: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_hide_row,
+    init: Some(BitmaskInit {
+        from_profile: |p| {
+            let mut bits = super::super::state::HideMask::empty();
+            if p.hide_targets {
+                bits.insert(super::super::state::HideMask::TARGETS);
+            }
+            if p.hide_song_bg {
+                bits.insert(super::super::state::HideMask::BACKGROUND);
+            }
+            if p.hide_combo {
+                bits.insert(super::super::state::HideMask::COMBO);
+            }
+            if p.hide_lifebar {
+                bits.insert(super::super::state::HideMask::LIFE);
+            }
+            if p.hide_score {
+                bits.insert(super::super::state::HideMask::SCORE);
+            }
+            if p.hide_danger {
+                bits.insert(super::super::state::HideMask::DANGER);
+            }
+            if p.hide_combo_explosions {
+                bits.insert(super::super::state::HideMask::COMBO_EXPLOSIONS);
+            }
+            bits.bits() as u32
+        },
+        get_active: |m| m.hide.bits() as u32,
+        set_active: |m, b| {
+            m.hide = super::super::state::HideMask::from_bits_truncate(b as u8);
+        },
+        cursor: CursorInit::FirstActiveBit,
+    }),
 };
 const LIFE_BAR_OPTIONS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_life_bar_options_row,
+    init: None,
 };
 const GAMEPLAY_EXTRAS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_gameplay_extras_row,
+    init: None,
 };
 const ERROR_BAR: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_error_bar_row,
+    init: None,
 };
 const ERROR_BAR_OPTIONS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_error_bar_options_row,
+    init: None,
 };
 const MEASURE_COUNTER_OPTIONS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_measure_counter_options_row,
+    init: None,
 };
 const FA_PLUS_OPTIONS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_fa_plus_row,
+    init: Some(BitmaskInit {
+        from_profile: |p| {
+            let mut bits = super::super::state::FaPlusMask::empty();
+            if p.show_fa_plus_window {
+                bits.insert(super::super::state::FaPlusMask::WINDOW);
+            }
+            if p.show_ex_score {
+                bits.insert(super::super::state::FaPlusMask::EX_SCORE);
+            }
+            if p.show_hard_ex_score {
+                bits.insert(super::super::state::FaPlusMask::HARD_EX_SCORE);
+            }
+            if p.show_fa_plus_pane {
+                bits.insert(super::super::state::FaPlusMask::PANE);
+            }
+            if p.fa_plus_10ms_blue_window {
+                bits.insert(super::super::state::FaPlusMask::BLUE_WINDOW_10MS);
+            }
+            if p.split_15_10ms {
+                bits.insert(super::super::state::FaPlusMask::SPLIT_15_10MS);
+            }
+            bits.bits() as u32
+        },
+        get_active: |m| m.fa_plus.bits() as u32,
+        set_active: |m, b| {
+            m.fa_plus = super::super::state::FaPlusMask::from_bits_truncate(b as u8);
+        },
+        cursor: CursorInit::Fixed(0),
+    }),
 };
 const EARLY_DW_OPTIONS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_early_dw_row,
+    init: None,
 };
 const RESULTS_EXTRAS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_results_extras_row,
+    init: None,
 };
 
 const ACTION_ON_MISSED_TARGET: CustomBinding = CustomBinding {
@@ -835,4 +905,115 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
         mirror_across_players: false,
     });
     b.finish()
+}
+
+#[cfg(test)]
+mod bitmask_binding_init_tests {
+    use super::*;
+    use super::super::super::row::{init_bitmask_row_from_binding, Row, RowBehavior, RowId};
+    use super::super::super::state::{FaPlusMask, HideMask, PlayerOptionMasks};
+    use crate::assets::i18n::{lookup_key, LookupKey};
+    use crate::game::profile::Profile;
+
+    fn ensure_i18n() {
+        use std::sync::Once;
+        static INIT: Once = Once::new();
+        INIT.call_once(|| {
+            crate::assets::i18n::init("en");
+        });
+    }
+
+    fn make_bitmask_row(id: RowId, name: LookupKey, choices: &[&str]) -> Row {
+        Row {
+            id,
+            behavior: RowBehavior::Bitmask(BitmaskBinding {
+                toggle: |_, _| {},
+                init: None,
+            }),
+            name,
+            choices: choices.iter().map(ToString::to_string).collect(),
+            selected_choice_index: [0, 0],
+            help: Vec::new(),
+            choice_difficulty_indices: None,
+            mirror_across_players: false,
+        }
+    }
+
+    /// HIDE binding's data-driven init must reproduce the bits and cursor
+    /// that the legacy `apply_profile_defaults` path produces for the same
+    /// profile.
+    #[test]
+    fn hide_binding_init_matches_legacy_path() {
+        ensure_i18n();
+        let mut profile = Profile::default();
+        profile.hide_targets = false;
+        profile.hide_song_bg = true;
+        profile.hide_combo = true;
+
+        let mut row = make_bitmask_row(
+            RowId::Hide,
+            lookup_key("PlayerOptions", "Hide"),
+            &["Targets", "BG", "Combo", "Life", "Score", "Danger", "ComboExp"],
+        );
+        let mut masks = PlayerOptionMasks::default();
+        let applied = init_bitmask_row_from_binding(&mut row, &HIDE, &profile, &mut masks, 0);
+        assert!(applied, "HIDE binding has init contract");
+        assert_eq!(
+            masks.hide,
+            HideMask::BACKGROUND | HideMask::COMBO,
+            "data-driven HIDE bits match profile",
+        );
+        assert_eq!(
+            row.selected_choice_index[0], 1,
+            "FirstActiveBit cursor lands on BACKGROUND (index 1)",
+        );
+    }
+
+    /// FA_PLUS_OPTIONS binding's data-driven init must populate the bits
+    /// AND pin the cursor to 0 even when a non-first bit is the only one
+    /// set (Pattern E: cursor=Fixed(0)).
+    #[test]
+    fn fa_plus_binding_init_pins_cursor_to_zero() {
+        ensure_i18n();
+        let mut profile = Profile::default();
+        profile.show_fa_plus_window = false;
+        profile.show_ex_score = true;
+
+        let mut row = make_bitmask_row(
+            RowId::FAPlusOptions,
+            lookup_key("PlayerOptions", "FAPlusOptions"),
+            &["Window", "EX", "HardEX", "Pane", "Blue10", "Split"],
+        );
+        let mut masks = PlayerOptionMasks::default();
+        let applied = init_bitmask_row_from_binding(&mut row, &FA_PLUS_OPTIONS, &profile, &mut masks, 0);
+        assert!(applied, "FA_PLUS_OPTIONS binding has init contract");
+        assert_eq!(
+            masks.fa_plus,
+            FaPlusMask::EX_SCORE,
+            "data-driven FA+ bits match profile",
+        );
+        assert_eq!(
+            row.selected_choice_index[0], 0,
+            "Fixed(0) cursor pins to 0 even though EX_SCORE is the only active bit",
+        );
+    }
+
+    /// Bindings without an init contract must report `false` and leave
+    /// row/masks untouched (legacy init path remains in charge).
+    #[test]
+    fn binding_without_init_is_noop() {
+        ensure_i18n();
+        let mut row = make_bitmask_row(
+            RowId::Scroll,
+            lookup_key("PlayerOptions", "Scroll"),
+            &["Reverse", "Split", "Alternate", "Cross", "Centered"],
+        );
+        row.selected_choice_index = [3, 4];
+        let mut masks = PlayerOptionMasks::default();
+        let profile = Profile::default();
+        let applied = init_bitmask_row_from_binding(&mut row, &SCROLL, &profile, &mut masks, 0);
+        assert!(!applied, "SCROLL binding has no init contract yet");
+        assert_eq!(row.selected_choice_index, [3, 4], "row untouched");
+        assert_eq!(masks, PlayerOptionMasks::default(), "masks untouched");
+    }
 }

--- a/src/screens/player_options/panes/advanced.rs
+++ b/src/screens/player_options/panes/advanced.rs
@@ -253,7 +253,34 @@ const LIFE_BAR_OPTIONS: BitmaskBinding = BitmaskBinding {
 };
 const GAMEPLAY_EXTRAS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_gameplay_extras_row,
-    init: None,
+    init: Some(BitmaskInit {
+        from_profile: |p| {
+            let mut bits = super::super::state::GameplayExtrasMask::empty();
+            if p.column_flash_on_miss {
+                bits.insert(super::super::state::GameplayExtrasMask::FLASH_COLUMN_FOR_MISS);
+            }
+            if p.nps_graph_at_top {
+                bits.insert(super::super::state::GameplayExtrasMask::DENSITY_GRAPH_AT_TOP);
+            }
+            if p.column_cues {
+                bits.insert(super::super::state::GameplayExtrasMask::COLUMN_CUES);
+            }
+            if p.display_scorebox {
+                bits.insert(super::super::state::GameplayExtrasMask::DISPLAY_SCOREBOX);
+            }
+            bits.bits() as u32
+        },
+        get_active: |m| m.gameplay_extras.bits() as u32,
+        set_active: |m, b| {
+            debug_assert_eq!(
+                b & !(u8::MAX as u32), 0,
+                "GameplayExtrasMask init bits exceed u8 width",
+            );
+            m.gameplay_extras =
+                super::super::state::GameplayExtrasMask::from_bits_retain(b as u8);
+        },
+        cursor: CursorInit::FirstActiveBit,
+    }),
 };
 const ERROR_BAR: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_error_bar_row,
@@ -1160,7 +1187,9 @@ mod bitmask_binding_init_tests {
     }
 
     /// Bindings without an init contract must report `false` and leave
-    /// row/masks untouched (legacy init path remains in charge).
+    /// row/masks untouched. Now that all production bindings opt in, this
+    /// guard uses a synthetic init-less binding to assert the contract
+    /// shape directly.
     #[test]
     fn binding_without_init_is_noop() {
         ensure_i18n();
@@ -1172,8 +1201,13 @@ mod bitmask_binding_init_tests {
         row.selected_choice_index = [3, 4];
         let mut masks = PlayerOptionMasks::default();
         let profile = Profile::default();
-        let applied = init_bitmask_row_from_binding(&mut row, &GAMEPLAY_EXTRAS, &profile, &mut masks, 0);
-        assert!(!applied, "GAMEPLAY_EXTRAS binding has no init contract yet");
+        let init_less = BitmaskBinding {
+            toggle: |_, _| {},
+            init: None,
+        };
+        let applied =
+            init_bitmask_row_from_binding(&mut row, &init_less, &profile, &mut masks, 0);
+        assert!(!applied, "init-less binding must short-circuit");
         assert_eq!(row.selected_choice_index, [3, 4], "row untouched");
         assert_eq!(masks, PlayerOptionMasks::default(), "masks untouched");
     }

--- a/src/screens/player_options/panes/main.rs
+++ b/src/screens/player_options/panes/main.rs
@@ -138,7 +138,7 @@ const NOTE_SKIN: CustomBinding = CustomBinding {
                 if should_persist {
                     gp::update_noteskin_for_side(side, setting);
                 }
-                sync_noteskin_previews_for_player(state, player_idx);
+                sync_noteskin_previews_for_player(&mut state.noteskin, &state.player_profiles[player_idx], player_idx);
             },
         )
     },
@@ -163,7 +163,7 @@ const MINE_SKIN: CustomBinding = CustomBinding {
                 if should_persist {
                     gp::update_mine_noteskin_for_side(side, setting);
                 }
-                sync_noteskin_previews_for_player(state, player_idx);
+                sync_noteskin_previews_for_player(&mut state.noteskin, &state.player_profiles[player_idx], player_idx);
             },
         )
     },
@@ -188,7 +188,7 @@ const RECEPTOR_SKIN: CustomBinding = CustomBinding {
                 if should_persist {
                     gp::update_receptor_noteskin_for_side(side, setting);
                 }
-                sync_noteskin_previews_for_player(state, player_idx);
+                sync_noteskin_previews_for_player(&mut state.noteskin, &state.player_profiles[player_idx], player_idx);
             },
         )
     },
@@ -216,7 +216,7 @@ const TAP_EXPLOSION_SKIN: CustomBinding = CustomBinding {
                 if should_persist {
                     gp::update_tap_explosion_noteskin_for_side(side, setting);
                 }
-                sync_noteskin_previews_for_player(state, player_idx);
+                sync_noteskin_previews_for_player(&mut state.noteskin, &state.player_profiles[player_idx], player_idx);
             },
         )
     },

--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -117,13 +117,8 @@ pub(super) fn apply_profile_defaults(
     init_opted_in_bitmask_rows(row_map, profile, &mut masks, player_idx);
 
     let mut scroll_active_mask = ScrollMask::empty();
-    let mut hide_active_mask = HideMask::empty();
-    let mut fa_plus_active_mask = FaPlusMask::empty();
-    let mut early_dw_active_mask = EarlyDwMask::empty();
     let mut gameplay_extras_active_mask = GameplayExtrasMask::empty();
     let mut gameplay_extras_more_active_mask = GameplayExtrasMoreMask::empty();
-    let mut results_extras_active_mask = ResultsExtrasMask::empty();
-    let mut life_bar_options_active_mask = LifeBarOptionsMask::empty();
     let mut error_bar_active_mask = profile.error_bar_active_mask;
     if error_bar_active_mask.is_empty() {
         error_bar_active_mask = crate::game::profile::error_bar_mask_from_style(
@@ -131,8 +126,6 @@ pub(super) fn apply_profile_defaults(
             profile.error_bar_text,
         );
     }
-    let mut error_bar_options_active_mask = ErrorBarOptionsMask::empty();
-    let mut measure_counter_options_active_mask = MeasureCounterOptionsMask::empty();
     let match_ns_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
     let no_tap_label = tr("PlayerOptions", NO_TAP_EXPLOSION_LABEL);
     // Initialize Background Filter row from profile setting (0..=100 %).
@@ -393,53 +386,12 @@ pub(super) fn apply_profile_defaults(
             .unwrap_or(0)
             .min(row.choices.len().saturating_sub(1));
     }
-    if profile.rainbow_max {
-        life_bar_options_active_mask.insert(LifeBarOptionsMask::RAINBOW_MAX);
-    }
-    if profile.responsive_colors {
-        life_bar_options_active_mask.insert(LifeBarOptionsMask::RESPONSIVE_COLORS);
-    }
-    if profile.show_life_percent {
-        life_bar_options_active_mask.insert(LifeBarOptionsMask::SHOW_LIFE_PERCENT);
-    }
-    if let Some(row) = row_map.get_mut(RowId::LifeBarOptions) {
-        if !life_bar_options_active_mask.is_empty() {
-            let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u8 << (*i as u8);
-                    (life_bar_options_active_mask.bits() & bit) != 0
-                })
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
-    }
     if let Some(row) = row_map.get_mut(RowId::ErrorBarTrim) {
         row.selected_choice_index[player_idx] = ERROR_BAR_TRIM_VARIANTS
             .iter()
             .position(|&v| v == profile.error_bar_trim)
             .unwrap_or(0)
             .min(row.choices.len().saturating_sub(1));
-    }
-    if profile.error_bar_up {
-        error_bar_options_active_mask.insert(ErrorBarOptionsMask::MOVE_UP);
-    }
-    if profile.error_bar_multi_tick {
-        error_bar_options_active_mask.insert(ErrorBarOptionsMask::MULTI_TICK);
-    }
-    if let Some(row) = row_map.get_mut(RowId::ErrorBarOptions) {
-        if !error_bar_options_active_mask.is_empty() {
-            let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u8 << (*i as u8);
-                    (error_bar_options_active_mask.bits() & bit) != 0
-                })
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
     }
     // Initialize Measure Counter rows (zmod semantics).
     if let Some(row) = row_map.get_mut(RowId::MeasureCounter) {
@@ -452,34 +404,6 @@ pub(super) fn apply_profile_defaults(
     if let Some(row) = row_map.get_mut(RowId::MeasureCounterLookahead) {
         row.selected_choice_index[player_idx] = (profile.measure_counter_lookahead.min(4) as usize)
             .min(row.choices.len().saturating_sub(1));
-    }
-    if profile.measure_counter_left {
-        measure_counter_options_active_mask.insert(MeasureCounterOptionsMask::MOVE_LEFT);
-    }
-    if profile.measure_counter_up {
-        measure_counter_options_active_mask.insert(MeasureCounterOptionsMask::MOVE_UP);
-    }
-    if profile.measure_counter_vert {
-        measure_counter_options_active_mask.insert(MeasureCounterOptionsMask::VERTICAL_LOOKAHEAD);
-    }
-    if profile.broken_run {
-        measure_counter_options_active_mask.insert(MeasureCounterOptionsMask::BROKEN_RUN_TOTAL);
-    }
-    if profile.run_timer {
-        measure_counter_options_active_mask.insert(MeasureCounterOptionsMask::RUN_TIMER);
-    }
-    if let Some(row) = row_map.get_mut(RowId::MeasureCounterOptions) {
-        if !measure_counter_options_active_mask.is_empty() {
-            let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u8 << (*i as u8);
-                    (measure_counter_options_active_mask.bits() & bit) != 0
-                })
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
     }
     if let Some(row) = row_map.get_mut(RowId::MeasureLines) {
         row.selected_choice_index[player_idx] = MEASURE_LINES_VARIANTS
@@ -506,22 +430,6 @@ pub(super) fn apply_profile_defaults(
             .unwrap_or(0)
             .min(row.choices.len().saturating_sub(1));
     }
-    if profile.track_early_judgments {
-        results_extras_active_mask.insert(ResultsExtrasMask::TRACK_EARLY_JUDGMENTS);
-    }
-    if let Some(row) = row_map.get_mut(RowId::ResultsExtras) {
-        if !results_extras_active_mask.is_empty() {
-            let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u8 << (*i as u8);
-                    (results_extras_active_mask.bits() & bit) != 0
-                })
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
-    }
     if let Some(row) = row_map.get_mut(RowId::MiniIndicator) {
         row.selected_choice_index[player_idx] = MINI_INDICATOR_VARIANTS
             .iter()
@@ -535,49 +443,6 @@ pub(super) fn apply_profile_defaults(
             .position(|&v| v == profile.mini_indicator_score_type)
             .unwrap_or(0)
             .min(row.choices.len().saturating_sub(1));
-    }
-    if let Some(row) = row_map.get_mut(RowId::EarlyDecentWayOffOptions) {
-        if profile.hide_early_dw_judgments {
-            early_dw_active_mask.insert(EarlyDwMask::HIDE_JUDGMENTS);
-        }
-        if profile.hide_early_dw_flash {
-            early_dw_active_mask.insert(EarlyDwMask::HIDE_FLASH);
-        }
-
-        if !early_dw_active_mask.is_empty() {
-            let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u8 << (*i as u8);
-                    (early_dw_active_mask.bits() & bit) != 0
-                })
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
-    }
-    // Initialize FA+ Options row from profile (independent toggles).
-    if let Some(row) = row_map.get_mut(RowId::FAPlusOptions) {
-        // Cursor always starts on the first option; toggled state is reflected visually.
-        row.selected_choice_index[player_idx] = 0;
-    }
-    if profile.show_fa_plus_window {
-        fa_plus_active_mask.insert(FaPlusMask::WINDOW);
-    }
-    if profile.show_ex_score {
-        fa_plus_active_mask.insert(FaPlusMask::EX_SCORE);
-    }
-    if profile.show_hard_ex_score {
-        fa_plus_active_mask.insert(FaPlusMask::HARD_EX_SCORE);
-    }
-    if profile.show_fa_plus_pane {
-        fa_plus_active_mask.insert(FaPlusMask::PANE);
-    }
-    if profile.fa_plus_10ms_blue_window {
-        fa_plus_active_mask.insert(FaPlusMask::BLUE_WINDOW_10MS);
-    }
-    if profile.split_15_10ms {
-        fa_plus_active_mask.insert(FaPlusMask::SPLIT_15_10MS);
     }
     if let Some(row) = row_map.get_mut(RowId::CustomBlueFantasticWindow) {
         row.selected_choice_index[player_idx] = if profile.custom_fantastic_window {
@@ -647,42 +512,6 @@ pub(super) fn apply_profile_defaults(
         }
     }
 
-    // Initialize Hide row from profile (multi-choice toggle group).
-    if profile.hide_targets {
-        hide_active_mask.insert(HideMask::TARGETS);
-    }
-    if profile.hide_song_bg {
-        hide_active_mask.insert(HideMask::BACKGROUND);
-    }
-    if profile.hide_combo {
-        hide_active_mask.insert(HideMask::COMBO);
-    }
-    if profile.hide_lifebar {
-        hide_active_mask.insert(HideMask::LIFE);
-    }
-    if profile.hide_score {
-        hide_active_mask.insert(HideMask::SCORE);
-    }
-    if profile.hide_danger {
-        hide_active_mask.insert(HideMask::DANGER);
-    }
-    if profile.hide_combo_explosions {
-        hide_active_mask.insert(HideMask::COMBO_EXPLOSIONS);
-    }
-    if let Some(row) = row_map.get_mut(RowId::Hide) {
-        if !hide_active_mask.is_empty() {
-            let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u8 << (*i as u8);
-                    (hide_active_mask.bits() & bit) != 0
-                })
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
-    }
-
     // Initialize Scroll row from profile setting (multi-choice toggle group).
     if let Some(row) = row_map.get_mut(RowId::Scroll) {
         use crate::game::profile::ScrollOption;
@@ -734,16 +563,9 @@ pub(super) fn apply_profile_defaults(
             .min(row.choices.len().saturating_sub(1));
     }
     masks.scroll = scroll_active_mask;
-    masks.hide = hide_active_mask;
-    masks.fa_plus = fa_plus_active_mask;
-    masks.early_dw = early_dw_active_mask;
     masks.gameplay_extras = gameplay_extras_active_mask;
     masks.gameplay_extras_more = gameplay_extras_more_active_mask;
-    masks.results_extras = results_extras_active_mask;
-    masks.life_bar_options = life_bar_options_active_mask;
     masks.error_bar = error_bar_active_mask;
-    masks.error_bar_options = error_bar_options_active_mask;
-    masks.measure_counter_options = measure_counter_options_active_mask;
     masks
 }
 

--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -116,16 +116,8 @@ pub(super) fn apply_profile_defaults(
     let mut masks = PlayerOptionMasks::default();
     init_opted_in_bitmask_rows(row_map, profile, &mut masks, player_idx);
 
-    let mut scroll_active_mask = ScrollMask::empty();
     let mut gameplay_extras_active_mask = GameplayExtrasMask::empty();
     let mut gameplay_extras_more_active_mask = GameplayExtrasMoreMask::empty();
-    let mut error_bar_active_mask = profile.error_bar_active_mask;
-    if error_bar_active_mask.is_empty() {
-        error_bar_active_mask = crate::game::profile::error_bar_mask_from_style(
-            profile.error_bar,
-            profile.error_bar_text,
-        );
-    }
     let match_ns_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
     let no_tap_label = tr("PlayerOptions", NO_TAP_EXPLOSION_LABEL);
     // Initialize Background Filter row from profile setting (0..=100 %).
@@ -351,20 +343,6 @@ pub(super) fn apply_profile_defaults(
     if let Some(row) = row_map.get_mut(RowId::OffsetIndicator) {
         row.selected_choice_index[player_idx] = if profile.error_ms_display { 1 } else { 0 };
     }
-    if let Some(row) = row_map.get_mut(RowId::ErrorBar) {
-        if !error_bar_active_mask.is_empty() {
-            let bits = error_bar_active_mask.bits();
-            let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u8 << (*i as u8);
-                    (bits & bit) != 0
-                })
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
-    }
     if let Some(row) = row_map.get_mut(RowId::DataVisualizations) {
         row.selected_choice_index[player_idx] = DATA_VISUALIZATIONS_VARIANTS
             .iter()
@@ -512,42 +490,6 @@ pub(super) fn apply_profile_defaults(
         }
     }
 
-    // Initialize Scroll row from profile setting (multi-choice toggle group).
-    if let Some(row) = row_map.get_mut(RowId::Scroll) {
-        use crate::game::profile::ScrollOption;
-        // Choice indices are fixed by construction order in build_advanced_rows:
-        // 0=Reverse, 1=Split, 2=Alternate, 3=Cross, 4=Centered
-        const REVERSE: usize = 0;
-        const SPLIT: usize = 1;
-        const ALTERNATE: usize = 2;
-        const CROSS: usize = 3;
-        const CENTERED: usize = 4;
-        let flags: &[(ScrollOption, usize)] = &[
-            (ScrollOption::Reverse, REVERSE),
-            (ScrollOption::Split, SPLIT),
-            (ScrollOption::Alternate, ALTERNATE),
-            (ScrollOption::Cross, CROSS),
-            (ScrollOption::Centered, CENTERED),
-        ];
-        for &(flag, idx) in flags {
-            if profile.scroll_option.contains(flag) && idx < row.choices.len() && idx < 8 {
-                scroll_active_mask.insert(ScrollMask::from_bits_truncate(1u8 << (idx as u8)));
-            }
-        }
-
-        // Cursor starts at the first active choice if any, otherwise at the first option.
-        if !scroll_active_mask.is_empty() {
-            let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u8 << (*i as u8);
-                    (scroll_active_mask.bits() & bit) != 0
-                })
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
-    }
     if let Some(row) = row_map.get_mut(RowId::Attacks) {
         row.selected_choice_index[player_idx] = ATTACK_MODE_VARIANTS
             .iter()
@@ -562,10 +504,8 @@ pub(super) fn apply_profile_defaults(
             .unwrap_or(0)
             .min(row.choices.len().saturating_sub(1));
     }
-    masks.scroll = scroll_active_mask;
     masks.gameplay_extras = gameplay_extras_active_mask;
     masks.gameplay_extras_more = gameplay_extras_more_active_mask;
-    masks.error_bar = error_bar_active_mask;
     masks
 }
 

--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -108,14 +108,20 @@ fn find_noteskin_choice_index(
     }
 }
 
+/// Initialize per-row cursor positions from `profile` and accumulate any
+/// bitmask state into `masks`. Production calls this once per (pane, player)
+/// pair, passing the same `&mut PlayerOptionMasks` for both pane calls of a
+/// given player so per-pane mask writes accumulate without needing a merge
+/// step. Each `BitmaskBinding` writes a disjoint mask field, and the derived
+/// pass is a pure function of `profile`, so multiple invocations are safe.
 pub(super) fn apply_profile_defaults(
     row_map: &mut RowMap,
     profile: &crate::game::profile::Profile,
     player_idx: usize,
-) -> PlayerOptionMasks {
-    let mut masks = PlayerOptionMasks::default();
-    init_opted_in_bitmask_rows(row_map, profile, &mut masks, player_idx);
-    apply_derived_masks(profile, &mut masks);
+    masks: &mut PlayerOptionMasks,
+) {
+    init_opted_in_bitmask_rows(row_map, profile, masks, player_idx);
+    apply_derived_masks(profile, masks);
 
     let match_ns_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
     let no_tap_label = tr("PlayerOptions", NO_TAP_EXPLOSION_LABEL);
@@ -460,7 +466,6 @@ pub(super) fn apply_profile_defaults(
             .unwrap_or(0)
             .min(row.choices.len().saturating_sub(1));
     }
-    masks
 }
 
 /// Run the data-driven init contract for every bitmask row whose

--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -117,7 +117,6 @@ pub(super) fn apply_profile_defaults(
     init_opted_in_bitmask_rows(row_map, profile, &mut masks, player_idx);
     apply_derived_masks(profile, &mut masks);
 
-    let mut gameplay_extras_active_mask = GameplayExtrasMask::empty();
     let match_ns_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
     let no_tap_label = tr("PlayerOptions", NO_TAP_EXPLOSION_LABEL);
     // Initialize Background Filter row from profile setting (0..=100 %).
@@ -439,32 +438,6 @@ pub(super) fn apply_profile_defaults(
         }
     }
 
-    // Initialize Gameplay Extras row from profile (multi-choice toggle group).
-    if profile.column_flash_on_miss {
-        gameplay_extras_active_mask.insert(GameplayExtrasMask::FLASH_COLUMN_FOR_MISS);
-    }
-    if profile.nps_graph_at_top {
-        gameplay_extras_active_mask.insert(GameplayExtrasMask::DENSITY_GRAPH_AT_TOP);
-    }
-    if profile.column_cues {
-        gameplay_extras_active_mask.insert(GameplayExtrasMask::COLUMN_CUES);
-    }
-    if profile.display_scorebox {
-        gameplay_extras_active_mask.insert(GameplayExtrasMask::DISPLAY_SCOREBOX);
-    }
-    if let Some(row) = row_map.get_mut(RowId::GameplayExtras) {
-        if !gameplay_extras_active_mask.is_empty() {
-            let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u8 << (*i as u8);
-                    (gameplay_extras_active_mask.bits() & bit) != 0
-                })
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
-    }
     if let Some(row) = row_map.get_mut(RowId::DensityGraphBackground) {
         row.selected_choice_index[player_idx] = if profile.transparent_density_graph_bg {
             1
@@ -487,7 +460,6 @@ pub(super) fn apply_profile_defaults(
             .unwrap_or(0)
             .min(row.choices.len().saturating_sub(1));
     }
-    masks.gameplay_extras = gameplay_extras_active_mask;
     masks
 }
 

--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -115,9 +115,9 @@ pub(super) fn apply_profile_defaults(
 ) -> PlayerOptionMasks {
     let mut masks = PlayerOptionMasks::default();
     init_opted_in_bitmask_rows(row_map, profile, &mut masks, player_idx);
+    apply_derived_masks(profile, &mut masks);
 
     let mut gameplay_extras_active_mask = GameplayExtrasMask::empty();
-    let mut gameplay_extras_more_active_mask = GameplayExtrasMoreMask::empty();
     let match_ns_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
     let no_tap_label = tr("PlayerOptions", NO_TAP_EXPLOSION_LABEL);
     // Initialize Background Filter row from profile setting (0..=100 %).
@@ -448,11 +448,9 @@ pub(super) fn apply_profile_defaults(
     }
     if profile.column_cues {
         gameplay_extras_active_mask.insert(GameplayExtrasMask::COLUMN_CUES);
-        gameplay_extras_more_active_mask.insert(GameplayExtrasMoreMask::COLUMN_CUES);
     }
     if profile.display_scorebox {
         gameplay_extras_active_mask.insert(GameplayExtrasMask::DISPLAY_SCOREBOX);
-        gameplay_extras_more_active_mask.insert(GameplayExtrasMoreMask::DISPLAY_SCOREBOX);
     }
     if let Some(row) = row_map.get_mut(RowId::GameplayExtras) {
         if !gameplay_extras_active_mask.is_empty() {
@@ -475,21 +473,6 @@ pub(super) fn apply_profile_defaults(
         };
     }
 
-    // Initialize Gameplay Extras (More) row from profile (multi-choice toggle group).
-    if let Some(row) = row_map.get_mut(RowId::GameplayExtrasMore) {
-        if !gameplay_extras_more_active_mask.is_empty() {
-            let first_idx = (0..row.choices.len())
-                .find(|i| {
-                    let bit = 1u8 << (*i as u8);
-                    (gameplay_extras_more_active_mask.bits() & bit) != 0
-                })
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
-    }
-
     if let Some(row) = row_map.get_mut(RowId::Attacks) {
         row.selected_choice_index[player_idx] = ATTACK_MODE_VARIANTS
             .iter()
@@ -505,7 +488,6 @@ pub(super) fn apply_profile_defaults(
             .min(row.choices.len().saturating_sub(1));
     }
     masks.gameplay_extras = gameplay_extras_active_mask;
-    masks.gameplay_extras_more = gameplay_extras_more_active_mask;
     masks
 }
 
@@ -534,5 +516,40 @@ fn init_opted_in_bitmask_rows(
         super::row::init_bitmask_row_from_binding(
             row, &binding, profile, masks, player_idx,
         );
+    }
+}
+
+/// Mask fields that are populated as a function of profile state alone, with
+/// no user-facing Row of their own. Each rule writes the entire target field
+/// based on the current profile, so the order of rules is irrelevant. Run
+/// after `init_opted_in_bitmask_rows` so the per-row contracts can no longer
+/// stomp derived state.
+struct DerivedMaskRule {
+    apply: fn(&crate::game::profile::Profile, &mut PlayerOptionMasks),
+}
+
+const DERIVED_MASKS: &[DerivedMaskRule] = &[DerivedMaskRule {
+    // GameplayExtrasMore has no constructed Row; its bits are derived from
+    // sibling profile fields that the GameplayExtras row also reads. Keeping
+    // both reads in one place prevents the two masks from drifting if a new
+    // shared toggle is added later.
+    apply: |profile, masks| {
+        let mut bits = super::state::GameplayExtrasMoreMask::empty();
+        if profile.column_cues {
+            bits.insert(super::state::GameplayExtrasMoreMask::COLUMN_CUES);
+        }
+        if profile.display_scorebox {
+            bits.insert(super::state::GameplayExtrasMoreMask::DISPLAY_SCOREBOX);
+        }
+        masks.gameplay_extras_more = bits;
+    },
+}];
+
+fn apply_derived_masks(
+    profile: &crate::game::profile::Profile,
+    masks: &mut PlayerOptionMasks,
+) {
+    for rule in DERIVED_MASKS {
+        (rule.apply)(profile, masks);
     }
 }

--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -113,14 +113,11 @@ pub(super) fn apply_profile_defaults(
     profile: &crate::game::profile::Profile,
     player_idx: usize,
 ) -> PlayerOptionMasks {
+    let mut masks = PlayerOptionMasks::default();
+    init_opted_in_bitmask_rows(row_map, profile, &mut masks, player_idx);
+
     let mut scroll_active_mask = ScrollMask::empty();
     let mut hide_active_mask = HideMask::empty();
-    let mut insert_active_mask = InsertMask::empty();
-    let mut remove_active_mask = RemoveMask::empty();
-    let mut holds_active_mask = HoldsMask::empty();
-    let mut accel_effects_active_mask = AccelEffectsMask::empty();
-    let mut visual_effects_active_mask = VisualEffectsMask::empty();
-    let mut appearance_effects_active_mask = AppearanceEffectsMask::empty();
     let mut fa_plus_active_mask = FaPlusMask::empty();
     let mut early_dw_active_mask = EarlyDwMask::empty();
     let mut gameplay_extras_active_mask = GameplayExtrasMask::empty();
@@ -722,78 +719,6 @@ pub(super) fn apply_profile_defaults(
             row.selected_choice_index[player_idx] = 0;
         }
     }
-    if let Some(row) = row_map.get_mut(RowId::Insert) {
-        insert_active_mask = profile.insert_active_mask;
-        let bits = insert_active_mask.bits();
-        if bits != 0 {
-            let first_idx = (0..row.choices.len())
-                .find(|i| (bits & (1u8 << (*i as u8))) != 0)
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
-    }
-    if let Some(row) = row_map.get_mut(RowId::Remove) {
-        remove_active_mask = profile.remove_active_mask;
-        let bits = remove_active_mask.bits();
-        if bits != 0 {
-            let first_idx = (0..row.choices.len())
-                .find(|i| (bits & (1u8 << (*i as u8))) != 0)
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
-    }
-    if let Some(row) = row_map.get_mut(RowId::Holds) {
-        holds_active_mask = profile.holds_active_mask;
-        let bits = holds_active_mask.bits();
-        if bits != 0 {
-            let first_idx = (0..row.choices.len())
-                .find(|i| (bits & (1u8 << (*i as u8))) != 0)
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
-    }
-    if let Some(row) = row_map.get_mut(RowId::Accel) {
-        accel_effects_active_mask = profile.accel_effects_active_mask;
-        let bits = accel_effects_active_mask.bits();
-        if bits != 0 {
-            let first_idx = (0..row.choices.len())
-                .find(|i| (bits & (1u8 << (*i as u8))) != 0)
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
-    }
-    if let Some(row) = row_map.get_mut(RowId::Effect) {
-        visual_effects_active_mask = profile.visual_effects_active_mask;
-        let bits = visual_effects_active_mask.bits();
-        if bits != 0 {
-            let first_idx = (0..row.choices.len())
-                .find(|i| (bits & (1u16 << (*i as u16))) != 0)
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
-    }
-    if let Some(row) = row_map.get_mut(RowId::Appearance) {
-        appearance_effects_active_mask = profile.appearance_effects_active_mask;
-        let bits = appearance_effects_active_mask.bits();
-        if bits != 0 {
-            let first_idx = (0..row.choices.len())
-                .find(|i| (bits & (1u8 << (*i as u8))) != 0)
-                .unwrap_or(0);
-            row.selected_choice_index[player_idx] = first_idx;
-        } else {
-            row.selected_choice_index[player_idx] = 0;
-        }
-    }
     if let Some(row) = row_map.get_mut(RowId::Attacks) {
         row.selected_choice_index[player_idx] = ATTACK_MODE_VARIANTS
             .iter()
@@ -808,23 +733,44 @@ pub(super) fn apply_profile_defaults(
             .unwrap_or(0)
             .min(row.choices.len().saturating_sub(1));
     }
-    PlayerOptionMasks {
-        scroll: scroll_active_mask,
-        hide: hide_active_mask,
-        insert: insert_active_mask,
-        remove: remove_active_mask,
-        holds: holds_active_mask,
-        accel_effects: accel_effects_active_mask,
-        visual_effects: visual_effects_active_mask,
-        appearance_effects: appearance_effects_active_mask,
-        fa_plus: fa_plus_active_mask,
-        early_dw: early_dw_active_mask,
-        gameplay_extras: gameplay_extras_active_mask,
-        gameplay_extras_more: gameplay_extras_more_active_mask,
-        results_extras: results_extras_active_mask,
-        life_bar_options: life_bar_options_active_mask,
-        error_bar: error_bar_active_mask,
-        error_bar_options: error_bar_options_active_mask,
-        measure_counter_options: measure_counter_options_active_mask,
+    masks.scroll = scroll_active_mask;
+    masks.hide = hide_active_mask;
+    masks.fa_plus = fa_plus_active_mask;
+    masks.early_dw = early_dw_active_mask;
+    masks.gameplay_extras = gameplay_extras_active_mask;
+    masks.gameplay_extras_more = gameplay_extras_more_active_mask;
+    masks.results_extras = results_extras_active_mask;
+    masks.life_bar_options = life_bar_options_active_mask;
+    masks.error_bar = error_bar_active_mask;
+    masks.error_bar_options = error_bar_options_active_mask;
+    masks.measure_counter_options = measure_counter_options_active_mask;
+    masks
+}
+
+/// Run the data-driven init contract for every bitmask row whose
+/// binding has opted in via `BitmaskBinding::init = Some(_)`. Walks the
+/// row map's display order so behavior is identical to the legacy
+/// per-row branches in `apply_profile_defaults`.
+fn init_opted_in_bitmask_rows(
+    row_map: &mut RowMap,
+    profile: &crate::game::profile::Profile,
+    masks: &mut PlayerOptionMasks,
+    player_idx: usize,
+) {
+    let ids: Vec<RowId> = row_map.display_order().to_vec();
+    for id in ids {
+        let Some(row) = row_map.get(id) else {
+            continue;
+        };
+        let RowBehavior::Bitmask(binding) = row.behavior else {
+            continue;
+        };
+        if binding.init.is_none() {
+            continue;
+        }
+        let row = row_map.get_mut(id).expect("row was just observed");
+        super::row::init_bitmask_row_from_binding(
+            row, &binding, profile, masks, player_idx,
+        );
     }
 }

--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -468,10 +468,6 @@ pub(super) fn apply_profile_defaults(
     }
 }
 
-/// Run the data-driven init contract for every bitmask row whose
-/// binding has opted in via `BitmaskBinding::init = Some(_)`. Walks the
-/// row map's display order so behavior is identical to the legacy
-/// per-row branches in `apply_profile_defaults`.
 fn init_opted_in_bitmask_rows(
     row_map: &mut RowMap,
     profile: &crate::game::profile::Profile,
@@ -501,6 +497,11 @@ fn init_opted_in_bitmask_rows(
 /// based on the current profile, so the order of rules is irrelevant. Run
 /// after `init_opted_in_bitmask_rows` so the per-row contracts can no longer
 /// stomp derived state.
+///
+/// To add a derived mask: append a new `DerivedMaskRule` with an `apply`
+/// closure that reads the relevant `profile` fields and assigns the target
+/// `masks.<field>`. Multiple rules writing the same field are allowed but
+/// discouraged; prefer a single closure that builds the full value.
 struct DerivedMaskRule {
     apply: fn(&crate::game::profile::Profile, &mut PlayerOptionMasks),
 }

--- a/src/screens/player_options/panes/uncommon.rs
+++ b/src/screens/player_options/panes/uncommon.rs
@@ -1,6 +1,10 @@
+use super::super::row::{BitmaskInit, CursorInit};
 use super::super::row::index_binding;
 use super::*;
 use crate::game::profile as gp;
+use crate::game::profile::{
+    AccelEffectsMask, AppearanceEffectsMask, HoldsMask, InsertMask, RemoveMask, VisualEffectsMask,
+};
 
 const ATTACKS: ChoiceBinding<usize> = index_binding!(
     ATTACK_MODE_VARIANTS,
@@ -19,27 +23,84 @@ const HIDE_LIGHT_TYPE: ChoiceBinding<usize> = index_binding!(
 
 const INSERT: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_insert_row,
-    init: None,
+    init: Some(BitmaskInit {
+        from_profile: |p| p.insert_active_mask.bits() as u32,
+        get_active: |m| m.insert.bits() as u32,
+        set_active: |m, b| {
+            debug_assert_eq!(b & !(u8::MAX as u32), 0, "InsertMask init bits exceed u8 width");
+            m.insert = InsertMask::from_bits_retain(b as u8);
+        },
+        cursor: CursorInit::FirstActiveBit,
+    }),
 };
 const REMOVE: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_remove_row,
-    init: None,
+    init: Some(BitmaskInit {
+        from_profile: |p| p.remove_active_mask.bits() as u32,
+        get_active: |m| m.remove.bits() as u32,
+        set_active: |m, b| {
+            debug_assert_eq!(b & !(u8::MAX as u32), 0, "RemoveMask init bits exceed u8 width");
+            m.remove = RemoveMask::from_bits_retain(b as u8);
+        },
+        cursor: CursorInit::FirstActiveBit,
+    }),
 };
 const HOLDS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_holds_row,
-    init: None,
+    init: Some(BitmaskInit {
+        from_profile: |p| p.holds_active_mask.bits() as u32,
+        get_active: |m| m.holds.bits() as u32,
+        set_active: |m, b| {
+            debug_assert_eq!(b & !(u8::MAX as u32), 0, "HoldsMask init bits exceed u8 width");
+            m.holds = HoldsMask::from_bits_retain(b as u8);
+        },
+        cursor: CursorInit::FirstActiveBit,
+    }),
 };
 const ACCEL: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_accel_effects_row,
-    init: None,
+    init: Some(BitmaskInit {
+        from_profile: |p| p.accel_effects_active_mask.bits() as u32,
+        get_active: |m| m.accel_effects.bits() as u32,
+        set_active: |m, b| {
+            debug_assert_eq!(
+                b & !(u8::MAX as u32), 0,
+                "AccelEffectsMask init bits exceed u8 width",
+            );
+            m.accel_effects = AccelEffectsMask::from_bits_retain(b as u8);
+        },
+        cursor: CursorInit::FirstActiveBit,
+    }),
 };
 const EFFECT: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_visual_effects_row,
-    init: None,
+    init: Some(BitmaskInit {
+        from_profile: |p| p.visual_effects_active_mask.bits() as u32,
+        get_active: |m| m.visual_effects.bits() as u32,
+        set_active: |m, b| {
+            debug_assert_eq!(
+                b & !(u16::MAX as u32), 0,
+                "VisualEffectsMask init bits exceed u16 width",
+            );
+            m.visual_effects = VisualEffectsMask::from_bits_retain(b as u16);
+        },
+        cursor: CursorInit::FirstActiveBit,
+    }),
 };
 const APPEARANCE: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_appearance_effects_row,
-    init: None,
+    init: Some(BitmaskInit {
+        from_profile: |p| p.appearance_effects_active_mask.bits() as u32,
+        get_active: |m| m.appearance_effects.bits() as u32,
+        set_active: |m, b| {
+            debug_assert_eq!(
+                b & !(u8::MAX as u32), 0,
+                "AppearanceEffectsMask init bits exceed u8 width",
+            );
+            m.appearance_effects = AppearanceEffectsMask::from_bits_retain(b as u8);
+        },
+        cursor: CursorInit::FirstActiveBit,
+    }),
 };
 
 pub(super) fn build_uncommon_rows(return_screen: Screen) -> RowMap {

--- a/src/screens/player_options/panes/uncommon.rs
+++ b/src/screens/player_options/panes/uncommon.rs
@@ -19,21 +19,27 @@ const HIDE_LIGHT_TYPE: ChoiceBinding<usize> = index_binding!(
 
 const INSERT: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_insert_row,
+    init: None,
 };
 const REMOVE: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_remove_row,
+    init: None,
 };
 const HOLDS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_holds_row,
+    init: None,
 };
 const ACCEL: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_accel_effects_row,
+    init: None,
 };
 const EFFECT: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_visual_effects_row,
+    init: None,
 };
 const APPEARANCE: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_appearance_effects_row,
+    init: None,
 };
 
 pub(super) fn build_uncommon_rows(return_screen: Screen) -> RowMap {

--- a/src/screens/player_options/render.rs
+++ b/src/screens/player_options/render.rs
@@ -1644,85 +1644,59 @@ fn draw_tap_explosion_preview(
 }
 
 fn draw_noteskin_row_preview(actors: &mut Vec<Actor>, rc: &RowCtx, primary_player_idx: usize) {
-    if let Some(ns) = rc.fc.state.noteskin_previews[primary_player_idx]
-        .base
-        .as_ref()
-    {
+    if let Some(ns) = rc.fc.state.noteskin.previews[primary_player_idx].base.as_ref() {
         draw_noteskin_preview(actors, rc, ns, rc.fc.preview_x[primary_player_idx]);
     }
-    if rc.fc.show_p2
-        && primary_player_idx != P2
-        && let Some(ns) = rc.fc.state.noteskin_previews[P2].base.as_ref()
+    if rc.fc.show_p2 && primary_player_idx != P2
+        && let Some(ns) = rc.fc.state.noteskin.previews[P2].base.as_ref()
     {
         draw_noteskin_preview(actors, rc, ns, rc.fc.preview_x[P2]);
     }
 }
 
 fn draw_mineskin_row_preview(actors: &mut Vec<Actor>, rc: &RowCtx, primary_player_idx: usize) {
-    if let Some(mine_ns) = rc.fc.state.noteskin_previews[primary_player_idx]
-        .mine
+    if let Some(mine_ns) = rc.fc.state.noteskin.previews[primary_player_idx].mine
         .as_deref()
-        .or_else(|| {
-            rc.fc.state.noteskin_previews[primary_player_idx]
-                .base
-                .as_deref()
-        })
+        .or_else(|| rc.fc.state.noteskin.previews[primary_player_idx].base.as_deref())
     {
         draw_mine_preview(actors, rc, mine_ns, rc.fc.preview_x[primary_player_idx]);
     }
-    if rc.fc.show_p2
-        && primary_player_idx != P2
-        && let Some(mine_ns) = rc.fc.state.noteskin_previews[P2]
-            .mine
+    if rc.fc.show_p2 && primary_player_idx != P2
+        && let Some(mine_ns) = rc.fc.state.noteskin.previews[P2].mine
             .as_deref()
-            .or_else(|| rc.fc.state.noteskin_previews[P2].base.as_deref())
+            .or_else(|| rc.fc.state.noteskin.previews[P2].base.as_deref())
     {
         draw_mine_preview(actors, rc, mine_ns, rc.fc.preview_x[P2]);
     }
 }
 
 fn draw_receptorskin_row_preview(actors: &mut Vec<Actor>, rc: &RowCtx, primary_player_idx: usize) {
-    if let Some(receptor_ns) = rc.fc.state.noteskin_previews[primary_player_idx]
-        .receptor
+    if let Some(receptor_ns) = rc.fc.state.noteskin.previews[primary_player_idx].receptor
         .as_deref()
-        .or_else(|| {
-            rc.fc.state.noteskin_previews[primary_player_idx]
-                .base
-                .as_deref()
-        })
+        .or_else(|| rc.fc.state.noteskin.previews[primary_player_idx].base.as_deref())
     {
         draw_receptor_preview(actors, rc, receptor_ns, rc.fc.preview_x[primary_player_idx]);
     }
     if rc.fc.show_p2
         && primary_player_idx != P2
-        && let Some(receptor_ns) = rc.fc.state.noteskin_previews[P2]
-            .receptor
+        && let Some(receptor_ns) = rc.fc.state.noteskin.previews[P2].receptor
             .as_deref()
-            .or_else(|| rc.fc.state.noteskin_previews[P2].base.as_deref())
+            .or_else(|| rc.fc.state.noteskin.previews[P2].base.as_deref())
     {
         draw_receptor_preview(actors, rc, receptor_ns, rc.fc.preview_x[P2]);
     }
 }
 
 fn draw_tap_explosion_row_preview(actors: &mut Vec<Actor>, rc: &RowCtx, primary_player_idx: usize) {
-    if !rc.fc.state.player_profiles[primary_player_idx].tap_explosion_noteskin_hidden()
-        && let Some(explosion_ns) = rc.fc.state.noteskin_previews[primary_player_idx]
-            .tap_explosion
+    if !rc.fc.state.player_profiles[primary_player_idx]
+        .tap_explosion_noteskin_hidden()
+        && let Some(explosion_ns) = rc.fc.state.noteskin.previews[primary_player_idx].tap_explosion
             .as_deref()
-            .or_else(|| {
-                rc.fc.state.noteskin_previews[primary_player_idx]
-                    .base
-                    .as_deref()
-            })
+            .or_else(|| rc.fc.state.noteskin.previews[primary_player_idx].base.as_deref())
     {
-        let receptor_ns = rc.fc.state.noteskin_previews[primary_player_idx]
-            .receptor
+        let receptor_ns = rc.fc.state.noteskin.previews[primary_player_idx].receptor
             .as_deref()
-            .or_else(|| {
-                rc.fc.state.noteskin_previews[primary_player_idx]
-                    .base
-                    .as_deref()
-            })
+            .or_else(|| rc.fc.state.noteskin.previews[primary_player_idx].base.as_deref())
             .unwrap_or(explosion_ns);
         draw_tap_explosion_preview(
             actors,
@@ -1735,15 +1709,13 @@ fn draw_tap_explosion_row_preview(actors: &mut Vec<Actor>, rc: &RowCtx, primary_
     if rc.fc.show_p2
         && primary_player_idx != P2
         && !rc.fc.state.player_profiles[P2].tap_explosion_noteskin_hidden()
-        && let Some(explosion_ns) = rc.fc.state.noteskin_previews[P2]
-            .tap_explosion
+        && let Some(explosion_ns) = rc.fc.state.noteskin.previews[P2].tap_explosion
             .as_deref()
-            .or_else(|| rc.fc.state.noteskin_previews[P2].base.as_deref())
+            .or_else(|| rc.fc.state.noteskin.previews[P2].base.as_deref())
     {
-        let receptor_ns = rc.fc.state.noteskin_previews[P2]
-            .receptor
+        let receptor_ns = rc.fc.state.noteskin.previews[P2].receptor
             .as_deref()
-            .or_else(|| rc.fc.state.noteskin_previews[P2].base.as_deref())
+            .or_else(|| rc.fc.state.noteskin.previews[P2].base.as_deref())
             .unwrap_or(explosion_ns);
         draw_tap_explosion_preview(actors, rc, explosion_ns, receptor_ns, rc.fc.preview_x[P2]);
     }

--- a/src/screens/player_options/row.rs
+++ b/src/screens/player_options/row.rs
@@ -149,14 +149,29 @@ pub struct ChoiceBinding<T: Copy + 'static> {
     pub persist_for_side: fn(PlayerSide, T),
 }
 
+/// # Adding a new mask row
+///
+/// 1. Add the bitflags type to `state.rs` (or use one from `game::profile`)
+///    and a field on `PlayerOptionMasks`.
+/// 2. Build the row in the appropriate pane's `build_*_rows` (or its row
+///    catalogue) with `behavior: RowBehavior::Bitmask(MY_BINDING)`.
+/// 3. Declare `const MY_BINDING: BitmaskBinding` in that pane's module
+///    (e.g. `panes/advanced.rs`) with `init: Some(BitmaskInit { ... })`:
+///    - `from_profile` reads the relevant profile fields and emits
+///      `mask.bits() as u32`.
+///    - `set_active` uses `from_bits_retain` plus a `debug_assert_eq!`
+///      width check (so unknown bits in profile-sourced masks are
+///      preserved, matching legacy direct-assignment semantics).
+///    - `cursor: CursorInit::FirstActiveBit` for normal rows, or
+///      `CursorInit::Fixed(0)` for pinned-cursor rows like FA+ Options.
+/// 4. Write the matching `toggle_my_row` helper in `choice.rs`.
 #[derive(Clone, Copy, Debug)]
 pub struct BitmaskBinding {
     pub toggle: fn(&mut State, usize),
     /// Opt-in init contract. When `Some`, a row's initial mask bits and
-    /// cursor position can be derived directly from a `Profile` via the
-    /// helpers in this struct, without going through the hand-written
-    /// branches in `panes/mod.rs::apply_profile_defaults`. `None` means
-    /// the row still relies on the legacy init path.
+    /// cursor position are derived directly from a `Profile` via the
+    /// helpers in `BitmaskInit`. Every production binding currently opts
+    /// in; `None` is reserved for synthetic bindings used in tests.
     pub init: Option<BitmaskInit>,
 }
 
@@ -213,8 +228,8 @@ impl BitmaskInit {
 /// binding's `set_active` semantics — including any masking applied by
 /// `from_bits_retain` — are reflected in cursor placement). Returns
 /// `true` when the binding had an `init` contract and was applied;
-/// `false` when the binding still relies on the legacy init path in
-/// `apply_profile_defaults`.
+/// `false` when the binding has no init (a synthetic test binding or a
+/// future row that has not yet been wired).
 pub fn init_bitmask_row_from_binding(
     row: &mut Row,
     binding: &BitmaskBinding,

--- a/src/screens/player_options/row.rs
+++ b/src/screens/player_options/row.rs
@@ -165,11 +165,13 @@ pub struct BitmaskInit {
     /// Compute the row's initial bits from the player's profile. Returned
     /// as `u32` for type erasure across the 17 different mask widths.
     pub from_profile: fn(&Profile) -> u32,
-    /// Read the row's current bits from a `PlayerOptionMasks`. Used by
-    /// `init_cursor_index` to compute the FirstActiveBit cursor.
+    /// Read the row's current bits from a `PlayerOptionMasks`. Used to
+    /// compute the cursor index from the *stored* (post-`set_active`) value.
     pub get_active: fn(&PlayerOptionMasks) -> u32,
-    /// Write the row's bits into a `PlayerOptionMasks`. Truncated to the
-    /// row's bitflag width.
+    /// Write the row's bits into a `PlayerOptionMasks`. Bindings should use
+    /// `from_bits_retain` (not `from_bits_truncate`) so unknown bits in
+    /// profile-sourced masks are preserved — matching the legacy
+    /// direct-assignment behaviour (`masks.x = profile.x`).
     pub set_active: fn(&mut PlayerOptionMasks, u32),
     /// Cursor placement policy at init time.
     pub cursor: CursorInit,
@@ -206,10 +208,13 @@ impl BitmaskInit {
 }
 
 /// Apply a `BitmaskBinding`'s init contract to a row: compute the bits
-/// from the profile, write them into `masks`, and place the row's cursor
-/// per its `CursorInit` policy. Returns `true` when the binding had an
-/// `init` contract and was applied; `false` when the binding still relies
-/// on the legacy init path in `apply_profile_defaults`.
+/// from the profile, write them into `masks`, then place the row's cursor
+/// based on the bits as **read back from `masks`** via `get_active` (so a
+/// binding's `set_active` semantics — including any masking applied by
+/// `from_bits_retain` — are reflected in cursor placement). Returns
+/// `true` when the binding had an `init` contract and was applied;
+/// `false` when the binding still relies on the legacy init path in
+/// `apply_profile_defaults`.
 pub fn init_bitmask_row_from_binding(
     row: &mut Row,
     binding: &BitmaskBinding,
@@ -222,7 +227,8 @@ pub fn init_bitmask_row_from_binding(
     };
     let bits = (init.from_profile)(profile);
     (init.set_active)(masks, bits);
-    row.selected_choice_index[player_idx] = init.init_cursor_index(bits, row.choices.len());
+    let stored = (init.get_active)(masks);
+    row.selected_choice_index[player_idx] = init.init_cursor_index(stored, row.choices.len());
     true
 }
 

--- a/src/screens/player_options/row.rs
+++ b/src/screens/player_options/row.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::game::profile::{PlayerSide, Profile};
+use super::state::PlayerOptionMasks;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(usize)]
@@ -151,6 +152,78 @@ pub struct ChoiceBinding<T: Copy + 'static> {
 #[derive(Clone, Copy, Debug)]
 pub struct BitmaskBinding {
     pub toggle: fn(&mut State, usize),
+    /// Opt-in init contract. When `Some`, a row's initial mask bits and
+    /// cursor position can be derived directly from a `Profile` via the
+    /// helpers in this struct, without going through the hand-written
+    /// branches in `panes/mod.rs::apply_profile_defaults`. `None` means
+    /// the row still relies on the legacy init path.
+    pub init: Option<BitmaskInit>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct BitmaskInit {
+    /// Compute the row's initial bits from the player's profile. Returned
+    /// as `u32` for type erasure across the 17 different mask widths.
+    pub from_profile: fn(&Profile) -> u32,
+    /// Read the row's current bits from a `PlayerOptionMasks`. Used by
+    /// `init_cursor_index` to compute the FirstActiveBit cursor.
+    pub get_active: fn(&PlayerOptionMasks) -> u32,
+    /// Write the row's bits into a `PlayerOptionMasks`. Truncated to the
+    /// row's bitflag width.
+    pub set_active: fn(&mut PlayerOptionMasks, u32),
+    /// Cursor placement policy at init time.
+    pub cursor: CursorInit,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum CursorInit {
+    /// Cursor lands on the first set bit, or `0` if no bits are set. Used
+    /// by every mask row except `FAPlusOptions`.
+    FirstActiveBit,
+    /// Cursor is pinned to a fixed index regardless of which bits are
+    /// active. Used by `FAPlusOptions` (always 0).
+    Fixed(usize),
+}
+
+impl BitmaskInit {
+    /// Compute the cursor index for a row of `choices_len` choices given
+    /// its currently-active bits (as `u32`).
+    #[inline]
+    pub fn init_cursor_index(&self, active_bits: u32, choices_len: usize) -> usize {
+        match self.cursor {
+            CursorInit::Fixed(idx) => idx,
+            CursorInit::FirstActiveBit => {
+                if active_bits == 0 {
+                    0
+                } else {
+                    (0..choices_len)
+                        .find(|i| (active_bits & (1u32 << *i as u32)) != 0)
+                        .unwrap_or(0)
+                }
+            }
+        }
+    }
+}
+
+/// Apply a `BitmaskBinding`'s init contract to a row: compute the bits
+/// from the profile, write them into `masks`, and place the row's cursor
+/// per its `CursorInit` policy. Returns `true` when the binding had an
+/// `init` contract and was applied; `false` when the binding still relies
+/// on the legacy init path in `apply_profile_defaults`.
+pub fn init_bitmask_row_from_binding(
+    row: &mut Row,
+    binding: &BitmaskBinding,
+    profile: &Profile,
+    masks: &mut PlayerOptionMasks,
+    player_idx: usize,
+) -> bool {
+    let Some(init) = binding.init.as_ref() else {
+        return false;
+    };
+    let bits = (init.from_profile)(profile);
+    (init.set_active)(masks, bits);
+    row.selected_choice_index[player_idx] = init.init_cursor_index(bits, row.choices.len());
+    true
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/screens/player_options/state.rs
+++ b/src/screens/player_options/state.rs
@@ -137,35 +137,6 @@ pub struct PlayerOptionMasks {
     pub measure_counter_options: MeasureCounterOptionsMask,
 }
 
-impl PlayerOptionMasks {
-    /// Field-wise bitwise OR of two mask sets. Used to accumulate the partial
-    /// results of `apply_profile_defaults` across the Main/Advanced/Uncommon
-    /// panes (each pane only populates the masks for rows it contains; the
-    /// rest are left at `Default::default()` and are identity under OR).
-    #[inline]
-    pub fn merge(self, other: Self) -> Self {
-        Self {
-            scroll: self.scroll | other.scroll,
-            hide: self.hide | other.hide,
-            insert: self.insert | other.insert,
-            remove: self.remove | other.remove,
-            holds: self.holds | other.holds,
-            accel_effects: self.accel_effects | other.accel_effects,
-            visual_effects: self.visual_effects | other.visual_effects,
-            appearance_effects: self.appearance_effects | other.appearance_effects,
-            fa_plus: self.fa_plus | other.fa_plus,
-            early_dw: self.early_dw | other.early_dw,
-            gameplay_extras: self.gameplay_extras | other.gameplay_extras,
-            gameplay_extras_more: self.gameplay_extras_more | other.gameplay_extras_more,
-            results_extras: self.results_extras | other.results_extras,
-            life_bar_options: self.life_bar_options | other.life_bar_options,
-            error_bar: self.error_bar | other.error_bar,
-            error_bar_options: self.error_bar_options | other.error_bar_options,
-            measure_counter_options: self.measure_counter_options | other.measure_counter_options,
-        }
-    }
-}
-
 /// Loaded noteskin previews for a single player slot.
 ///
 /// Stored as `[PlayerNoteskinPreviews; PLAYER_SLOTS]` on `NoteskinState` (one

--- a/src/screens/player_options/state.rs
+++ b/src/screens/player_options/state.rs
@@ -168,14 +168,21 @@ impl PlayerOptionMasks {
 
 /// Loaded noteskin previews for a single player slot.
 ///
-/// Stored as `[PlayerNoteskinPreviews; PLAYER_SLOTS]` on `State` (one entry
-/// per player slot).
+/// Stored as `[PlayerNoteskinPreviews; PLAYER_SLOTS]` on `NoteskinState` (one
+/// entry per player slot).
 #[derive(Clone, Default)]
 pub(super) struct PlayerNoteskinPreviews {
     pub(super) base: Option<Arc<Noteskin>>,
     pub(super) mine: Option<Arc<Noteskin>>,
     pub(super) receptor: Option<Arc<Noteskin>>,
     pub(super) tap_explosion: Option<Arc<Noteskin>>,
+}
+
+/// Owns the noteskin loading subsystem: the shared cache and the per-player
+/// resolved previews.
+pub(super) struct NoteskinState {
+    pub(super) cache: HashMap<String, Arc<Noteskin>>,
+    pub(super) previews: [PlayerNoteskinPreviews; PLAYER_SLOTS],
 }
 
 /// Per-player navigation key hold/repeat timing.
@@ -264,8 +271,7 @@ pub struct State {
     pub start_input: [PlayerStartInput; PLAYER_SLOTS],
     pub(super) allow_per_player_global_offsets: bool,
     pub player_profiles: [crate::game::profile::Profile; PLAYER_SLOTS],
-    pub(super) noteskin_cache: HashMap<String, Arc<Noteskin>>,
-    pub(super) noteskin_previews: [PlayerNoteskinPreviews; PLAYER_SLOTS],
+    pub(super) noteskin: NoteskinState,
     pub(super) preview_time: f32,
     pub(super) preview_beat: f32,
     pub(super) help_anim_time: [f32; PLAYER_SLOTS],

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -319,11 +319,41 @@ pub(super) mod tests {
             &["Exit"],
             [0, 0],
         )]);
-        let mut advanced_rows = test_row_map(vec![test_row(
+        let scroll_binding = BitmaskBinding {
+            toggle: super::super::choice::toggle_scroll_row,
+            init: Some(BitmaskInit {
+                from_profile: |p| {
+                    use crate::game::profile::ScrollOption;
+                    let mut bits = ScrollMask::empty();
+                    if p.scroll_option.contains(ScrollOption::Reverse) {
+                        bits.insert(ScrollMask::from_bits_retain(1 << 0));
+                    }
+                    if p.scroll_option.contains(ScrollOption::Split) {
+                        bits.insert(ScrollMask::from_bits_retain(1 << 1));
+                    }
+                    if p.scroll_option.contains(ScrollOption::Alternate) {
+                        bits.insert(ScrollMask::from_bits_retain(1 << 2));
+                    }
+                    if p.scroll_option.contains(ScrollOption::Cross) {
+                        bits.insert(ScrollMask::from_bits_retain(1 << 3));
+                    }
+                    if p.scroll_option.contains(ScrollOption::Centered) {
+                        bits.insert(ScrollMask::from_bits_retain(1 << 4));
+                    }
+                    bits.bits() as u32
+                },
+                get_active: |m| m.scroll.bits() as u32,
+                set_active: |m, b| {
+                    m.scroll = ScrollMask::from_bits_retain(b as u8);
+                },
+                cursor: CursorInit::FirstActiveBit,
+            }),
+        };
+        let mut advanced_rows = test_row_map(vec![test_bitmask_row(
             RowId::Scroll,
             lookup_key("PlayerOptions", "Scroll"),
             &["Reverse", "Split", "Alternate", "Cross", "Centered"],
-            [0, 0],
+            scroll_binding,
         )]);
         let mut uncommon_rows = test_row_map(vec![test_row(
             RowId::Exit,

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -3,12 +3,13 @@ use super::*;
 #[cfg(test)]
 pub(super) mod tests {
     use super::{
-        ErrorBarMask, FaPlusMask, GameplayExtrasMask, GameplayExtrasMoreMask, HUD_OFFSET_MAX,
-        HUD_OFFSET_MIN, HUD_OFFSET_ZERO_INDEX, HideMask, NAV_INITIAL_HOLD_DELAY,
-        NAV_REPEAT_SCROLL_INTERVAL, P1, P2, PlayerOptionMasks, Row, RowId, RowMap, ScrollMask,
-        SpeedMod, SpeedModType, handle_arcade_start_event, handle_start_event, hud_offset_choices,
-        is_row_visible, judgment_tilt_intensity_visible, repeat_held_arcade_start, row_visibility,
-        session_active_players, sync_profile_scroll_speed,
+        BitmaskBinding, BitmaskInit, CursorInit, ErrorBarMask, FaPlusMask, GameplayExtrasMask,
+        GameplayExtrasMoreMask, HUD_OFFSET_MAX, HUD_OFFSET_MIN, HUD_OFFSET_ZERO_INDEX, HideMask,
+        NAV_INITIAL_HOLD_DELAY, NAV_REPEAT_SCROLL_INTERVAL, P1, P2, PlayerOptionMasks, Row,
+        RowBehavior, RowId, RowMap, ScrollMask, SpeedMod, SpeedModType, handle_arcade_start_event,
+        handle_start_event, hud_offset_choices, is_row_visible, judgment_tilt_intensity_visible,
+        repeat_held_arcade_start, row_visibility, session_active_players,
+        sync_profile_scroll_speed,
     };
     use crate::assets::AssetManager;
     use crate::assets::i18n::{LookupKey, lookup_key};
@@ -38,6 +39,24 @@ pub(super) mod tests {
             name,
             choices: choices.iter().map(ToString::to_string).collect(),
             selected_choice_index,
+            help: Vec::new(),
+            choice_difficulty_indices: None,
+            mirror_across_players: false,
+        }
+    }
+
+    fn test_bitmask_row(
+        id: RowId,
+        name: LookupKey,
+        choices: &[&str],
+        binding: BitmaskBinding,
+    ) -> Row {
+        Row {
+            id,
+            behavior: RowBehavior::Bitmask(binding),
+            name,
+            choices: choices.iter().map(ToString::to_string).collect(),
+            selected_choice_index: [0, 0],
             help: Vec::new(),
             choice_difficulty_indices: None,
             mirror_across_players: false,
@@ -344,11 +363,32 @@ pub(super) mod tests {
         profile.hide_targets = false;
         profile.hide_song_bg = true;
 
-        let mut hide_rows = test_row_map(vec![test_row(
+        let hide_binding = BitmaskBinding {
+            toggle: super::super::choice::toggle_hide_row,
+            init: Some(BitmaskInit {
+                from_profile: |p| {
+                    let mut bits = HideMask::empty();
+                    if p.hide_targets { bits.insert(HideMask::TARGETS); }
+                    if p.hide_song_bg { bits.insert(HideMask::BACKGROUND); }
+                    if p.hide_combo { bits.insert(HideMask::COMBO); }
+                    if p.hide_lifebar { bits.insert(HideMask::LIFE); }
+                    if p.hide_score { bits.insert(HideMask::SCORE); }
+                    if p.hide_danger { bits.insert(HideMask::DANGER); }
+                    if p.hide_combo_explosions { bits.insert(HideMask::COMBO_EXPLOSIONS); }
+                    bits.bits() as u32
+                },
+                get_active: |m| m.hide.bits() as u32,
+                set_active: |m, b| {
+                    m.hide = HideMask::from_bits_retain(b as u8);
+                },
+                cursor: CursorInit::FirstActiveBit,
+            }),
+        };
+        let mut hide_rows = test_row_map(vec![test_bitmask_row(
             RowId::Hide,
             lookup_key("PlayerOptions", "Hide"),
             &["Targets", "BG", "Combo", "Life", "Score", "Danger", "ComboExp"],
-            [0, 0],
+            hide_binding,
         )]);
 
         let masks = super::super::panes::apply_profile_defaults(&mut hide_rows, &profile, P1);
@@ -378,11 +418,31 @@ pub(super) mod tests {
         profile.show_fa_plus_window = false;
         profile.show_ex_score = true;
 
-        let mut fa_plus_rows = test_row_map(vec![test_row(
+        let fa_plus_binding = BitmaskBinding {
+            toggle: super::super::choice::toggle_fa_plus_row,
+            init: Some(BitmaskInit {
+                from_profile: |p| {
+                    let mut bits = FaPlusMask::empty();
+                    if p.show_fa_plus_window { bits.insert(FaPlusMask::WINDOW); }
+                    if p.show_ex_score { bits.insert(FaPlusMask::EX_SCORE); }
+                    if p.show_hard_ex_score { bits.insert(FaPlusMask::HARD_EX_SCORE); }
+                    if p.show_fa_plus_pane { bits.insert(FaPlusMask::PANE); }
+                    if p.fa_plus_10ms_blue_window { bits.insert(FaPlusMask::BLUE_WINDOW_10MS); }
+                    if p.split_15_10ms { bits.insert(FaPlusMask::SPLIT_15_10MS); }
+                    bits.bits() as u32
+                },
+                get_active: |m| m.fa_plus.bits() as u32,
+                set_active: |m, b| {
+                    m.fa_plus = FaPlusMask::from_bits_retain(b as u8);
+                },
+                cursor: CursorInit::Fixed(0),
+            }),
+        };
+        let mut fa_plus_rows = test_row_map(vec![test_bitmask_row(
             RowId::FAPlusOptions,
             lookup_key("PlayerOptions", "FAPlusOptions"),
             &["Window", "EX", "HardEX", "Pane", "Blue10", "Split"],
-            [0, 0],
+            fa_plus_binding,
         )]);
 
         let masks = super::super::panes::apply_profile_defaults(&mut fa_plus_rows, &profile, P1);

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -362,21 +362,23 @@ pub(super) mod tests {
             [0, 0],
         )]);
 
-        let main = super::super::panes::apply_profile_defaults(&mut main_rows, &profile, P1);
-        let adv = super::super::panes::apply_profile_defaults(&mut advanced_rows, &profile, P1);
-        let unc = super::super::panes::apply_profile_defaults(&mut uncommon_rows, &profile, P1);
-
+        let mut main = PlayerOptionMasks::default();
+        super::super::panes::apply_profile_defaults(&mut main_rows, &profile, P1, &mut main);
         // Main alone: Scroll row absent, mask comes back empty (the bug source).
         assert_eq!(main.scroll, ScrollMask::empty());
+
         // Accumulated across all three panes (the fix): Reverse + Cross preserved.
-        let combined = main.merge(adv).merge(unc);
+        let mut combined = PlayerOptionMasks::default();
+        super::super::panes::apply_profile_defaults(&mut main_rows, &profile, P1, &mut combined);
+        super::super::panes::apply_profile_defaults(&mut advanced_rows, &profile, P1, &mut combined);
+        super::super::panes::apply_profile_defaults(&mut uncommon_rows, &profile, P1, &mut combined);
         assert!(
             combined.scroll.contains(ScrollMask::REVERSE),
-            "Reverse bit preserved after OR-accumulation"
+            "Reverse bit preserved after in-place accumulation"
         );
         assert!(
             combined.scroll.contains(ScrollMask::CROSS),
-            "Cross bit preserved after OR-accumulation"
+            "Cross bit preserved after in-place accumulation"
         );
     }
 
@@ -421,7 +423,8 @@ pub(super) mod tests {
             hide_binding,
         )]);
 
-        let masks = super::super::panes::apply_profile_defaults(&mut hide_rows, &profile, P1);
+        let mut masks = PlayerOptionMasks::default();
+        super::super::panes::apply_profile_defaults(&mut hide_rows, &profile, P1, &mut masks);
 
         assert_eq!(
             masks.hide,
@@ -475,7 +478,8 @@ pub(super) mod tests {
             fa_plus_binding,
         )]);
 
-        let masks = super::super::panes::apply_profile_defaults(&mut fa_plus_rows, &profile, P1);
+        let mut masks = PlayerOptionMasks::default();
+        super::super::panes::apply_profile_defaults(&mut fa_plus_rows, &profile, P1, &mut masks);
 
         assert_eq!(
             masks.fa_plus,
@@ -539,7 +543,8 @@ pub(super) mod tests {
             gameplay_extras_binding,
         )]);
 
-        let masks = super::super::panes::apply_profile_defaults(&mut rows, &profile, P1);
+        let mut masks = PlayerOptionMasks::default();
+        super::super::panes::apply_profile_defaults(&mut rows, &profile, P1, &mut masks);
 
         assert!(
             masks

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -633,6 +633,7 @@ pub(super) mod tests {
             id: RowId::Scroll,
             behavior: super::RowBehavior::Bitmask(super::BitmaskBinding {
                 toggle: super::choice::toggle_scroll_row,
+                init: None,
             }),
             name: lookup_key("PlayerOptions", "Scroll"),
             choices: ["Reverse", "Split", "Alternate", "Cross", "Centered"]
@@ -927,6 +928,7 @@ pub(super) mod tests {
             id: RowId::Scroll,
             behavior: super::RowBehavior::Bitmask(super::BitmaskBinding {
                 toggle: super::choice::toggle_scroll_row,
+                init: None,
             }),
             name: lookup_key("PlayerOptions", "Scroll"),
             choices: ["Reverse", "Split", "Alternate", "Cross", "Centered"]

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -506,11 +506,37 @@ pub(super) mod tests {
         // No GameplayExtrasMore row exists (orphan; see the
         // `every_row_id_is_constructed_by_some_pane` test) — we still expect
         // the derived mask bits to be populated.
-        let mut rows = test_row_map(vec![test_row(
+        let gameplay_extras_binding = BitmaskBinding {
+            toggle: super::super::choice::toggle_gameplay_extras_row,
+            init: Some(BitmaskInit {
+                from_profile: |p| {
+                    let mut bits = GameplayExtrasMask::empty();
+                    if p.column_flash_on_miss {
+                        bits.insert(GameplayExtrasMask::FLASH_COLUMN_FOR_MISS);
+                    }
+                    if p.nps_graph_at_top {
+                        bits.insert(GameplayExtrasMask::DENSITY_GRAPH_AT_TOP);
+                    }
+                    if p.column_cues {
+                        bits.insert(GameplayExtrasMask::COLUMN_CUES);
+                    }
+                    if p.display_scorebox {
+                        bits.insert(GameplayExtrasMask::DISPLAY_SCOREBOX);
+                    }
+                    bits.bits() as u32
+                },
+                get_active: |m| m.gameplay_extras.bits() as u32,
+                set_active: |m, b| {
+                    m.gameplay_extras = GameplayExtrasMask::from_bits_retain(b as u8);
+                },
+                cursor: CursorInit::FirstActiveBit,
+            }),
+        };
+        let mut rows = test_row_map(vec![test_bitmask_row(
             RowId::GameplayExtras,
             lookup_key("PlayerOptions", "GameplayExtras"),
             &["FlashMiss", "DensityTop", "ColumnCues", "Scorebox"],
-            [0, 0],
+            gameplay_extras_binding,
         )]);
 
         let masks = super::super::panes::apply_profile_defaults(&mut rows, &profile, P1);

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -3,12 +3,12 @@ use super::*;
 #[cfg(test)]
 pub(super) mod tests {
     use super::{
-        ErrorBarMask, HUD_OFFSET_MAX, HUD_OFFSET_MIN, HUD_OFFSET_ZERO_INDEX, HideMask,
-        NAV_INITIAL_HOLD_DELAY, NAV_REPEAT_SCROLL_INTERVAL, P1, P2, PlayerOptionMasks, Row, RowId,
-        RowMap, ScrollMask, SpeedMod, SpeedModType, handle_arcade_start_event, handle_start_event,
-        hud_offset_choices, is_row_visible, judgment_tilt_intensity_visible,
-        repeat_held_arcade_start, row_visibility, session_active_players,
-        sync_profile_scroll_speed,
+        ErrorBarMask, FaPlusMask, GameplayExtrasMask, GameplayExtrasMoreMask, HUD_OFFSET_MAX,
+        HUD_OFFSET_MIN, HUD_OFFSET_ZERO_INDEX, HideMask, NAV_INITIAL_HOLD_DELAY,
+        NAV_REPEAT_SCROLL_INTERVAL, P1, P2, PlayerOptionMasks, Row, RowId, RowMap, ScrollMask,
+        SpeedMod, SpeedModType, handle_arcade_start_event, handle_start_event, hud_offset_choices,
+        is_row_visible, judgment_tilt_intensity_visible, repeat_held_arcade_start, row_visibility,
+        session_active_players, sync_profile_scroll_speed,
     };
     use crate::assets::AssetManager;
     use crate::assets::i18n::{LookupKey, lookup_key};
@@ -328,6 +328,126 @@ pub(super) mod tests {
         assert!(
             combined.scroll.contains(ScrollMask::CROSS),
             "Cross bit preserved after OR-accumulation"
+        );
+    }
+
+    /// Regression guard: bitmask rows initialise their cursor to the
+    /// position of the first active bit. If a future refactor moves mask
+    /// init out of `apply_profile_defaults` (e.g. into a
+    /// `BitmaskBinding`-driven table), this behaviour must be preserved.
+    #[test]
+    fn init_bitmask_row_cursor_starts_at_first_active_bit() {
+        ensure_i18n();
+        let mut profile = Profile::default();
+        // Only the second Hide bit (BACKGROUND, 1 << 1) — cursor must land on
+        // choice index 1, not 0.
+        profile.hide_targets = false;
+        profile.hide_song_bg = true;
+
+        let mut hide_rows = test_row_map(vec![test_row(
+            RowId::Hide,
+            lookup_key("PlayerOptions", "Hide"),
+            &["Targets", "BG", "Combo", "Life", "Score", "Danger", "ComboExp"],
+            [0, 0],
+        )]);
+
+        let masks = super::super::panes::apply_profile_defaults(&mut hide_rows, &profile, P1);
+
+        assert_eq!(
+            masks.hide,
+            HideMask::BACKGROUND,
+            "only BACKGROUND bit should be active",
+        );
+        let row = hide_rows.get(RowId::Hide).expect("Hide row present");
+        assert_eq!(
+            row.selected_choice_index[P1], 1,
+            "cursor must start at the first active bit (BACKGROUND = index 1)",
+        );
+    }
+
+    /// Regression guard: `FAPlusOptions` is the lone bitmask row whose
+    /// cursor always starts at 0, regardless of which bits are active. Any
+    /// data-driven mask-init scheme must preserve this Fixed(0) policy.
+    #[test]
+    fn init_fa_plus_options_cursor_always_zero() {
+        ensure_i18n();
+        let mut profile = Profile::default();
+        // Activate only the second FA+ bit (EX_SCORE = 1 << 1). Under the
+        // generic FirstActiveBit policy the cursor would land on 1; FAPlus
+        // pins it to 0.
+        profile.show_fa_plus_window = false;
+        profile.show_ex_score = true;
+
+        let mut fa_plus_rows = test_row_map(vec![test_row(
+            RowId::FAPlusOptions,
+            lookup_key("PlayerOptions", "FAPlusOptions"),
+            &["Window", "EX", "HardEX", "Pane", "Blue10", "Split"],
+            [0, 0],
+        )]);
+
+        let masks = super::super::panes::apply_profile_defaults(&mut fa_plus_rows, &profile, P1);
+
+        assert_eq!(
+            masks.fa_plus,
+            FaPlusMask::EX_SCORE,
+            "only EX_SCORE bit should be active",
+        );
+        let row = fa_plus_rows
+            .get(RowId::FAPlusOptions)
+            .expect("FAPlusOptions row present");
+        assert_eq!(
+            row.selected_choice_index[P1], 0,
+            "FAPlusOptions cursor must be pinned to 0 even when a non-first bit is active",
+        );
+    }
+
+    /// Regression guard: `GameplayExtrasMore` is a derived mask with no
+    /// constructed Row. Its bits are populated as a side effect of the
+    /// `GameplayExtras` profile processing (`column_cues` and
+    /// `display_scorebox` toggles contribute to BOTH masks). A row-driven
+    /// mask registry must explicitly handle this derivation.
+    #[test]
+    fn init_gameplay_extras_more_derived_from_sibling_profile_fields() {
+        ensure_i18n();
+        let mut profile = Profile::default();
+        profile.column_cues = true;
+        profile.display_scorebox = true;
+
+        // No GameplayExtrasMore row exists (orphan; see the
+        // `every_row_id_is_constructed_by_some_pane` test) — we still expect
+        // the derived mask bits to be populated.
+        let mut rows = test_row_map(vec![test_row(
+            RowId::GameplayExtras,
+            lookup_key("PlayerOptions", "GameplayExtras"),
+            &["FlashMiss", "DensityTop", "ColumnCues", "Scorebox"],
+            [0, 0],
+        )]);
+
+        let masks = super::super::panes::apply_profile_defaults(&mut rows, &profile, P1);
+
+        assert!(
+            masks
+                .gameplay_extras
+                .contains(GameplayExtrasMask::COLUMN_CUES),
+            "GameplayExtras COLUMN_CUES bit set from profile",
+        );
+        assert!(
+            masks
+                .gameplay_extras
+                .contains(GameplayExtrasMask::DISPLAY_SCOREBOX),
+            "GameplayExtras DISPLAY_SCOREBOX bit set from profile",
+        );
+        assert!(
+            masks
+                .gameplay_extras_more
+                .contains(GameplayExtrasMoreMask::COLUMN_CUES),
+            "derived GameplayExtrasMore COLUMN_CUES bit set from sibling profile field",
+        );
+        assert!(
+            masks
+                .gameplay_extras_more
+                .contains(GameplayExtrasMoreMask::DISPLAY_SCOREBOX),
+            "derived GameplayExtrasMore DISPLAY_SCOREBOX bit set from sibling profile field",
         );
     }
 


### PR DESCRIPTION
Eliminate the per-mask-row plumbing in `panes/mod.rs::apply_profile_defaults` and the OR-merge step in `mod.rs::init`. Mask rows now declare how to initialise themselves from the profile alongside their `BitmaskBinding`; a derived-mask table handles the one row-less mask (`GameplayExtrasMore`).

Adding a new mask row goes from "edit `apply_profile_defaults` (per-row branch) + `mod.rs::init` (merge step) + `PlayerOptionMasks::merge` (field-wise OR) + the `BitmaskBinding` declaration" to "the `BitmaskBinding` declaration."

### What's in the contract

`BitmaskBinding` (previously `{ toggle: fn(&mut State, usize) }`) gains an optional `init: BitmaskInit` carrying:

- `from_profile: fn(&Profile) -> u32` - bits derived from the profile.
- `get_active: fn(&PlayerOptionMasks) -> u32` - read-back accessor.
- `set_active: fn(&mut PlayerOptionMasks, u32)` - writer (`from_bits_retain` + width assert preserves forward-compat bits).
- `cursor: CursorInit` - `FirstActiveBit` or `Fixed(usize)`.

A free helper applies the contract per row (compute -> store -> re-read -> place cursor) and another walks `display_order()` and applies it to every binding whose `init.is_some()`. After the per-row pass, `apply_derived_masks` populates `GameplayExtrasMore` from the same profile fields that drive `column_cues` / `display_scorebox` in `GameplayExtras`.

### Patterns covered

All 17 mask fields fit one of six patterns; every pattern is exercised:

| Pattern | Shape | Example rows |
|---|---|---|
| A | Direct profile mask passthrough, `FirstActiveBit` cursor | `Insert`, `Remove`, `Holds`, `Accel`, `Effect`, `Appearance` |
| B | Per-bit profile-bool OR, `FirstActiveBit` cursor | `Hide`, `LifeBarOptions`, `ErrorBarOptions`, `MeasureCounterOptions`, `ResultsExtras`, `EarlyDw`, `GameplayExtras` |
| C | Profile enum bitset -> bits at fixed indices | `Scroll` |
| D | Profile mask + style fallback when empty | `ErrorBar` |
| E | Per-bit profile-bool OR, `Fixed(0)` cursor | `FaPlusOptions` |
| F | Derived sibling mask, no Row, no cursor | `GameplayExtrasMore` (handled via `apply_derived_masks`) |

### What the diff deletes

- All mask-init branches in `apply_profile_defaults` (the per-row local mask accumulators and cursor placement); only the choice-index init for non-bitmask rows remains.
- The 6-call (3 panes x 2 players) `apply_profile_defaults` invocations + `.merge().merge()` accumulation in `mod.rs::init`. Per-pane init now writes in-place against `&mut PlayerOptionMasks`.
- `PlayerOptionMasks::merge`, now dead.

**Behaviour is unchanged.** New regression tests pin the bits and cursor produced by every cursor-init shape (`FirstActiveBit`, `Fixed(0)`, derived-sibling) and a new `scroll_choice_order_matches_scroll_option_bits` assertion locks down the bit-i / choice-index-i / `ScrollOption`-variant-i invariant for Pattern C. 30/30 player_options tests pass.

### Dependencies

- Stacked on #247 (`Player Options: Lift NoteskinState`). Review/merge that one first; this PR's diff against `main` will shrink once #247 lands.
- Next PR will move the cursor-init hook for *non-bitmask* rows onto each binding type (`NumericBinding`, `ChoiceBinding<T>`, `CustomBinding`), completing the data-driven init story.