### PR TITLE
refactor(player_options): add CycleInit and NumericInit contracts

### DIFF
--- a/src/screens/player_options/panes/advanced.rs
+++ b/src/screens/player_options/panes/advanced.rs
@@ -90,6 +90,7 @@ const DENSITY_GRAPH_BACKGROUND: ChoiceBinding<bool> = ChoiceBinding::<bool> {
         Outcome::persisted()
     },
     persist_for_side: gp::update_transparent_density_graph_bg_for_side,
+    init: None,
 };
 const CARRY_COMBO: ChoiceBinding<bool> = ChoiceBinding::<bool> {
     apply: |p, v| {
@@ -97,6 +98,7 @@ const CARRY_COMBO: ChoiceBinding<bool> = ChoiceBinding::<bool> {
         Outcome::persisted()
     },
     persist_for_side: gp::update_carry_combo_between_songs_for_side,
+    init: None,
 };
 const JUDGMENT_TILT: ChoiceBinding<bool> = ChoiceBinding::<bool> {
     apply: |p, v| {
@@ -104,6 +106,7 @@ const JUDGMENT_TILT: ChoiceBinding<bool> = ChoiceBinding::<bool> {
         Outcome::persisted_with_visibility()
     },
     persist_for_side: gp::update_judgment_tilt_for_side,
+    init: None,
 };
 const JUDGMENT_BEHIND_ARROWS: ChoiceBinding<bool> = ChoiceBinding::<bool> {
     apply: |p, v| {
@@ -111,6 +114,7 @@ const JUDGMENT_BEHIND_ARROWS: ChoiceBinding<bool> = ChoiceBinding::<bool> {
         Outcome::persisted()
     },
     persist_for_side: gp::update_judgment_back_for_side,
+    init: None,
 };
 const OFFSET_INDICATOR: ChoiceBinding<bool> = ChoiceBinding::<bool> {
     apply: |p, v| {
@@ -118,6 +122,7 @@ const OFFSET_INDICATOR: ChoiceBinding<bool> = ChoiceBinding::<bool> {
         Outcome::persisted()
     },
     persist_for_side: gp::update_error_ms_display_for_side,
+    init: None,
 };
 const RESCORE_EARLY_HITS: ChoiceBinding<bool> = ChoiceBinding::<bool> {
     apply: |p, v| {
@@ -125,6 +130,7 @@ const RESCORE_EARLY_HITS: ChoiceBinding<bool> = ChoiceBinding::<bool> {
         Outcome::persisted()
     },
     persist_for_side: gp::update_rescore_early_hits_for_side,
+    init: None,
 };
 const CUSTOM_BLUE_FANTASTIC_WINDOW: ChoiceBinding<bool> = ChoiceBinding::<bool> {
     apply: |p, v| {
@@ -132,6 +138,7 @@ const CUSTOM_BLUE_FANTASTIC_WINDOW: ChoiceBinding<bool> = ChoiceBinding::<bool> 
         Outcome::persisted_with_visibility()
     },
     persist_for_side: gp::update_custom_fantastic_window_for_side,
+    init: None,
 };
 
 const ERROR_BAR_OFFSET_X: NumericBinding = NumericBinding {
@@ -141,6 +148,7 @@ const ERROR_BAR_OFFSET_X: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_error_bar_offset_x_for_side,
+    init: None,
 };
 const ERROR_BAR_OFFSET_Y: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -149,6 +157,7 @@ const ERROR_BAR_OFFSET_Y: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_error_bar_offset_y_for_side,
+    init: None,
 };
 
 const SCROLL: BitmaskBinding = BitmaskBinding {

--- a/src/screens/player_options/panes/main.rs
+++ b/src/screens/player_options/panes/main.rs
@@ -25,6 +25,7 @@ const BACKGROUND_FILTER: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_background_filter_for_side,
+    init: None,
 };
 
 const JUDGMENT_OFFSET_X: NumericBinding = NumericBinding {
@@ -34,6 +35,7 @@ const JUDGMENT_OFFSET_X: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_judgment_offset_x_for_side,
+    init: None,
 };
 const JUDGMENT_OFFSET_Y: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -42,6 +44,7 @@ const JUDGMENT_OFFSET_Y: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_judgment_offset_y_for_side,
+    init: None,
 };
 const COMBO_OFFSET_X: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -50,6 +53,7 @@ const COMBO_OFFSET_X: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_combo_offset_x_for_side,
+    init: None,
 };
 const COMBO_OFFSET_Y: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -58,6 +62,7 @@ const COMBO_OFFSET_Y: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_combo_offset_y_for_side,
+    init: None,
 };
 const NOTEFIELD_OFFSET_X: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -66,6 +71,7 @@ const NOTEFIELD_OFFSET_X: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_notefield_offset_x_for_side,
+    init: None,
 };
 const NOTEFIELD_OFFSET_Y: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -74,6 +80,7 @@ const NOTEFIELD_OFFSET_Y: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_notefield_offset_y_for_side,
