### PR TITLE
fix(input): drop background keystrokes when window is unfocused (#276)

### DIFF
--- a/src/app/graphics.rs
+++ b/src/app/graphics.rs
@@ -248,6 +248,13 @@ impl App {
         self.state.shell.current_frame_vpf = 0;
 
         window.set_visible(true);
+        // Seed window focus from the OS now that the window is visible. If the
+        // game launched into the background, `has_focus()` returns false and the
+        // raw input backends keep dropping global keystrokes. If it launched
+        // focused, this propagates true through `apply_window_focus_change` and
+        // wakes the rest of the input pipeline.
+        let focused_now = window.has_focus();
+        self.apply_window_focus_change(focused_now, Instant::now(), Some(&window));
         self.request_redraw(&window, "init_graphics");
 
         self.window = Some(window);
@@ -299,6 +306,10 @@ impl App {
         }
         self.backend = None;
         self.window = None;
+        // The window is gone; mark unfocused so the global raw-input backends
+        // stop forwarding keystrokes during the tear-down/init gap. The new
+        // window's focus will be seeded by `init_graphics` below.
+        self.apply_window_focus_change(false, Instant::now(), None);
         self.state.shell.pending_window_position = old_window_pos;
 
         self.backend_type = target;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -928,7 +928,10 @@ impl ShellState {
             tab_held: false,
             backquote_held: false,
             tab_acceleration_enabled: cfg.tab_acceleration,
-            window_focused: true,
+            // Default to unfocused so background input backends (Win32 RawInput,
+            // evdev, IOHID) drop globally-observed key events until the window
+            // is created and proven focused.
+            window_focused: false,
             window_occluded: false,
             surface_active: cfg.display_width > 0 && cfg.display_height > 0,
             screenshot_pending: false,
@@ -2615,6 +2618,41 @@ impl App {
             self.state.shell.window_focused,
             self.state.shell.surface_active,
         )
+    }
+
+    /// Apply a window focus change to all subsystems that care about it.
+    ///
+    /// Used by both the `WindowEvent::Focused` handler and the initial focus
+    /// seed performed in `init_graphics` (and on renderer-switch window
+    /// recreation). Always pushes the new focus state to the raw input
+    /// backends so their gating flag stays in sync with the shell, and only
+    /// runs the change-only side effects (capture sync, modifier reset,
+    /// debounce/queue clear, redraw) when the shell focus actually toggled.
+    pub(super) fn apply_window_focus_change(
+        &mut self,
+        focused: bool,
+        now: Instant,
+        window: Option<&Arc<Window>>,
+    ) {
+        input::set_raw_keyboard_window_focused(focused);
+        if !self.state.shell.set_window_focus(focused, now) {
+            return;
+        }
+        self.sync_gameplay_input_capture();
+        debug!(
+            "Window focus changed: focused={} screen={:?}",
+            focused, self.state.screens.current_screen
+        );
+        if !focused {
+            self.state.shell.shift_held = false;
+            self.state.shell.ctrl_held = false;
+            self.state.shell.tab_held = false;
+            self.state.shell.backquote_held = false;
+            input::clear_debounce_state();
+            self.clear_gameplay_input_events();
+        } else if let Some(w) = window {
+            self.request_redraw(w, "focus");
+        }
     }
 
     #[inline(always)]
@@ -7154,25 +7192,7 @@ impl ApplicationHandler<UserEvent> for App {
                 }
             }
             WindowEvent::Focused(focused) => {
-                input::set_raw_keyboard_window_focused(focused);
-                if self.state.shell.set_window_focus(focused, Instant::now()) {
-                    self.sync_gameplay_input_capture();
-                    debug!(
-                        "Window focus changed: focused={} screen={:?}",
-                        focused, self.state.screens.current_screen
-                    );
-                    if !focused {
-                        self.state.shell.shift_held = false;
-                        self.state.shell.ctrl_held = false;
-                        self.state.shell.tab_held = false;
-                        self.state.shell.backquote_held = false;
-                        input::clear_debounce_state();
-                        self.clear_gameplay_input_events();
-                    }
-                    if focused {
-                        self.request_redraw(&window, "focus");
-                    }
-                }
+                self.apply_window_focus_change(focused, Instant::now(), Some(&window));
             }
             WindowEvent::Occluded(occluded) => {
                 if self
@@ -7193,6 +7213,9 @@ impl ApplicationHandler<UserEvent> for App {
             WindowEvent::KeyboardInput {
                 event: key_event, ..
             } => {
+                if !self.accepts_live_input() {
+                    return;
+                }
                 if key_event.state == winit::event::ElementState::Pressed
                     && let Some(text) = key_event.text.as_deref()
                 {
@@ -7293,7 +7316,10 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     // Spawn background input backend threads; all input stays decoupled from frame rate.
     let proxy: EventLoopProxy<UserEvent> = event_loop.create_proxy();
-    input::set_raw_keyboard_window_focused(true);
+    // Raw input backends default to "unfocused" until init_graphics seeds the
+    // real focus state from the created window. This prevents global keyboard
+    // input (e.g. Win32 RawInput RIDEV_INPUTSINK, evdev, IOHID) from being
+    // routed into the game while it is launched into the background.
     app.sync_gameplay_input_capture();
     #[cfg(windows)]
     {

--- a/src/engine/input/backends/evdev/freebsd.rs
+++ b/src/engine/input/backends/evdev/freebsd.rs
@@ -145,7 +145,7 @@ enum ProbeResult {
 #[derive(Default)]
 struct CapabilityBits(Vec<u64>);
 
-static KEYBOARD_WINDOW_FOCUSED: AtomicBool = AtomicBool::new(true);
+static KEYBOARD_WINDOW_FOCUSED: AtomicBool = AtomicBool::new(false);
 static KEYBOARD_CAPTURE_ENABLED: AtomicBool = AtomicBool::new(true);
 static KEYBOARD_BACKEND_ACTIVE: AtomicBool = AtomicBool::new(false);
 

--- a/src/engine/input/backends/evdev/linux.rs
+++ b/src/engine/input/backends/evdev/linux.rs
@@ -216,7 +216,7 @@ enum HotplugEvent {
     Remove(String),
 }
 
-static KEYBOARD_WINDOW_FOCUSED: AtomicBool = AtomicBool::new(true);
+static KEYBOARD_WINDOW_FOCUSED: AtomicBool = AtomicBool::new(false);
 static KEYBOARD_CAPTURE_ENABLED: AtomicBool = AtomicBool::new(true);
 static KEYBOARD_BACKEND_ACTIVE: AtomicBool = AtomicBool::new(false);
 

--- a/src/engine/input/backends/iohid.rs
+++ b/src/engine/input/backends/iohid.rs
@@ -199,7 +199,7 @@ fn axis_changed(last_axis: &mut Vec<AxisState>, code: u32, value: i64) -> bool {
     true
 }
 
-static KEYBOARD_WINDOW_FOCUSED: AtomicBool = AtomicBool::new(true);
+static KEYBOARD_WINDOW_FOCUSED: AtomicBool = AtomicBool::new(false);
 static KEYBOARD_CAPTURE_ENABLED: AtomicBool = AtomicBool::new(true);
 
 #[inline(always)]

--- a/src/engine/input/backends/w32_raw_input.rs
+++ b/src/engine/input/backends/w32_raw_input.rs
@@ -56,7 +56,7 @@ const WIN_SC_NUMLOCK: u16 = 0x0045;
 const WIN_SC_IGNORE_PAUSE_PREFIX: u16 = 0xe11d;
 const WIN_SC_IGNORE_PRTSC_PREFIX: u16 = 0xe02a;
 
-static WINDOW_FOCUSED: AtomicBool = AtomicBool::new(true);
+static WINDOW_FOCUSED: AtomicBool = AtomicBool::new(false);
 static CAPTURE_ENABLED: AtomicBool = AtomicBool::new(false);
 static RAW_INPUT_HWND: AtomicIsize = AtomicIsize::new(0);
 


### PR DESCRIPTION
Win32 RawInput (RIDEV_INPUTSINK), Linux/FreeBSD evdev, and macOS IOHID all observe keyboard devices globally and gate emission on a per-process WINDOW_FOCUSED atomic that defaulted to true. winit's WindowEvent::Focused is delta-only, so a game launched into the background never received Focused(false) and the gate stayed open, letting Enter etc. pressed in another app navigate the menu.

- Default the focus gate to false in all four backends and in ShellState so the raw input threads drop events until the window proves it has focus.
- Extract the focus-change side effects (capture sync, modifier/debounce/queue clear, redraw request) into App::apply_window_focus_change and reuse it from WindowEvent::Focused, the new init_graphics seed, and renderer-switch tear-down.
- Seed focus from window.has_focus() after set_visible(true) in init_graphics so a focused launch is correctly enabled even though winit may not emit an initial Focused(true).
- Clear focus while the window is torn down during a renderer switch.
- Defensively gate WindowEvent::KeyboardInput text handling on accepts_live_input.