### PR TITLE
feat(menus): clamp held-arrow scrolling at boundaries (ITG behavior)

### DIFF
--- a/src/screens/manage_local_profiles.rs
+++ b/src/screens/manage_local_profiles.rs
@@ -80,6 +80,12 @@ enum NavDirection {
     Down,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum NavWrap {
+    Wrap,
+    Clamp,
+}
+
 #[derive(Clone, Debug)]
 struct NameEntryState {
     mode: NameEntryMode,
@@ -198,22 +204,35 @@ fn refresh_rows(state: &mut State) {
     state.prev_selected = state.prev_selected.min(state.rows.len() - 1);
 }
 
-fn move_selected(state: &mut State, dir: NavDirection) {
+fn move_selected(state: &mut State, dir: NavDirection, wrap: NavWrap) {
     let total = state.rows.len();
     if total == 0 {
         state.selected = 0;
         return;
     }
+    let last = total - 1;
     state.prev_selected = state.selected;
     state.selected = match dir {
         NavDirection::Up => {
             if state.selected == 0 {
-                total - 1
+                match wrap {
+                    NavWrap::Wrap => last,
+                    NavWrap::Clamp => 0,
+                }
             } else {
                 state.selected - 1
             }
         }
-        NavDirection::Down => (state.selected + 1) % total,
+        NavDirection::Down => {
+            if state.selected >= last {
+                match wrap {
+                    NavWrap::Wrap => 0,
+                    NavWrap::Clamp => last,
+                }
+            } else {
+                state.selected + 1
+            }
+        }
     };
 }
 
@@ -271,7 +290,7 @@ fn update_hold_scroll(state: &mut State) {
         return;
     }
 
-    move_selected(state, dir);
+    move_selected(state, dir, NavWrap::Clamp);
     state.nav_key_last_scrolled_at = Some(now);
 }
 
@@ -559,8 +578,8 @@ fn activate_selected_row(state: &mut State) -> ScreenAction {
 #[inline(always)]
 fn undo_nav_move(state: &mut State, undo: i8) {
     match undo {
-        1 => move_selected(state, NavDirection::Down),
-        -1 => move_selected(state, NavDirection::Up),
+        1 => move_selected(state, NavDirection::Down, NavWrap::Wrap),
+        -1 => move_selected(state, NavDirection::Up, NavWrap::Wrap),
         _ => {}
     }
 }
@@ -641,13 +660,13 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
             }
             return match nav {
                 screen_input::ThreeKeyMenuAction::Prev => {
-                    move_selected(state, NavDirection::Up);
+                    move_selected(state, NavDirection::Up, NavWrap::Wrap);
                     on_nav_press(state, NavDirection::Up);
                     state.menu_lr_undo = 1;
                     ScreenAction::None
                 }
                 screen_input::ThreeKeyMenuAction::Next => {
-                    move_selected(state, NavDirection::Down);
+                    move_selected(state, NavDirection::Down, NavWrap::Wrap);
                     on_nav_press(state, NavDirection::Down);
                     state.menu_lr_undo = -1;
                     ScreenAction::None
@@ -703,7 +722,7 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
         VirtualAction::p1_back if ev.pressed => return ScreenAction::Navigate(Screen::Options),
         VirtualAction::p1_up | VirtualAction::p1_menu_up => {
             if ev.pressed {
-                move_selected(state, NavDirection::Up);
+                move_selected(state, NavDirection::Up, NavWrap::Wrap);
                 on_nav_press(state, NavDirection::Up);
             } else {
                 on_nav_release(state, NavDirection::Up);
@@ -711,7 +730,7 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
         }
         VirtualAction::p1_down | VirtualAction::p1_menu_down => {
             if ev.pressed {
-                move_selected(state, NavDirection::Down);
+                move_selected(state, NavDirection::Down, NavWrap::Wrap);
                 on_nav_press(state, NavDirection::Down);
             } else {
                 on_nav_release(state, NavDirection::Down);

--- a/src/screens/mappings.rs
+++ b/src/screens/mappings.rs
@@ -155,6 +155,12 @@ pub enum NavDirection {
     Down,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NavWrap {
+    Wrap,
+    Clamp,
+}
+
 /// Which slot (player + primary/secondary) is currently focused.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ActiveSlot {
@@ -278,21 +284,34 @@ const fn total_rows() -> usize {
     NUM_MAPPING_ROWS + 1 // + Exit row
 }
 
-fn move_selection(state: &mut State, dir: NavDirection) {
+fn move_selection(state: &mut State, dir: NavDirection, wrap: NavWrap) {
     let total = total_rows();
     if total == 0 {
         return;
     }
     let old = state.selected_row;
+    let last = total - 1;
     let new = match dir {
         NavDirection::Up => {
             if state.selected_row == 0 {
-                total.saturating_sub(1)
+                match wrap {
+                    NavWrap::Wrap => last,
+                    NavWrap::Clamp => 0,
+                }
             } else {
                 state.selected_row - 1
             }
         }
-        NavDirection::Down => (state.selected_row + 1) % total,
+        NavDirection::Down => {
+            if state.selected_row >= last {
+                match wrap {
+                    NavWrap::Wrap => 0,
+                    NavWrap::Clamp => last,
+                }
+            } else {
+                state.selected_row + 1
+            }
+        }
     };
     if new != old {
         state.selected_row = new;
@@ -443,7 +462,7 @@ pub fn update(state: &mut State, dt: f32) {
         if now.duration_since(held_since) > NAV_INITIAL_HOLD_DELAY
             && now.duration_since(last_scrolled_at) >= NAV_REPEAT_SCROLL_INTERVAL
         {
-            move_selection(state, direction);
+            move_selection(state, direction, NavWrap::Clamp);
             state.nav_key_last_scrolled_at = Some(now);
         }
     }
@@ -596,7 +615,7 @@ pub fn handle_raw_key_event(state: &mut State, key_event: &RawKeyboardEvent) -> 
     match code {
         KeyCode::ArrowUp => {
             if is_pressed {
-                move_selection(state, NavDirection::Up);
+                move_selection(state, NavDirection::Up, NavWrap::Wrap);
                 on_nav_press(state, NavDirection::Up);
             } else {
                 on_nav_release(state, NavDirection::Up);
@@ -604,7 +623,7 @@ pub fn handle_raw_key_event(state: &mut State, key_event: &RawKeyboardEvent) -> 
         }
         KeyCode::ArrowDown => {
             if is_pressed {
-                move_selection(state, NavDirection::Down);
+                move_selection(state, NavDirection::Down, NavWrap::Wrap);
                 on_nav_press(state, NavDirection::Down);
             } else {
                 on_nav_release(state, NavDirection::Down);
@@ -767,7 +786,7 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
             return match nav {
                 screen_input::ThreeKeyMenuAction::Prev => {
                     if matches!(state.three_key_focus, ThreeKeyFocus::Row) {
-                        move_selection(state, NavDirection::Up);
+                        move_selection(state, NavDirection::Up, NavWrap::Wrap);
                         on_nav_press(state, NavDirection::Up);
                         state.menu_lr_undo_row = 1;
                     } else if state.selected_row < NUM_MAPPING_ROWS {
@@ -780,7 +799,7 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
                 }
                 screen_input::ThreeKeyMenuAction::Next => {
                     if matches!(state.three_key_focus, ThreeKeyFocus::Row) {
-                        move_selection(state, NavDirection::Down);
+                        move_selection(state, NavDirection::Down, NavWrap::Wrap);
                         on_nav_press(state, NavDirection::Down);
                         state.menu_lr_undo_row = -1;
                     } else if state.selected_row < NUM_MAPPING_ROWS {
@@ -821,8 +840,8 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
                         ScreenAction::None
                     } else {
                         match state.menu_lr_undo_row {
-                            1 => move_selection(state, NavDirection::Down),
-                            -1 => move_selection(state, NavDirection::Up),
+                            1 => move_selection(state, NavDirection::Down, NavWrap::Wrap),
+                            -1 => move_selection(state, NavDirection::Up, NavWrap::Wrap),
                             _ => {}
                         }
                         state.menu_lr_undo_row = 0;
@@ -842,7 +861,7 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
         | VirtualAction::p2_up
         | VirtualAction::p2_menu_up => {
             if ev.pressed {
-                move_selection(state, NavDirection::Up);
+                move_selection(state, NavDirection::Up, NavWrap::Wrap);
                 on_nav_press(state, NavDirection::Up);
             } else {
                 on_nav_release(state, NavDirection::Up);
@@ -853,7 +872,7 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
         | VirtualAction::p2_down
         | VirtualAction::p2_menu_down => {
             if ev.pressed {
-                move_selection(state, NavDirection::Down);
+                move_selection(state, NavDirection::Down, NavWrap::Wrap);
                 on_nav_press(state, NavDirection::Down);
             } else {
                 on_nav_release(state, NavDirection::Down);

--- a/src/screens/options.rs
+++ b/src/screens/options.rs
@@ -627,6 +627,12 @@ pub enum NavDirection {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NavWrap {
+    Wrap,
+    Clamp,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SubmenuKind {
     System,
     Graphics,
@@ -5046,24 +5052,38 @@ fn move_submenu_selection_vertical(
     asset_manager: &AssetManager,
     kind: SubmenuKind,
     dir: NavDirection,
+    wrap: NavWrap,
 ) {
     let total = submenu_total_rows(state, kind);
     if total == 0 {
         return;
     }
     let current_row = state.sub_selected.min(total.saturating_sub(1));
+    let last = total - 1;
     if !state.sub_inline_x.is_finite() {
         sync_submenu_inline_x_from_row(state, asset_manager, kind, current_row);
     }
     state.sub_selected = match dir {
         NavDirection::Up => {
             if current_row == 0 {
-                total - 1
+                match wrap {
+                    NavWrap::Wrap => last,
+                    NavWrap::Clamp => 0,
+                }
             } else {
                 current_row - 1
             }
         }
-        NavDirection::Down => (current_row + 1) % total,
+        NavDirection::Down => {
+            if current_row >= last {
+                match wrap {
+                    NavWrap::Wrap => 0,
+                    NavWrap::Clamp => last,
+                }
+            } else {
+                current_row + 1
+            }
+        }
     };
     apply_submenu_inline_x_to_row(state, asset_manager, kind, state.sub_selected);
 }
@@ -7614,23 +7634,24 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
                 OptionsView::Main => {
                     let total = ITEMS.len();
                     if total > 0 {
+                        let last = total - 1;
                         match direction {
                             NavDirection::Up => {
-                                state.selected = if state.selected == 0 {
-                                    total - 1
-                                } else {
-                                    state.selected - 1
-                                };
+                                if state.selected > 0 {
+                                    state.selected -= 1;
+                                }
                             }
                             NavDirection::Down => {
-                                state.selected = (state.selected + 1) % total;
+                                if state.selected < last {
+                                    state.selected += 1;
+                                }
                             }
                         }
                         state.nav_key_last_scrolled_at = Some(now);
                     }
                 }
                 OptionsView::Submenu(kind) => {
-                    move_submenu_selection_vertical(state, asset_manager, kind, direction);
+                    move_submenu_selection_vertical(state, asset_manager, kind, direction, NavWrap::Clamp);
                     state.nav_key_last_scrolled_at = Some(now);
                 }
             }
@@ -7648,9 +7669,9 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
             && matches!(state.view, OptionsView::Submenu(_))
         {
             if pending_action.is_none() {
-                pending_action = apply_submenu_choice_delta(state, asset_manager, delta_lr);
+                pending_action = apply_submenu_choice_delta(state, asset_manager, delta_lr, NavWrap::Clamp);
             } else {
-                apply_submenu_choice_delta(state, asset_manager, delta_lr);
+                apply_submenu_choice_delta(state, asset_manager, delta_lr, NavWrap::Clamp);
             }
             state.nav_lr_last_adjusted_at = Some(now);
         }
@@ -7807,6 +7828,7 @@ fn apply_submenu_choice_delta(
     state: &mut State,
     asset_manager: &AssetManager,
     delta: isize,
+    wrap: NavWrap,
 ) -> Option<ScreenAction> {
     if !matches!(state.submenu_transition, SubmenuTransition::None) {
         return None;
@@ -8007,7 +8029,11 @@ fn apply_submenu_choice_delta(
         submenu_cursor_indices(state, kind)[row_index].min(num_choices.saturating_sub(1));
     let cur = choice_index as isize;
     let n = num_choices as isize;
-    let mut new_index = ((cur + delta).rem_euclid(n)) as usize;
+    let raw = cur + delta;
+    let mut new_index = match wrap {
+        NavWrap::Wrap => raw.rem_euclid(n) as usize,
+        NavWrap::Clamp => raw.clamp(0, n - 1) as usize,
+    };
     if new_index >= num_choices {
         new_index = num_choices.saturating_sub(1);
     }
@@ -8379,7 +8405,7 @@ fn undo_three_key_selection(state: &mut State, asset_manager: &AssetManager) {
                 }
             }
             OptionsView::Submenu(kind) => {
-                move_submenu_selection_vertical(state, asset_manager, kind, NavDirection::Down);
+                move_submenu_selection_vertical(state, asset_manager, kind, NavDirection::Down, NavWrap::Wrap);
             }
         },
         -1 => match state.view {
@@ -8394,7 +8420,7 @@ fn undo_three_key_selection(state: &mut State, asset_manager: &AssetManager) {
                 }
             }
             OptionsView::Submenu(kind) => {
-                move_submenu_selection_vertical(state, asset_manager, kind, NavDirection::Up);
+                move_submenu_selection_vertical(state, asset_manager, kind, NavDirection::Up, NavWrap::Wrap);
             }
         },
         _ => {}
@@ -8692,7 +8718,7 @@ fn activate_current_selection(state: &mut State, asset_manager: &AssetManager) -
                 }
             }
             if screen_input::dedicated_three_key_nav_enabled()
-                && let Some(action) = apply_submenu_choice_delta(state, asset_manager, 1)
+                && let Some(action) = apply_submenu_choice_delta(state, asset_manager, 1, NavWrap::Wrap)
             {
                 return action;
             }
@@ -8936,6 +8962,7 @@ pub fn handle_input(
                             asset_manager,
                             kind,
                             NavDirection::Up,
+                            NavWrap::Wrap,
                         );
                     }
                 }
@@ -8957,6 +8984,7 @@ pub fn handle_input(
                             asset_manager,
                             kind,
                             NavDirection::Down,
+                            NavWrap::Wrap,
                         );
                     }
                 }
@@ -9004,6 +9032,7 @@ pub fn handle_input(
                             asset_manager,
                             kind,
                             NavDirection::Up,
+                            NavWrap::Wrap,
                         );
                     }
                 }
@@ -9030,6 +9059,7 @@ pub fn handle_input(
                             asset_manager,
                             kind,
                             NavDirection::Down,
+                            NavWrap::Wrap,
                         );
                     }
                 }
@@ -9043,7 +9073,7 @@ pub fn handle_input(
         | VirtualAction::p2_left
         | VirtualAction::p2_menu_left => {
             if ev.pressed {
-                if let Some(action) = apply_submenu_choice_delta(state, asset_manager, -1) {
+                if let Some(action) = apply_submenu_choice_delta(state, asset_manager, -1, NavWrap::Wrap) {
                     on_lr_press(state, -1);
                     return action;
                 }
@@ -9057,7 +9087,7 @@ pub fn handle_input(
         | VirtualAction::p2_right
         | VirtualAction::p2_menu_right => {
             if ev.pressed {
-                if let Some(action) = apply_submenu_choice_delta(state, asset_manager, 1) {
+                if let Some(action) = apply_submenu_choice_delta(state, asset_manager, 1, NavWrap::Wrap) {
                     on_lr_press(state, 1);
                     return action;
                 }

--- a/src/screens/player_options/choice.rs
+++ b/src/screens/player_options/choice.rs
@@ -74,6 +74,7 @@ pub(super) fn cycle_choice_index(
     player_idx: usize,
     row_id: RowId,
     delta: isize,
+    wrap: NavWrap,
 ) -> Option<usize> {
     let row = state.pane_mut().row_map.get_mut(row_id)?;
     let n = row.choices.len();
@@ -81,7 +82,11 @@ pub(super) fn cycle_choice_index(
         return None;
     }
     let cur = row.selected_choice_index[player_idx] as isize;
-    let new_index = (cur + delta).rem_euclid(n as isize) as usize;
+    let raw = cur + delta;
+    let new_index = match wrap {
+        NavWrap::Wrap => raw.rem_euclid(n as isize) as usize,
+        NavWrap::Clamp => raw.clamp(0, (n as isize) - 1) as usize,
+    };
     row.selected_choice_index[player_idx] = new_index;
     Some(new_index)
 }
@@ -94,6 +99,7 @@ pub(super) fn dispatch_behavior_delta(
     asset_manager: &AssetManager,
     player_idx: usize,
     delta: isize,
+    wrap: NavWrap,
 ) {
     if state.pane().row_map.is_empty() {
         return;
@@ -114,9 +120,9 @@ pub(super) fn dispatch_behavior_delta(
     };
 
     let outcome = match behavior {
-        RowBehavior::Numeric(b) => apply_numeric(state, player_idx, id, delta, b),
-        RowBehavior::Cycle(b) => apply_cycle(state, player_idx, id, delta, &b),
-        RowBehavior::Custom(b) => (b.apply)(state, player_idx, id, delta),
+        RowBehavior::Numeric(b) => apply_numeric(state, player_idx, id, delta, b, wrap),
+        RowBehavior::Cycle(b) => apply_cycle(state, player_idx, id, delta, &b, wrap),
+        RowBehavior::Custom(b) => (b.apply)(state, player_idx, id, delta, wrap),
         RowBehavior::Bitmask(_) => Outcome::NONE,
         RowBehavior::Exit => Outcome::NONE,
     };
@@ -157,8 +163,9 @@ fn apply_numeric(
     id: RowId,
     delta: isize,
     binding: NumericBinding,
+    wrap: NavWrap,
 ) -> Outcome {
-    let new_index = match cycle_choice_index(state, player_idx, id, delta) {
+    let new_index = match cycle_choice_index(state, player_idx, id, delta, wrap) {
         Some(i) => i,
         None => return Outcome::NONE,
     };
@@ -183,8 +190,9 @@ fn apply_cycle(
     id: RowId,
     delta: isize,
     binding: &CycleBinding,
+    wrap: NavWrap,
 ) -> Outcome {
-    let new_index = match cycle_choice_index(state, player_idx, id, delta) {
+    let new_index = match cycle_choice_index(state, player_idx, id, delta, wrap) {
         Some(i) => i,
         None => return Outcome::NONE,
     };
@@ -201,8 +209,9 @@ pub(super) fn change_choice_for_player(
     asset_manager: &AssetManager,
     player_idx: usize,
     delta: isize,
+    wrap: NavWrap,
 ) {
-    dispatch_behavior_delta(state, asset_manager, player_idx, delta);
+    dispatch_behavior_delta(state, asset_manager, player_idx, delta, wrap);
 }
 
 pub fn apply_choice_delta(
@@ -210,6 +219,7 @@ pub fn apply_choice_delta(
     asset_manager: &AssetManager,
     player_idx: usize,
     delta: isize,
+    wrap: NavWrap,
 ) {
     if state.pane().row_map.is_empty() {
         return;
@@ -225,15 +235,15 @@ pub fn apply_choice_delta(
         && row_supports_inline_nav(row)
     {
         if state.current_pane == OptionsPane::Main || row_selects_on_focus_move(row.id) {
-            change_choice_for_player(state, asset_manager, idx, delta);
+            change_choice_for_player(state, asset_manager, idx, delta, wrap);
             return;
         }
-        if move_inline_focus(state, asset_manager, idx, delta) {
+        if move_inline_focus(state, asset_manager, idx, delta, wrap) {
             audio::play_sfx("assets/sounds/change_value.ogg");
         }
         return;
     }
-    change_choice_for_player(state, asset_manager, player_idx, delta);
+    change_choice_for_player(state, asset_manager, player_idx, delta, wrap);
 }
 
 pub(super) fn toggle_scroll_row(state: &mut State, player_idx: usize) {

--- a/src/screens/player_options/inline_nav.rs
+++ b/src/screens/player_options/inline_nav.rs
@@ -76,6 +76,7 @@ pub(super) fn move_inline_focus(
     asset_manager: &AssetManager,
     player_idx: usize,
     delta: isize,
+    wrap: NavWrap,
 ) -> bool {
     if state.pane().row_map.is_empty() || delta == 0 {
         return false;
@@ -117,7 +118,14 @@ pub(super) fn move_inline_focus(
         return false;
     };
     let n = centers.len() as isize;
-    let next_idx = ((current_idx as isize + delta).rem_euclid(n)) as usize;
+    let raw = current_idx as isize + delta;
+    let next_idx = match wrap {
+        NavWrap::Wrap => raw.rem_euclid(n) as usize,
+        NavWrap::Clamp => raw.clamp(0, n - 1) as usize,
+    };
+    if next_idx == current_idx {
+        return false;
+    }
     state.pane_mut().inline_choice_x[idx] = centers[next_idx];
     true
 }
@@ -209,6 +217,7 @@ pub(super) fn move_selection_vertical(
     active: [bool; PLAYER_SLOTS],
     player_idx: usize,
     dir: NavDirection,
+    wrap: NavWrap,
 ) {
     if !matches!(dir, NavDirection::Up | NavDirection::Down) || state.pane().row_map.is_empty() {
         return;
@@ -230,7 +239,9 @@ pub(super) fn move_selection_vertical(
             sync_inline_intent_from_row(state, asset_manager, idx, current_row);
         }
     }
-    if let Some(next_row) = next_visible_row(&state.pane().row_map, current_row, dir, visibility) {
+    if let Some(next_row) =
+        next_visible_row(&state.pane().row_map, current_row, dir, visibility, wrap)
+    {
         state.pane_mut().selected_row[idx] = next_row;
         state.pane_mut().arcade_row_focus[idx] = row_allows_arcade_next_row(state, next_row);
         apply_inline_intent_to_row(state, asset_manager, idx, next_row);

--- a/src/screens/player_options/input.rs
+++ b/src/screens/player_options/input.rs
@@ -33,7 +33,14 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
         }
         match direction {
             NavDirection::Up => {
-                move_selection_vertical(state, asset_manager, active, player_idx, NavDirection::Up);
+                move_selection_vertical(
+                    state,
+                    asset_manager,
+                    active,
+                    player_idx,
+                    NavDirection::Up,
+                    NavWrap::Clamp,
+                );
             }
             NavDirection::Down => {
                 move_selection_vertical(
@@ -42,16 +49,17 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
                     active,
                     player_idx,
                     NavDirection::Down,
+                    NavWrap::Clamp,
                 );
             }
             NavDirection::Left => {
                 if !move_arcade_horizontal_focus(state, asset_manager, player_idx, -1) {
-                    apply_choice_delta(state, asset_manager, player_idx, -1);
+                    apply_choice_delta(state, asset_manager, player_idx, -1, NavWrap::Clamp);
                 }
             }
             NavDirection::Right => {
                 if !move_arcade_horizontal_focus(state, asset_manager, player_idx, 1) {
-                    apply_choice_delta(state, asset_manager, player_idx, 1);
+                    apply_choice_delta(state, asset_manager, player_idx, 1, NavWrap::Clamp);
                 }
             }
         }
@@ -382,19 +390,25 @@ pub(super) fn handle_nav_event(
     if pressed {
         sync_selected_rows_with_visibility(state, active);
         match dir {
-            NavDirection::Up => {
-                move_selection_vertical(state, asset_manager, active, player_idx, NavDirection::Up)
-            }
+            NavDirection::Up => move_selection_vertical(
+                state,
+                asset_manager,
+                active,
+                player_idx,
+                NavDirection::Up,
+                NavWrap::Wrap,
+            ),
             NavDirection::Down => move_selection_vertical(
                 state,
                 asset_manager,
                 active,
                 player_idx,
                 NavDirection::Down,
+                NavWrap::Wrap,
             ),
             NavDirection::Left => {
                 if !move_arcade_horizontal_focus(state, asset_manager, player_idx, -1) {
-                    apply_choice_delta(state, asset_manager, player_idx, -1);
+                    apply_choice_delta(state, asset_manager, player_idx, -1, NavWrap::Wrap);
                     if arcade_row_uses_choice_focus(state, player_idx) {
                         state.pane_mut().arcade_row_focus[player_idx.min(PLAYER_SLOTS - 1)] = false;
                     }
@@ -402,7 +416,7 @@ pub(super) fn handle_nav_event(
             }
             NavDirection::Right => {
                 if !move_arcade_horizontal_focus(state, asset_manager, player_idx, 1) {
-                    apply_choice_delta(state, asset_manager, player_idx, 1);
+                    apply_choice_delta(state, asset_manager, player_idx, 1, NavWrap::Wrap);
                     if arcade_row_uses_choice_focus(state, player_idx) {
                         state.pane_mut().arcade_row_focus[player_idx.min(PLAYER_SLOTS - 1)] = false;
                     }
@@ -513,7 +527,7 @@ pub(super) fn move_arcade_horizontal_focus(
         return false;
     }
     if row_supports_inline {
-        apply_choice_delta(state, asset_manager, idx, delta);
+        apply_choice_delta(state, asset_manager, idx, delta, NavWrap::Wrap);
         return true;
     }
     if num_choices <= 1 {
@@ -527,7 +541,7 @@ pub(super) fn move_arcade_horizontal_focus(
         if current_choice == 0 {
             audio::play_sfx("assets/sounds/change_value.ogg");
         } else {
-            change_choice_for_player(state, asset_manager, idx, -(current_choice as isize));
+            change_choice_for_player(state, asset_manager, idx, -(current_choice as isize), NavWrap::Wrap);
         }
         return true;
     }
@@ -537,13 +551,13 @@ pub(super) fn move_arcade_horizontal_focus(
             audio::play_sfx("assets/sounds/change_value.ogg");
             return true;
         }
-        change_choice_for_player(state, asset_manager, idx, -1);
+        change_choice_for_player(state, asset_manager, idx, -1, NavWrap::Wrap);
         return true;
     }
     if current_choice + 1 >= num_choices {
         return false;
     }
-    change_choice_for_player(state, asset_manager, idx, 1);
+    change_choice_for_player(state, asset_manager, idx, 1, NavWrap::Wrap);
     true
 }
 
@@ -559,7 +573,7 @@ pub(super) fn handle_arcade_prev_event(
     let idx = player_idx.min(PLAYER_SLOTS - 1);
     let prev_row = state.pane().selected_row[idx];
     clear_nav_hold(state, player_idx);
-    move_selection_vertical(state, asset_manager, active, player_idx, NavDirection::Up);
+    move_selection_vertical(state, asset_manager, active, player_idx, NavDirection::Up, NavWrap::Wrap);
     if state.pane().selected_row[idx] != prev_row {
         audio::play_sfx("assets/sounds/prev_row.ogg");
         state.help_anim_time[idx] = 0.0;
@@ -592,7 +606,7 @@ pub(super) fn handle_arcade_start_event(
         state.pane_mut().arcade_row_focus[idx] = row_allows_arcade_next_row(state, row_index);
         return action;
     }
-    move_selection_vertical(state, asset_manager, active, idx, NavDirection::Down);
+    move_selection_vertical(state, asset_manager, active, idx, NavDirection::Down, NavWrap::Wrap);
     state.pane_mut().arcade_row_focus[idx] =
         row_allows_arcade_next_row(state, state.pane().selected_row[idx]);
     None
@@ -626,7 +640,7 @@ pub(super) fn handle_start_event(
     if row_supports_inline {
         let changed = commit_inline_focus_selection(state, asset_manager, player_idx, row_index);
         if changed && !row_toggles {
-            change_choice_for_player(state, asset_manager, player_idx, 0);
+            change_choice_for_player(state, asset_manager, player_idx, 0, NavWrap::Wrap);
             return finish_start_without_action(state, active, player_idx, should_focus_exit);
         }
     }

--- a/src/screens/player_options/pane.rs
+++ b/src/screens/player_options/pane.rs
@@ -7,6 +7,12 @@ pub enum NavDirection {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NavWrap {
+    Wrap,
+    Clamp,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum OptionsPane {
     Main,
     Advanced,

--- a/src/screens/player_options/panes/advanced.rs
+++ b/src/screens/player_options/panes/advanced.rs
@@ -182,8 +182,10 @@ const RESULTS_EXTRAS: BitmaskBinding = BitmaskBinding {
 };
 
 const ACTION_ON_MISSED_TARGET: CustomBinding = CustomBinding {
-    apply: |state, player_idx, row_id, delta| {
-        if super::super::choice::cycle_choice_index(state, player_idx, row_id, delta).is_none() {
+    apply: |state, player_idx, row_id, delta, wrap| {
+        if super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
+            .is_none()
+        {
             return Outcome::NONE;
         }
         Outcome::persisted()
@@ -191,9 +193,9 @@ const ACTION_ON_MISSED_TARGET: CustomBinding = CustomBinding {
 };
 
 const MINI_INDICATOR: CustomBinding = CustomBinding {
-    apply: |state, player_idx, row_id, delta| {
+    apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta)
+            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };
@@ -223,9 +225,9 @@ const MINI_INDICATOR: CustomBinding = CustomBinding {
 };
 
 const JUDGMENT_TILT_INTENSITY: CustomBinding = CustomBinding {
-    apply: |state, player_idx, row_id, delta| {
+    apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta)
+            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };
@@ -253,9 +255,9 @@ const JUDGMENT_TILT_INTENSITY: CustomBinding = CustomBinding {
 };
 
 const MEASURE_COUNTER_LOOKAHEAD: CustomBinding = CustomBinding {
-    apply: |state, player_idx, row_id, delta| {
+    apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta)
+            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };
@@ -270,9 +272,9 @@ const MEASURE_COUNTER_LOOKAHEAD: CustomBinding = CustomBinding {
 };
 
 const CUSTOM_BLUE_FANTASTIC_WINDOW_MS: CustomBinding = CustomBinding {
-    apply: |state, player_idx, row_id, delta| {
+    apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta)
+            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };

--- a/src/screens/player_options/panes/main.rs
+++ b/src/screens/player_options/panes/main.rs
@@ -101,10 +101,11 @@ fn apply_noteskin_delta(
     player_idx: usize,
     row_id: RowId,
     delta: isize,
+    wrap: NavWrap,
     apply: fn(&mut State, usize, &str, bool, gp::PlayerSide),
 ) -> Outcome {
     let Some(new_index) =
-        super::super::choice::cycle_choice_index(state, player_idx, row_id, delta)
+        super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
     else {
         return Outcome::NONE;
     };
@@ -121,12 +122,13 @@ fn apply_noteskin_delta(
 }
 
 const NOTE_SKIN: CustomBinding = CustomBinding {
-    apply: |state, player_idx, row_id, delta| {
+    apply: |state, player_idx, row_id, delta, wrap| {
         apply_noteskin_delta(
             state,
             player_idx,
             row_id,
             delta,
+            wrap,
             |state, player_idx, choice, should_persist, side| {
                 let name = if choice.is_empty() {
                     gp::NoteSkin::DEFAULT_NAME.to_string()
@@ -144,12 +146,13 @@ const NOTE_SKIN: CustomBinding = CustomBinding {
     },
 };
 const MINE_SKIN: CustomBinding = CustomBinding {
-    apply: |state, player_idx, row_id, delta| {
+    apply: |state, player_idx, row_id, delta, wrap| {
         apply_noteskin_delta(
             state,
             player_idx,
             row_id,
             delta,
+            wrap,
             |state, player_idx, choice, should_persist, side| {
                 let match_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
                 let setting = if choice == match_label.as_ref() {
@@ -169,12 +172,13 @@ const MINE_SKIN: CustomBinding = CustomBinding {
     },
 };
 const RECEPTOR_SKIN: CustomBinding = CustomBinding {
-    apply: |state, player_idx, row_id, delta| {
+    apply: |state, player_idx, row_id, delta, wrap| {
         apply_noteskin_delta(
             state,
             player_idx,
             row_id,
             delta,
+            wrap,
             |state, player_idx, choice, should_persist, side| {
                 let match_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
                 let setting = if choice == match_label.as_ref() {
@@ -194,12 +198,13 @@ const RECEPTOR_SKIN: CustomBinding = CustomBinding {
     },
 };
 const TAP_EXPLOSION_SKIN: CustomBinding = CustomBinding {
-    apply: |state, player_idx, row_id, delta| {
+    apply: |state, player_idx, row_id, delta, wrap| {
         apply_noteskin_delta(
             state,
             player_idx,
             row_id,
             delta,
+            wrap,
             |state, player_idx, choice, should_persist, side| {
                 let match_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
                 let no_tap_label = tr("PlayerOptions", NO_TAP_EXPLOSION_LABEL);
@@ -223,7 +228,7 @@ const TAP_EXPLOSION_SKIN: CustomBinding = CustomBinding {
 };
 
 const MUSIC_RATE: CustomBinding = CustomBinding {
-    apply: |state, _player_idx, row_id, delta| {
+    apply: |state, _player_idx, row_id, delta, _wrap| {
         let increment = 0.01f32;
         state.music_rate += delta as f32 * increment;
         state.music_rate = (state.music_rate / increment).round() * increment;
@@ -242,7 +247,7 @@ const MUSIC_RATE: CustomBinding = CustomBinding {
 };
 
 const SPEED_MOD: CustomBinding = CustomBinding {
-    apply: |state, player_idx, _row_id, delta| {
+    apply: |state, player_idx, _row_id, delta, _wrap| {
         let speed_mod = {
             let speed_mod = &mut state.speed_mod[player_idx];
             let (upper, increment) = match speed_mod.mod_type {
@@ -260,9 +265,9 @@ const SPEED_MOD: CustomBinding = CustomBinding {
 };
 
 const TYPE_OF_SPEED_MOD: CustomBinding = CustomBinding {
-    apply: |state, player_idx, row_id, delta| {
+    apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta)
+            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };
@@ -308,9 +313,9 @@ const TYPE_OF_SPEED_MOD: CustomBinding = CustomBinding {
 };
 
 const MINI: CustomBinding = CustomBinding {
-    apply: |state, player_idx, row_id, delta| {
+    apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta)
+            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };
@@ -336,9 +341,9 @@ const MINI: CustomBinding = CustomBinding {
 };
 
 const JUDGMENT_FONT: CustomBinding = CustomBinding {
-    apply: |state, player_idx, row_id, delta| {
+    apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta)
+            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };
@@ -359,9 +364,9 @@ const JUDGMENT_FONT: CustomBinding = CustomBinding {
 };
 
 const HOLD_JUDGMENT: CustomBinding = CustomBinding {
-    apply: |state, player_idx, row_id, delta| {
+    apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta)
+            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };
@@ -384,9 +389,9 @@ const HOLD_JUDGMENT: CustomBinding = CustomBinding {
 };
 
 const STEPCHART: CustomBinding = CustomBinding {
-    apply: |state, player_idx, row_id, delta| {
+    apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta)
+            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };

--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -18,8 +18,9 @@ fn apply_what_comes_next_cycle(
     player_idx: usize,
     id: RowId,
     delta: isize,
+    wrap: NavWrap,
 ) -> Outcome {
-    match super::choice::cycle_choice_index(state, player_idx, id, delta) {
+    match super::choice::cycle_choice_index(state, player_idx, id, delta, wrap) {
         Some(_) => Outcome::persisted(),
         None => Outcome::NONE,
     }

--- a/src/screens/player_options/row.rs
+++ b/src/screens/player_options/row.rs
@@ -155,7 +155,7 @@ pub struct BitmaskBinding {
 
 #[derive(Clone, Copy, Debug)]
 pub struct CustomBinding {
-    pub apply: fn(&mut State, usize, RowId, isize) -> Outcome,
+    pub apply: fn(&mut State, usize, RowId, isize, NavWrap) -> Outcome,
 }
 
 /// What kind of row this is, and any state owned by the row's behaviour.

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -458,7 +458,7 @@ pub(super) mod tests {
         state.pane_mut().selected_row[P1] = row_index;
 
         // delta=0 should still apply the current choice
-        super::change_choice_for_player(&mut state, &asset_manager, P1, 0);
+        super::change_choice_for_player(&mut state, &asset_manager, P1, 0, super::NavWrap::Wrap);
 
         assert_eq!(
             state.player_profiles[P1].background_filter,
@@ -488,7 +488,7 @@ pub(super) mod tests {
             .unwrap()
             .selected_choice_index[P1];
 
-        super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
+        super::change_choice_for_player(&mut state, &asset_manager, P1, 1, super::NavWrap::Wrap);
 
         let row = state.pane().row_map.get(RowId::WhatComesNext).unwrap();
         let n = row.choices.len();
@@ -599,7 +599,7 @@ pub(super) mod tests {
         );
 
         // Advance to index 1 (enabled) — apply returns persisted_with_visibility → syncs
-        super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
+        super::change_choice_for_player(&mut state, &asset_manager, P1, 1, super::NavWrap::Wrap);
 
         assert!(
             judgment_tilt_intensity_visible(&state.pane().row_map, active),
@@ -631,7 +631,7 @@ pub(super) mod tests {
         assert!(n >= 2, "BackgroundFilter should have at least 2 choices");
         state.pane_mut().selected_row[P1] = row_index;
 
-        super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
+        super::change_choice_for_player(&mut state, &asset_manager, P1, 1, super::NavWrap::Wrap);
 
         let row = state.pane().row_map.get(RowId::BackgroundFilter).unwrap();
         assert_eq!(row.selected_choice_index[0], 1, "P1 should have advanced");
@@ -671,7 +671,7 @@ pub(super) mod tests {
             .get_mut(RowId::BackgroundFilter)
             .unwrap()
             .selected_choice_index[P1] = n - 1;
-        super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
+        super::change_choice_for_player(&mut state, &asset_manager, P1, 1, super::NavWrap::Wrap);
         assert_eq!(
             state
                 .pane()
@@ -690,7 +690,7 @@ pub(super) mod tests {
             .get_mut(RowId::BackgroundFilter)
             .unwrap()
             .selected_choice_index[P1] = 0;
-        super::change_choice_for_player(&mut state, &asset_manager, P1, -1);
+        super::change_choice_for_player(&mut state, &asset_manager, P1, -1, super::NavWrap::Wrap);
         assert_eq!(
             state
                 .pane()
@@ -726,8 +726,8 @@ pub(super) mod tests {
 
         // RowBehavior::Exit returns Outcome::NONE so the dispatcher must not panic,
         // mutate the row, or play SFX (which would panic — audio uninit in tests).
-        super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
-        super::change_choice_for_player(&mut state, &asset_manager, P1, -3);
+        super::change_choice_for_player(&mut state, &asset_manager, P1, 1, super::NavWrap::Wrap);
+        super::change_choice_for_player(&mut state, &asset_manager, P1, -3, super::NavWrap::Wrap);
 
         let after = state
             .pane()
@@ -827,8 +827,8 @@ pub(super) mod tests {
 
         // L/R on a bitmask row returns Outcome::NONE — mask must not change,
         // and no SFX should be played (audio uninit in tests would panic).
-        super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
-        super::change_choice_for_player(&mut state, &asset_manager, P1, -1);
+        super::change_choice_for_player(&mut state, &asset_manager, P1, 1, super::NavWrap::Wrap);
+        super::change_choice_for_player(&mut state, &asset_manager, P1, -1, super::NavWrap::Wrap);
 
         assert_eq!(
             [state.option_masks[P1].scroll, state.option_masks[P2].scroll],
@@ -952,7 +952,7 @@ pub(super) mod tests {
         );
         let p2_before = row.selected_choice_index[1];
 
-        super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
+        super::change_choice_for_player(&mut state, &asset_manager, P1, 1, super::NavWrap::Wrap);
 
         let row = state.pane().row_map.get(RowId::BackgroundFilter).unwrap();
         assert_eq!(
@@ -970,7 +970,7 @@ pub(super) mod tests {
         // even though mirror_across_players is true. The dispatcher must NOT
         // overwrite P2 in that case.
         let custom = super::CustomBinding {
-            apply: |_state, _player_idx, _id, _delta| super::Outcome::NONE,
+            apply: |_state, _player_idx, _id, _delta, _wrap| super::Outcome::NONE,
         };
         let mirror_row = Row {
             id: RowId::Hide,
@@ -995,7 +995,7 @@ pub(super) mod tests {
             .unwrap()
             .selected_choice_index[1] = 2;
 
-        super::change_choice_for_player(&mut state, &asset_manager, P1, 1);
+        super::change_choice_for_player(&mut state, &asset_manager, P1, 1, super::NavWrap::Wrap);
 
         let row = state.pane().row_map.get(RowId::Hide).unwrap();
         assert_eq!(

--- a/src/screens/player_options/visibility.rs
+++ b/src/screens/player_options/visibility.rs
@@ -354,6 +354,7 @@ pub(super) fn next_visible_row(
     current_row: usize,
     dir: NavDirection,
     visibility: RowVisibility,
+    wrap: NavWrap,
 ) -> Option<usize> {
     if row_map.display_order().is_empty() {
         return None;
@@ -365,8 +366,26 @@ pub(super) fn next_visible_row(
     }
     for _ in 0..len {
         idx = match dir {
-            NavDirection::Up => (idx + len - 1) % len,
-            NavDirection::Down => (idx + 1) % len,
+            NavDirection::Up => {
+                if idx == 0 {
+                    match wrap {
+                        NavWrap::Wrap => len - 1,
+                        NavWrap::Clamp => return None,
+                    }
+                } else {
+                    idx - 1
+                }
+            }
+            NavDirection::Down => {
+                if idx + 1 >= len {
+                    match wrap {
+                        NavWrap::Wrap => 0,
+                        NavWrap::Clamp => return None,
+                    }
+                } else {
+                    idx + 1
+                }
+            }
             NavDirection::Left | NavDirection::Right => return Some(idx),
         };
         if is_row_visible(row_map, idx, visibility) {


### PR DESCRIPTION
in ITG, if you hold a menu key to scroll to the end of an options list (e.g. settings, player options, etc), it stops when you get to the end. it only wraps around to the beginning of the menu on an explicit press, not a hold-repeat.

this PR implements that behavior in deadsync, by adding a new `NavWrap` enum parameter to `move_selection()` and similar methods. `NavWrap::Wrap` is passed when the input is first registered, and `NavWrap::Clamp` is passed in the key-repeat/hold-to-scroll code path.