### PR TITLE
refactor(player_options): migrate Main pane init to binding contracts

### DIFF
--- a/src/screens/player_options/panes/advanced.rs
+++ b/src/screens/player_options/panes/advanced.rs
@@ -90,6 +90,7 @@ const DENSITY_GRAPH_BACKGROUND: ChoiceBinding<bool> = ChoiceBinding::<bool> {
         Outcome::persisted()
     },
     persist_for_side: gp::update_transparent_density_graph_bg_for_side,
+    init: None,
 };
 const CARRY_COMBO: ChoiceBinding<bool> = ChoiceBinding::<bool> {
     apply: |p, v| {
@@ -97,6 +98,7 @@ const CARRY_COMBO: ChoiceBinding<bool> = ChoiceBinding::<bool> {
         Outcome::persisted()
     },
     persist_for_side: gp::update_carry_combo_between_songs_for_side,
+    init: None,
 };
 const JUDGMENT_TILT: ChoiceBinding<bool> = ChoiceBinding::<bool> {
     apply: |p, v| {
@@ -104,6 +106,7 @@ const JUDGMENT_TILT: ChoiceBinding<bool> = ChoiceBinding::<bool> {
         Outcome::persisted_with_visibility()
     },
     persist_for_side: gp::update_judgment_tilt_for_side,
+    init: None,
 };
 const JUDGMENT_BEHIND_ARROWS: ChoiceBinding<bool> = ChoiceBinding::<bool> {
     apply: |p, v| {
@@ -111,6 +114,7 @@ const JUDGMENT_BEHIND_ARROWS: ChoiceBinding<bool> = ChoiceBinding::<bool> {
         Outcome::persisted()
     },
     persist_for_side: gp::update_judgment_back_for_side,
+    init: None,
 };
 const OFFSET_INDICATOR: ChoiceBinding<bool> = ChoiceBinding::<bool> {
     apply: |p, v| {
@@ -118,6 +122,7 @@ const OFFSET_INDICATOR: ChoiceBinding<bool> = ChoiceBinding::<bool> {
         Outcome::persisted()
     },
     persist_for_side: gp::update_error_ms_display_for_side,
+    init: None,
 };
 const RESCORE_EARLY_HITS: ChoiceBinding<bool> = ChoiceBinding::<bool> {
     apply: |p, v| {
@@ -125,6 +130,7 @@ const RESCORE_EARLY_HITS: ChoiceBinding<bool> = ChoiceBinding::<bool> {
         Outcome::persisted()
     },
     persist_for_side: gp::update_rescore_early_hits_for_side,
+    init: None,
 };
 const CUSTOM_BLUE_FANTASTIC_WINDOW: ChoiceBinding<bool> = ChoiceBinding::<bool> {
     apply: |p, v| {
@@ -132,6 +138,7 @@ const CUSTOM_BLUE_FANTASTIC_WINDOW: ChoiceBinding<bool> = ChoiceBinding::<bool> 
         Outcome::persisted_with_visibility()
     },
     persist_for_side: gp::update_custom_fantastic_window_for_side,
+    init: None,
 };
 
 const ERROR_BAR_OFFSET_X: NumericBinding = NumericBinding {
@@ -141,6 +148,7 @@ const ERROR_BAR_OFFSET_X: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_error_bar_offset_x_for_side,
+    init: None,
 };
 const ERROR_BAR_OFFSET_Y: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -149,6 +157,7 @@ const ERROR_BAR_OFFSET_Y: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_error_bar_offset_y_for_side,
+    init: None,
 };
 
 const SCROLL: BitmaskBinding = BitmaskBinding {

--- a/src/screens/player_options/panes/main.rs
+++ b/src/screens/player_options/panes/main.rs
@@ -25,6 +25,7 @@ const BACKGROUND_FILTER: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_background_filter_for_side,
+    init: None,
 };
 
 const JUDGMENT_OFFSET_X: NumericBinding = NumericBinding {
@@ -34,6 +35,7 @@ const JUDGMENT_OFFSET_X: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_judgment_offset_x_for_side,
+    init: None,
 };
 const JUDGMENT_OFFSET_Y: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -42,6 +44,7 @@ const JUDGMENT_OFFSET_Y: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_judgment_offset_y_for_side,
+    init: None,
 };
 const COMBO_OFFSET_X: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -50,6 +53,7 @@ const COMBO_OFFSET_X: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_combo_offset_x_for_side,
+    init: None,
 };
 const COMBO_OFFSET_Y: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -58,6 +62,7 @@ const COMBO_OFFSET_Y: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_combo_offset_y_for_side,
+    init: None,
 };
 const NOTEFIELD_OFFSET_X: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -66,6 +71,7 @@ const NOTEFIELD_OFFSET_X: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_notefield_offset_x_for_side,
+    init: None,
 };
 const NOTEFIELD_OFFSET_Y: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -74,6 +80,7 @@ const NOTEFIELD_OFFSET_Y: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_notefield_offset_y_for_side,
+    init: None,
 };
 const VISUAL_DELAY: NumericBinding = NumericBinding {
     parse: parse_i32_ms,
@@ -82,6 +89,7 @@ const VISUAL_DELAY: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_visual_delay_ms_for_side,
+    init: None,
 };
 const GLOBAL_OFFSET_SHIFT: NumericBinding = NumericBinding {
     parse: parse_i32_ms,
@@ -90,6 +98,7 @@ const GLOBAL_OFFSET_SHIFT: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_global_offset_shift_ms_for_side,
+    init: None,
 };
 const SPACING: NumericBinding = NumericBinding {
     parse: parse_i32_percent,
@@ -98,6 +107,7 @@ const SPACING: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_spacing_percent_for_side,
+    init: None,
 };
 
 /// Shared boilerplate for a noteskin-style cycle row implemented via

