### PR TITLE
fix(evaluation): restore SL-faithful percentage and meter fonts

### DIFF
--- a/src/assets/mod.rs
+++ b/src/assets/mod.rs
@@ -602,6 +602,8 @@ pub enum FontRole {
     Numbers,
     /// Evaluation panel numerics (large grade/percentage on results).
     ScreenEval,
+    /// Big white headline numerals (e.g., the evaluation-screen percentage).
+    Headline,
 }
 
 /// Resolve a logical [`FontRole`] under the given [`crate::config::MachineFont`]
@@ -617,6 +619,7 @@ pub enum FontRole {
 /// | `Footer`     | `wendy`                     | `mega_alpha`                  |
 /// | `Numbers`    | `wendy_monospace_numbers`   | `mega_monospace_numbers`      |
 /// | `ScreenEval` | `wendy_screenevaluation`    | `mega_screenevaluation`       |
+/// | `Headline`   | `wendy_white`               | `mega_alpha`                  |
 pub fn machine_font_key(machine_font: crate::config::MachineFont, role: FontRole) -> &'static str {
     use crate::config::MachineFont::{Common, Mega};
     match (machine_font, role) {
@@ -627,6 +630,8 @@ pub fn machine_font_key(machine_font: crate::config::MachineFont, role: FontRole
         (Mega, FontRole::Numbers) => "mega_monospace_numbers",
         (Common, FontRole::ScreenEval) => "wendy_screenevaluation",
         (Mega, FontRole::ScreenEval) => "mega_screenevaluation",
+        (Common, FontRole::Headline) => "wendy_white",
+        (Mega, FontRole::Headline) => "mega_alpha",
     }
 }
 
@@ -740,6 +745,10 @@ mod tests {
             machine_font_key(MachineFont::Common, FontRole::ScreenEval),
             "wendy_screenevaluation"
         );
+        assert_eq!(
+            machine_font_key(MachineFont::Common, FontRole::Headline),
+            "wendy_white"
+        );
     }
 
     #[test]
@@ -763,6 +772,10 @@ mod tests {
         assert_eq!(
             machine_font_key(MachineFont::Mega, FontRole::ScreenEval),
             "mega_screenevaluation"
+        );
+        assert_eq!(
+            machine_font_key(MachineFont::Mega, FontRole::Headline),
+            "mega_alpha"
         );
     }
 

