### PR TITLE
Fix Options cursor highlight bounds after language change

### DIFF
--- a/src/screens/options.rs
+++ b/src/screens/options.rs
@@ -9891,7 +9891,8 @@ fn submenu_cursor_dest(
         item_col_w.mul_add(0.5, item_col_left) + SUB_SINGLE_VALUE_CENTER_OFFSET * s;
 
     if selected_row == total_rows - 1 {
-        let (draw_w, text_h) = measure_text_box(asset_manager, "Exit", value_zoom);
+        let exit_label = tr("Common", "Exit");
+        let (draw_w, text_h) = measure_text_box(asset_manager, &exit_label, value_zoom);
         let (ring_w, ring_h) = ring_size_for_text(draw_w, text_h);
         return Some((single_center_x, row_mid_y, ring_w, ring_h));
     }


### PR DESCRIPTION
The submenu cursor highlight on the Exit row was sized using the literal English `Exit` string while the row actually renders the translated label from `tr("Common", "Exit")`. After switching to a language whose translated `Exit` string is wider or narrower than the English original, the highlight rectangle remained sized to the previous text and no longer matched the rendered text bounds.

Measure the cursor ring using the translated label so it stays in sync with the rendered text in any locale.

Closes #292