### PR TITLE
fix(eval): show scatter for active scoring mode

### DIFF
--- a/src/screens/evaluation.rs
+++ b/src/screens/evaluation.rs
@@ -1424,6 +1424,17 @@ enum EvalGraphPane {
 }
 
 #[inline(always)]
+const fn eval_graph_default_for(show_fa_plus_pane: bool, show_hard_ex: bool) -> EvalGraphPane {
+    if show_hard_ex {
+        EvalGraphPane::HardEx
+    } else if show_fa_plus_pane {
+        EvalGraphPane::Ex
+    } else {
+        EvalGraphPane::Itg
+    }
+}
+
+#[inline(always)]
 const fn eval_graph_next(pane: EvalGraphPane) -> EvalGraphPane {
     match pane {
         EvalGraphPane::Itg => EvalGraphPane::Ex,
@@ -1544,7 +1555,7 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
     let mut scatter_mesh_foot: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
         std::array::from_fn(|_| None);
     let mut active_pane: [EvalPane; MAX_PLAYERS] = [EvalPane::Standard; MAX_PLAYERS];
-    let active_graph: [EvalGraphPane; MAX_PLAYERS] = [EvalGraphPane::Itg; MAX_PLAYERS];
+    let mut active_graph: [EvalGraphPane; MAX_PLAYERS] = [EvalGraphPane::Itg; MAX_PLAYERS];
     let mut stage_duration_seconds: f32 = 0.0;
     let mut machine_records_by_hash: HashMap<String, Vec<scores::LeaderboardEntry>> =
         HashMap::new();
@@ -1961,6 +1972,12 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
                 active_pane[1] = score_info[1].as_ref().map_or(EvalPane::Standard, |si| {
                     eval_pane_default_for(si.show_fa_plus_pane)
                 });
+                active_graph[0] = score_info[0].as_ref().map_or(EvalGraphPane::Itg, |si| {
+                    eval_graph_default_for(si.show_fa_plus_pane, si.show_hard_ex_score)
+                });
+                active_graph[1] = score_info[1].as_ref().map_or(EvalGraphPane::Itg, |si| {
+                    eval_graph_default_for(si.show_fa_plus_pane, si.show_hard_ex_score)
+                });
             }
             profile::PlayStyle::Single | profile::PlayStyle::Double => {
                 let joined = profile::get_session_player_side();
@@ -1977,6 +1994,13 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
                 active_pane = match joined {
                     profile::PlayerSide::P1 => [primary, secondary],
                     profile::PlayerSide::P2 => [secondary, primary],
+                };
+                let primary_graph = score_info[0].as_ref().map_or(EvalGraphPane::Itg, |si| {
+                    eval_graph_default_for(si.show_fa_plus_pane, si.show_hard_ex_score)
+                });
+                active_graph = match joined {
+                    profile::PlayerSide::P1 => [primary_graph, EvalGraphPane::Itg],
+                    profile::PlayerSide::P2 => [EvalGraphPane::Itg, primary_graph],
                 };
             }
         }
@@ -2025,7 +2049,7 @@ pub fn init_from_score_info(
     stage_duration_seconds: f32,
 ) -> State {
     let mut active_pane: [EvalPane; MAX_PLAYERS] = [EvalPane::Standard; MAX_PLAYERS];
-    let active_graph: [EvalGraphPane; MAX_PLAYERS] = [EvalGraphPane::Itg; MAX_PLAYERS];
+    let mut active_graph: [EvalGraphPane; MAX_PLAYERS] = [EvalGraphPane::Itg; MAX_PLAYERS];
     let play_style = profile::get_session_play_style();
     match play_style {
         profile::PlayStyle::Versus => {
@@ -2034,6 +2058,12 @@ pub fn init_from_score_info(
             });
             active_pane[1] = score_info[1].as_ref().map_or(EvalPane::Standard, |si| {
                 eval_pane_default_for(si.show_fa_plus_pane)
+            });
+            active_graph[0] = score_info[0].as_ref().map_or(EvalGraphPane::Itg, |si| {
+                eval_graph_default_for(si.show_fa_plus_pane, si.show_hard_ex_score)
+            });
+            active_graph[1] = score_info[1].as_ref().map_or(EvalGraphPane::Itg, |si| {
+                eval_graph_default_for(si.show_fa_plus_pane, si.show_hard_ex_score)
             });
         }
         profile::PlayStyle::Single | profile::PlayStyle::Double => {
@@ -2045,6 +2075,13 @@ pub fn init_from_score_info(
             active_pane = match joined {
                 profile::PlayerSide::P1 => [primary, secondary],
                 profile::PlayerSide::P2 => [secondary, primary],
+            };
+            let primary_graph = score_info[0].as_ref().map_or(EvalGraphPane::Itg, |si| {
+                eval_graph_default_for(si.show_fa_plus_pane, si.show_hard_ex_score)
+            });
+            active_graph = match joined {
+                profile::PlayerSide::P1 => [primary_graph, EvalGraphPane::Itg],
+                profile::PlayerSide::P2 => [EvalGraphPane::Itg, primary_graph],
             };
         }
     }

--- a/src/screens/evaluation.rs
+++ b/src/screens/evaluation.rs
@@ -1435,25 +1435,26 @@ const fn eval_graph_default_for(show_fa_plus_pane: bool, show_hard_ex: bool) -> 
 }
 
 #[inline(always)]
