### PR TITLE
feat(select_music): show current stage number in header bar

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4408,6 +4408,7 @@ impl App {
             CurrentScreen::SelectMusic => select_music::get_actors(
                 &self.state.screens.select_music_state,
                 &self.asset_manager,
+                self.state.session.played_stages.len() + 1,
             ),
             CurrentScreen::SelectCourse => select_course::get_actors(
                 &self.state.screens.select_course_state,

--- a/src/screens/components/select_music/screen_bars.rs
+++ b/src/screens/components/select_music/screen_bars.rs
@@ -5,7 +5,7 @@ use crate::screens::components::shared::screen_bar::{
     self, AvatarParams, ScreenBarParams, ScreenBarPosition, ScreenBarTitlePlacement,
 };
 
-pub fn build(top_title: &str) -> [Actor; 2] {
+pub fn build(top_title: &str, stage_number: Option<usize>) -> [Actor; 2] {
     let p1_profile = profile::get_for_side(profile::PlayerSide::P1);
     let p2_profile = profile::get_for_side(profile::PlayerSide::P2);
     let p1_avatar = p1_profile
@@ -25,6 +25,8 @@ pub fn build(top_title: &str) -> [Actor; 2] {
     let insert_card = tr("Common", "InsertCard");
     let press_start = tr("Common", "PressStart");
     let event_mode = tr("Common", "EventMode");
+
+    let stage_text = stage_number.map(|n| format!("Stage {n}"));
 
     let (footer_left, left_avatar) = if p1_joined {
         (
@@ -60,7 +62,7 @@ pub fn build(top_title: &str) -> [Actor; 2] {
             fg_color: [1.0; 4],
             left_text: None,
             center_text: None,
-            right_text: None,
+            right_text: stage_text.as_deref(),
             left_avatar: None,
             right_avatar: None,
         }),

--- a/src/screens/select_course.rs
+++ b/src/screens/select_course.rs
@@ -2006,7 +2006,7 @@ pub fn get_actors(state: &State, _asset_manager: &AssetManager) -> Vec<Actor> {
         alpha_mul: 1.0,
     }));
     actors.push(sl_select_music_bg_flash());
-    actors.extend(screen_bars::build(&tr("ScreenTitles", "SelectCourse")));
+    actors.extend(screen_bars::build(&tr("ScreenTitles", "SelectCourse"), None));
     actors.push(timers::build_session(format_session_time(
         state.session_elapsed,
     )));

--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -7889,7 +7889,11 @@ fn sl_select_music_wheel_cascade_mask() -> Vec<Actor> {
     actors
 }
 
-pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
+pub fn get_actors(
+    state: &State,
+    asset_manager: &AssetManager,
+    stage_number: usize,
+) -> Vec<Actor> {
     let mut actors = Vec::with_capacity(256);
     let side = crate::game::profile::get_session_player_side();
     let play_style = crate::game::profile::get_session_play_style();
@@ -7921,7 +7925,7 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
         alpha_mul: 1.0,
     }));
     actors.push(sl_select_music_bg_flash());
-    actors.extend(screen_bars::build("SELECT MUSIC"));
+    actors.extend(screen_bars::build("SELECT MUSIC", Some(stage_number)));
 
     let p1_profile = crate::game::profile::get_for_side(crate::game::profile::PlayerSide::P1);
     let p2_profile = crate::game::profile::get_for_side(crate::game::profile::PlayerSide::P2);


### PR DESCRIPTION
Fixes #140

## Problem

The stage number (e.g., "Stage 1", "Stage 2") that shows how many songs have been played in the current session was missing from the top of the select music screen header.

## Fix

Display the current stage number in the top-right corner of the header bar, matching Simply Love's behavior. The stage number is `played_stages.len() + 1` (the next song to be played).

### Changes
- `screen_bars::build` now accepts an optional `stage_number` parameter
- `select_music::get_actors` receives the stage count from the session state
- `select_course` passes `None` (no stage display on course select)