+    init: None,
 };
 const VISUAL_DELAY: NumericBinding = NumericBinding {
     parse: parse_i32_ms,
@@ -82,6 +89,7 @@ const VISUAL_DELAY: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_visual_delay_ms_for_side,
+    init: None,
 };
 const GLOBAL_OFFSET_SHIFT: NumericBinding = NumericBinding {
     parse: parse_i32_ms,
@@ -90,6 +98,7 @@ const GLOBAL_OFFSET_SHIFT: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_global_offset_shift_ms_for_side,
+    init: None,
 };
 const SPACING: NumericBinding = NumericBinding {
     parse: parse_i32_percent,
@@ -98,6 +107,7 @@ const SPACING: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_spacing_percent_for_side,
+    init: None,
 };
 
 /// Shared boilerplate for a noteskin-style cycle row implemented via

--- a/src/screens/player_options/row.rs
+++ b/src/screens/player_options/row.rs
@@ -130,6 +130,11 @@ pub struct NumericBinding {
     pub parse: fn(&str) -> Option<i32>,
     pub apply: fn(&mut Profile, i32) -> Outcome,
     pub persist_for_side: fn(PlayerSide, i32),
+    /// Opt-in init contract. When `Some`, the row's initial cursor position is
+    /// derived directly from a `Profile` via `init_numeric_row_from_binding`.
+    /// `None` means the row's selection is initialized elsewhere (today: a
+    /// hand-written block in `apply_profile_defaults`).
+    pub init: Option<NumericInit>,
 }
 
 /// How a cycle row writes its currently selected index back to the persisted
@@ -148,6 +153,11 @@ pub enum CycleBinding {
 pub struct ChoiceBinding<T: Copy + 'static> {
     pub apply: fn(&mut Profile, T) -> Outcome,
     pub persist_for_side: fn(PlayerSide, T),
+    /// Opt-in init contract. When `Some`, the row's initial cursor position is
+    /// derived directly from a `Profile` via `init_cycle_row_from_binding`.
+    /// `None` means the row's selection is initialized elsewhere (today: a
+    /// hand-written block in `apply_profile_defaults`).
+    pub init: Option<CycleInit>,
 }
 
 /// # Adding a new mask row
@@ -248,6 +258,84 @@ pub fn init_bitmask_row_from_binding(
     true
 }
 
