### PR TITLE
fix(noteskin): play HeldCommand explosion on hold success

### DIFF
--- a/src/game/gameplay.rs
+++ b/src/game/gameplay.rs
@@ -6154,6 +6154,16 @@ fn trigger_tap_explosion(state: &mut State, column: usize, grade: JudgeGrade) {
     let Some(window_key) = grade_to_window(grade) else {
         return;
     };
+    spawn_tap_explosion(state, column, window_key);
+}
+
+pub(super) fn trigger_hold_explosion(state: &mut State, column: usize) {
+    // Hold success uses the noteskin's `HeldCommand` (matching ITGMania), which
+    // is plumbed through the parser as the "Held" pseudo-window.
+    spawn_tap_explosion(state, column, "Held");
+}
+
+fn spawn_tap_explosion(state: &mut State, column: usize, window_key: &str) {
     let player = player_for_col(state, column);
     let spawn_window = tap_explosion_noteskin_for_player(state, player).and_then(|ns| {
         if ns.tap_explosions.contains_key(window_key) {

--- a/src/game/gameplay/holds.rs
+++ b/src/game/gameplay/holds.rs
@@ -1,4 +1,3 @@
-use crate::game::judgment::JudgeGrade;
 use crate::game::note::{HoldData, HoldResult, NoteType};
 use crate::game::timing::TimingData;
 
@@ -8,7 +7,7 @@ use super::{
     apply_life_change, autoplay_blocks_scoring, break_combo_state, capture_failed_ex_score_inputs,
     clear_full_combo_state, current_music_time_s, is_state_dead, player_for_col,
     song_time_ns_delta_seconds, song_time_ns_from_seconds, song_time_ns_invalid,
-    song_time_ns_to_seconds, sync_active_hold_pressed_state, trigger_tap_explosion,
+    song_time_ns_to_seconds, sync_active_hold_pressed_state, trigger_hold_explosion,
     update_itg_grade_totals,
 };
 
@@ -371,7 +370,7 @@ pub(super) fn handle_hold_success(state: &mut State, column: usize, note_index: 
     if !scoring_blocked {
         apply_hold_success_combo_state(&mut state.players[player]);
     }
-    trigger_tap_explosion(state, column, JudgeGrade::Excellent);
+    trigger_hold_explosion(state, column);
     state.hold_judgments[column] = Some(HoldJudgmentRenderInfo {
         result: HoldResult::Held,
         started_at_screen_s: state.total_elapsed_in_screen,

--- a/src/game/parsing/noteskin/mod.rs
+++ b/src/game/parsing/noteskin/mod.rs
@@ -2656,7 +2656,7 @@ fn load_itg_sprite_noteskin_compiled(
                 .or_else(|| bright_sprites.first().copied())
         };
 
-        for window in ["W1", "W2", "W3", "W4", "W5"] {
+        for window in ["W1", "W2", "W3", "W4", "W5", "Held"] {
             let key = format!("{}command", window.to_ascii_lowercase());
             let source = select_tap_explosion_source(window);
             let command = source
@@ -2669,6 +2669,13 @@ fn load_itg_sprite_noteskin_compiled(
                         .or_else(|| data.metrics.get("GhostArrowBright", &metric_key))
                         .map(str::to_string)
                 });
+            // The "Held" pseudo-window is only populated when the noteskin
+            // actually defines a HeldCommand; otherwise hold-success explosions
+            // would silently fall back to a default 0.3s flash on every hold,
+            // which is not what unmodified ITGMania-style noteskins expect.
+            if window == "Held" && command.as_deref().map_or(true, |c| c.trim().is_empty()) {
+                continue;
+            }
             let command_with_init = command.and_then(|cmd| {
                 if cmd.trim().is_empty() {
                     return None;


### PR DESCRIPTION
## Summary

Hold-success explosions previously routed through `JudgeGrade::Excellent`, which always picked the noteskin's `W2` sprite. ITGMania instead fires the GhostArrow tap-explosion actors' `HeldCommand` on hold success, so noteskins that define `HeldCommand` on a different sprite (e.g. a W0/purple-tinted actor) render that sprite for held notes.

Addresses #253 

## Compatibility

For shipped noteskins like `cel`, `devcel-2024`, `vivid`, and `common`, `HeldCommand` is defined on the same actor that already responds to `W2Command`, so the rendered visuals are unchanged. Noteskins that put `HeldCommand` on a separate sprite (the user's case) now correctly use that sprite for hold-success flashes.