--- a/src/screens/components/evaluation/pane_percentage.rs
+++ b/src/screens/components/evaluation/pane_percentage.rs
@@ -62,7 +62,7 @@ pub(crate) fn build_pane_percentage_display(
                 diffuse(score_bg_color[0], score_bg_color[1], score_bg_color[2], 1.0)
             ));
             children.push(act!(text:
-                font(current_machine_font_key(FontRole::Header)):
+                font(current_machine_font_key(FontRole::Headline)):
                 settext(percent_text):
                 align(1.0, 0.5):
                 xy(30.0, -2.0):
@@ -78,7 +78,7 @@ pub(crate) fn build_pane_percentage_display(
                 diffuse(score_bg_color[0], score_bg_color[1], score_bg_color[2], 1.0)
             ));
             children.push(act!(text:
-                font(current_machine_font_key(FontRole::Header)):
+                font(current_machine_font_key(FontRole::Headline)):
                 settext(percent_text):
                 align(1.0, 0.5):
                 xy(percent_x, 0.0):
@@ -94,7 +94,7 @@ pub(crate) fn build_pane_percentage_display(
             };
             let bottom_label_x = bottom_value_x - 108.0;
             children.push(act!(text:
-                font(current_machine_font_key(FontRole::Header)):
+                font(current_machine_font_key(FontRole::Headline)):
                 settext("EX"):
                 align(1.0, 0.5):
                 xy(bottom_label_x, 40.0):
@@ -103,7 +103,7 @@ pub(crate) fn build_pane_percentage_display(
                 diffuse(ex_color[0], ex_color[1], ex_color[2], ex_color[3])
             ));
             children.push(act!(text:
-                font(current_machine_font_key(FontRole::Header)):
+                font(current_machine_font_key(FontRole::Headline)):
                 settext(ex_percent_text):
                 align(1.0, 0.5):
                 xy(bottom_value_x, 40.0):
@@ -123,7 +123,7 @@ pub(crate) fn build_pane_percentage_display(
             let ex_color = color::JUDGMENT_RGBA[0];
             let hex_color = color::HARD_EX_SCORE_RGBA;
             children.push(act!(text:
-                font(current_machine_font_key(FontRole::Header)):
+                font(current_machine_font_key(FontRole::Headline)):
                 settext(ex_percent_text):
                 align(1.0, 0.5):
                 xy(percent_x, 0.0):
@@ -139,7 +139,7 @@ pub(crate) fn build_pane_percentage_display(
             };
             let bottom_label_x = bottom_value_x - 92.0;
             children.push(act!(text:
-                font(current_machine_font_key(FontRole::Header)):
+                font(current_machine_font_key(FontRole::Headline)):
                 settext("H.EX"):
                 align(1.0, 0.5):
                 xy(bottom_label_x, 40.0):
@@ -148,7 +148,7 @@ pub(crate) fn build_pane_percentage_display(
                 diffuse(hex_color[0], hex_color[1], hex_color[2], hex_color[3])
             ));
             children.push(act!(text:
-                font(current_machine_font_key(FontRole::Header)):
+                font(current_machine_font_key(FontRole::Headline)):
                 settext(hard_ex_percent_text):
                 align(1.0, 0.5):
                 xy(bottom_value_x, 40.0):
@@ -165,7 +165,7 @@ pub(crate) fn build_pane_percentage_display(
                 diffuse(score_bg_color[0], score_bg_color[1], score_bg_color[2], 1.0)
             ));
             children.push(act!(text:
-                font(current_machine_font_key(FontRole::Header)):
+                font(current_machine_font_key(FontRole::Headline)):
                 settext(percent_text):
                 align(1.0, 0.5):
                 xy(percent_x, 0.0):

--- a/src/screens/evaluation.rs
+++ b/src/screens/evaluation.rs
@@ -3120,7 +3120,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                         diffuse(difficulty_color[0], difficulty_color[1], difficulty_color[2], 1.0)
                     ));
                     actors.push(act!(text:
-                        font(current_machine_font_key(FontRole::Numbers)):
+                        font(current_machine_font_key(FontRole::Bold)):
                         settext(si.chart.meter.to_string()):
                         align(0.5, 0.5):
                         xy(box_x, cy - 76.0):
@@ -3179,7 +3179,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                         diffuse(difficulty_color[0], difficulty_color[1], difficulty_color[2], 1.0)
                     ));
                     actors.push(act!(text:
-                        font(current_machine_font_key(FontRole::Numbers)):
+                        font(current_machine_font_key(FontRole::Bold)):
                         settext(si.chart.meter.to_string()):
                         align(0.5, 0.5):
                         xy(box_x, cy - 71.0):


### PR DESCRIPTION
Fixes part of #284.

Commit `91b534b5` (feat(theme-font): route Init splash + Evaluation panes through ThemeFont) rerouted two font callsites incorrectly:

1. **Percentage / EX / H.EX displays** (`pane_percentage.rs`, 8 sites) were swapped from `font(\"wendy_white\")` to `font(current_machine_font_key(FontRole::Header))`. `Header` resolves to `wendy` (= `_wendy small.ini`, baseline 69) instead of `wendy_white` (= `_wendy white.ini`, LineSpacing=48), shrinking the headline percentage and breaking the money/EX layout in the score black-box.

2. **Difficulty-meter digits** (`evaluation.rs`, zmod and non-zmod paths) were swapped from `font(\"wendy\")` to `font(current_machine_font_key(FontRole::Numbers))`. `Numbers` resolves to `wendy_monospace_numbers` (LineSpacing=48, baseline=50), making the meter digit visually different from SL's `Common Bold` = wendy small.

## Fix

- Adds a new `FontRole::Display` variant mapping `Common -> wendy_white`, `Mega -> mega_alpha` (matching the original `91b534b5` commit-message intent `Common -> Wendy/_wendy white, Mega -> Mega/_mega font`).
- Switches the 8 percentage/EX/H.EX callsites in `pane_percentage.rs` to `FontRole::Display`.
- Reverts the meter-digit role from `Numbers` to `Bold` in both `evaluation.rs` zmod and non-zmod paths (`Bold` already resolves to `wendy` for Common / `mega_alpha` for Mega).