### PR TITLE
fix: prevent translation status workflow push race condition

### DIFF
--- a/.github/workflows/update-translation-status.yml
+++ b/.github/workflows/update-translation-status.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "assets/languages/*.ini"
 
+concurrency:
+  group: update-translation-status
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -44,5 +48,6 @@ jobs:
             echo "No changes to TRANSLATION_STATUS.md"
           else
             git commit -m "docs: auto-update TRANSLATION_STATUS.md"
+            git pull --rebase
             git push
           fi


### PR DESCRIPTION
The `update-translation-status` workflow fails when `main` advances between checkout and push (e.g. [run #24978197685](https://github.com/pnn64/deadsync/actions/runs/24978197685)).

**Changes:**
- Add `concurrency` group to serialize workflow runs instead of letting them race
- Add `git pull --rebase` before `git push` to handle any commits that land during the build