-const fn eval_graph_next(pane: EvalGraphPane) -> EvalGraphPane {
-    match pane {
-        EvalGraphPane::Itg => EvalGraphPane::Ex,
-        EvalGraphPane::Ex => EvalGraphPane::HardEx,
-        EvalGraphPane::HardEx => EvalGraphPane::Arrow,
-        EvalGraphPane::Arrow => EvalGraphPane::Foot,
-        EvalGraphPane::Foot => EvalGraphPane::Itg,
-    }
+fn eval_graph_cycle(show_fa_plus_pane: bool, show_hard_ex: bool) -> Vec<EvalGraphPane> {
+    let scoring = eval_graph_default_for(show_fa_plus_pane, show_hard_ex);
+    vec![scoring, EvalGraphPane::Arrow, EvalGraphPane::Foot]
 }
 
 #[inline(always)]
-const fn eval_graph_prev(pane: EvalGraphPane) -> EvalGraphPane {
-    match pane {
-        EvalGraphPane::Itg => EvalGraphPane::Foot,
-        EvalGraphPane::Ex => EvalGraphPane::Itg,
-        EvalGraphPane::HardEx => EvalGraphPane::Ex,
-        EvalGraphPane::Arrow => EvalGraphPane::HardEx,
-        EvalGraphPane::Foot => EvalGraphPane::Arrow,
-    }
+fn eval_graph_shift(
+    pane: EvalGraphPane,
+    dir: i32,
+    show_fa_plus_pane: bool,
+    show_hard_ex: bool,
+) -> EvalGraphPane {
+    let cycle = eval_graph_cycle(show_fa_plus_pane, show_hard_ex);
+    let cur_idx = cycle
+        .iter()
+        .position(|&candidate| candidate == pane)
+        .unwrap_or(0);
+    let step = if dir >= 0 { 1 } else { -1 };
+    let next_idx = (cur_idx as i32 + step).rem_euclid(cycle.len() as i32) as usize;
+    cycle[next_idx]
 }
 
 pub struct State {
@@ -1836,50 +1837,59 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
                 (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
             };
 
-            scatter_mesh_itg[player_idx] = {
-                const GRAPH_H: f32 = 64.0;
-                let verts = crate::screens::components::evaluation::eval_graphs::build_scatter_mesh(
-                    &si.scatter,
-                    si.graph_first_second,
-                    si.graph_last_second,
-                    graph_width,
-                    GRAPH_H,
-                    si.scatter_worst_window_ms,
-                    crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::Itg,
-                );
-                (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
-            };
+            let scoring_scatter =
+                eval_graph_default_for(si.show_fa_plus_pane, si.show_hard_ex_score);
 
-            scatter_mesh_ex[player_idx] = {
-                const GRAPH_H: f32 = 64.0;
-                let verts = crate::screens::components::evaluation::eval_graphs::build_scatter_mesh(
-                    &si.scatter,
-                    si.graph_first_second,
-                    si.graph_last_second,
-                    graph_width,
-                    GRAPH_H,
-                    si.scatter_worst_window_ms,
-                    crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::Ex,
-                );
-                (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
-            };
+            if scoring_scatter == EvalGraphPane::Itg {
+                scatter_mesh_itg[player_idx] = {
+                    const GRAPH_H: f32 = 64.0;
+                    let verts = crate::screens::components::evaluation::eval_graphs::build_scatter_mesh(
+                        &si.scatter,
+                        si.graph_first_second,
+                        si.graph_last_second,
+                        graph_width,
+                        GRAPH_H,
+                        si.scatter_worst_window_ms,
+                        crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::Itg,
+                    );
+                    (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
+                };
+            }
 
-            scatter_mesh_hard_ex[player_idx] = {
-                const GRAPH_H: f32 = 64.0;
-                let hard_ex_worst_window = si
-                    .scatter_worst_window_ms
-                    .min(timing_stats::effective_windows_ms()[1]);
-                let verts = crate::screens::components::evaluation::eval_graphs::build_scatter_mesh(
-                    &si.scatter,
-                    si.graph_first_second,
-                    si.graph_last_second,
-                    graph_width,
-                    GRAPH_H,
-                    hard_ex_worst_window,
-                    crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::HardEx,
-                );
-                (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
-            };
+            if scoring_scatter == EvalGraphPane::Ex {
+                scatter_mesh_ex[player_idx] = {
+                    const GRAPH_H: f32 = 64.0;
+                    let verts = crate::screens::components::evaluation::eval_graphs::build_scatter_mesh(
+                        &si.scatter,
+                        si.graph_first_second,
+                        si.graph_last_second,
+                        graph_width,
+                        GRAPH_H,
+                        si.scatter_worst_window_ms,
+                        crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::Ex,
+                    );
+                    (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
+                };
+            }
+
+            if scoring_scatter == EvalGraphPane::HardEx {
+                scatter_mesh_hard_ex[player_idx] = {
+                    const GRAPH_H: f32 = 64.0;
+                    let hard_ex_worst_window = si
+                        .scatter_worst_window_ms
+                        .min(timing_stats::effective_windows_ms()[1]);
+                    let verts = crate::screens::components::evaluation::eval_graphs::build_scatter_mesh(
+                        &si.scatter,
+                        si.graph_first_second,
+                        si.graph_last_second,
+                        graph_width,
+                        GRAPH_H,
+                        hard_ex_worst_window,
+                        crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::HardEx,
+                    );
+                    (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
+                };
+            }
 
             scatter_mesh_arrow[player_idx] = {
                 const GRAPH_H: f32 = 64.0;
@@ -2779,20 +2789,20 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
     let mut shift_graph_for = |controller: profile::PlayerSide, dir: i32| {
         let controller_idx = side_idx(controller);
         let player_idx = player_idx_for_controller(controller);
-        if state
+        let Some(si) = state
             .score_info
             .get(player_idx)
             .and_then(|s| s.as_ref())
-            .is_none()
-        {
+        else {
             return;
-        }
-
-        state.active_graph[controller_idx] = if dir >= 0 {
-            eval_graph_next(state.active_graph[controller_idx])
-        } else {
-            eval_graph_prev(state.active_graph[controller_idx])
         };
+
+        state.active_graph[controller_idx] = eval_graph_shift(
+            state.active_graph[controller_idx],
+            dir,
+            si.show_fa_plus_pane,
+            si.show_hard_ex_score,
+        );
 
         // Single/double have one lower graph; keep both controller slots in sync.
         if play_style != profile::PlayStyle::Versus {


### PR DESCRIPTION
Fixes #285.

## Problem

The evaluation scatter plot always defaulted to the ITG variant, so white fantastics were rolled into blue for players using FA+ or H.EX scoring. The screen also eagerly built all five scatter meshes (Itg/Ex/HardEx/Arrow/Foot) and let L/R cycle through every option, even when the unused scoring meshes could never be the right answer for the player's selected mode.

## Changes

- `fix(eval): default scatter graph to active scoring mode` — initialize `active_graph` from each player's `ScoreInfo` so the displayed scatter matches the active scoring mode (HardEx > FA+/Ex > ITG), mirroring how `active_pane` already picks the FA+ pane.
- `perf(eval): build only the scatter for the active scoring mode` — restrict the cycle to the single scoring scatter that matches the active mode plus Arrow and Foot, and skip building the two unused scoring meshes.