--- a/src/screens/player_options/panes/main.rs
+++ b/src/screens/player_options/panes/main.rs
@@ -9,14 +9,30 @@ const PERSPECTIVE: ChoiceBinding<usize> = index_binding!(
     gp::Perspective::Overhead,
     perspective,
     gp::update_perspective_for_side,
-    false
+    false,
+    Some(CycleInit {
+        from_profile: |p| {
+            PERSPECTIVE_VARIANTS
+                .iter()
+                .position(|&v| v == p.perspective)
+                .unwrap_or(0)
+        }
+    })
 );
 const COMBO_FONT: ChoiceBinding<usize> = index_binding!(
     COMBO_FONT_VARIANTS,
     gp::ComboFont::Wendy,
     combo_font,
     gp::update_combo_font_for_side,
-    true
+    true,
+    Some(CycleInit {
+        from_profile: |p| {
+            COMBO_FONT_VARIANTS
+                .iter()
+                .position(|&v| v == p.combo_font)
+                .unwrap_or(0)
+        }
+    })
 );
 const BACKGROUND_FILTER: NumericBinding = NumericBinding {
     parse: parse_i32_percent,
@@ -25,7 +41,10 @@ const BACKGROUND_FILTER: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_background_filter_for_side,
-    init: None,
+    init: Some(NumericInit {
+        from_profile: |p| p.background_filter.percent() as i32,
+        format: |v| format!("{v}%"),
+    }),
 };
 
 const JUDGMENT_OFFSET_X: NumericBinding = NumericBinding {
@@ -35,7 +54,10 @@ const JUDGMENT_OFFSET_X: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_judgment_offset_x_for_side,
-    init: None,
+    init: Some(NumericInit {
+        from_profile: |p| p.judgment_offset_x.clamp(HUD_OFFSET_MIN, HUD_OFFSET_MAX),
+        format: |v| format!("{v}"),
+    }),
 };
 const JUDGMENT_OFFSET_Y: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -44,7 +66,10 @@ const JUDGMENT_OFFSET_Y: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_judgment_offset_y_for_side,
-    init: None,
+    init: Some(NumericInit {
+        from_profile: |p| p.judgment_offset_y.clamp(HUD_OFFSET_MIN, HUD_OFFSET_MAX),
+        format: |v| format!("{v}"),
+    }),
 };
 const COMBO_OFFSET_X: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -53,7 +78,10 @@ const COMBO_OFFSET_X: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_combo_offset_x_for_side,
-    init: None,
+    init: Some(NumericInit {
+        from_profile: |p| p.combo_offset_x.clamp(HUD_OFFSET_MIN, HUD_OFFSET_MAX),
+        format: |v| format!("{v}"),
+    }),
 };
 const COMBO_OFFSET_Y: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -62,7 +90,10 @@ const COMBO_OFFSET_Y: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_combo_offset_y_for_side,
-    init: None,
+    init: Some(NumericInit {
+        from_profile: |p| p.combo_offset_y.clamp(HUD_OFFSET_MIN, HUD_OFFSET_MAX),
+        format: |v| format!("{v}"),
+    }),
 };
 const NOTEFIELD_OFFSET_X: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -71,7 +102,10 @@ const NOTEFIELD_OFFSET_X: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_notefield_offset_x_for_side,
-    init: None,
+    init: Some(NumericInit {
+        from_profile: |p| p.note_field_offset_x.clamp(0, 50),
+        format: |v| format!("{v}"),
+    }),
 };
 const NOTEFIELD_OFFSET_Y: NumericBinding = NumericBinding {
     parse: parse_i32,
@@ -80,7 +114,10 @@ const NOTEFIELD_OFFSET_Y: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_notefield_offset_y_for_side,
-    init: None,
+    init: Some(NumericInit {
+        from_profile: |p| p.note_field_offset_y.clamp(-50, 50),
+        format: |v| format!("{v}"),
+    }),
 };
 const VISUAL_DELAY: NumericBinding = NumericBinding {
     parse: parse_i32_ms,
@@ -89,7 +126,10 @@ const VISUAL_DELAY: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_visual_delay_ms_for_side,
-    init: None,
+    init: Some(NumericInit {
+        from_profile: |p| p.visual_delay_ms.clamp(-100, 100),
+        format: |v| format!("{v}ms"),
+    }),
 };
 const GLOBAL_OFFSET_SHIFT: NumericBinding = NumericBinding {
     parse: parse_i32_ms,
@@ -98,7 +138,10 @@ const GLOBAL_OFFSET_SHIFT: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_global_offset_shift_ms_for_side,
-    init: None,
+    init: Some(NumericInit {
+        from_profile: |p| p.global_offset_shift_ms.clamp(-100, 100),
+        format: |v| format!("{v}ms"),
+    }),
 };
 const SPACING: NumericBinding = NumericBinding {
     parse: parse_i32_percent,
@@ -107,7 +150,13 @@ const SPACING: NumericBinding = NumericBinding {
         Outcome::persisted()
     },
     persist_for_side: gp::update_spacing_percent_for_side,
-    init: None,
+    init: Some(NumericInit {
+        from_profile: |p| {
+            p.spacing_percent
+                .clamp(SPACING_PERCENT_MIN, SPACING_PERCENT_MAX)
+        },
+        format: |v| format!("{v}%"),
+    }),
 };
 
 /// Shared boilerplate for a noteskin-style cycle row implemented via