+/// Opt-in init contract for a `CycleBinding` row. The function returns the
+/// initial cursor index for a row given the current `Profile`. The helper
+/// `init_cycle_row_from_binding` clamps the returned index to
+/// `row.choices.len() - 1`, so implementations can return a raw
+/// `position(...).unwrap_or(0)` without separate clamping.
+///
+/// **Scope:** only `CycleBinding::Bool` and `CycleBinding::Index` rows.
+/// `CustomBinding` rows whose init logic depends on translated strings or
+/// runtime asset lookups (e.g. `NoteSkin`, `JudgmentFont`, `MineSkin`,
+/// `ReceptorSkin`, `TapExplosionSkin`, `HoldJudgment`) are intentionally not
+/// covered by this contract; they continue to be initialized in
+/// `apply_profile_defaults`.
+#[derive(Clone, Copy, Debug)]
+pub struct CycleInit {
+    pub from_profile: fn(&Profile) -> usize,
+}
+
+/// Opt-in init contract for a `NumericBinding` row. `from_profile` reads the
+/// row's `i32` value from the profile; `format` renders that value the same
+/// way the row's `choices` were generated (e.g. `|v| format!("{v}%")`,
+/// `|v| format!("{v}ms")`, `|v| v.to_string()`), so the rendered string can
+/// be looked up in `Row::choices`.
+///
+/// **Scope:** only `NumericBinding` rows. Numeric profile fields whose row
+/// does not exist (or whose init depends on runtime asset state) remain in
+/// `apply_profile_defaults`.
+#[derive(Clone, Copy, Debug)]
+pub struct NumericInit {
+    pub from_profile: fn(&Profile) -> i32,
+    pub format: fn(i32) -> String,
+}
+
+/// Apply a `ChoiceBinding`'s init contract to a row: compute the desired
+/// cursor index from the profile and clamp it to the row's choices length.
+/// Returns `true` when the binding had an `init` contract and was applied;
+/// `false` when the binding has no init.
+#[allow(dead_code)] // wired up by phase-2b migration
+pub fn init_cycle_row_from_binding<T: Copy + 'static>(
+    row: &mut Row,
+    binding: &ChoiceBinding<T>,
+    profile: &Profile,
+    player_idx: usize,
+) -> bool {
+    let Some(init) = binding.init.as_ref() else {
+        return false;
+    };
+    let max = row.choices.len().saturating_sub(1);
+    row.selected_choice_index[player_idx] = (init.from_profile)(profile).min(max);
+    true
+}
+
+/// Apply a `NumericBinding`'s init contract to a row: read the profile value,
+/// format it via `init.format`, and place the cursor on the matching entry in
+/// `Row::choices`. If no entry matches the formatted value, the row's
+/// existing selection is left unchanged — this matches the legacy behaviour
+/// of `apply_profile_defaults` for numeric rows (e.g. `Mini`, `Spacing`,
+/// `NoteFieldOffsetX/Y`, `JudgmentOffsetX/Y`), which all do
+/// `if let Some(idx) = row.choices.iter().position(...) { row.selected_choice_index[idx] = ... }`.
+/// Returns `true` when the binding had an `init` contract and was applied
+/// (even if the format produced no match); `false` when the binding has no
+/// init.
+#[allow(dead_code)] // wired up by phase-2b migration
+pub fn init_numeric_row_from_binding(
+    row: &mut Row,
+    binding: &NumericBinding,
+    profile: &Profile,
+    player_idx: usize,
+) -> bool {
+    let Some(init) = binding.init.as_ref() else {
+        return false;
+    };
+    let needle = (init.format)((init.from_profile)(profile));
+    if let Some(idx) = row.choices.iter().position(|c| c == &needle) {
+        row.selected_choice_index[player_idx] = idx;
+    }
+    true
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct CustomBinding {
     pub apply: fn(&mut State, usize, RowId, isize, NavWrap) -> Outcome,
@@ -294,6 +382,7 @@ macro_rules! index_binding {
                 }
             },
             persist_for_side: |s, i| $persist(s, $table.get(i).copied().unwrap_or($default)),
+            init: None,
         }
     };
 }

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -3,13 +3,14 @@ use super::*;
 #[cfg(test)]
 pub(super) mod tests {
     use super::{
-        BitmaskBinding, BitmaskInit, CursorInit, ErrorBarMask, FaPlusMask, GameplayExtrasMask,
-        GameplayExtrasMoreMask, HUD_OFFSET_MAX, HUD_OFFSET_MIN, HUD_OFFSET_ZERO_INDEX, HideMask,
-        NAV_INITIAL_HOLD_DELAY, NAV_REPEAT_SCROLL_INTERVAL, P1, P2, PlayerOptionMasks, Row,
-        RowBehavior, RowId, RowMap, ScrollMask, SpeedMod, SpeedModType, handle_arcade_start_event,
-        handle_start_event, hud_offset_choices, is_row_visible, judgment_tilt_intensity_visible,
-        repeat_held_arcade_start, row_visibility, session_active_players,
-        sync_profile_scroll_speed,
+        BitmaskBinding, BitmaskInit, ChoiceBinding, CursorInit, CycleInit, ErrorBarMask,
+        FaPlusMask, GameplayExtrasMask, GameplayExtrasMoreMask, HUD_OFFSET_MAX, HUD_OFFSET_MIN,
+        HUD_OFFSET_ZERO_INDEX, HideMask, NAV_INITIAL_HOLD_DELAY, NAV_REPEAT_SCROLL_INTERVAL,
+        NumericBinding, NumericInit, P1, P2, PlayerOptionMasks, Row, RowBehavior, RowId, RowMap,
+        ScrollMask, SpeedMod, SpeedModType, handle_arcade_start_event, handle_start_event,
+        hud_offset_choices, init_cycle_row_from_binding, init_numeric_row_from_binding,
+        is_row_visible, judgment_tilt_intensity_visible, repeat_held_arcade_start, row_visibility,
+        session_active_players, sync_profile_scroll_speed,
     };
     use crate::assets::AssetManager;
     use crate::assets::i18n::{LookupKey, lookup_key};
@@ -832,6 +833,7 @@ pub(super) mod tests {
                 super::Outcome::persisted_with_visibility()
             },
             persist_for_side: profile::update_judgment_tilt_for_side,
+            init: None,
         };
         let tilt_row = Row {
             id: RowId::JudgmentTilt,
@@ -1340,5 +1342,154 @@ pub(super) mod tests {
             [target, target],
             "WhatComesNext (mirror_across_players=true) must sync both player slots on inline focus commit"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // CycleInit / NumericInit contract helpers
+    //
+    // Direct unit tests for `init_cycle_row_from_binding` and
+    // `init_numeric_row_from_binding`. These guard the legacy semantics
+    // mirrored from `apply_profile_defaults`:
+    //
+    //   * Cycle helper clamps the returned index to `choices.len() - 1`
+    //     (matches the `.min(row.choices.len().saturating_sub(1))` pattern
+    //     used by every variant-table init block in `panes/mod.rs`).
+    //   * Numeric helper preserves the row's existing selection when the
+    //     formatted value does not match any entry in `Row::choices`
+    //     (matches the `if let Some(idx) = ... position(...)` pattern used
+    //     by every numeric init block in `panes/mod.rs`).
+    //   * Both helpers return `false` (no-op) when the binding has no
+    //     `init` contract — letting callers fall back to the legacy
+    //     hand-written init blocks during the in-progress migration.
+    // ---------------------------------------------------------------------
+
+    fn cycle_test_row(choices: &[&str], initial: [usize; 2]) -> Row {
+        Row {
+            id: RowId::Perspective,
+            behavior: RowBehavior::Exit, // behavior unused by the helper
+            name: lookup_key("PlayerOptions", "Perspective"),
+            choices: choices.iter().map(ToString::to_string).collect(),
+            selected_choice_index: initial,
+            help: Vec::new(),
+            choice_difficulty_indices: None,
+            mirror_across_players: false,
+        }
+    }
+
+    fn numeric_test_row(choices: &[&str], initial: [usize; 2]) -> Row {
+        Row {
+            id: RowId::Spacing,
+            behavior: RowBehavior::Exit, // behavior unused by the helper
+            name: lookup_key("PlayerOptions", "Spacing"),
+            choices: choices.iter().map(ToString::to_string).collect(),
+            selected_choice_index: initial,
+            help: Vec::new(),
+            choice_difficulty_indices: None,
+            mirror_across_players: false,
+        }
+    }
+
+    #[test]
+    fn init_cycle_row_from_binding_uses_init_function() {
+        let binding: ChoiceBinding<usize> = ChoiceBinding::<usize> {
+            apply: |_, _| super::Outcome::NONE,
+            persist_for_side: |_, _| {},
+            init: Some(CycleInit { from_profile: |_| 2 }),
+        };
+        let mut row = cycle_test_row(&["A", "B", "C", "D"], [0, 0]);
+        let applied = init_cycle_row_from_binding(&mut row, &binding, &Profile::default(), P1);
+        assert!(applied, "binding has init; helper must apply it");
+        assert_eq!(row.selected_choice_index[P1], 2);
+        assert_eq!(row.selected_choice_index[P2], 0, "P2 untouched");
+    }
+
+    #[test]
+    fn init_cycle_row_from_binding_clamps_to_choices_length() {
+        // Mirrors the `.min(row.choices.len().saturating_sub(1))` clamp used
+        // by every variant-table init block in apply_profile_defaults.
+        let binding: ChoiceBinding<usize> = ChoiceBinding::<usize> {
+            apply: |_, _| super::Outcome::NONE,
+            persist_for_side: |_, _| {},
+            init: Some(CycleInit {
+                from_profile: |_| 99,
+            }),
+        };
+        let mut row = cycle_test_row(&["A", "B", "C"], [0, 0]);
+        init_cycle_row_from_binding(&mut row, &binding, &Profile::default(), P1);
+        assert_eq!(
+            row.selected_choice_index[P1], 2,
+            "out-of-range init must clamp to choices.len()-1"
+        );
+    }
+
+    #[test]
+    fn init_cycle_row_from_binding_returns_false_without_init() {
+        let binding: ChoiceBinding<usize> = ChoiceBinding::<usize> {
+            apply: |_, _| super::Outcome::NONE,
+            persist_for_side: |_, _| {},
+            init: None,
+        };
+        let mut row = cycle_test_row(&["A", "B", "C"], [1, 1]);
+        let applied = init_cycle_row_from_binding(&mut row, &binding, &Profile::default(), P1);
+        assert!(!applied, "no init contract => helper reports no-op");
+        assert_eq!(
+            row.selected_choice_index, [1, 1],
+            "selection must be untouched when no init is wired"
+        );
+    }
+
+    #[test]
+    fn init_numeric_row_from_binding_finds_matching_choice() {
+        let binding = NumericBinding {
+            parse: super::parse_i32_percent,
+            apply: |_, _| super::Outcome::NONE,
+            persist_for_side: |_, _| {},
+            init: Some(NumericInit {
+                from_profile: |_| 50,
+                format: |v| format!("{v}%"),
+            }),
+        };
+        let mut row = numeric_test_row(&["0%", "25%", "50%", "75%", "100%"], [0, 0]);
+        let applied = init_numeric_row_from_binding(&mut row, &binding, &Profile::default(), P2);
+        assert!(applied);
+        assert_eq!(row.selected_choice_index[P2], 2);
+        assert_eq!(row.selected_choice_index[P1], 0, "P1 untouched");
+    }
+
+    #[test]
+    fn init_numeric_row_from_binding_preserves_selection_on_no_match() {
+        // Mirrors the legacy `if let Some(idx) = row.choices.iter().position(...)`
+        // pattern in apply_profile_defaults — when the formatted value is not
+        // present in choices, the row's existing selection is left alone.
+        let binding = NumericBinding {
+            parse: super::parse_i32_percent,
+            apply: |_, _| super::Outcome::NONE,
+            persist_for_side: |_, _| {},
+            init: Some(NumericInit {
+                from_profile: |_| 33,
+                format: |v| format!("{v}%"),
+            }),
+        };
+        let mut row = numeric_test_row(&["0%", "50%", "100%"], [1, 1]);
+        let applied = init_numeric_row_from_binding(&mut row, &binding, &Profile::default(), P1);
+        assert!(applied, "binding has init; helper applied it (even if no-op)");
+        assert_eq!(
+            row.selected_choice_index, [1, 1],
+            "no matching choice => selection preserved"
+        );
+    }
+
+    #[test]
+    fn init_numeric_row_from_binding_returns_false_without_init() {
+        let binding = NumericBinding {
+            parse: super::parse_i32_percent,
+            apply: |_, _| super::Outcome::NONE,
+            persist_for_side: |_, _| {},
+            init: None,
+        };
+        let mut row = numeric_test_row(&["0%", "50%", "100%"], [1, 1]);
+        let applied = init_numeric_row_from_binding(&mut row, &binding, &Profile::default(), P1);
+        assert!(!applied);
+        assert_eq!(row.selected_choice_index, [1, 1]);
     }
 }

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -1344,29 +1344,10 @@ pub(super) mod tests {
         );
     }
 
