### PR TITLE
Fix Null-Or-Die overlay text overlap

### DIFF
--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -4821,6 +4821,15 @@ fn build_sync_overlay(state: &SyncOverlayState, active_color_index: i32) -> Opti
     } else {
         None
     };
+    let ready_prompt_text = if overlay.phase == SyncOverlayPhase::Ready {
+        Some(build_sync_save_prompt_text(overlay))
+    } else {
+        None
+    };
+    let ready_prompt_line_count = ready_prompt_text
+        .as_deref()
+        .map(|s| s.lines().count().max(1))
+        .unwrap_or(0);
 
     actors.push(act!(quad:
         align(0.0, 0.0):
@@ -5005,12 +5014,24 @@ fn build_sync_overlay(state: &SyncOverlayState, active_color_index: i32) -> Opti
             .map(Arc::from)
             .unwrap_or_else(|| tr("SelectMusic", "UnknownSyncError")),
     };
-    let status_y =
-        if matches!(overlay.phase, SyncOverlayPhase::Ready) && ready_offset_line.is_some() {
-            ready_prompt_y - SYNC_READY_LINE_STEP * 1.5
+    let status_y = if matches!(overlay.phase, SyncOverlayPhase::Ready) {
+        // Anchor the prompt's bottom edge to the same position it had with the
+        // default 2-line prompt, then stack the optional offset line and the
+        // status line above it with a one-line gap.  This keeps the YES/NO
+        // buttons clear of the prompt and prevents the status line from
+        // overlapping the prompt when a low-confidence warning expands it.
+        let prompt_bottom = ready_prompt_y + SYNC_READY_LINE_STEP * 0.5;
+        let half_prompt = (ready_prompt_line_count.max(1) as f32 - 1.0) * 0.5;
+        let prompt_top = prompt_bottom - half_prompt * 2.0 * SYNC_READY_LINE_STEP;
+        let above_prompt = prompt_top - SYNC_READY_LINE_STEP;
+        if ready_offset_line.is_some() {
+            above_prompt - SYNC_READY_LINE_STEP
         } else {
-            graph_y + graph_h + 18.0
-        };
+            above_prompt
+        }
+    } else {
+        graph_y + graph_h + 18.0
+    };
     actors.push(act!(text:
         font("miso"):
         settext(status_text):
@@ -5033,12 +5054,11 @@ fn build_sync_overlay(state: &SyncOverlayState, active_color_index: i32) -> Opti
             } else {
                 choice_no_x
             };
-            let prompt = build_sync_save_prompt_text(overlay);
-            let prompt_y = if ready_offset_line.is_some() {
-                ready_prompt_y + SYNC_READY_LINE_STEP
-            } else {
-                ready_prompt_y
-            };
+            let prompt = ready_prompt_text.clone().unwrap_or_default();
+            let prompt_bottom = ready_prompt_y + SYNC_READY_LINE_STEP * 0.5;
+            let half_prompt = (ready_prompt_line_count.max(1) as f32 - 1.0) * 0.5;
+            let prompt_y = prompt_bottom - half_prompt * SYNC_READY_LINE_STEP;
+            let prompt_top = prompt_y - half_prompt * SYNC_READY_LINE_STEP;
 
             actors.push(act!(quad:
                 align(0.5, 0.5):
@@ -5052,7 +5072,7 @@ fn build_sync_overlay(state: &SyncOverlayState, active_color_index: i32) -> Opti
                     font("miso"):
                     settext(line.clone()):
                     align(0.5, 0.5):
-                    xy(pane_cx, ready_prompt_y - SYNC_READY_LINE_STEP * 0.5):
+                    xy(pane_cx, prompt_top - SYNC_READY_LINE_STEP):
                     zoom(SYNC_READY_TEXT_ZOOM):
                     maxwidth(pane_w - 90.0):
                     diffuse(1.0, 1.0, 1.0, 1.0):
@@ -6254,7 +6274,7 @@ fn build_sync_save_prompt_text(overlay: &SyncOverlayStateData) -> String {
         sync_low_confidence_warning(overlay.final_confidence, sync_confidence_threshold())
     {
         prompt.push_str(&warning);
-        prompt.push_str("\n\n");
+        prompt.push('\n');
     }
     prompt.push_str(&tr("SelectMusic", "SyncSaveQuestion"));
     prompt.push('\n');


### PR DESCRIPTION
Fixes #302.

When the low-confidence warning expanded the Sync save prompt from 2 to 5 lines, its top edge collided with the `Suggested sync` status line just below the heat graph (see screenshot in the issue).

## Fix
- Switched the Ready-phase overlay layout to **bottom-anchored**: the prompt's bottom edge stays where the original 2-line prompt's bottom was. Optional offset line and status line are stacked above the prompt's top edge with a consistent one-line gap, so the layout stays clean regardless of how many lines the prompt has.
- Precomputed the prompt text/line count once and reused it (avoids a duplicate `tr` lookup).
- Collapsed the blank line between the warning and `SyncSaveQuestion` (`\n\n` -> `\n`) to keep the prompt compact.