--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -122,15 +122,12 @@ pub(super) fn apply_profile_defaults(
     masks: &mut PlayerOptionMasks,
 ) {
     init_opted_in_bitmask_rows(row_map, profile, masks, player_idx);
+    init_opted_in_cycle_rows(row_map, profile, player_idx);
+    init_opted_in_numeric_rows(row_map, profile, player_idx);
     apply_derived_masks(profile, masks);
 
     let match_ns_label = tr("PlayerOptions", MATCH_NOTESKIN_LABEL);
     let no_tap_label = tr("PlayerOptions", NO_TAP_EXPLOSION_LABEL);
-    // Initialize Background Filter row from profile setting (0..=100 %).
-    if let Some(row) = row_map.get_mut(RowId::BackgroundFilter) {
-        row.selected_choice_index[player_idx] =
-            (profile.background_filter.percent() as usize).min(row.choices.len().saturating_sub(1));
-    }
     // Initialize Judgment Font row from profile setting
     if let Some(row) = row_map.get_mut(RowId::JudgmentFont) {
         row.selected_choice_index[player_idx] = assets::judgment_texture_choices()
@@ -180,13 +177,6 @@ pub(super) fn apply_profile_defaults(
         );
     }
     // Initialize Combo Font row from profile setting
-    if let Some(row) = row_map.get_mut(RowId::ComboFont) {
-        row.selected_choice_index[player_idx] = COMBO_FONT_VARIANTS
-            .iter()
-            .position(|&v| v == profile.combo_font)
-            .unwrap_or(0)
-            .min(row.choices.len().saturating_sub(1));
-    }
     if let Some(row) = row_map.get_mut(RowId::ComboColors) {
         row.selected_choice_index[player_idx] = COMBO_COLORS_VARIANTS
             .iter()
@@ -227,77 +217,7 @@ pub(super) fn apply_profile_defaults(
             row.selected_choice_index[player_idx] = idx;
         }
     }
-    // Initialize Spacing row from profile (range SPACING_PERCENT_MIN..=SPACING_PERCENT_MAX).
-    if let Some(row) = row_map.get_mut(RowId::Spacing) {
-        let val = profile
-            .spacing_percent
-            .clamp(SPACING_PERCENT_MIN, SPACING_PERCENT_MAX);
-        let needle = format!("{val}%");
-        if let Some(idx) = row.choices.iter().position(|c| c == &needle) {
-            row.selected_choice_index[player_idx] = idx;
-        }
-    }
-    // Initialize Perspective row from profile setting (Overhead, Hallway, Distant, Incoming, Space).
-    if let Some(row) = row_map.get_mut(RowId::Perspective) {
-        row.selected_choice_index[player_idx] = PERSPECTIVE_VARIANTS
-            .iter()
-            .position(|&v| v == profile.perspective)
-            .unwrap_or(0)
-            .min(row.choices.len().saturating_sub(1));
-    }
-    // Initialize NoteField Offset X from profile (0..50, non-negative; P1 uses negative sign at render time)
-    if let Some(row) = row_map.get_mut(RowId::NoteFieldOffsetX) {
-        let val = profile.note_field_offset_x.clamp(0, 50);
-        let val_str = val.to_string();
-        if let Some(idx) = row.choices.iter().position(|c| c == &val_str) {
-            row.selected_choice_index[player_idx] = idx;
-        }
-    }
-    // Initialize NoteField Offset Y from profile (-50..50)
-    if let Some(row) = row_map.get_mut(RowId::NoteFieldOffsetY) {
-        let val = profile.note_field_offset_y.clamp(-50, 50);
-        let val_str = val.to_string();
-        if let Some(idx) = row.choices.iter().position(|c| c == &val_str) {
-            row.selected_choice_index[player_idx] = idx;
-        }
-    }
     // Initialize Judgment Offset X from profile (HUD offset range)
-    if let Some(row) = row_map.get_mut(RowId::JudgmentOffsetX) {
-        let val = profile
-            .judgment_offset_x
-            .clamp(HUD_OFFSET_MIN, HUD_OFFSET_MAX);
-        let val_str = val.to_string();
-        if let Some(idx) = row.choices.iter().position(|c| c == &val_str) {
-            row.selected_choice_index[player_idx] = idx;
-        }
-    }
-    // Initialize Judgment Offset Y from profile (HUD offset range)
-    if let Some(row) = row_map.get_mut(RowId::JudgmentOffsetY) {
-        let val = profile
-            .judgment_offset_y
-            .clamp(HUD_OFFSET_MIN, HUD_OFFSET_MAX);
-        let val_str = val.to_string();
-        if let Some(idx) = row.choices.iter().position(|c| c == &val_str) {
-            row.selected_choice_index[player_idx] = idx;
-        }
-    }
-    // Initialize Combo Offset X from profile (HUD offset range)
-    if let Some(row) = row_map.get_mut(RowId::ComboOffsetX) {
-        let val = profile.combo_offset_x.clamp(HUD_OFFSET_MIN, HUD_OFFSET_MAX);
-        let val_str = val.to_string();
-        if let Some(idx) = row.choices.iter().position(|c| c == &val_str) {
-            row.selected_choice_index[player_idx] = idx;
-        }
-    }
-    // Initialize Combo Offset Y from profile (HUD offset range)
-    if let Some(row) = row_map.get_mut(RowId::ComboOffsetY) {
-        let val = profile.combo_offset_y.clamp(HUD_OFFSET_MIN, HUD_OFFSET_MAX);
-        let val_str = val.to_string();
-        if let Some(idx) = row.choices.iter().position(|c| c == &val_str) {
-            row.selected_choice_index[player_idx] = idx;
-        }
-    }
-    // Initialize Error Bar Offset X from profile (HUD offset range)
     if let Some(row) = row_map.get_mut(RowId::ErrorBarOffsetX) {
         let val = profile
             .error_bar_offset_x
@@ -314,21 +234,6 @@ pub(super) fn apply_profile_defaults(
             .clamp(HUD_OFFSET_MIN, HUD_OFFSET_MAX);
         let val_str = val.to_string();
         if let Some(idx) = row.choices.iter().position(|c| c == &val_str) {
-            row.selected_choice_index[player_idx] = idx;
-        }
-    }
-    // Initialize Visual Delay from profile (-100..100ms)
-    if let Some(row) = row_map.get_mut(RowId::VisualDelay) {
-        let val = profile.visual_delay_ms.clamp(-100, 100);
-        let needle = format!("{val}ms");
-        if let Some(idx) = row.choices.iter().position(|c| c == &needle) {
-            row.selected_choice_index[player_idx] = idx;
-        }
-    }
-    if let Some(row) = row_map.get_mut(RowId::GlobalOffsetShift) {
-        let val = profile.global_offset_shift_ms.clamp(-100, 100);
-        let needle = format!("{val}ms");
-        if let Some(idx) = row.choices.iter().position(|c| c == &needle) {
             row.selected_choice_index[player_idx] = idx;
         }
     }
@@ -498,6 +403,49 @@ fn init_opted_in_bitmask_rows(
         }
         let row = row_map.get_mut(id).expect("row was just observed");
         super::row::init_bitmask_row_from_binding(row, &binding, profile, masks, player_idx);
+    }
+}
+
+fn init_opted_in_cycle_rows(
+    row_map: &mut RowMap,
+    profile: &crate::game::profile::Profile,
+    player_idx: usize,
+) {
+    let ids: Vec<RowId> = row_map.display_order().to_vec();
+    for id in ids {
+        let Some(row) = row_map.get_mut(id) else {
+            continue;
+        };
+        match row.behavior {
+            RowBehavior::Cycle(super::row::CycleBinding::Index(binding)) => {
+                super::row::init_cycle_row_from_binding(row, &binding, profile, player_idx);
+            }
+            RowBehavior::Cycle(super::row::CycleBinding::Bool(binding)) => {
+                super::row::init_cycle_row_from_binding(row, &binding, profile, player_idx);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn init_opted_in_numeric_rows(
+    row_map: &mut RowMap,
+    profile: &crate::game::profile::Profile,
+    player_idx: usize,
+) {
+    let ids: Vec<RowId> = row_map.display_order().to_vec();
+    for id in ids {
+        let Some(row) = row_map.get(id) else {
+            continue;
+        };
+        let RowBehavior::Numeric(binding) = row.behavior else {
+            continue;
+        };
+        if binding.init.is_none() {
+            continue;
+        }
+        let row = row_map.get_mut(id).expect("row was just observed");
+        super::row::init_numeric_row_from_binding(row, &binding, profile, player_idx);
     }
 }
 

--- a/src/screens/player_options/row.rs
+++ b/src/screens/player_options/row.rs
@@ -130,6 +130,11 @@ pub struct NumericBinding {
     pub parse: fn(&str) -> Option<i32>,
     pub apply: fn(&mut Profile, i32) -> Outcome,
     pub persist_for_side: fn(PlayerSide, i32),
+    /// Opt-in init contract. When `Some`, the row's initial cursor position is
+    /// derived directly from a `Profile` via `init_numeric_row_from_binding`.
+    /// `None` means the row's selection is initialized elsewhere (today: a
+    /// hand-written block in `apply_profile_defaults`).
+    pub init: Option<NumericInit>,
 }
 
 /// How a cycle row writes its currently selected index back to the persisted
@@ -148,6 +153,11 @@ pub enum CycleBinding {
 pub struct ChoiceBinding<T: Copy + 'static> {
     pub apply: fn(&mut Profile, T) -> Outcome,
     pub persist_for_side: fn(PlayerSide, T),
+    /// Opt-in init contract. When `Some`, the row's initial cursor position is
+    /// derived directly from a `Profile` via `init_cycle_row_from_binding`.
+    /// `None` means the row's selection is initialized elsewhere (today: a
+    /// hand-written block in `apply_profile_defaults`).
+    pub init: Option<CycleInit>,
 }
 
 /// # Adding a new mask row
@@ -248,6 +258,84 @@ pub fn init_bitmask_row_from_binding(
     true
 }
 
+/// Opt-in init contract for a `CycleBinding` row. The function returns the
+/// initial cursor index for a row given the current `Profile`. The helper
+/// `init_cycle_row_from_binding` clamps the returned index to
+/// `row.choices.len() - 1`, so implementations can return a raw
+/// `position(...).unwrap_or(0)` without separate clamping.
+///
+/// **Scope:** only `CycleBinding::Bool` and `CycleBinding::Index` rows.
+/// `CustomBinding` rows whose init logic depends on translated strings or
+/// runtime asset lookups (e.g. `NoteSkin`, `JudgmentFont`, `MineSkin`,
+/// `ReceptorSkin`, `TapExplosionSkin`, `HoldJudgment`) are intentionally not
+/// covered by this contract; they continue to be initialized in
+/// `apply_profile_defaults`.
+#[derive(Clone, Copy, Debug)]
+pub struct CycleInit {
+    pub from_profile: fn(&Profile) -> usize,
+}
+
+/// Opt-in init contract for a `NumericBinding` row. `from_profile` reads the
+/// row's `i32` value from the profile; `format` renders that value the same
+/// way the row's `choices` were generated (e.g. `|v| format!("{v}%")`,
+/// `|v| format!("{v}ms")`, `|v| v.to_string()`), so the rendered string can
+/// be looked up in `Row::choices`.
+///
+/// **Scope:** only `NumericBinding` rows. Numeric profile fields whose row
+/// does not exist (or whose init depends on runtime asset state) remain in
+/// `apply_profile_defaults`.
+#[derive(Clone, Copy, Debug)]
+pub struct NumericInit {
+    pub from_profile: fn(&Profile) -> i32,
+    pub format: fn(i32) -> String,
+}
+
+/// Apply a `ChoiceBinding`'s init contract to a row: compute the desired
+/// cursor index from the profile and clamp it to the row's choices length.
+/// Returns `true` when the binding had an `init` contract and was applied;
+/// `false` when the binding has no init.
+#[allow(dead_code)] // wired up by phase-2b migration
+pub fn init_cycle_row_from_binding<T: Copy + 'static>(
+    row: &mut Row,
+    binding: &ChoiceBinding<T>,
+    profile: &Profile,
+    player_idx: usize,
+) -> bool {
+    let Some(init) = binding.init.as_ref() else {
+        return false;
+    };
+    let max = row.choices.len().saturating_sub(1);
+    row.selected_choice_index[player_idx] = (init.from_profile)(profile).min(max);
+    true
+}
+
+/// Apply a `NumericBinding`'s init contract to a row: read the profile value,
+/// format it via `init.format`, and place the cursor on the matching entry in
+/// `Row::choices`. If no entry matches the formatted value, the row's
+/// existing selection is left unchanged — this matches the legacy behaviour
+/// of `apply_profile_defaults` for numeric rows (e.g. `Mini`, `Spacing`,
+/// `NoteFieldOffsetX/Y`, `JudgmentOffsetX/Y`), which all do
+/// `if let Some(idx) = row.choices.iter().position(...) { row.selected_choice_index[idx] = ... }`.
+/// Returns `true` when the binding had an `init` contract and was applied
+/// (even if the format produced no match); `false` when the binding has no
+/// init.
+#[allow(dead_code)] // wired up by phase-2b migration
+pub fn init_numeric_row_from_binding(
+    row: &mut Row,
+    binding: &NumericBinding,
+    profile: &Profile,
+    player_idx: usize,
+) -> bool {
+    let Some(init) = binding.init.as_ref() else {
+        return false;
+    };
+    let needle = (init.format)((init.from_profile)(profile));
+    if let Some(idx) = row.choices.iter().position(|c| c == &needle) {
+        row.selected_choice_index[player_idx] = idx;
+    }
+    true
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct CustomBinding {
     pub apply: fn(&mut State, usize, RowId, isize, NavWrap) -> Outcome,
@@ -294,6 +382,7 @@ macro_rules! index_binding {
                 }
             },
             persist_for_side: |s, i| $persist(s, $table.get(i).copied().unwrap_or($default)),
+            init: None,
         }
     };
 }

--- a/src/screens/player_options/row.rs
+++ b/src/screens/player_options/row.rs
@@ -294,7 +294,6 @@ pub struct NumericInit {
 /// cursor index from the profile and clamp it to the row's choices length.
 /// Returns `true` when the binding had an `init` contract and was applied;
 /// `false` when the binding has no init.
-#[allow(dead_code)] // wired up by phase-2b migration
 pub fn init_cycle_row_from_binding<T: Copy + 'static>(
     row: &mut Row,
     binding: &ChoiceBinding<T>,
@@ -319,7 +318,6 @@ pub fn init_cycle_row_from_binding<T: Copy + 'static>(
 /// Returns `true` when the binding had an `init` contract and was applied
 /// (even if the format produced no match); `false` when the binding has no
 /// init.
-#[allow(dead_code)] // wired up by phase-2b migration
 pub fn init_numeric_row_from_binding(
     row: &mut Row,
     binding: &NumericBinding,
@@ -372,6 +370,9 @@ pub(super) fn parse_i32_percent(s: &str) -> Option<i32> {
 /// `[Enum; N]` variant table. Cuts per-binding boilerplate down to its data.
 macro_rules! index_binding {
     ($table:expr, $default:expr, $field:ident, $persist:expr, $vis:expr) => {
+        index_binding!($table, $default, $field, $persist, $vis, None)
+    };
+    ($table:expr, $default:expr, $field:ident, $persist:expr, $vis:expr, $init:expr) => {
         $crate::screens::player_options::row::ChoiceBinding::<usize> {
             apply: |p, i| {
                 p.$field = $table.get(i).copied().unwrap_or($default);
@@ -382,7 +383,7 @@ macro_rules! index_binding {
                 }
             },
             persist_for_side: |s, i| $persist(s, $table.get(i).copied().unwrap_or($default)),
-            init: None,
+            init: $init,
         }
     };
 }

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -1468,4 +1468,150 @@ pub(super) mod tests {
         assert!(!applied);
         assert_eq!(row.selected_choice_index, [1, 1]);
     }
+
+    /// End-to-end check that the cycle/numeric init dispatchers in
+    /// `apply_profile_defaults` produce the same `selected_choice_index`
+    /// values that the legacy hand-written if-let blocks did, for every
+    /// Main pane row migrated to the binding-driven contract.
+    ///
+    /// Sets a non-default value on each migrated profile field so a stale
+    /// `[0, 0]` result would fail the assertion.
+    #[test]
+    fn apply_profile_defaults_initializes_main_pane_rows_via_contracts() {
+        ensure_i18n();
+        let (mut state, _asset_manager) = setup_state();
+
+        // Mutate every profile field whose Main pane row was migrated to the
+        // CycleInit / NumericInit contract.
+        let p = &mut state.player_profiles[P1];
+        p.perspective = profile::Perspective::Distant;
+        p.combo_font = profile::ComboFont::Wendy;
+        p.background_filter = profile::BackgroundFilter::from_i32(42);
+        p.spacing_percent = 95;
+        p.judgment_offset_x = -25;
+        p.judgment_offset_y = 30;
+        p.combo_offset_x = 12;
+        p.combo_offset_y = -8;
+        p.note_field_offset_x = 17;
+        p.note_field_offset_y = -22;
+        p.visual_delay_ms = 35;
+        p.global_offset_shift_ms = -45;
+
+        let profile = state.player_profiles[P1].clone();
+        let noteskin_names = super::discover_noteskin_names();
+        let mut row_map = super::build_rows(
+            &state.song,
+            &state.speed_mod[P1],
+            state.chart_steps_index,
+            [0; 2],
+            state.music_rate,
+            super::OptionsPane::Main,
+            &noteskin_names,
+            Screen::SelectMusic,
+            state.fixed_stepchart.as_ref(),
+        );
+        let mut masks = PlayerOptionMasks::default();
+        super::super::panes::apply_profile_defaults(&mut row_map, &profile, P1, &mut masks);
+
+        // Cycle rows: assert the selected variant matches the profile value.
+        assert_variant_at_cursor(
+            &row_map,
+            RowId::Perspective,
+            &super::PERSPECTIVE_VARIANTS,
+            profile.perspective,
+        );
+        assert_variant_at_cursor(
+            &row_map,
+            RowId::ComboFont,
+            &super::COMBO_FONT_VARIANTS,
+            profile.combo_font,
+        );
+
+        // Numeric rows: assert the choice string at the cursor matches the
+        // formatted profile value (the same lookup the dispatcher does).
+        assert_choice_at_cursor(&row_map, RowId::BackgroundFilter, "42%");
+        assert_choice_at_cursor(&row_map, RowId::Spacing, "95%");
+        assert_choice_at_cursor(&row_map, RowId::JudgmentOffsetX, "-25");
+        assert_choice_at_cursor(&row_map, RowId::JudgmentOffsetY, "30");
+        assert_choice_at_cursor(&row_map, RowId::ComboOffsetX, "12");
+        assert_choice_at_cursor(&row_map, RowId::ComboOffsetY, "-8");
+        assert_choice_at_cursor(&row_map, RowId::NoteFieldOffsetX, "17");
+        assert_choice_at_cursor(&row_map, RowId::NoteFieldOffsetY, "-22");
+        assert_choice_at_cursor(&row_map, RowId::VisualDelay, "35ms");
+        assert_choice_at_cursor(&row_map, RowId::GlobalOffsetShift, "-45ms");
+    }
+
+    /// Numeric values outside the row's choice range (clamped by the binding's
+    /// `from_profile` closure) must still land on a valid in-range choice,
+    /// matching the legacy behaviour. Picks the largest representable value
+    /// for each row's clamp range; the cursor must end up on the choice that
+    /// formats to the clamped value.
+    #[test]
+    fn apply_profile_defaults_clamps_numeric_values_to_range() {
+        ensure_i18n();
+        let (mut state, _asset_manager) = setup_state();
+
+        let p = &mut state.player_profiles[P1];
+        p.judgment_offset_x = 10_000; // clamps to HUD_OFFSET_MAX
+        p.note_field_offset_x = -10; // clamps to 0 (range 0..50)
+        p.visual_delay_ms = -10_000; // clamps to -100
+        p.spacing_percent = 100_000; // clamps to SPACING_PERCENT_MAX
+
+        let profile = state.player_profiles[P1].clone();
+        let noteskin_names = super::discover_noteskin_names();
+        let mut row_map = super::build_rows(
+            &state.song,
+            &state.speed_mod[P1],
+            state.chart_steps_index,
+            [0; 2],
+            state.music_rate,
+            super::OptionsPane::Main,
+            &noteskin_names,
+            Screen::SelectMusic,
+            state.fixed_stepchart.as_ref(),
+        );
+        let mut masks = PlayerOptionMasks::default();
+        super::super::panes::apply_profile_defaults(&mut row_map, &profile, P1, &mut masks);
+
+        assert_choice_at_cursor(&row_map, RowId::JudgmentOffsetX, &HUD_OFFSET_MAX.to_string());
+        assert_choice_at_cursor(&row_map, RowId::NoteFieldOffsetX, "0");
+        assert_choice_at_cursor(&row_map, RowId::VisualDelay, "-100ms");
+        assert_choice_at_cursor(
+            &row_map,
+            RowId::Spacing,
+            &format!("{}%", super::SPACING_PERCENT_MAX),
+        );
+    }
+
+    fn assert_choice_at_cursor(row_map: &RowMap, id: RowId, expected: &str) {
+        let row = row_map
+            .get(id)
+            .unwrap_or_else(|| panic!("Row {id:?} missing from Main pane row map"));
+        let idx = row.selected_choice_index[P1];
+        let actual = row.choices.get(idx).map(String::as_str).unwrap_or("<oob>");
+        assert_eq!(
+            actual, expected,
+            "Row {id:?}: cursor at {idx} points to {actual:?}, expected {expected:?}"
+        );
+    }
+
+    fn assert_variant_at_cursor<T: Copy + PartialEq + std::fmt::Debug>(
+        row_map: &RowMap,
+        id: RowId,
+        variants: &[T],
+        expected: T,
+    ) {
+        let row = row_map
+            .get(id)
+            .unwrap_or_else(|| panic!("Row {id:?} missing from Main pane row map"));
+        let idx = row.selected_choice_index[P1];
+        let actual = variants
+            .get(idx)
+            .copied()
+            .unwrap_or_else(|| panic!("Row {id:?}: cursor {idx} out of variant range"));
+        assert_eq!(
+            actual, expected,
+            "Row {id:?}: variant at cursor {idx} = {actual:?}, expected {expected:?}"
+        );
+    }
 }

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -3,13 +3,14 @@ use super::*;
 #[cfg(test)]
 pub(super) mod tests {
     use super::{
-        BitmaskBinding, BitmaskInit, CursorInit, ErrorBarMask, FaPlusMask, GameplayExtrasMask,
-        GameplayExtrasMoreMask, HUD_OFFSET_MAX, HUD_OFFSET_MIN, HUD_OFFSET_ZERO_INDEX, HideMask,
-        NAV_INITIAL_HOLD_DELAY, NAV_REPEAT_SCROLL_INTERVAL, P1, P2, PlayerOptionMasks, Row,
-        RowBehavior, RowId, RowMap, ScrollMask, SpeedMod, SpeedModType, handle_arcade_start_event,
-        handle_start_event, hud_offset_choices, is_row_visible, judgment_tilt_intensity_visible,
-        repeat_held_arcade_start, row_visibility, session_active_players,
-        sync_profile_scroll_speed,
+        BitmaskBinding, BitmaskInit, ChoiceBinding, CursorInit, CycleInit, ErrorBarMask,
+        FaPlusMask, GameplayExtrasMask, GameplayExtrasMoreMask, HUD_OFFSET_MAX, HUD_OFFSET_MIN,
+        HUD_OFFSET_ZERO_INDEX, HideMask, NAV_INITIAL_HOLD_DELAY, NAV_REPEAT_SCROLL_INTERVAL,
+        NumericBinding, NumericInit, P1, P2, PlayerOptionMasks, Row, RowBehavior, RowId, RowMap,
+        ScrollMask, SpeedMod, SpeedModType, handle_arcade_start_event, handle_start_event,
+        hud_offset_choices, init_cycle_row_from_binding, init_numeric_row_from_binding,
+        is_row_visible, judgment_tilt_intensity_visible, repeat_held_arcade_start, row_visibility,
+        session_active_players, sync_profile_scroll_speed,
     };
     use crate::assets::AssetManager;
     use crate::assets::i18n::{LookupKey, lookup_key};
@@ -832,6 +833,7 @@ pub(super) mod tests {
                 super::Outcome::persisted_with_visibility()
             },
             persist_for_side: profile::update_judgment_tilt_for_side,
+            init: None,
         };
         let tilt_row = Row {
             id: RowId::JudgmentTilt,
@@ -1340,5 +1342,154 @@ pub(super) mod tests {
             [target, target],
             "WhatComesNext (mirror_across_players=true) must sync both player slots on inline focus commit"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // CycleInit / NumericInit contract helpers
+    //
+    // Direct unit tests for `init_cycle_row_from_binding` and
+    // `init_numeric_row_from_binding`. These guard the legacy semantics
+    // mirrored from `apply_profile_defaults`:
+    //
+    //   * Cycle helper clamps the returned index to `choices.len() - 1`
+    //     (matches the `.min(row.choices.len().saturating_sub(1))` pattern
+    //     used by every variant-table init block in `panes/mod.rs`).
+    //   * Numeric helper preserves the row's existing selection when the
+    //     formatted value does not match any entry in `Row::choices`
+    //     (matches the `if let Some(idx) = ... position(...)` pattern used
+    //     by every numeric init block in `panes/mod.rs`).
+    //   * Both helpers return `false` (no-op) when the binding has no
+    //     `init` contract — letting callers fall back to the legacy
+    //     hand-written init blocks during the in-progress migration.
+    // ---------------------------------------------------------------------
+
+    fn cycle_test_row(choices: &[&str], initial: [usize; 2]) -> Row {
+        Row {
+            id: RowId::Perspective,
+            behavior: RowBehavior::Exit, // behavior unused by the helper
+            name: lookup_key("PlayerOptions", "Perspective"),
+            choices: choices.iter().map(ToString::to_string).collect(),
+            selected_choice_index: initial,
+            help: Vec::new(),
+            choice_difficulty_indices: None,
+            mirror_across_players: false,
+        }
+    }
+
+    fn numeric_test_row(choices: &[&str], initial: [usize; 2]) -> Row {
+        Row {
+            id: RowId::Spacing,
+            behavior: RowBehavior::Exit, // behavior unused by the helper
+            name: lookup_key("PlayerOptions", "Spacing"),
+            choices: choices.iter().map(ToString::to_string).collect(),
+            selected_choice_index: initial,
+            help: Vec::new(),
+            choice_difficulty_indices: None,
+            mirror_across_players: false,
+        }
+    }
+
+    #[test]
+    fn init_cycle_row_from_binding_uses_init_function() {
+        let binding: ChoiceBinding<usize> = ChoiceBinding::<usize> {
+            apply: |_, _| super::Outcome::NONE,
+            persist_for_side: |_, _| {},
+            init: Some(CycleInit { from_profile: |_| 2 }),
+        };
+        let mut row = cycle_test_row(&["A", "B", "C", "D"], [0, 0]);
+        let applied = init_cycle_row_from_binding(&mut row, &binding, &Profile::default(), P1);
+        assert!(applied, "binding has init; helper must apply it");
+        assert_eq!(row.selected_choice_index[P1], 2);
+        assert_eq!(row.selected_choice_index[P2], 0, "P2 untouched");
+    }
+
+    #[test]
+    fn init_cycle_row_from_binding_clamps_to_choices_length() {
+        // Mirrors the `.min(row.choices.len().saturating_sub(1))` clamp used
+        // by every variant-table init block in apply_profile_defaults.
+        let binding: ChoiceBinding<usize> = ChoiceBinding::<usize> {
+            apply: |_, _| super::Outcome::NONE,
+            persist_for_side: |_, _| {},
+            init: Some(CycleInit {
+                from_profile: |_| 99,
+            }),
+        };
+        let mut row = cycle_test_row(&["A", "B", "C"], [0, 0]);
+        init_cycle_row_from_binding(&mut row, &binding, &Profile::default(), P1);
+        assert_eq!(
+            row.selected_choice_index[P1], 2,
+            "out-of-range init must clamp to choices.len()-1"
+        );
+    }
+
+    #[test]
+    fn init_cycle_row_from_binding_returns_false_without_init() {
+        let binding: ChoiceBinding<usize> = ChoiceBinding::<usize> {
+            apply: |_, _| super::Outcome::NONE,
+            persist_for_side: |_, _| {},
+            init: None,
+        };
+        let mut row = cycle_test_row(&["A", "B", "C"], [1, 1]);
+        let applied = init_cycle_row_from_binding(&mut row, &binding, &Profile::default(), P1);
+        assert!(!applied, "no init contract => helper reports no-op");
+        assert_eq!(
+            row.selected_choice_index, [1, 1],
+            "selection must be untouched when no init is wired"
+        );
+    }
+
+    #[test]
+    fn init_numeric_row_from_binding_finds_matching_choice() {
+        let binding = NumericBinding {
+            parse: super::parse_i32_percent,
+            apply: |_, _| super::Outcome::NONE,
+            persist_for_side: |_, _| {},
+            init: Some(NumericInit {
+                from_profile: |_| 50,
+                format: |v| format!("{v}%"),
+            }),
+        };
+        let mut row = numeric_test_row(&["0%", "25%", "50%", "75%", "100%"], [0, 0]);
+        let applied = init_numeric_row_from_binding(&mut row, &binding, &Profile::default(), P2);
+        assert!(applied);
+        assert_eq!(row.selected_choice_index[P2], 2);
+        assert_eq!(row.selected_choice_index[P1], 0, "P1 untouched");
+    }
+
+    #[test]
+    fn init_numeric_row_from_binding_preserves_selection_on_no_match() {
+        // Mirrors the legacy `if let Some(idx) = row.choices.iter().position(...)`
+        // pattern in apply_profile_defaults — when the formatted value is not
+        // present in choices, the row's existing selection is left alone.
+        let binding = NumericBinding {
+            parse: super::parse_i32_percent,
+            apply: |_, _| super::Outcome::NONE,
+            persist_for_side: |_, _| {},
+            init: Some(NumericInit {
+                from_profile: |_| 33,
+                format: |v| format!("{v}%"),
+            }),
+        };
+        let mut row = numeric_test_row(&["0%", "50%", "100%"], [1, 1]);
+        let applied = init_numeric_row_from_binding(&mut row, &binding, &Profile::default(), P1);
+        assert!(applied, "binding has init; helper applied it (even if no-op)");
+        assert_eq!(
+            row.selected_choice_index, [1, 1],
+            "no matching choice => selection preserved"
+        );
+    }
+
+    #[test]
+    fn init_numeric_row_from_binding_returns_false_without_init() {
+        let binding = NumericBinding {
+            parse: super::parse_i32_percent,
+            apply: |_, _| super::Outcome::NONE,
+            persist_for_side: |_, _| {},
+            init: None,
+        };
+        let mut row = numeric_test_row(&["0%", "50%", "100%"], [1, 1]);
+        let applied = init_numeric_row_from_binding(&mut row, &binding, &Profile::default(), P1);
+        assert!(!applied);
+        assert_eq!(row.selected_choice_index, [1, 1]);
     }
 }

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -1344,29 +1344,10 @@ pub(super) mod tests {
         );
     }
 
-    // ---------------------------------------------------------------------
-    // CycleInit / NumericInit contract helpers
-    //
-    // Direct unit tests for `init_cycle_row_from_binding` and
-    // `init_numeric_row_from_binding`. These guard the legacy semantics
-    // mirrored from `apply_profile_defaults`:
-    //
-    //   * Cycle helper clamps the returned index to `choices.len() - 1`
-    //     (matches the `.min(row.choices.len().saturating_sub(1))` pattern
-    //     used by every variant-table init block in `panes/mod.rs`).
-    //   * Numeric helper preserves the row's existing selection when the
-    //     formatted value does not match any entry in `Row::choices`
-    //     (matches the `if let Some(idx) = ... position(...)` pattern used
-    //     by every numeric init block in `panes/mod.rs`).
-    //   * Both helpers return `false` (no-op) when the binding has no
-    //     `init` contract — letting callers fall back to the legacy
-    //     hand-written init blocks during the in-progress migration.
-    // ---------------------------------------------------------------------
-
     fn cycle_test_row(choices: &[&str], initial: [usize; 2]) -> Row {
         Row {
             id: RowId::Perspective,
-            behavior: RowBehavior::Exit, // behavior unused by the helper
+            behavior: RowBehavior::Exit,
             name: lookup_key("PlayerOptions", "Perspective"),
             choices: choices.iter().map(ToString::to_string).collect(),
             selected_choice_index: initial,
@@ -1379,7 +1360,7 @@ pub(super) mod tests {
     fn numeric_test_row(choices: &[&str], initial: [usize; 2]) -> Row {
         Row {
             id: RowId::Spacing,
-            behavior: RowBehavior::Exit, // behavior unused by the helper
+            behavior: RowBehavior::Exit,
             name: lookup_key("PlayerOptions", "Spacing"),
             choices: choices.iter().map(ToString::to_string).collect(),
             selected_choice_index: initial,
@@ -1405,8 +1386,6 @@ pub(super) mod tests {
 
     #[test]
     fn init_cycle_row_from_binding_clamps_to_choices_length() {
-        // Mirrors the `.min(row.choices.len().saturating_sub(1))` clamp used
-        // by every variant-table init block in apply_profile_defaults.
         let binding: ChoiceBinding<usize> = ChoiceBinding::<usize> {
             apply: |_, _| super::Outcome::NONE,
             persist_for_side: |_, _| {},
@@ -1458,9 +1437,6 @@ pub(super) mod tests {
 
     #[test]
     fn init_numeric_row_from_binding_preserves_selection_on_no_match() {
-        // Mirrors the legacy `if let Some(idx) = row.choices.iter().position(...)`
-        // pattern in apply_profile_defaults — when the formatted value is not
-        // present in choices, the row's existing selection is left alone.
         let binding = NumericBinding {
             parse: super::parse_i32_percent,
             apply: |_, _| super::Outcome::NONE,


### PR DESCRIPTION
## Summary

Wires Main pane rows through the `CycleInit` / `NumericInit` contracts from #277. Two new dispatchers in `panes/mod.rs` walk the row map and run each binding's init for any opted-in Cycle or Numeric row, mirroring the existing `init_opted_in_bitmask_rows` pattern.

## Dependencies

Based on #277. Targets `main` so the diff renders against the merge-base; rebase once #277 lands.