-    // ---------------------------------------------------------------------
-    // CycleInit / NumericInit contract helpers
-    //
-    // Direct unit tests for `init_cycle_row_from_binding` and
-    // `init_numeric_row_from_binding`. These guard the legacy semantics
-    // mirrored from `apply_profile_defaults`:
-    //
-    //   * Cycle helper clamps the returned index to `choices.len() - 1`
-    //     (matches the `.min(row.choices.len().saturating_sub(1))` pattern
-    //     used by every variant-table init block in `panes/mod.rs`).
-    //   * Numeric helper preserves the row's existing selection when the
-    //     formatted value does not match any entry in `Row::choices`
-    //     (matches the `if let Some(idx) = ... position(...)` pattern used
-    //     by every numeric init block in `panes/mod.rs`).
-    //   * Both helpers return `false` (no-op) when the binding has no
-    //     `init` contract — letting callers fall back to the legacy
-    //     hand-written init blocks during the in-progress migration.
-    // ---------------------------------------------------------------------
-
     fn cycle_test_row(choices: &[&str], initial: [usize; 2]) -> Row {
         Row {
             id: RowId::Perspective,
-            behavior: RowBehavior::Exit, // behavior unused by the helper
+            behavior: RowBehavior::Exit,
             name: lookup_key("PlayerOptions", "Perspective"),
             choices: choices.iter().map(ToString::to_string).collect(),
             selected_choice_index: initial,
@@ -1379,7 +1360,7 @@ pub(super) mod tests {
     fn numeric_test_row(choices: &[&str], initial: [usize; 2]) -> Row {
         Row {
             id: RowId::Spacing,
-            behavior: RowBehavior::Exit, // behavior unused by the helper
+            behavior: RowBehavior::Exit,
             name: lookup_key("PlayerOptions", "Spacing"),
             choices: choices.iter().map(ToString::to_string).collect(),
             selected_choice_index: initial,
@@ -1405,8 +1386,6 @@ pub(super) mod tests {
 
     #[test]
     fn init_cycle_row_from_binding_clamps_to_choices_length() {
-        // Mirrors the `.min(row.choices.len().saturating_sub(1))` clamp used
-        // by every variant-table init block in apply_profile_defaults.
         let binding: ChoiceBinding<usize> = ChoiceBinding::<usize> {
             apply: |_, _| super::Outcome::NONE,
             persist_for_side: |_, _| {},
@@ -1458,9 +1437,6 @@ pub(super) mod tests {
 
     #[test]
     fn init_numeric_row_from_binding_preserves_selection_on_no_match() {
-        // Mirrors the legacy `if let Some(idx) = row.choices.iter().position(...)`
-        // pattern in apply_profile_defaults — when the formatted value is not
-        // present in choices, the row's existing selection is left alone.
         let binding = NumericBinding {
             parse: super::parse_i32_percent,
             apply: |_, _| super::Outcome::NONE,


### PR DESCRIPTION
## Summary

Introduces optional per-binding init contracts (`CycleInit`, `NumericInit`) that mirror the existing `BitmaskInit` pattern in `row.rs`.

This PR is **purely additive** — every existing binding literal carries `init: None` and behavior is unchanged at runtime.

## What's in scope

- `CycleInit { from_profile: fn(&Profile) -> usize }` and `NumericInit { from_profile, format }` structs in `row.rs`
- `init_cycle_row_from_binding` / `init_numeric_row_from_binding` free functions
- `init: Option<...>` field on `NumericBinding` and `ChoiceBinding<T>`
- `index_binding!` macro updated to emit `init: None`
- All existing binding literals in `panes/main.rs` and `panes/advanced.rs` updated to pass `init: None`
- Unit tests covering apply / clamp / no-match-preserve / no-init-noop for both helpers