### PR TITLE
refactor(player_options): add Row constructors and migrate Main pane

### DIFF
--- a/src/game/profile.rs
+++ b/src/game/profile.rs
@@ -27,6 +27,23 @@ pub const HUD_OFFSET_MAX: i32 = 250;
 pub const SPACING_PERCENT_MIN: i32 = -100;
 pub const SPACING_PERCENT_MAX: i32 = 100;
 
+/// Min/max for the Mini player option (Simply Love parity).
+pub const MINI_PERCENT_MIN: i32 = -100;
+pub const MINI_PERCENT_MAX: i32 = 150;
+
+/// Min/max for the per-player NoteField horizontal offset.
+pub const NOTE_FIELD_OFFSET_X_MIN: i32 = 0;
+pub const NOTE_FIELD_OFFSET_X_MAX: i32 = 50;
+
+/// Min/max for the per-player NoteField vertical offset.
+pub const NOTE_FIELD_OFFSET_Y_MIN: i32 = -50;
+pub const NOTE_FIELD_OFFSET_Y_MAX: i32 = 50;
+
+/// Min/max (in milliseconds) for the per-player visual-delay calibration
+/// (Simply Love parity). Also used as the range for the global offset shift.
+pub const VISUAL_DELAY_MS_MIN: i32 = -100;
+pub const VISUAL_DELAY_MS_MAX: i32 = 100;
+
 #[inline(always)]
 const fn clamp_weight_pounds(weight_pounds: i32) -> i32 {
     if weight_pounds == 0 {

--- a/src/game/profile/update.rs
+++ b/src/game/profile/update.rs
@@ -2,11 +2,13 @@ use super::{
     AccelEffectsMask, AppearanceEffectsMask, AttackMode, BackgroundFilter, ComboColors, ComboFont,
     ComboMode, DataVisualizations, ErrorBarMask, ErrorBarTrim, HUD_OFFSET_MAX, HUD_OFFSET_MIN,
     HideLightType, HoldJudgmentGraphic, HoldsMask, InsertMask, JudgmentGraphic, LifeMeterType,
-    MeasureCounter, MeasureLines, MiniIndicator, MiniIndicatorScoreType, NoteSkin, Perspective,
-    PlayStyle, PlayerSide, RemoveMask, SPACING_PERCENT_MAX, SPACING_PERCENT_MIN, ScrollOption,
-    ScrollSpeedSetting, TargetScoreSetting, TimingWindowsOption, TurnOption, VisualEffectsMask,
-    clamp_custom_fantastic_window_ms, error_bar_style_from_mask, error_bar_text_from_mask,
-    lock_profiles, sanitize_player_initials, save_profile_ini_for_side,
+    MINI_PERCENT_MAX, MINI_PERCENT_MIN, MeasureCounter, MeasureLines, MiniIndicator,
+    MiniIndicatorScoreType, NOTE_FIELD_OFFSET_X_MAX, NOTE_FIELD_OFFSET_X_MIN,
+    NOTE_FIELD_OFFSET_Y_MAX, NOTE_FIELD_OFFSET_Y_MIN, NoteSkin, Perspective, PlayStyle, PlayerSide,
+    RemoveMask, SPACING_PERCENT_MAX, SPACING_PERCENT_MIN, ScrollOption, ScrollSpeedSetting,
+    TargetScoreSetting, TimingWindowsOption, TurnOption, VISUAL_DELAY_MS_MAX, VISUAL_DELAY_MS_MIN,
+    VisualEffectsMask, clamp_custom_fantastic_window_ms, error_bar_style_from_mask,
+    error_bar_text_from_mask, lock_profiles, sanitize_player_initials, save_profile_ini_for_side,
     save_profile_stats_for_side, session_side_is_guest, side_ix,
 };
 use chrono::Local;
@@ -521,7 +523,7 @@ pub fn update_tap_explosion_noteskin_for_side(side: PlayerSide, setting: Option<
 }
 
 pub fn update_notefield_offset_x_for_side(side: PlayerSide, offset: i32) {
-    let clamped = offset.clamp(0, 50);
+    let clamped = offset.clamp(NOTE_FIELD_OFFSET_X_MIN, NOTE_FIELD_OFFSET_X_MAX);
     {
         let mut profiles = lock_profiles();
         let profile = &mut profiles[side_ix(side)];
@@ -534,7 +536,7 @@ pub fn update_notefield_offset_x_for_side(side: PlayerSide, offset: i32) {
 }
 
 pub fn update_notefield_offset_y_for_side(side: PlayerSide, offset: i32) {
-    let clamped = offset.clamp(-50, 50);
+    let clamped = offset.clamp(NOTE_FIELD_OFFSET_Y_MIN, NOTE_FIELD_OFFSET_Y_MAX);
     {
         let mut profiles = lock_profiles();
         let profile = &mut profiles[side_ix(side)];
@@ -626,7 +628,7 @@ pub fn update_error_bar_offset_y_for_side(side: PlayerSide, offset: i32) {
 
 pub fn update_mini_percent_for_side(side: PlayerSide, percent: i32) {
     // Mirror Simply Love's range: -100% to +150%.
-    let clamped = percent.clamp(-100, 150);
+    let clamped = percent.clamp(MINI_PERCENT_MIN, MINI_PERCENT_MAX);
     {
         let mut profiles = lock_profiles();
         let profile = &mut profiles[side_ix(side)];
@@ -666,7 +668,7 @@ pub fn update_perspective_for_side(side: PlayerSide, perspective: Perspective) {
 
 pub fn update_visual_delay_ms_for_side(side: PlayerSide, ms: i32) {
     // Mirror Simply Love's range: -100ms to +100ms.
-    let clamped = ms.clamp(-100, 100);
+    let clamped = ms.clamp(VISUAL_DELAY_MS_MIN, VISUAL_DELAY_MS_MAX);
     {
         let mut profiles = lock_profiles();
         let profile = &mut profiles[side_ix(side)];
@@ -680,7 +682,7 @@ pub fn update_visual_delay_ms_for_side(side: PlayerSide, ms: i32) {
 
 pub fn update_global_offset_shift_ms_for_side(side: PlayerSide, ms: i32) {
     // Keep the personal timing shift in the same small-calibration range as visual delay.
-    let clamped = ms.clamp(-100, 100);
+    let clamped = ms.clamp(VISUAL_DELAY_MS_MIN, VISUAL_DELAY_MS_MAX);
     {
         let mut profiles = lock_profiles();
         let profile = &mut profiles[side_ix(side)];

--- a/src/screens/player_options/panes/main.rs
+++ b/src/screens/player_options/panes/main.rs
@@ -566,7 +566,9 @@ pub(super) fn build_main_rows(
         lookup_key("PlayerOptions", "Mini"),
         lookup_key("PlayerOptionsHelp", "MiniHelp"),
         MINI,
-        (-100..=150).map(|v| format!("{v}%")).collect(),
+        (gp::MINI_PERCENT_MIN..=gp::MINI_PERCENT_MAX)
+            .map(|v| format!("{v}%"))
+            .collect(),
     ));
     b.push(Row::numeric(
         RowId::Spacing,
@@ -716,14 +718,18 @@ pub(super) fn build_main_rows(
         lookup_key("PlayerOptions", "NoteFieldOffsetX"),
         lookup_key("PlayerOptionsHelp", "NoteFieldOffsetXHelp"),
         NOTEFIELD_OFFSET_X,
-        (0..=50).map(|v| v.to_string()).collect(),
+        (gp::NOTE_FIELD_OFFSET_X_MIN..=gp::NOTE_FIELD_OFFSET_X_MAX)
+            .map(|v| v.to_string())
+            .collect(),
     ));
     b.push(Row::numeric(
         RowId::NoteFieldOffsetY,
         lookup_key("PlayerOptions", "NoteFieldOffsetY"),
         lookup_key("PlayerOptionsHelp", "NoteFieldOffsetYHelp"),
         NOTEFIELD_OFFSET_Y,
-        (-50..=50).map(|v| v.to_string()).collect(),
+        (gp::NOTE_FIELD_OFFSET_Y_MIN..=gp::NOTE_FIELD_OFFSET_Y_MAX)
+            .map(|v| v.to_string())
+            .collect(),
     ));
     b.push(
         Row::numeric(
@@ -731,9 +737,11 @@ pub(super) fn build_main_rows(
             lookup_key("PlayerOptions", "VisualDelay"),
             lookup_key("PlayerOptionsHelp", "VisualDelayHelp"),
             VISUAL_DELAY,
-            (-100..=100).map(|v| format!("{v}ms")).collect(),
+            (gp::VISUAL_DELAY_MS_MIN..=gp::VISUAL_DELAY_MS_MAX)
+                .map(|v| format!("{v}ms"))
+                .collect(),
         )
-        .with_initial_choice_index(100),
+        .with_initial_choice_index((-gp::VISUAL_DELAY_MS_MIN) as usize),
     );
     b.push(
         Row::numeric(
@@ -741,9 +749,11 @@ pub(super) fn build_main_rows(
             lookup_key("PlayerOptions", "GlobalOffsetShift"),
             lookup_key("PlayerOptionsHelp", "GlobalOffsetShiftHelp"),
             GLOBAL_OFFSET_SHIFT,
-            (-100..=100).map(|v| format!("{v}ms")).collect(),
+            (gp::VISUAL_DELAY_MS_MIN..=gp::VISUAL_DELAY_MS_MAX)
+                .map(|v| format!("{v}ms"))
+                .collect(),
         )
-        .with_initial_choice_index(100),
+        .with_initial_choice_index((-gp::VISUAL_DELAY_MS_MIN) as usize),
     );
     b.push(Row::custom(
         RowId::MusicRate,

--- a/src/screens/player_options/panes/main.rs
+++ b/src/screens/player_options/panes/main.rs
@@ -540,186 +540,124 @@ pub(super) fn build_main_rows(
             )
         };
     let mut b = RowBuilder::new();
-    b.push(Row {
-        id: RowId::TypeOfSpeedMod,
-        behavior: RowBehavior::Custom(TYPE_OF_SPEED_MOD),
-        name: lookup_key("PlayerOptions", "TypeOfSpeedMod"),
-        choices: vec![
-            tr("PlayerOptions", "SpeedModTypeX").to_string(),
-            tr("PlayerOptions", "SpeedModTypeC").to_string(),
-            tr("PlayerOptions", "SpeedModTypeM").to_string(),
-        ],
-        selected_choice_index: [speed_mod.mod_type.choice_index(); PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "TypeOfSpeedModHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::SpeedMod,
-        behavior: RowBehavior::Custom(SPEED_MOD),
-        name: lookup_key("PlayerOptions", "SpeedMod"),
-        choices: vec![speed_mod_value_str], // Display only the current value
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "SpeedModHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::Mini,
-        behavior: RowBehavior::Custom(MINI),
-        name: lookup_key("PlayerOptions", "Mini"),
-        choices: (-100..=150).map(|v| format!("{v}%")).collect(),
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "MiniHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::Spacing,
-        behavior: RowBehavior::Numeric(SPACING),
-        name: lookup_key("PlayerOptions", "Spacing"),
-        choices: (SPACING_PERCENT_MIN..=SPACING_PERCENT_MAX)
+    b.push(
+        Row::custom(
+            RowId::TypeOfSpeedMod,
+            lookup_key("PlayerOptions", "TypeOfSpeedMod"),
+            lookup_key("PlayerOptionsHelp", "TypeOfSpeedModHelp"),
+            TYPE_OF_SPEED_MOD,
+            vec![
+                tr("PlayerOptions", "SpeedModTypeX").to_string(),
+                tr("PlayerOptions", "SpeedModTypeC").to_string(),
+                tr("PlayerOptions", "SpeedModTypeM").to_string(),
+            ],
+        )
+        .with_initial_choice_index(speed_mod.mod_type.choice_index()),
+    );
+    b.push(Row::custom(
+        RowId::SpeedMod,
+        lookup_key("PlayerOptions", "SpeedMod"),
+        lookup_key("PlayerOptionsHelp", "SpeedModHelp"),
+        SPEED_MOD,
+        vec![speed_mod_value_str], // Display only the current value
+    ));
+    b.push(Row::custom(
+        RowId::Mini,
+        lookup_key("PlayerOptions", "Mini"),
+        lookup_key("PlayerOptionsHelp", "MiniHelp"),
+        MINI,
+        (-100..=150).map(|v| format!("{v}%")).collect(),
+    ));
+    b.push(Row::numeric(
+        RowId::Spacing,
+        lookup_key("PlayerOptions", "Spacing"),
+        lookup_key("PlayerOptionsHelp", "SpacingHelp"),
+        SPACING,
+        (SPACING_PERCENT_MIN..=SPACING_PERCENT_MAX)
             .map(|v| format!("{v}%"))
             .collect(),
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "SpacingHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::Perspective,
-        behavior: RowBehavior::Cycle(CycleBinding::Index(PERSPECTIVE)),
-        name: lookup_key("PlayerOptions", "Perspective"),
-        choices: vec![
+    ));
+    b.push(Row::cycle(
+        RowId::Perspective,
+        lookup_key("PlayerOptions", "Perspective"),
+        lookup_key("PlayerOptionsHelp", "PerspectiveHelp"),
+        CycleBinding::Index(PERSPECTIVE),
+        vec![
             tr("PlayerOptions", "PerspectiveOverhead").to_string(),
             tr("PlayerOptions", "PerspectiveHallway").to_string(),
             tr("PlayerOptions", "PerspectiveDistant").to_string(),
             tr("PlayerOptions", "PerspectiveIncoming").to_string(),
             tr("PlayerOptions", "PerspectiveSpace").to_string(),
         ],
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "PerspectiveHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::NoteSkin,
-        behavior: RowBehavior::Custom(NOTE_SKIN),
-        name: lookup_key("PlayerOptions", "NoteSkin"),
-        choices: if noteskin_names.is_empty() {
+    ));
+    b.push(Row::custom(
+        RowId::NoteSkin,
+        lookup_key("PlayerOptions", "NoteSkin"),
+        lookup_key("PlayerOptionsHelp", "NoteSkinHelp"),
+        NOTE_SKIN,
+        if noteskin_names.is_empty() {
             vec![crate::game::profile::NoteSkin::DEFAULT_NAME.to_string()]
         } else {
             noteskin_names.to_vec()
         },
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "NoteSkinHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::MineSkin,
-        behavior: RowBehavior::Custom(MINE_SKIN),
-        name: lookup_key("PlayerOptions", "MineSkin"),
-        choices: build_noteskin_override_choices(noteskin_names),
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "MineSkinHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::ReceptorSkin,
-        behavior: RowBehavior::Custom(RECEPTOR_SKIN),
-        name: lookup_key("PlayerOptions", "ReceptorSkin"),
-        choices: build_noteskin_override_choices(noteskin_names),
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "ReceptorSkinHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::TapExplosionSkin,
-        behavior: RowBehavior::Custom(TAP_EXPLOSION_SKIN),
-        name: lookup_key("PlayerOptions", "TapExplosionSkin"),
-        choices: build_tap_explosion_noteskin_choices(noteskin_names),
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "TapExplosionSkinHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::JudgmentFont,
-        behavior: RowBehavior::Custom(JUDGMENT_FONT),
-        name: lookup_key("PlayerOptions", "JudgmentFont"),
-        choices: assets::judgment_texture_choices()
+    ));
+    b.push(Row::custom(
+        RowId::MineSkin,
+        lookup_key("PlayerOptions", "MineSkin"),
+        lookup_key("PlayerOptionsHelp", "MineSkinHelp"),
+        MINE_SKIN,
+        build_noteskin_override_choices(noteskin_names),
+    ));
+    b.push(Row::custom(
+        RowId::ReceptorSkin,
+        lookup_key("PlayerOptions", "ReceptorSkin"),
+        lookup_key("PlayerOptionsHelp", "ReceptorSkinHelp"),
+        RECEPTOR_SKIN,
+        build_noteskin_override_choices(noteskin_names),
+    ));
+    b.push(Row::custom(
+        RowId::TapExplosionSkin,
+        lookup_key("PlayerOptions", "TapExplosionSkin"),
+        lookup_key("PlayerOptionsHelp", "TapExplosionSkinHelp"),
+        TAP_EXPLOSION_SKIN,
+        build_tap_explosion_noteskin_choices(noteskin_names),
+    ));
+    b.push(Row::custom(
+        RowId::JudgmentFont,
+        lookup_key("PlayerOptions", "JudgmentFont"),
+        lookup_key("PlayerOptionsHelp", "JudgmentFontHelp"),
+        JUDGMENT_FONT,
+        assets::judgment_texture_choices()
             .iter()
             .map(|choice| choice.label.clone())
             .collect(),
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "JudgmentFontHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::JudgmentOffsetX,
-        behavior: RowBehavior::Numeric(JUDGMENT_OFFSET_X),
-        name: lookup_key("PlayerOptions", "JudgmentOffsetX"),
-        choices: hud_offset_choices(),
-        selected_choice_index: [HUD_OFFSET_ZERO_INDEX; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "JudgmentOffsetXHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::JudgmentOffsetY,
-        behavior: RowBehavior::Numeric(JUDGMENT_OFFSET_Y),
-        name: lookup_key("PlayerOptions", "JudgmentOffsetY"),
-        choices: hud_offset_choices(),
-        selected_choice_index: [HUD_OFFSET_ZERO_INDEX; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "JudgmentOffsetYHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::ComboFont,
-        behavior: RowBehavior::Cycle(CycleBinding::Index(COMBO_FONT)),
-        name: lookup_key("PlayerOptions", "ComboFont"),
-        choices: vec![
+    ));
+    b.push(
+        Row::numeric(
+            RowId::JudgmentOffsetX,
+            lookup_key("PlayerOptions", "JudgmentOffsetX"),
+            lookup_key("PlayerOptionsHelp", "JudgmentOffsetXHelp"),
+            JUDGMENT_OFFSET_X,
+            hud_offset_choices(),
+        )
+        .with_initial_choice_index(HUD_OFFSET_ZERO_INDEX),
+    );
+    b.push(
+        Row::numeric(
+            RowId::JudgmentOffsetY,
+            lookup_key("PlayerOptions", "JudgmentOffsetY"),
+            lookup_key("PlayerOptionsHelp", "JudgmentOffsetYHelp"),
+            JUDGMENT_OFFSET_Y,
+            hud_offset_choices(),
+        )
+        .with_initial_choice_index(HUD_OFFSET_ZERO_INDEX),
+    );
+    b.push(Row::cycle(
+        RowId::ComboFont,
+        lookup_key("PlayerOptions", "ComboFont"),
+        lookup_key("PlayerOptionsHelp", "ComboFontHelp"),
+        CycleBinding::Index(COMBO_FONT),
+        vec![
             tr("PlayerOptions", "ComboFontWendy").to_string(),
             tr("PlayerOptions", "ComboFontArialRounded").to_string(),
             tr("PlayerOptions", "ComboFontAsap").to_string(),
@@ -730,171 +668,111 @@ pub(super) fn build_main_rows(
             tr("PlayerOptions", "ComboFontMega").to_string(),
             tr("PlayerOptions", "ComboFontNone").to_string(),
         ],
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "ComboFontHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::ComboOffsetX,
-        behavior: RowBehavior::Numeric(COMBO_OFFSET_X),
-        name: lookup_key("PlayerOptions", "ComboOffsetX"),
-        choices: hud_offset_choices(),
-        selected_choice_index: [HUD_OFFSET_ZERO_INDEX; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "ComboOffsetXHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::ComboOffsetY,
-        behavior: RowBehavior::Numeric(COMBO_OFFSET_Y),
-        name: lookup_key("PlayerOptions", "ComboOffsetY"),
-        choices: hud_offset_choices(),
-        selected_choice_index: [HUD_OFFSET_ZERO_INDEX; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "ComboOffsetYHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::HoldJudgment,
-        behavior: RowBehavior::Custom(HOLD_JUDGMENT),
-        name: lookup_key("PlayerOptions", "HoldJudgment"),
-        choices: assets::hold_judgment_texture_choices()
+    ));
+    b.push(
+        Row::numeric(
+            RowId::ComboOffsetX,
+            lookup_key("PlayerOptions", "ComboOffsetX"),
+            lookup_key("PlayerOptionsHelp", "ComboOffsetXHelp"),
+            COMBO_OFFSET_X,
+            hud_offset_choices(),
+        )
+        .with_initial_choice_index(HUD_OFFSET_ZERO_INDEX),
+    );
+    b.push(
+        Row::numeric(
+            RowId::ComboOffsetY,
+            lookup_key("PlayerOptions", "ComboOffsetY"),
+            lookup_key("PlayerOptionsHelp", "ComboOffsetYHelp"),
+            COMBO_OFFSET_Y,
+            hud_offset_choices(),
+        )
+        .with_initial_choice_index(HUD_OFFSET_ZERO_INDEX),
+    );
+    b.push(Row::custom(
+        RowId::HoldJudgment,
+        lookup_key("PlayerOptions", "HoldJudgment"),
+        lookup_key("PlayerOptionsHelp", "HoldJudgmentHelp"),
+        HOLD_JUDGMENT,
+        assets::hold_judgment_texture_choices()
             .iter()
             .map(|choice| choice.label.clone())
             .collect(),
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "HoldJudgmentHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::BackgroundFilter,
-        behavior: RowBehavior::Numeric(BACKGROUND_FILTER),
-        name: lookup_key("PlayerOptions", "BackgroundFilter"),
-        choices: (0..=gp::BackgroundFilter::MAX_PERCENT)
-            .map(|v| format!("{v}%"))
-            .collect(),
-        selected_choice_index: [gp::BackgroundFilter::DEFAULT.percent() as usize; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "BackgroundFilterHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::NoteFieldOffsetX,
-        behavior: RowBehavior::Numeric(NOTEFIELD_OFFSET_X),
-        name: lookup_key("PlayerOptions", "NoteFieldOffsetX"),
-        choices: (0..=50).map(|v| v.to_string()).collect(),
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "NoteFieldOffsetXHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::NoteFieldOffsetY,
-        behavior: RowBehavior::Numeric(NOTEFIELD_OFFSET_Y),
-        name: lookup_key("PlayerOptions", "NoteFieldOffsetY"),
-        choices: (-50..=50).map(|v| v.to_string()).collect(),
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "NoteFieldOffsetYHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::VisualDelay,
-        behavior: RowBehavior::Numeric(VISUAL_DELAY),
-        name: lookup_key("PlayerOptions", "VisualDelay"),
-        choices: (-100..=100).map(|v| format!("{v}ms")).collect(),
-        selected_choice_index: [100; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "VisualDelayHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::GlobalOffsetShift,
-        behavior: RowBehavior::Numeric(GLOBAL_OFFSET_SHIFT),
-        name: lookup_key("PlayerOptions", "GlobalOffsetShift"),
-        choices: (-100..=100).map(|v| format!("{v}ms")).collect(),
-        selected_choice_index: [100; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "GlobalOffsetShiftHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::MusicRate,
-        behavior: RowBehavior::Custom(MUSIC_RATE),
-        name: lookup_key("PlayerOptions", "MusicRate"),
-        choices: vec![fmt_music_rate(session_music_rate.clamp(0.5, 3.0))],
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "MusicRateHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::Stepchart,
-        behavior: RowBehavior::Custom(STEPCHART),
-        name: lookup_key("PlayerOptions", "Stepchart"),
-        choices: stepchart_choices,
-        selected_choice_index: initial_stepchart_choice_index,
-        help: tr("PlayerOptionsHelp", "StepchartHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: Some(stepchart_choice_indices),
-        mirror_across_players: false,
-    });
-    b.push(Row {
-        id: RowId::WhatComesNext,
-        behavior: RowBehavior::Custom(super::WHAT_COMES_NEXT),
-        name: lookup_key("PlayerOptions", "WhatComesNext"),
-        choices: what_comes_next_choices(OptionsPane::Main, return_screen),
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: tr("PlayerOptionsHelp", "WhatComesNextHelp")
-            .split("\\n")
-            .map(|s| s.to_string())
-            .collect(),
-        choice_difficulty_indices: None,
-        mirror_across_players: true,
-    });
-    b.push(Row {
-        id: RowId::Exit,
-        behavior: RowBehavior::Exit,
-        name: lookup_key("Common", "Exit"),
-        choices: vec![tr("Common", "Exit").to_string()],
-        selected_choice_index: [0; PLAYER_SLOTS],
-        help: vec![String::new()],
-        choice_difficulty_indices: None,
-        mirror_across_players: false,
-    });
+    ));
+    b.push(
+        Row::numeric(
+            RowId::BackgroundFilter,
+            lookup_key("PlayerOptions", "BackgroundFilter"),
+            lookup_key("PlayerOptionsHelp", "BackgroundFilterHelp"),
+            BACKGROUND_FILTER,
+            (0..=gp::BackgroundFilter::MAX_PERCENT)
+                .map(|v| format!("{v}%"))
+                .collect(),
+        )
+        .with_initial_choice_index(gp::BackgroundFilter::DEFAULT.percent() as usize),
+    );
+    b.push(Row::numeric(
+        RowId::NoteFieldOffsetX,
+        lookup_key("PlayerOptions", "NoteFieldOffsetX"),
+        lookup_key("PlayerOptionsHelp", "NoteFieldOffsetXHelp"),
+        NOTEFIELD_OFFSET_X,
+        (0..=50).map(|v| v.to_string()).collect(),
+    ));
+    b.push(Row::numeric(
+        RowId::NoteFieldOffsetY,
+        lookup_key("PlayerOptions", "NoteFieldOffsetY"),
+        lookup_key("PlayerOptionsHelp", "NoteFieldOffsetYHelp"),
+        NOTEFIELD_OFFSET_Y,
+        (-50..=50).map(|v| v.to_string()).collect(),
+    ));
+    b.push(
+        Row::numeric(
+            RowId::VisualDelay,
+            lookup_key("PlayerOptions", "VisualDelay"),
+            lookup_key("PlayerOptionsHelp", "VisualDelayHelp"),
+            VISUAL_DELAY,
+            (-100..=100).map(|v| format!("{v}ms")).collect(),
+        )
+        .with_initial_choice_index(100),
+    );
+    b.push(
+        Row::numeric(
+            RowId::GlobalOffsetShift,
+            lookup_key("PlayerOptions", "GlobalOffsetShift"),
+            lookup_key("PlayerOptionsHelp", "GlobalOffsetShiftHelp"),
+            GLOBAL_OFFSET_SHIFT,
+            (-100..=100).map(|v| format!("{v}ms")).collect(),
+        )
+        .with_initial_choice_index(100),
+    );
+    b.push(Row::custom(
+        RowId::MusicRate,
+        lookup_key("PlayerOptions", "MusicRate"),
+        lookup_key("PlayerOptionsHelp", "MusicRateHelp"),
+        MUSIC_RATE,
+        vec![fmt_music_rate(session_music_rate.clamp(0.5, 3.0))],
+    ));
+    b.push(
+        Row::custom(
+            RowId::Stepchart,
+            lookup_key("PlayerOptions", "Stepchart"),
+            lookup_key("PlayerOptionsHelp", "StepchartHelp"),
+            STEPCHART,
+            stepchart_choices,
+        )
+        .with_initial_choice_indices(initial_stepchart_choice_index)
+        .with_choice_difficulty_indices(stepchart_choice_indices),
+    );
+    b.push(
+        Row::custom(
+            RowId::WhatComesNext,
+            lookup_key("PlayerOptions", "WhatComesNext"),
+            lookup_key("PlayerOptionsHelp", "WhatComesNextHelp"),
+            super::WHAT_COMES_NEXT,
+            what_comes_next_choices(OptionsPane::Main, return_screen),
+        )
+        .with_mirror_across_players(),
+    );
+    b.push(Row::exit());
     b.finish()
 }

--- a/src/screens/player_options/row.rs
+++ b/src/screens/player_options/row.rs
@@ -408,6 +408,135 @@ pub struct Row {
     pub mirror_across_players: bool,
 }
 
+/// Expand a help `LookupKey` into the pre-split `Vec<String>` shape that
+/// `Row::help` expects.
+#[inline]
+pub(super) fn expand_help(help: LookupKey) -> Vec<String> {
+    help.get().split("\\n").map(|s| s.to_string()).collect()
+}
+
+impl Row {
+    /// Construct a `RowBehavior::Numeric` row with the standard defaults
+    /// (`selected_choice_index = [0; PLAYER_SLOTS]`,
+    /// `choice_difficulty_indices = None`, `mirror_across_players = false`).
+    /// Override defaults via the chain methods below.
+    pub fn numeric(
+        id: RowId,
+        name: LookupKey,
+        help: LookupKey,
+        binding: NumericBinding,
+        choices: Vec<String>,
+    ) -> Self {
+        Self::base(id, RowBehavior::Numeric(binding), name, help, choices)
+    }
+
+    /// Construct a `RowBehavior::Cycle` row.
+    pub fn cycle(
+        id: RowId,
+        name: LookupKey,
+        help: LookupKey,
+        binding: CycleBinding,
+        choices: Vec<String>,
+    ) -> Self {
+        Self::base(id, RowBehavior::Cycle(binding), name, help, choices)
+    }
+
+    /// Construct a `RowBehavior::Bitmask` row.
+    pub fn bitmask(
+        id: RowId,
+        name: LookupKey,
+        help: LookupKey,
+        binding: BitmaskBinding,
+        choices: Vec<String>,
+    ) -> Self {
+        Self::base(id, RowBehavior::Bitmask(binding), name, help, choices)
+    }
+
+    /// Construct a `RowBehavior::Custom` row. See the `CustomBinding` shape
+    /// in `row.rs` for the apply-fn signature.
+    pub fn custom(
+        id: RowId,
+        name: LookupKey,
+        help: LookupKey,
+        binding: CustomBinding,
+        choices: Vec<String>,
+    ) -> Self {
+        Self::base(id, RowBehavior::Custom(binding), name, help, choices)
+    }
+
+    /// Construct an Exit row. All three pane Exit rows are byte-identical;
+    /// this no-arg constructor centralizes the boilerplate.
+    pub fn exit() -> Self {
+        Self::base(
+            RowId::Exit,
+            RowBehavior::Exit,
+            lookup_key("Common", "Exit"),
+            // Exit rows historically have an empty help line, not a
+            // translated string. Preserve that by skipping `expand_help`.
+            lookup_key("Common", "Exit"),
+            vec![tr("Common", "Exit").to_string()],
+        )
+        .with_help_lines(vec![String::new()])
+    }
+
+    /// Set every slot's initial cursor to the same index. Used when a row
+    /// has a meaningful "default position" (e.g. the zero offset for HUD
+    /// offset rows).
+    pub fn with_initial_choice_index(mut self, idx: usize) -> Self {
+        self.selected_choice_index = [idx; PLAYER_SLOTS];
+        self
+    }
+
+    /// Set per-player initial cursor positions. Used by Stepchart, where
+    /// each player's initial difficulty selection is independent.
+    pub fn with_initial_choice_indices(mut self, idxs: [usize; PLAYER_SLOTS]) -> Self {
+        self.selected_choice_index = idxs;
+        self
+    }
+
+    /// Attach a `choice_difficulty_indices` lookup table. Currently used
+    /// only by Stepchart to map UI choices back to underlying difficulty
+    /// indices.
+    pub fn with_choice_difficulty_indices(mut self, idxs: Vec<usize>) -> Self {
+        self.choice_difficulty_indices = Some(idxs);
+        self
+    }
+
+    /// Mark the row as mirrored across all player slots. Used by
+    /// `WhatComesNext` so a change on one player propagates to all.
+    pub fn with_mirror_across_players(mut self) -> Self {
+        self.mirror_across_players = true;
+        self
+    }
+
+    /// Escape hatch for rows whose help text is not a translated string
+    /// (currently only the Exit row's empty placeholder line). Prefer the
+    /// `help: LookupKey` parameter on the public constructors.
+    fn with_help_lines(mut self, lines: Vec<String>) -> Self {
+        self.help = lines;
+        self
+    }
+
+    fn base(
+        id: RowId,
+        behavior: RowBehavior,
+        name: LookupKey,
+        help: LookupKey,
+        choices: Vec<String>,
+    ) -> Self {
+        Self {
+            id,
+            behavior,
+            name,
+            choices,
+            selected_choice_index: [0; PLAYER_SLOTS],
+            help: expand_help(help),
+            choice_difficulty_indices: None,
+            mirror_across_players: false,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct FixedStepchart {
     pub label: String,


### PR DESCRIPTION
Refactor work toward consolidating per-row code in `src/screens/player_options/`. First slice of a phased plan; covers the Main pane only.

## Changes

**1. `refactor(player_options): add Row constructors and migrate Main pane`**
- Adds 5 `Row` constructors in `row.rs`: `numeric`, `cycle`, `bitmask`, `custom`, `exit`
- Adds 4 chain methods: `with_initial_choice_index`, `with_initial_choice_indices`, `with_choice_difficulty_indices`, `with_mirror_across_players`
- Adds private `expand_help()` helper to centralize the `help.get().split(""\n"")` boilerplate previously repeated 25x
- Migrates all 25 rows in `panes/main.rs` to use the new constructors

**2. `refactor(profile): hoist player-option range magic numbers to constants`**
- Adds `MINI_PERCENT_MIN/MAX`, `NOTE_FIELD_OFFSET_X_MIN/MAX`, `NOTE_FIELD_OFFSET_Y_MIN/MAX`, `VISUAL_DELAY_MS_MIN/MAX` in `src/game/profile.rs` (next to existing `HUD_OFFSET_*` and `SPACING_PERCENT_*`)
- Updates the 5 `clamp()` call sites in `src/game/profile/update.rs`
- Updates `panes/main.rs` choices-vec construction to use the same constants
- Derives initial cursor index from the constants instead of a hard-coded `100`
