### PR TITLE
refactor(options): replace 34 per-submenu Vec fields with SubmenuState array

### DIFF
--- a/src/screens/options/pack_sync.rs
+++ b/src/screens/options/pack_sync.rs
@@ -14,7 +14,7 @@ pub(super) struct SyncPackConfirmState {
 
 pub(super) fn selected_sync_pack_selection(state: &State) -> SyncPackSelection {
     let pack_idx = state
-        .sub_choice_indices_sync_packs
+        .sub[SubmenuKind::SyncPacks].choice_indices
         .get(SYNC_PACK_ROW_PACK_INDEX)
         .copied()
         .unwrap_or(0)

--- a/src/screens/options/score_import.rs
+++ b/src/screens/options/score_import.rs
@@ -88,7 +88,7 @@ pub(super) const fn score_import_endpoint_from_choice_index(
 #[inline(always)]
 pub(super) fn score_import_selected_endpoint(state: &State) -> scores::ScoreImportEndpoint {
     let idx = state
-        .sub_choice_indices_score_import
+        .sub[SubmenuKind::ScoreImport].choice_indices
         .get(SCORE_IMPORT_ROW_ENDPOINT_INDEX)
         .copied()
         .unwrap_or(0);
@@ -222,13 +222,13 @@ pub(super) fn refresh_score_import_profile_options(state: &mut State) {
 
     let max_idx = state.score_import_profile_choices.len().saturating_sub(1);
     if let Some(slot) = state
-        .sub_choice_indices_score_import
+        .sub[SubmenuKind::ScoreImport].choice_indices
         .get_mut(SCORE_IMPORT_ROW_PROFILE_INDEX)
     {
         *slot = (*slot).min(max_idx);
     }
     if let Some(slot) = state
-        .sub_cursor_indices_score_import
+        .sub[SubmenuKind::ScoreImport].cursor_indices
         .get_mut(SCORE_IMPORT_ROW_PROFILE_INDEX)
     {
         *slot = (*slot).min(max_idx);
@@ -241,13 +241,13 @@ pub(super) fn refresh_score_import_pack_options(state: &mut State) {
     state.score_import_pack_filters = filters;
     let max_idx = state.score_import_pack_choices.len().saturating_sub(1);
     if let Some(slot) = state
-        .sub_choice_indices_score_import
+        .sub[SubmenuKind::ScoreImport].choice_indices
         .get_mut(SCORE_IMPORT_ROW_PACK_INDEX)
     {
         *slot = (*slot).min(max_idx);
     }
     if let Some(slot) = state
-        .sub_cursor_indices_score_import
+        .sub[SubmenuKind::ScoreImport].cursor_indices
         .get_mut(SCORE_IMPORT_ROW_PACK_INDEX)
     {
         *slot = (*slot).min(max_idx);
@@ -260,13 +260,13 @@ pub(super) fn refresh_sync_pack_options(state: &mut State) {
     state.sync_pack_filters = filters;
     let max_idx = state.sync_pack_choices.len().saturating_sub(1);
     if let Some(slot) = state
-        .sub_choice_indices_sync_packs
+        .sub[SubmenuKind::SyncPacks].choice_indices
         .get_mut(SYNC_PACK_ROW_PACK_INDEX)
     {
         *slot = (*slot).min(max_idx);
     }
     if let Some(slot) = state
-        .sub_cursor_indices_sync_packs
+        .sub[SubmenuKind::SyncPacks].cursor_indices
         .get_mut(SYNC_PACK_ROW_PACK_INDEX)
     {
         *slot = (*slot).min(max_idx);
@@ -285,7 +285,7 @@ pub(super) fn refresh_null_or_die_options(state: &mut State) {
 
 pub(super) fn selected_score_import_pack_group(state: &State) -> Option<String> {
     let pack_idx = state
-        .sub_choice_indices_score_import
+        .sub[SubmenuKind::ScoreImport].choice_indices
         .get(SCORE_IMPORT_ROW_PACK_INDEX)
         .copied()
         .unwrap_or(0)
@@ -299,7 +299,7 @@ pub(super) fn selected_score_import_pack_group(state: &State) -> Option<String> 
 
 pub(super) fn selected_score_import_profile(state: &State) -> Option<ScoreImportProfileConfig> {
     let profile_idx = state
-        .sub_choice_indices_score_import
+        .sub[SubmenuKind::ScoreImport].choice_indices
         .get(SCORE_IMPORT_ROW_PROFILE_INDEX)
         .copied()
         .unwrap_or(0)
@@ -319,7 +319,7 @@ pub(super) fn selected_score_import_profile(state: &State) -> Option<ScoreImport
 pub(super) fn score_import_only_missing_gs_scores(state: &State) -> bool {
     yes_no_from_choice(
         state
-            .sub_choice_indices_score_import
+            .sub[SubmenuKind::ScoreImport].choice_indices
             .get(SCORE_IMPORT_ROW_ONLY_MISSING_INDEX)
             .copied()
             .unwrap_or_else(|| yes_no_choice_index(false)),

--- a/src/screens/options/state.rs
+++ b/src/screens/options/state.rs
@@ -33,6 +33,68 @@ pub enum SubmenuKind {
     ScoreImport,
 }
 
+impl SubmenuKind {
+    pub(super) const ALL: [Self; 17] = [
+        Self::System,
+        Self::Graphics,
+        Self::Input,
+        Self::InputBackend,
+        Self::OnlineScoring,
+        Self::NullOrDie,
+        Self::NullOrDieOptions,
+        Self::SyncPacks,
+        Self::Machine,
+        Self::Advanced,
+        Self::Course,
+        Self::Gameplay,
+        Self::Sound,
+        Self::SelectMusic,
+        Self::GrooveStats,
+        Self::ArrowCloud,
+        Self::ScoreImport,
+    ];
+    pub(super) const COUNT: usize = Self::ALL.len();
+
+    #[inline]
+    pub(super) const fn index(self) -> usize {
+        self as usize
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct SubmenuState {
+    pub(super) choice_indices: Vec<usize>,
+    pub(super) cursor_indices: Vec<usize>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct SubmenuStates([SubmenuState; SubmenuKind::COUNT]);
+
+impl SubmenuStates {
+    pub(super) fn new(init: impl FnMut(usize) -> SubmenuState) -> Self {
+        Self(std::array::from_fn(init))
+    }
+
+    pub(super) fn iter_mut(&mut self) -> std::slice::IterMut<'_, SubmenuState> {
+        self.0.iter_mut()
+    }
+}
+
+impl std::ops::Index<SubmenuKind> for SubmenuStates {
+    type Output = SubmenuState;
+    #[inline]
+    fn index(&self, kind: SubmenuKind) -> &SubmenuState {
+        &self.0[kind.index()]
+    }
+}
+
+impl std::ops::IndexMut<SubmenuKind> for SubmenuStates {
+    #[inline]
+    fn index_mut(&mut self, kind: SubmenuKind) -> &mut SubmenuState {
+        &mut self.0[kind.index()]
+    }
+}
+
 #[inline(always)]
 pub(super) const fn is_launcher_submenu(kind: SubmenuKind) -> bool {
     matches!(
@@ -105,41 +167,8 @@ pub struct State {
     pub(super) sub_selected: usize,
     pub(super) sub_prev_selected: usize,
     pub(super) sub_inline_x: f32,
-    pub(super) sub_choice_indices_system: Vec<usize>,
-    pub(super) sub_choice_indices_graphics: Vec<usize>,
-    pub(super) sub_choice_indices_input: Vec<usize>,
-    pub(super) sub_choice_indices_input_backend: Vec<usize>,
-    pub(super) sub_choice_indices_online_scoring: Vec<usize>,
-    pub(super) sub_choice_indices_null_or_die: Vec<usize>,
-    pub(super) sub_choice_indices_null_or_die_options: Vec<usize>,
-    pub(super) sub_choice_indices_sync_packs: Vec<usize>,
-    pub(super) sub_choice_indices_machine: Vec<usize>,
-    pub(super) sub_choice_indices_advanced: Vec<usize>,
-    pub(super) sub_choice_indices_course: Vec<usize>,
-    pub(super) sub_choice_indices_gameplay: Vec<usize>,
-    pub(super) sub_choice_indices_sound: Vec<usize>,
-    pub(super) sub_choice_indices_select_music: Vec<usize>,
-    pub(super) sub_choice_indices_groovestats: Vec<usize>,
-    pub(super) sub_choice_indices_arrowcloud: Vec<usize>,
-    pub(super) sub_choice_indices_score_import: Vec<usize>,
+    pub(super) sub: SubmenuStates,
     pub(super) system_noteskin_choices: Vec<String>,
-    pub(super) sub_cursor_indices_system: Vec<usize>,
-    pub(super) sub_cursor_indices_graphics: Vec<usize>,
-    pub(super) sub_cursor_indices_input: Vec<usize>,
-    pub(super) sub_cursor_indices_input_backend: Vec<usize>,
-    pub(super) sub_cursor_indices_online_scoring: Vec<usize>,
-    pub(super) sub_cursor_indices_null_or_die: Vec<usize>,
-    pub(super) sub_cursor_indices_null_or_die_options: Vec<usize>,
-    pub(super) sub_cursor_indices_sync_packs: Vec<usize>,
-    pub(super) sub_cursor_indices_machine: Vec<usize>,
-    pub(super) sub_cursor_indices_advanced: Vec<usize>,
-    pub(super) sub_cursor_indices_course: Vec<usize>,
-    pub(super) sub_cursor_indices_gameplay: Vec<usize>,
-    pub(super) sub_cursor_indices_sound: Vec<usize>,
-    pub(super) sub_cursor_indices_select_music: Vec<usize>,
-    pub(super) sub_cursor_indices_groovestats: Vec<usize>,
-    pub(super) sub_cursor_indices_arrowcloud: Vec<usize>,
-    pub(super) sub_cursor_indices_score_import: Vec<usize>,
     pub(super) score_import_profiles: Vec<ScoreImportProfileConfig>,
     pub(super) score_import_profile_choices: Vec<String>,
     pub(super) score_import_profile_ids: Vec<Option<String>>,
@@ -244,41 +273,14 @@ pub fn init() -> State {
         sub_selected: 0,
         sub_prev_selected: 0,
         sub_inline_x: f32::NAN,
-        sub_choice_indices_system: vec![0; SYSTEM_OPTIONS_ROWS.len()],
-        sub_choice_indices_graphics: vec![0; GRAPHICS_OPTIONS_ROWS.len()],
-        sub_choice_indices_input: vec![0; INPUT_OPTIONS_ROWS.len()],
-        sub_choice_indices_input_backend: vec![0; INPUT_BACKEND_OPTIONS_ROWS.len()],
-        sub_choice_indices_online_scoring: vec![0; ONLINE_SCORING_OPTIONS_ROWS.len()],
-        sub_choice_indices_null_or_die: vec![0; NULL_OR_DIE_MENU_ROWS.len()],
-        sub_choice_indices_null_or_die_options: vec![0; NULL_OR_DIE_OPTIONS_ROWS.len()],
-        sub_choice_indices_sync_packs: vec![0; SYNC_PACK_OPTIONS_ROWS.len()],
-        sub_choice_indices_machine: vec![0; MACHINE_OPTIONS_ROWS.len()],
-        sub_choice_indices_advanced: vec![0; ADVANCED_OPTIONS_ROWS.len()],
-        sub_choice_indices_course: vec![0; COURSE_OPTIONS_ROWS.len()],
-        sub_choice_indices_gameplay: vec![0; GAMEPLAY_OPTIONS_ROWS.len()],
-        sub_choice_indices_sound: vec![0; SOUND_OPTIONS_ROWS.len()],
-        sub_choice_indices_select_music: vec![0; SELECT_MUSIC_OPTIONS_ROWS.len()],
-        sub_choice_indices_groovestats: vec![0; GROOVESTATS_OPTIONS_ROWS.len()],
-        sub_choice_indices_arrowcloud: vec![0; ARROWCLOUD_OPTIONS_ROWS.len()],
-        sub_choice_indices_score_import: vec![0; SCORE_IMPORT_OPTIONS_ROWS.len()],
+        sub: SubmenuStates::new(|i| {
+            let len = submenu_rows(SubmenuKind::ALL[i]).len();
+            SubmenuState {
+                choice_indices: vec![0; len],
+                cursor_indices: vec![0; len],
+            }
+        }),
         system_noteskin_choices,
-        sub_cursor_indices_system: vec![0; SYSTEM_OPTIONS_ROWS.len()],
-        sub_cursor_indices_graphics: vec![0; GRAPHICS_OPTIONS_ROWS.len()],
-        sub_cursor_indices_input: vec![0; INPUT_OPTIONS_ROWS.len()],
-        sub_cursor_indices_input_backend: vec![0; INPUT_BACKEND_OPTIONS_ROWS.len()],
-        sub_cursor_indices_online_scoring: vec![0; ONLINE_SCORING_OPTIONS_ROWS.len()],
-        sub_cursor_indices_null_or_die: vec![0; NULL_OR_DIE_MENU_ROWS.len()],
-        sub_cursor_indices_null_or_die_options: vec![0; NULL_OR_DIE_OPTIONS_ROWS.len()],
-        sub_cursor_indices_sync_packs: vec![0; SYNC_PACK_OPTIONS_ROWS.len()],
-        sub_cursor_indices_machine: vec![0; MACHINE_OPTIONS_ROWS.len()],
-        sub_cursor_indices_advanced: vec![0; ADVANCED_OPTIONS_ROWS.len()],
-        sub_cursor_indices_course: vec![0; COURSE_OPTIONS_ROWS.len()],
-        sub_cursor_indices_gameplay: vec![0; GAMEPLAY_OPTIONS_ROWS.len()],
-        sub_cursor_indices_sound: vec![0; SOUND_OPTIONS_ROWS.len()],
-        sub_cursor_indices_select_music: vec![0; SELECT_MUSIC_OPTIONS_ROWS.len()],
-        sub_cursor_indices_groovestats: vec![0; GROOVESTATS_OPTIONS_ROWS.len()],
-        sub_cursor_indices_arrowcloud: vec![0; ARROWCLOUD_OPTIONS_ROWS.len()],
-        sub_cursor_indices_score_import: vec![0; SCORE_IMPORT_OPTIONS_ROWS.len()],
         score_import_profiles: Vec::new(),
         score_import_profile_choices: vec![
             tr("OptionsScoreImport", "NoEligibleProfiles").to_string(),
@@ -370,31 +372,31 @@ pub fn init() -> State {
     sync_display_resolution(&mut state, cfg.display_width, cfg.display_height);
 
     set_choice_by_id(
-        &mut state.sub_choice_indices_system,
+        &mut state.sub[SubmenuKind::System].choice_indices,
         SYSTEM_OPTIONS_ROWS,
         SubRowId::Game,
         0,
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_system,
+        &mut state.sub[SubmenuKind::System].choice_indices,
         SYSTEM_OPTIONS_ROWS,
         SubRowId::Theme,
         0,
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_system,
+        &mut state.sub[SubmenuKind::System].choice_indices,
         SYSTEM_OPTIONS_ROWS,
         SubRowId::Language,
         language_choice_index(cfg.language_flag),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_system,
+        &mut state.sub[SubmenuKind::System].choice_indices,
         SYSTEM_OPTIONS_ROWS,
         SubRowId::LogLevel,
         log_level_choice_index(cfg.log_level),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_system,
+        &mut state.sub[SubmenuKind::System].choice_indices,
         SYSTEM_OPTIONS_ROWS,
         SubRowId::LogFile,
         usize::from(cfg.log_to_file),
@@ -402,44 +404,44 @@ pub fn init() -> State {
     if let Some(noteskin_row_idx) = SYSTEM_OPTIONS_ROWS
         .iter()
         .position(|row| row.id == SubRowId::DefaultNoteSkin)
-        && let Some(slot) = state.sub_choice_indices_system.get_mut(noteskin_row_idx)
+        && let Some(slot) = state.sub[SubmenuKind::System].choice_indices.get_mut(noteskin_row_idx)
     {
         *slot = machine_noteskin_idx;
     }
 
     set_choice_by_id(
-        &mut state.sub_choice_indices_graphics,
+        &mut state.sub[SubmenuKind::Graphics].choice_indices,
         GRAPHICS_OPTIONS_ROWS,
         SubRowId::VSync,
         yes_no_choice_index(cfg.vsync),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_graphics,
+        &mut state.sub[SubmenuKind::Graphics].choice_indices,
         GRAPHICS_OPTIONS_ROWS,
         SubRowId::PresentMode,
         present_mode_choice_index(cfg.present_mode_policy),
     );
     sync_max_fps(&mut state, cfg.max_fps);
     set_choice_by_id(
-        &mut state.sub_choice_indices_graphics,
+        &mut state.sub[SubmenuKind::Graphics].choice_indices,
         GRAPHICS_OPTIONS_ROWS,
         SubRowId::ShowStats,
         cfg.show_stats_mode.min(3) as usize,
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_graphics,
+        &mut state.sub[SubmenuKind::Graphics].choice_indices,
         GRAPHICS_OPTIONS_ROWS,
         SubRowId::ValidationLayers,
         yes_no_choice_index(cfg.gfx_debug),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_graphics,
+        &mut state.sub[SubmenuKind::Graphics].choice_indices,
         GRAPHICS_OPTIONS_ROWS,
         SubRowId::HighDpi,
         yes_no_choice_index(cfg.high_dpi),
     );
     if let Some(slot) = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get_mut(SOFTWARE_THREADS_ROW_INDEX)
     {
         *slot = software_thread_choice_index(
@@ -449,188 +451,188 @@ pub fn init() -> State {
     }
     #[cfg(target_os = "windows")]
     set_choice_by_id(
-        &mut state.sub_choice_indices_input_backend,
+        &mut state.sub[SubmenuKind::InputBackend].choice_indices,
         INPUT_BACKEND_OPTIONS_ROWS,
         SubRowId::GamepadBackend,
         windows_backend_choice_index(cfg.windows_gamepad_backend),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_input_backend,
+        &mut state.sub[SubmenuKind::InputBackend].choice_indices,
         INPUT_BACKEND_OPTIONS_ROWS,
         SubRowId::UseFsrs,
         yes_no_choice_index(cfg.use_fsrs),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_input_backend,
+        &mut state.sub[SubmenuKind::InputBackend].choice_indices,
         INPUT_BACKEND_OPTIONS_ROWS,
         SubRowId::MenuNavigation,
         usize::from(cfg.three_key_navigation),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_input_backend,
+        &mut state.sub[SubmenuKind::InputBackend].choice_indices,
         INPUT_BACKEND_OPTIONS_ROWS,
         SubRowId::OptionsNavigation,
         usize::from(cfg.arcade_options_navigation),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_input_backend,
+        &mut state.sub[SubmenuKind::InputBackend].choice_indices,
         INPUT_BACKEND_OPTIONS_ROWS,
         SubRowId::MenuButtons,
         usize::from(cfg.only_dedicated_menu_buttons),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::SelectProfile,
         usize::from(cfg.machine_show_select_profile),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::SelectColor,
         usize::from(cfg.machine_show_select_color),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::SelectStyle,
         usize::from(cfg.machine_show_select_style),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::PreferredStyle,
         machine_preferred_style_choice_index(cfg.machine_preferred_style),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::SelectPlayMode,
         usize::from(cfg.machine_show_select_play_mode),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::PreferredMode,
         machine_preferred_mode_choice_index(cfg.machine_preferred_play_mode),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::Font,
         machine_font_choice_index(cfg.machine_font),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::EvalSummary,
         usize::from(cfg.machine_show_eval_summary),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::NameEntry,
         usize::from(cfg.machine_show_name_entry),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::GameoverScreen,
         usize::from(cfg.machine_show_gameover),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::MenuMusic,
         usize::from(cfg.menu_music),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::VisualStyle,
         visual_style_choice_index(cfg.visual_style),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::Replays,
         usize::from(cfg.machine_enable_replays),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::PerPlayerGlobalOffsets,
         usize::from(cfg.machine_allow_per_player_global_offsets),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::KeyboardFeatures,
         usize::from(cfg.keyboard_features),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::VideoBgs,
         usize::from(cfg.show_video_backgrounds),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_machine,
+        &mut state.sub[SubmenuKind::Machine].choice_indices,
         MACHINE_OPTIONS_ROWS,
         SubRowId::WriteCurrentScreen,
         usize::from(cfg.write_current_screen),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_advanced,
+        &mut state.sub[SubmenuKind::Advanced].choice_indices,
         ADVANCED_OPTIONS_ROWS,
         SubRowId::DefaultFailType,
         default_fail_type_choice_index(cfg.default_fail_type),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_advanced,
+        &mut state.sub[SubmenuKind::Advanced].choice_indices,
         ADVANCED_OPTIONS_ROWS,
         SubRowId::BannerCache,
         usize::from(cfg.banner_cache),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_advanced,
+        &mut state.sub[SubmenuKind::Advanced].choice_indices,
         ADVANCED_OPTIONS_ROWS,
         SubRowId::CdTitleCache,
         usize::from(cfg.cdtitle_cache),
     );
     if let Some(slot) = state
-        .sub_choice_indices_advanced
+        .sub[SubmenuKind::Advanced].choice_indices
         .get_mut(ADVANCED_SONG_PARSING_THREADS_ROW_INDEX)
     {
         *slot =
             software_thread_choice_index(&state.software_thread_choices, cfg.song_parsing_threads);
     }
     set_choice_by_id(
-        &mut state.sub_choice_indices_advanced,
+        &mut state.sub[SubmenuKind::Advanced].choice_indices,
         ADVANCED_OPTIONS_ROWS,
         SubRowId::CacheSongs,
         usize::from(cfg.cachesongs),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_advanced,
+        &mut state.sub[SubmenuKind::Advanced].choice_indices,
         ADVANCED_OPTIONS_ROWS,
         SubRowId::FastLoad,
         usize::from(cfg.fastload),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_null_or_die_options,
+        &mut state.sub[SubmenuKind::NullOrDieOptions].choice_indices,
         NULL_OR_DIE_OPTIONS_ROWS,
         SubRowId::SyncGraph,
         sync_graph_mode_choice_index(cfg.null_or_die_sync_graph),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_null_or_die_options,
+        &mut state.sub[SubmenuKind::NullOrDieOptions].choice_indices,
         NULL_OR_DIE_OPTIONS_ROWS,
         SubRowId::SyncConfidence,
         sync_confidence_choice_index(cfg.null_or_die_confidence_percent),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_null_or_die_options,
+        &mut state.sub[SubmenuKind::NullOrDieOptions].choice_indices,
         NULL_OR_DIE_OPTIONS_ROWS,
         SubRowId::PackSyncThreads,
         software_thread_choice_index(
@@ -639,98 +641,98 @@ pub fn init() -> State {
         ),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_null_or_die_options,
+        &mut state.sub[SubmenuKind::NullOrDieOptions].choice_indices,
         NULL_OR_DIE_OPTIONS_ROWS,
         SubRowId::KernelTarget,
         null_or_die_kernel_target_choice_index(cfg.null_or_die_kernel_target),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_null_or_die_options,
+        &mut state.sub[SubmenuKind::NullOrDieOptions].choice_indices,
         NULL_OR_DIE_OPTIONS_ROWS,
         SubRowId::KernelType,
         null_or_die_kernel_type_choice_index(cfg.null_or_die_kernel_type),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_null_or_die_options,
+        &mut state.sub[SubmenuKind::NullOrDieOptions].choice_indices,
         NULL_OR_DIE_OPTIONS_ROWS,
         SubRowId::FullSpectrogram,
         yes_no_choice_index(cfg.null_or_die_full_spectrogram),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_course,
+        &mut state.sub[SubmenuKind::Course].choice_indices,
         COURSE_OPTIONS_ROWS,
         SubRowId::ShowRandomCourses,
         yes_no_choice_index(cfg.show_random_courses),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_course,
+        &mut state.sub[SubmenuKind::Course].choice_indices,
         COURSE_OPTIONS_ROWS,
         SubRowId::ShowMostPlayed,
         yes_no_choice_index(cfg.show_most_played_courses),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_course,
+        &mut state.sub[SubmenuKind::Course].choice_indices,
         COURSE_OPTIONS_ROWS,
         SubRowId::ShowIndividualScores,
         yes_no_choice_index(cfg.show_course_individual_scores),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_course,
+        &mut state.sub[SubmenuKind::Course].choice_indices,
         COURSE_OPTIONS_ROWS,
         SubRowId::AutosubmitIndividual,
         yes_no_choice_index(cfg.autosubmit_course_scores_individually),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_gameplay,
+        &mut state.sub[SubmenuKind::Gameplay].choice_indices,
         GAMEPLAY_OPTIONS_ROWS,
         SubRowId::BgBrightness,
         bg_brightness_choice_index(cfg.bg_brightness),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_gameplay,
+        &mut state.sub[SubmenuKind::Gameplay].choice_indices,
         GAMEPLAY_OPTIONS_ROWS,
         SubRowId::CenteredP1Notefield,
         usize::from(cfg.center_1player_notefield),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_gameplay,
+        &mut state.sub[SubmenuKind::Gameplay].choice_indices,
         GAMEPLAY_OPTIONS_ROWS,
         SubRowId::ZmodRatingBox,
         usize::from(cfg.zmod_rating_box_text),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_gameplay,
+        &mut state.sub[SubmenuKind::Gameplay].choice_indices,
         GAMEPLAY_OPTIONS_ROWS,
         SubRowId::BpmDecimal,
         usize::from(cfg.show_bpm_decimal),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_gameplay,
+        &mut state.sub[SubmenuKind::Gameplay].choice_indices,
         GAMEPLAY_OPTIONS_ROWS,
         SubRowId::AutoScreenshot,
         auto_screenshot_cursor_index(cfg.auto_screenshot_eval),
     );
 
     set_choice_by_id(
-        &mut state.sub_choice_indices_sound,
+        &mut state.sub[SubmenuKind::Sound].choice_indices,
         SOUND_OPTIONS_ROWS,
         SubRowId::MasterVolume,
         master_volume_choice_index(cfg.master_volume),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_sound,
+        &mut state.sub[SubmenuKind::Sound].choice_indices,
         SOUND_OPTIONS_ROWS,
         SubRowId::SfxVolume,
         master_volume_choice_index(cfg.sfx_volume),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_sound,
+        &mut state.sub[SubmenuKind::Sound].choice_indices,
         SOUND_OPTIONS_ROWS,
         SubRowId::AssistTickVolume,
         master_volume_choice_index(cfg.assist_tick_volume),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_sound,
+        &mut state.sub[SubmenuKind::Sound].choice_indices,
         SOUND_OPTIONS_ROWS,
         SubRowId::MusicVolume,
         master_volume_choice_index(cfg.music_volume),
@@ -756,103 +758,103 @@ pub fn init() -> State {
     let sound_rate_idx = sample_rate_choice_index(&state, cfg.audio_sample_rate_hz);
     set_sound_choice_index(&mut state, SubRowId::AudioSampleRate, sound_rate_idx);
     set_choice_by_id(
-        &mut state.sub_choice_indices_sound,
+        &mut state.sub[SubmenuKind::Sound].choice_indices,
         SOUND_OPTIONS_ROWS,
         SubRowId::MineSounds,
         usize::from(cfg.mine_hit_sound),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_sound,
+        &mut state.sub[SubmenuKind::Sound].choice_indices,
         SOUND_OPTIONS_ROWS,
         SubRowId::RateModPreservesPitch,
         usize::from(cfg.rate_mod_preserves_pitch),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::ShowBanners,
         yes_no_choice_index(cfg.show_select_music_banners),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::ShowVideoBanners,
         yes_no_choice_index(cfg.show_select_music_video_banners),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::ShowBreakdown,
         yes_no_choice_index(cfg.show_select_music_breakdown),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::BreakdownStyle,
         breakdown_style_choice_index(cfg.select_music_breakdown_style),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::ShowNativeLanguage,
         translated_titles_choice_index(cfg.translated_titles),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::MusicWheelSpeed,
         music_wheel_scroll_speed_choice_index(cfg.music_wheel_switch_speed),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::MusicWheelStyle,
         select_music_wheel_style_choice_index(cfg.select_music_wheel_style),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::ShowCdTitles,
         yes_no_choice_index(cfg.show_select_music_cdtitles),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::ShowWheelGrades,
         yes_no_choice_index(cfg.show_music_wheel_grades),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::ShowWheelLamps,
         yes_no_choice_index(cfg.show_music_wheel_lamps),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::ItlRank,
         select_music_itl_rank_choice_index(cfg.select_music_itl_rank_mode),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::ItlWheelData,
         select_music_itl_wheel_choice_index(cfg.select_music_itl_wheel_mode),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::NewPackBadge,
         new_pack_mode_choice_index(cfg.select_music_new_pack_mode),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::ShowPatternInfo,
         select_music_pattern_info_choice_index(cfg.select_music_pattern_info_mode),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::ChartInfo,
         select_music_chart_info_cursor_index(
@@ -861,43 +863,43 @@ pub fn init() -> State {
         ),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::MusicPreviews,
         yes_no_choice_index(cfg.show_select_music_previews),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::PreviewMarker,
         yes_no_choice_index(cfg.show_select_music_preview_marker),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::LoopMusic,
         usize::from(cfg.select_music_preview_loop),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::ShowGameplayTimer,
         yes_no_choice_index(cfg.show_select_music_gameplay_timer),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::ShowGsBox,
         yes_no_choice_index(cfg.show_select_music_scorebox),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::GsBoxPlacement,
         select_music_scorebox_placement_choice_index(cfg.select_music_scorebox_placement),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::GsBoxLeaderboards,
         scorebox_cycle_cursor_index(
@@ -908,43 +910,43 @@ pub fn init() -> State {
         ),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_groovestats,
+        &mut state.sub[SubmenuKind::GrooveStats].choice_indices,
         GROOVESTATS_OPTIONS_ROWS,
         SubRowId::EnableGrooveStats,
         yes_no_choice_index(cfg.enable_groovestats),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_groovestats,
+        &mut state.sub[SubmenuKind::GrooveStats].choice_indices,
         GROOVESTATS_OPTIONS_ROWS,
         SubRowId::EnableBoogieStats,
         yes_no_choice_index(cfg.enable_boogiestats),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_groovestats,
+        &mut state.sub[SubmenuKind::GrooveStats].choice_indices,
         GROOVESTATS_OPTIONS_ROWS,
         SubRowId::AutoPopulateScores,
         yes_no_choice_index(cfg.auto_populate_gs_scores),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_groovestats,
+        &mut state.sub[SubmenuKind::GrooveStats].choice_indices,
         GROOVESTATS_OPTIONS_ROWS,
         SubRowId::AutoDownloadUnlocks,
         yes_no_choice_index(cfg.auto_download_unlocks),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_groovestats,
+        &mut state.sub[SubmenuKind::GrooveStats].choice_indices,
         GROOVESTATS_OPTIONS_ROWS,
         SubRowId::SeparateUnlocksByPlayer,
         yes_no_choice_index(cfg.separate_unlocks_by_player),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_arrowcloud,
+        &mut state.sub[SubmenuKind::ArrowCloud].choice_indices,
         ARROWCLOUD_OPTIONS_ROWS,
         SubRowId::EnableArrowCloud,
         yes_no_choice_index(cfg.enable_arrowcloud),
     );
     set_choice_by_id(
-        &mut state.sub_choice_indices_arrowcloud,
+        &mut state.sub[SubmenuKind::ArrowCloud].choice_indices,
         ARROWCLOUD_OPTIONS_ROWS,
         SubRowId::ArrowCloudSubmitFails,
         yes_no_choice_index(cfg.submit_arrowcloud_fails),
@@ -952,7 +954,7 @@ pub fn init() -> State {
     refresh_score_import_options(&mut state);
     refresh_null_or_die_options(&mut state);
     set_choice_by_id(
-        &mut state.sub_choice_indices_score_import,
+        &mut state.sub[SubmenuKind::ScoreImport].choice_indices,
         SCORE_IMPORT_OPTIONS_ROWS,
         SubRowId::ScoreImportOnlyMissing,
         yes_no_choice_index(false),

--- a/src/screens/options/submenus/graphics.rs
+++ b/src/screens/options/submenus/graphics.rs
@@ -413,7 +413,7 @@ pub(in crate::screens::options) fn renderer_choice_index_to_backend(idx: usize) 
 
 pub(in crate::screens::options) fn selected_video_renderer(state: &State) -> BackendType {
     let choice_idx = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get(VIDEO_RENDERER_ROW_INDEX)
         .copied()
         .unwrap_or(0);
@@ -479,8 +479,8 @@ pub(in crate::screens::options) fn build_max_fps_choices() -> Vec<u16> {
 }
 
 pub(in crate::screens::options) fn selected_max_fps_label(state: &State) -> String {
-    let idx = state
-        .sub_choice_indices_graphics
+    let idx = state.sub[SubmenuKind::Graphics]
+        .choice_indices
         .get(MAX_FPS_VALUE_ROW_INDEX)
         .copied()
         .unwrap_or(0);
@@ -496,8 +496,8 @@ pub(in crate::screens::options) fn adjust_max_fps_value_choice(
     if n == 0 {
         return false;
     }
-    let current = state
-        .sub_cursor_indices_graphics
+    let current = state.sub[SubmenuKind::Graphics]
+        .cursor_indices
         .get(MAX_FPS_VALUE_ROW_INDEX)
         .copied()
         .unwrap_or(0)
@@ -594,7 +594,7 @@ pub(in crate::screens::options) fn selected_present_mode_policy(
     state: &State,
 ) -> PresentModePolicy {
     state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get(PRESENT_MODE_ROW_INDEX)
         .copied()
         .map_or(state.present_mode_policy_at_load, present_mode_from_choice)
@@ -604,7 +604,7 @@ pub(in crate::screens::options) fn selected_high_dpi(state: &State) -> bool {
     GRAPHICS_OPTIONS_ROWS
         .iter()
         .position(|row| row.id == SubRowId::HighDpi)
-        .and_then(|idx| state.sub_choice_indices_graphics.get(idx).copied())
+        .and_then(|idx| state.sub[SubmenuKind::Graphics].choice_indices.get(idx).copied())
         .is_some_and(yes_no_from_choice)
 }
 
@@ -612,13 +612,13 @@ pub(in crate::screens::options) fn selected_high_dpi(state: &State) -> bool {
 pub(in crate::screens::options) fn set_max_fps_enabled_choice(state: &mut State, enabled: bool) {
     let idx = yes_no_choice_index(enabled);
     if let Some(slot) = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get_mut(MAX_FPS_ENABLED_ROW_INDEX)
     {
         *slot = idx;
     }
     if let Some(slot) = state
-        .sub_cursor_indices_graphics
+        .sub[SubmenuKind::Graphics].cursor_indices
         .get_mut(MAX_FPS_ENABLED_ROW_INDEX)
     {
         *slot = idx;
@@ -630,13 +630,13 @@ pub(in crate::screens::options) fn set_max_fps_value_choice_index(state: &mut St
     let max_idx = state.max_fps_choices.len().saturating_sub(1);
     let clamped = idx.min(max_idx);
     if let Some(slot) = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get_mut(MAX_FPS_VALUE_ROW_INDEX)
     {
         *slot = clamped;
     }
     if let Some(slot) = state
-        .sub_cursor_indices_graphics
+        .sub[SubmenuKind::Graphics].cursor_indices
         .get_mut(MAX_FPS_VALUE_ROW_INDEX)
     {
         *slot = clamped;
@@ -651,7 +651,7 @@ pub(in crate::screens::options) fn graphics_show_software_threads(state: &State)
 #[inline(always)]
 pub(in crate::screens::options) fn graphics_show_present_mode(state: &State) -> bool {
     state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get(VSYNC_ROW_INDEX)
         .copied()
         .is_some_and(|idx| !yes_no_from_choice(idx))
@@ -665,7 +665,7 @@ pub(in crate::screens::options) fn graphics_show_max_fps(state: &State) -> bool 
 #[inline(always)]
 pub(in crate::screens::options) fn max_fps_enabled(state: &State) -> bool {
     state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get(MAX_FPS_ENABLED_ROW_INDEX)
         .copied()
         .is_some_and(yes_no_from_choice)
@@ -701,7 +701,7 @@ pub(in crate::screens::options) const fn choice_index_to_fullscreen_type(
 
 pub(in crate::screens::options) fn selected_fullscreen_type(state: &State) -> FullscreenType {
     state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get(FULLSCREEN_TYPE_ROW_INDEX)
         .copied()
         .map_or(FullscreenType::Exclusive, choice_index_to_fullscreen_type)
@@ -709,7 +709,7 @@ pub(in crate::screens::options) fn selected_fullscreen_type(state: &State) -> Fu
 
 pub(in crate::screens::options) fn selected_display_mode(state: &State) -> DisplayMode {
     let display_choice = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get(DISPLAY_MODE_ROW_INDEX)
         .copied()
         .unwrap_or(0);
@@ -723,7 +723,7 @@ pub(in crate::screens::options) fn selected_display_mode(state: &State) -> Displ
 
 pub(in crate::screens::options) fn selected_display_monitor(state: &State) -> usize {
     let display_choice = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get(DISPLAY_MODE_ROW_INDEX)
         .copied()
         .unwrap_or(0);
@@ -737,7 +737,7 @@ pub(in crate::screens::options) fn selected_display_monitor(state: &State) -> us
 
 pub(in crate::screens::options) fn selected_refresh_rate_millihertz(state: &State) -> u32 {
     let idx = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get(REFRESH_RATE_ROW_INDEX)
         .copied()
         .unwrap_or(0);
@@ -790,7 +790,7 @@ pub(in crate::screens::options) fn selected_max_fps(state: &State) -> u16 {
         return 0;
     }
     let idx = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get(MAX_FPS_VALUE_ROW_INDEX)
         .copied()
         .unwrap_or(0);
@@ -801,18 +801,18 @@ pub(in crate::screens::options) fn ensure_display_mode_choices(state: &mut State
     state.display_mode_choices = build_display_mode_choices(&state.monitor_specs);
     // If current selection is out of bounds, reset it.
     if let Some(idx) = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get_mut(DISPLAY_MODE_ROW_INDEX)
         && *idx >= state.display_mode_choices.len()
     {
         *idx = 0;
     }
     if let Some(choice_idx) = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get(DISPLAY_MODE_ROW_INDEX)
         .copied()
         && let Some(cursor_idx) = state
-            .sub_cursor_indices_graphics
+            .sub[SubmenuKind::Graphics].cursor_indices
             .get_mut(DISPLAY_MODE_ROW_INDEX)
     {
         *cursor_idx = choice_idx;
@@ -859,13 +859,13 @@ pub(in crate::screens::options) fn set_display_mode_row_selection(
         }
     };
     if let Some(slot) = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get_mut(DISPLAY_MODE_ROW_INDEX)
     {
         *slot = idx;
     }
     if let Some(slot) = state
-        .sub_cursor_indices_graphics
+        .sub[SubmenuKind::Graphics].cursor_indices
         .get_mut(DISPLAY_MODE_ROW_INDEX)
     {
         *slot = idx;
@@ -877,7 +877,7 @@ pub(in crate::screens::options) fn set_display_mode_row_selection(
 
 pub(in crate::screens::options) fn selected_aspect_label(state: &State) -> &'static str {
     let idx = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get(DISPLAY_ASPECT_RATIO_ROW_INDEX)
         .copied()
         .unwrap_or(0);
@@ -930,13 +930,13 @@ pub(in crate::screens::options) fn sync_display_aspect_ratio(
 ) {
     let idx = inferred_aspect_choice(width, height);
     if let Some(slot) = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get_mut(DISPLAY_ASPECT_RATIO_ROW_INDEX)
     {
         *slot = idx;
     }
     if let Some(slot) = state
-        .sub_cursor_indices_graphics
+        .sub[SubmenuKind::Graphics].cursor_indices
         .get_mut(DISPLAY_ASPECT_RATIO_ROW_INDEX)
     {
         *slot = idx;
@@ -982,7 +982,7 @@ pub(in crate::screens::options) fn aspect_matches(width: u32, height: u32, label
 
 pub(in crate::screens::options) fn selected_resolution(state: &State) -> (u32, u32) {
     let idx = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get(DISPLAY_RESOLUTION_ROW_INDEX)
         .copied()
         .unwrap_or(0);
@@ -998,13 +998,13 @@ pub(in crate::screens::options) fn rebuild_refresh_rate_choices(state: &mut Stat
     if matches!(selected_display_mode(state), DisplayMode::Windowed) {
         state.refresh_rate_choices = vec![0];
         if let Some(slot) = state
-            .sub_choice_indices_graphics
+            .sub[SubmenuKind::Graphics].choice_indices
             .get_mut(REFRESH_RATE_ROW_INDEX)
         {
             *slot = 0;
         }
         if let Some(slot) = state
-            .sub_cursor_indices_graphics
+            .sub[SubmenuKind::Graphics].cursor_indices
             .get_mut(REFRESH_RATE_ROW_INDEX)
         {
             *slot = 0;
@@ -1030,7 +1030,7 @@ pub(in crate::screens::options) fn rebuild_refresh_rate_choices(state: &mut Stat
 
     // Preserve current selection if possible, else default to "Default".
     let current_rate = if let Some(idx) = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get(REFRESH_RATE_ROW_INDEX)
     {
         state.refresh_rate_choices.get(*idx).copied().unwrap_or(0)
@@ -1046,13 +1046,13 @@ pub(in crate::screens::options) fn rebuild_refresh_rate_choices(state: &mut Stat
         .position(|&r| r == current_rate)
         .unwrap_or(0);
     if let Some(slot) = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get_mut(REFRESH_RATE_ROW_INDEX)
     {
         *slot = next_idx;
     }
     if let Some(slot) = state
-        .sub_cursor_indices_graphics
+        .sub[SubmenuKind::Graphics].cursor_indices
         .get_mut(REFRESH_RATE_ROW_INDEX)
     {
         *slot = next_idx;
@@ -1096,13 +1096,13 @@ pub(in crate::screens::options) fn rebuild_resolution_choices(
         .position(|&(w, h)| w == width && h == height)
         .unwrap_or(0);
     if let Some(slot) = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get_mut(DISPLAY_RESOLUTION_ROW_INDEX)
     {
         *slot = next_idx;
     }
     if let Some(slot) = state
-        .sub_cursor_indices_graphics
+        .sub[SubmenuKind::Graphics].cursor_indices
         .get_mut(DISPLAY_RESOLUTION_ROW_INDEX)
     {
         *slot = next_idx;

--- a/src/screens/options/submenus/select_music.rs
+++ b/src/screens/options/submenus/select_music.rs
@@ -532,13 +532,13 @@ pub(in crate::screens::options) fn toggle_select_music_scorebox_cycle_option(
 
     let clamped = choice_idx.min(SELECT_MUSIC_SCOREBOX_CYCLE_NUM_CHOICES.saturating_sub(1));
     if let Some(slot) = state
-        .sub_choice_indices_select_music
+        .sub[SubmenuKind::SelectMusic].choice_indices
         .get_mut(SELECT_MUSIC_SCOREBOX_CYCLE_ROW_INDEX)
     {
         *slot = clamped;
     }
     if let Some(slot) = state
-        .sub_cursor_indices_select_music
+        .sub[SubmenuKind::SelectMusic].cursor_indices
         .get_mut(SELECT_MUSIC_SCOREBOX_CYCLE_ROW_INDEX)
     {
         *slot = clamped;
@@ -579,13 +579,13 @@ pub(in crate::screens::options) fn toggle_auto_screenshot_option(
 
     let clamped = choice_idx.min(config::AUTO_SS_NUM_FLAGS.saturating_sub(1));
     set_choice_by_id(
-        &mut state.sub_choice_indices_gameplay,
+        &mut state.sub[SubmenuKind::Gameplay].choice_indices,
         GAMEPLAY_OPTIONS_ROWS,
         SubRowId::AutoScreenshot,
         clamped,
     );
     set_choice_by_id(
-        &mut state.sub_cursor_indices_gameplay,
+        &mut state.sub[SubmenuKind::Gameplay].cursor_indices,
         GAMEPLAY_OPTIONS_ROWS,
         SubRowId::AutoScreenshot,
         clamped,
@@ -681,13 +681,13 @@ pub(in crate::screens::options) fn toggle_select_music_chart_info_option(
 
     let clamped = choice_idx.min(SELECT_MUSIC_CHART_INFO_NUM_CHOICES.saturating_sub(1));
     if let Some(slot) = state
-        .sub_choice_indices_select_music
+        .sub[SubmenuKind::SelectMusic].choice_indices
         .get_mut(SELECT_MUSIC_CHART_INFO_ROW_INDEX)
     {
         *slot = clamped;
     }
     if let Some(slot) = state
-        .sub_cursor_indices_select_music
+        .sub[SubmenuKind::SelectMusic].cursor_indices
         .get_mut(SELECT_MUSIC_CHART_INFO_ROW_INDEX)
     {
         *slot = clamped;

--- a/src/screens/options/submenus/sound.rs
+++ b/src/screens/options/submenus/sound.rs
@@ -303,7 +303,7 @@ pub(in crate::screens::options) fn sound_row_index(id: SubRowId) -> Option<usize
 
 pub(in crate::screens::options) fn selected_sound_device_choice(state: &State) -> usize {
     sound_row_index(SubRowId::SoundDevice)
-        .and_then(|idx| state.sub_choice_indices_sound.get(idx).copied())
+        .and_then(|idx| state.sub[SubmenuKind::Sound].choice_indices.get(idx).copied())
         .unwrap_or(0)
 }
 
@@ -373,7 +373,7 @@ pub(in crate::screens::options) fn selected_audio_output_mode(
     state: &State,
 ) -> config::AudioOutputMode {
     sound_row_index(SubRowId::AudioOutputMode)
-        .and_then(|idx| state.sub_choice_indices_sound.get(idx).copied())
+        .and_then(|idx| state.sub[SubmenuKind::Sound].choice_indices.get(idx).copied())
         .map(audio_output_mode_from_choice)
         .unwrap_or(config::AudioOutputMode::Auto)
 }
@@ -416,7 +416,7 @@ pub(in crate::screens::options) fn selected_linux_audio_backend(
     state: &State,
 ) -> config::LinuxAudioBackend {
     sound_row_index(SubRowId::LinuxAudioBackend)
-        .and_then(|idx| state.sub_choice_indices_sound.get(idx).copied())
+        .and_then(|idx| state.sub[SubmenuKind::Sound].choice_indices.get(idx).copied())
         .map(|idx| linux_audio_backend_from_choice(state, idx))
         .unwrap_or(config::LinuxAudioBackend::Auto)
 }
@@ -447,10 +447,10 @@ pub(in crate::screens::options) fn set_sound_choice_index(
     let Some(row_idx) = sound_row_index(id) else {
         return;
     };
-    if let Some(slot) = state.sub_choice_indices_sound.get_mut(row_idx) {
+    if let Some(slot) = state.sub[SubmenuKind::Sound].choice_indices.get_mut(row_idx) {
         *slot = idx;
     }
-    if let Some(slot) = state.sub_cursor_indices_sound.get_mut(row_idx) {
+    if let Some(slot) = state.sub[SubmenuKind::Sound].cursor_indices.get_mut(row_idx) {
         *slot = idx;
     }
 }

--- a/src/screens/options/tests.rs
+++ b/src/screens/options/tests.rs
@@ -78,7 +78,7 @@ fn p2_can_navigate_and_change_system_options() {
     press(&mut state, &asset_manager, VirtualAction::p2_down);
     assert_eq!(state.sub_selected, 3);
 
-    let before = state.sub_cursor_indices_system[3];
+    let before = state.sub[SubmenuKind::System].cursor_indices[3];
     press(&mut state, &asset_manager, VirtualAction::p2_right);
-    assert_eq!(state.sub_cursor_indices_system[3], before + 1);
+    assert_eq!(state.sub[SubmenuKind::System].cursor_indices[3], before + 1);
 }

--- a/src/screens/options/update.rs
+++ b/src/screens/options/update.rs
@@ -34,7 +34,7 @@ pub(super) fn clear_navigation_holds(state: &mut State) {
 pub fn sync_video_renderer(state: &mut State, renderer: BackendType) {
     state.video_renderer_at_load = renderer;
     if let Some(slot) = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get_mut(VIDEO_RENDERER_ROW_INDEX)
     {
         *slot = backend_to_renderer_choice_index(renderer);
@@ -58,7 +58,7 @@ pub fn sync_display_mode(
         DisplayMode::Windowed => fullscreen_type,
     };
     if let Some(slot) = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get_mut(FULLSCREEN_TYPE_ROW_INDEX)
     {
         *slot = fullscreen_type_to_choice_index(target_type);
@@ -78,7 +78,7 @@ pub fn sync_display_resolution(state: &mut State, width: u32, height: u32) {
 
 pub fn sync_show_stats_mode(state: &mut State, mode: u8) {
     set_choice_by_id(
-        &mut state.sub_choice_indices_graphics,
+        &mut state.sub[SubmenuKind::Graphics].choice_indices,
         GRAPHICS_OPTIONS_ROWS,
         SubRowId::ShowStats,
         mode.min(3) as usize,
@@ -89,7 +89,7 @@ pub fn sync_show_stats_mode(state: &mut State, mode: u8) {
 
 pub fn sync_translated_titles(state: &mut State, enabled: bool) {
     set_choice_by_id(
-        &mut state.sub_choice_indices_select_music,
+        &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::ShowNativeLanguage,
         translated_titles_choice_index(enabled),
@@ -111,7 +111,7 @@ pub fn sync_max_fps(state: &mut State, max_fps: u16) {
 
 pub fn sync_vsync(state: &mut State, enabled: bool) {
     state.vsync_at_load = enabled;
-    if let Some(slot) = state.sub_choice_indices_graphics.get_mut(VSYNC_ROW_INDEX) {
+    if let Some(slot) = state.sub[SubmenuKind::Graphics].choice_indices.get_mut(VSYNC_ROW_INDEX) {
         *slot = yes_no_choice_index(enabled);
     }
     sync_submenu_cursor_indices(state);
@@ -121,7 +121,7 @@ pub fn sync_vsync(state: &mut State, enabled: bool) {
 pub fn sync_high_dpi(state: &mut State, enabled: bool) {
     state.high_dpi_at_load = enabled;
     set_choice_by_id(
-        &mut state.sub_choice_indices_graphics,
+        &mut state.sub[SubmenuKind::Graphics].choice_indices,
         GRAPHICS_OPTIONS_ROWS,
         SubRowId::HighDpi,
         yes_no_choice_index(enabled),
@@ -133,7 +133,7 @@ pub fn sync_high_dpi(state: &mut State, enabled: bool) {
 pub fn sync_present_mode_policy(state: &mut State, mode: PresentModePolicy) {
     state.present_mode_policy_at_load = mode;
     if let Some(slot) = state
-        .sub_choice_indices_graphics
+        .sub[SubmenuKind::Graphics].choice_indices
         .get_mut(PRESENT_MODE_ROW_INDEX)
     {
         *slot = present_mode_choice_index(mode);
@@ -269,7 +269,7 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
                 desired_high_dpi,
             ) = if leaving_graphics {
                 let vsync = state
-                    .sub_choice_indices_graphics
+                    .sub[SubmenuKind::Graphics].choice_indices
                     .get(VSYNC_ROW_INDEX)
                     .copied()
                     .is_none_or(yes_no_from_choice);

--- a/src/screens/options/visibility.rs
+++ b/src/screens/options/visibility.rs
@@ -80,11 +80,7 @@ pub(super) const fn submenu_title(kind: SubmenuKind) -> &'static str {
     }
 }
 
-pub(super) fn submenu_visible_row_indices(
-    state: &State,
-    kind: SubmenuKind,
-    rows: &[SubRow],
-) -> Vec<usize> {
+pub(super) fn submenu_visible_row_indices(state: &State, kind: SubmenuKind, rows: &[SubRow]) -> Vec<usize> {
     match kind {
         SubmenuKind::Graphics => {
             let show_sw = graphics_show_software_threads(state);
@@ -114,25 +110,25 @@ pub(super) fn submenu_visible_row_indices(
         SubmenuKind::Advanced => rows.iter().enumerate().map(|(idx, _)| idx).collect(),
         SubmenuKind::SelectMusic => {
             let show_banners = state
-                .sub_choice_indices_select_music
+                .sub[SubmenuKind::SelectMusic].choice_indices
                 .get(SELECT_MUSIC_SHOW_BANNERS_ROW_INDEX)
                 .copied()
                 .unwrap_or_else(|| yes_no_choice_index(true));
             let show_banners = yes_no_from_choice(show_banners);
             let show_breakdown = state
-                .sub_choice_indices_select_music
+                .sub[SubmenuKind::SelectMusic].choice_indices
                 .get(SELECT_MUSIC_SHOW_BREAKDOWN_ROW_INDEX)
                 .copied()
                 .unwrap_or_else(|| yes_no_choice_index(true));
             let show_breakdown = yes_no_from_choice(show_breakdown);
             let show_previews = state
-                .sub_choice_indices_select_music
+                .sub[SubmenuKind::SelectMusic].choice_indices
                 .get(SELECT_MUSIC_MUSIC_PREVIEWS_ROW_INDEX)
                 .copied()
                 .unwrap_or_else(|| yes_no_choice_index(true));
             let show_previews = yes_no_from_choice(show_previews);
             let show_scorebox = state
-                .sub_choice_indices_select_music
+                .sub[SubmenuKind::SelectMusic].choice_indices
                 .get(SELECT_MUSIC_SHOW_SCOREBOX_ROW_INDEX)
                 .copied()
                 .unwrap_or_else(|| yes_no_choice_index(true));
@@ -158,13 +154,13 @@ pub(super) fn submenu_visible_row_indices(
         }
         SubmenuKind::Machine => {
             let show_preferred_style = state
-                .sub_choice_indices_machine
+                .sub[SubmenuKind::Machine].choice_indices
                 .get(MACHINE_SELECT_STYLE_ROW_INDEX)
                 .copied()
                 .unwrap_or(1)
                 == 0;
             let show_preferred_mode = state
-                .sub_choice_indices_machine
+                .sub[SubmenuKind::Machine].choice_indices
                 .get(MACHINE_SELECT_PLAY_MODE_ROW_INDEX)
                 .copied()
                 .unwrap_or(1)
@@ -230,116 +226,23 @@ pub(super) const fn windows_backend_from_choice(idx: usize) -> WindowsPadBackend
 }
 
 pub(super) fn submenu_choice_indices(state: &State, kind: SubmenuKind) -> &[usize] {
-    match kind {
-        SubmenuKind::System => &state.sub_choice_indices_system,
-        SubmenuKind::Graphics => &state.sub_choice_indices_graphics,
-        SubmenuKind::Input => &state.sub_choice_indices_input,
-        SubmenuKind::InputBackend => &state.sub_choice_indices_input_backend,
-        SubmenuKind::OnlineScoring => &state.sub_choice_indices_online_scoring,
-        SubmenuKind::NullOrDie => &state.sub_choice_indices_null_or_die,
-        SubmenuKind::NullOrDieOptions => &state.sub_choice_indices_null_or_die_options,
-        SubmenuKind::SyncPacks => &state.sub_choice_indices_sync_packs,
-        SubmenuKind::Machine => &state.sub_choice_indices_machine,
-        SubmenuKind::Advanced => &state.sub_choice_indices_advanced,
-        SubmenuKind::Course => &state.sub_choice_indices_course,
-        SubmenuKind::Gameplay => &state.sub_choice_indices_gameplay,
-        SubmenuKind::Sound => &state.sub_choice_indices_sound,
-        SubmenuKind::SelectMusic => &state.sub_choice_indices_select_music,
-        SubmenuKind::GrooveStats => &state.sub_choice_indices_groovestats,
-        SubmenuKind::ArrowCloud => &state.sub_choice_indices_arrowcloud,
-        SubmenuKind::ScoreImport => &state.sub_choice_indices_score_import,
-    }
+    &state.sub[kind].choice_indices
 }
 
-pub(super) const fn submenu_choice_indices_mut(
-    state: &mut State,
-    kind: SubmenuKind,
-) -> &mut Vec<usize> {
-    match kind {
-        SubmenuKind::System => &mut state.sub_choice_indices_system,
-        SubmenuKind::Graphics => &mut state.sub_choice_indices_graphics,
-        SubmenuKind::Input => &mut state.sub_choice_indices_input,
-        SubmenuKind::InputBackend => &mut state.sub_choice_indices_input_backend,
-        SubmenuKind::OnlineScoring => &mut state.sub_choice_indices_online_scoring,
-        SubmenuKind::NullOrDie => &mut state.sub_choice_indices_null_or_die,
-        SubmenuKind::NullOrDieOptions => &mut state.sub_choice_indices_null_or_die_options,
-        SubmenuKind::SyncPacks => &mut state.sub_choice_indices_sync_packs,
-        SubmenuKind::Machine => &mut state.sub_choice_indices_machine,
-        SubmenuKind::Advanced => &mut state.sub_choice_indices_advanced,
-        SubmenuKind::Course => &mut state.sub_choice_indices_course,
-        SubmenuKind::Gameplay => &mut state.sub_choice_indices_gameplay,
-        SubmenuKind::Sound => &mut state.sub_choice_indices_sound,
-        SubmenuKind::SelectMusic => &mut state.sub_choice_indices_select_music,
-        SubmenuKind::GrooveStats => &mut state.sub_choice_indices_groovestats,
-        SubmenuKind::ArrowCloud => &mut state.sub_choice_indices_arrowcloud,
-        SubmenuKind::ScoreImport => &mut state.sub_choice_indices_score_import,
-    }
+pub(super) fn submenu_choice_indices_mut(state: &mut State, kind: SubmenuKind) -> &mut Vec<usize> {
+    &mut state.sub[kind].choice_indices
 }
 
 pub(super) fn submenu_cursor_indices(state: &State, kind: SubmenuKind) -> &[usize] {
-    match kind {
-        SubmenuKind::System => &state.sub_cursor_indices_system,
-        SubmenuKind::Graphics => &state.sub_cursor_indices_graphics,
-        SubmenuKind::Input => &state.sub_cursor_indices_input,
-        SubmenuKind::InputBackend => &state.sub_cursor_indices_input_backend,
-        SubmenuKind::OnlineScoring => &state.sub_cursor_indices_online_scoring,
-        SubmenuKind::NullOrDie => &state.sub_cursor_indices_null_or_die,
-        SubmenuKind::NullOrDieOptions => &state.sub_cursor_indices_null_or_die_options,
-        SubmenuKind::SyncPacks => &state.sub_cursor_indices_sync_packs,
-        SubmenuKind::Machine => &state.sub_cursor_indices_machine,
-        SubmenuKind::Advanced => &state.sub_cursor_indices_advanced,
-        SubmenuKind::Course => &state.sub_cursor_indices_course,
-        SubmenuKind::Gameplay => &state.sub_cursor_indices_gameplay,
-        SubmenuKind::Sound => &state.sub_cursor_indices_sound,
-        SubmenuKind::SelectMusic => &state.sub_cursor_indices_select_music,
-        SubmenuKind::GrooveStats => &state.sub_cursor_indices_groovestats,
-        SubmenuKind::ArrowCloud => &state.sub_cursor_indices_arrowcloud,
-        SubmenuKind::ScoreImport => &state.sub_cursor_indices_score_import,
-    }
+    &state.sub[kind].cursor_indices
 }
 
-pub(super) const fn submenu_cursor_indices_mut(
-    state: &mut State,
-    kind: SubmenuKind,
-) -> &mut Vec<usize> {
-    match kind {
-        SubmenuKind::System => &mut state.sub_cursor_indices_system,
-        SubmenuKind::Graphics => &mut state.sub_cursor_indices_graphics,
-        SubmenuKind::Input => &mut state.sub_cursor_indices_input,
-        SubmenuKind::InputBackend => &mut state.sub_cursor_indices_input_backend,
-        SubmenuKind::OnlineScoring => &mut state.sub_cursor_indices_online_scoring,
-        SubmenuKind::NullOrDie => &mut state.sub_cursor_indices_null_or_die,
-        SubmenuKind::NullOrDieOptions => &mut state.sub_cursor_indices_null_or_die_options,
-        SubmenuKind::SyncPacks => &mut state.sub_cursor_indices_sync_packs,
-        SubmenuKind::Machine => &mut state.sub_cursor_indices_machine,
-        SubmenuKind::Advanced => &mut state.sub_cursor_indices_advanced,
-        SubmenuKind::Course => &mut state.sub_cursor_indices_course,
-        SubmenuKind::Gameplay => &mut state.sub_cursor_indices_gameplay,
-        SubmenuKind::Sound => &mut state.sub_cursor_indices_sound,
-        SubmenuKind::SelectMusic => &mut state.sub_cursor_indices_select_music,
-        SubmenuKind::GrooveStats => &mut state.sub_cursor_indices_groovestats,
-        SubmenuKind::ArrowCloud => &mut state.sub_cursor_indices_arrowcloud,
-        SubmenuKind::ScoreImport => &mut state.sub_cursor_indices_score_import,
-    }
+pub(super) fn submenu_cursor_indices_mut(state: &mut State, kind: SubmenuKind) -> &mut Vec<usize> {
+    &mut state.sub[kind].cursor_indices
 }
 
 pub(super) fn sync_submenu_cursor_indices(state: &mut State) {
-    state.sub_cursor_indices_system = state.sub_choice_indices_system.clone();
-    state.sub_cursor_indices_graphics = state.sub_choice_indices_graphics.clone();
-    state.sub_cursor_indices_input = state.sub_choice_indices_input.clone();
-    state.sub_cursor_indices_input_backend = state.sub_choice_indices_input_backend.clone();
-    state.sub_cursor_indices_online_scoring = state.sub_choice_indices_online_scoring.clone();
-    state.sub_cursor_indices_null_or_die = state.sub_choice_indices_null_or_die.clone();
-    state.sub_cursor_indices_null_or_die_options =
-        state.sub_choice_indices_null_or_die_options.clone();
-    state.sub_cursor_indices_sync_packs = state.sub_choice_indices_sync_packs.clone();
-    state.sub_cursor_indices_machine = state.sub_choice_indices_machine.clone();
-    state.sub_cursor_indices_advanced = state.sub_choice_indices_advanced.clone();
-    state.sub_cursor_indices_course = state.sub_choice_indices_course.clone();
-    state.sub_cursor_indices_gameplay = state.sub_choice_indices_gameplay.clone();
-    state.sub_cursor_indices_sound = state.sub_choice_indices_sound.clone();
-    state.sub_cursor_indices_select_music = state.sub_choice_indices_select_music.clone();
-    state.sub_cursor_indices_groovestats = state.sub_choice_indices_groovestats.clone();
-    state.sub_cursor_indices_arrowcloud = state.sub_choice_indices_arrowcloud.clone();
-    state.sub_cursor_indices_score_import = state.sub_choice_indices_score_import.clone();
+    for s in state.sub.iter_mut() {
+        s.cursor_indices.clone_from(&s.choice_indices);
+    }
 }


### PR DESCRIPTION
## Summary

Replaces 34 per-submenu `Vec` fields on `State` with a single `[SubmenuState; 17]` array indexed by `SubmenuKind`, eliminating four parallel 17-arm dispatch matches.
