### PR TITLE
Fix compilation errors and flaky tests on main

### DIFF
--- a/src/app/dynamic_media.rs
+++ b/src/app/dynamic_media.rs
@@ -23,6 +23,7 @@ struct DynamicVideoState {
 
 struct PreparedBannerVideo {
     key: String,
+    path: PathBuf,
     poster: RgbaImage,
     player: video::Player,
 }
@@ -761,10 +762,12 @@ impl DynamicMedia {
         backend: &mut Backend,
     ) {
         self.destroy_current_dynamic_background(assets, backend);
-        for key in self.active_song_lua_videos.drain().map(|(key, _)| key) {
+        let lua_video_keys: Vec<_> = self.active_song_lua_videos.drain().map(|(key, _)| key).collect();
+        for key in lua_video_keys {
             self.release_texture_key(assets, backend, key);
         }
-        for key in self.failed_song_lua_video_keys.drain() {
+        let failed_keys: Vec<_> = self.failed_song_lua_video_keys.drain().collect();
+        for key in failed_keys {
             self.release_texture_key(assets, backend, key);
         }
         self.reset_pending_gameplay_background();
@@ -1090,6 +1093,7 @@ fn prepare_banner_video(key: String, path: PathBuf) -> BannerVideoPrepResult {
         return match video::open(&path, true) {
             Ok(video) => BannerVideoPrepResult::Ready(PreparedBannerVideo {
                 key,
+                path,
                 poster: video.poster,
                 player: video.player,
             }),
@@ -1111,6 +1115,7 @@ fn prepare_banner_video(key: String, path: PathBuf) -> BannerVideoPrepResult {
     };
     BannerVideoPrepResult::Ready(PreparedBannerVideo {
         key,
+        path,
         poster,
         player,
     })

--- a/src/engine/input/debounce.rs
+++ b/src/engine/input/debounce.rs
@@ -68,9 +68,8 @@ impl DebounceStore {
         self.slots.clear();
         self.due_slots.clear();
         self.active_len = 0;
-        let needed = cap.saturating_sub(self.slots.capacity());
-        if needed > 0 {
-            self.slots.reserve(needed);
+        if self.slots.capacity() < cap {
+            self.slots.reserve(cap);
         }
     }
 

--- a/src/game/gameplay.rs
+++ b/src/game/gameplay.rs
@@ -8130,9 +8130,21 @@ mod tests {
 
     #[test]
     fn regression_state_passes_hot_state_audit() {
-        let profiles = [profile::Profile::default(), profile::Profile::default()];
-        let state = regression_state(profiles);
-        super::assert_valid_hot_state_for_tests(&state, 0.0, state.current_music_time_display);
+        with_session(
+            profile::PlayStyle::Double,
+            profile::PlayerSide::P1,
+            true,
+            false,
+            || {
+                let profiles = [profile::Profile::default(), profile::Profile::default()];
+                let state = regression_state(profiles);
+                super::assert_valid_hot_state_for_tests(
+                    &state,
+                    0.0,
+                    state.current_music_time_display,
+                );
+            },
+        );
     }
 
     fn test_row_entry(

--- a/src/screens/components/shared/heart_bg.rs
+++ b/src/screens/components/shared/heart_bg.rs
@@ -218,6 +218,9 @@ fn set_global_elapsed_for_test(elapsed_s: f32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{LazyLock, Mutex};
+
+    static TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     const EPS: f32 = 1e-3;
 
@@ -239,6 +242,7 @@ mod tests {
 
     #[test]
     fn build_reads_shared_elapsed_clock() {
+        let _lock = TEST_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         set_global_elapsed_for_test(2.5);
         let state = State::new();
         let shared_xy = first_heart_xy(&state.build(params()));
@@ -252,6 +256,7 @@ mod tests {
 
     #[test]
     fn tick_global_accumulates_positive_dt() {
+        let _lock = TEST_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         set_global_elapsed_for_test(1.0);
         tick_global(0.5);
         assert!(

--- a/src/screens/gameplay.rs
+++ b/src/screens/gameplay.rs
@@ -4753,6 +4753,9 @@ mod tests {
                 y: 240.0,
                 size: Some([100.0, 50.0]),
                 zoom: 0.5,
+                zoom_x: 0.5,
+                zoom_y: 0.5,
+                zoom_z: 0.5,
                 ..SongLuaOverlayState::default()
             },
             None,

--- a/src/test_support/compose_case.rs
+++ b/src/test_support/compose_case.rs
@@ -1643,9 +1643,13 @@ impl From<EffectStateSnapshot> for EffectState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{LazyLock, Mutex};
+
+    static TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     #[test]
     fn capture_roundtrip_keeps_output_hash() {
+        let _lock = TEST_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let scenario = crate::test_support::compose_scenarios::build_scenario("hud")
             .expect("hud scenario should exist");
         let (case, output) = capture_case(
@@ -1671,6 +1675,7 @@ mod tests {
 
     #[test]
     fn render_snapshot_roundtrip_keeps_output_hash() {
+        let _lock = TEST_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let scenario = crate::test_support::compose_scenarios::build_scenario("mask")
             .expect("mask scenario should exist");
         let (_, output) = capture_case(


### PR DESCRIPTION
## Summary

Fixes compilation errors introduced by recent commits and resolves several flaky tests caused by unsynchronized global state.

### Compilation fixes
- **`dynamic_media.rs`**: Restore missing `path: PathBuf` field on `PreparedBannerVideo` and fix double mutable borrow in `clear_gameplay_backgrounds`

### Test fixes
- **`gameplay.rs`**: Update quad zoom test to set `zoom_x`/`zoom_y`/`zoom_z` matching the axis-override semantics from c60e82ce
- **`gameplay.rs`**: Wrap `regression_state_passes_hot_state_audit` in `with_session()` to prevent races on global play style
- **`debounce.rs`**: Fix `clear_and_reserve` which used `Vec::reserve` incorrectly (relative to capacity instead of len), causing `set_keymap_prepares_dense_debounce_slots` to flake
- **`heart_bg.rs`**: Add mutex to serialize tests that race on `GLOBAL_ELAPSED_BITS`
- **`compose_case.rs`**: Add mutex to serialize tests that race on global texture registry

### Verification
All 645 tests pass consistently (30/30 runs with no failures).