### PR TITLE
fix(gfx): fix screenshot capture across graphics backends

### DIFF
--- a/src/engine/gfx/backends/opengl.rs
+++ b/src/engine/gfx/backends/opengl.rs
@@ -66,14 +66,6 @@ impl GlApi {
             },
         }
     }
-
-    const fn screenshot_read_buffer(self) -> u32 {
-        match self {
-            Self::Desktop => glow::FRONT,
-            #[cfg(all(unix, not(target_os = "macos")))]
-            Self::Gles => glow::BACK,
-        }
-    }
 }
 
 #[derive(Clone, Copy)]
@@ -125,6 +117,8 @@ pub struct State {
     cached_tmesh: FastU64Map<CachedTMeshGeom>,
     cached_tmesh_bytes: usize,
     vsync_enabled: bool,
+    screenshot_requested: bool,
+    captured_frame: Option<RgbaImage>,
 }
 
 pub fn init(
@@ -441,6 +435,8 @@ pub fn init(
         cached_tmesh: FastU64Map::default(),
         cached_tmesh_bytes: 0,
         vsync_enabled,
+        screenshot_requested: false,
+        captured_frame: None,
     };
 
     info!("OpenGL backend initialized successfully.");
@@ -645,7 +641,9 @@ fn ensure_cached_tmesh(
 }
 
 #[inline(always)]
-pub const fn request_screenshot(_state: &mut State) {}
+pub fn request_screenshot(state: &mut State) {
+    state.screenshot_requested = true;
+}
 
 pub fn draw(
     state: &mut State,
@@ -1100,6 +1098,32 @@ pub fn draw(
     }
     stats.backend_record_us = elapsed_us_since(backend_record_started);
 
+    if state.screenshot_requested {
+        state.screenshot_requested = false;
+        state.captured_frame = None;
+        let (width, height) = state.window_size;
+        if width > 0 && height > 0 {
+            let byte_len = width as usize * height as usize * 4;
+            let mut pixels = vec![0u8; byte_len];
+            // SAFETY: reads RGBA bytes from the back buffer before swap.
+            unsafe {
+                state.gl.pixel_store_i32(glow::PACK_ALIGNMENT, 1);
+                state.gl.read_buffer(glow::BACK);
+                state.gl.read_pixels(
+                    0,
+                    0,
+                    width as i32,
+                    height as i32,
+                    glow::RGBA,
+                    glow::UNSIGNED_BYTE,
+                    PixelPackData::Slice(Some(pixels.as_mut_slice())),
+                );
+            }
+            flip_rows_rgba_in_place(width as usize, height as usize, &mut pixels);
+            state.captured_frame = RgbaImage::from_raw(width, height, pixels);
+        }
+    }
+
     let present_started = Instant::now();
     state.gl_surface.swap_buffers(&state.gl_context)?;
     stats.present_us = elapsed_us_since(present_started);
@@ -1132,34 +1156,10 @@ pub fn draw(
 }
 
 pub fn capture_frame(state: &mut State) -> Result<RgbaImage, Box<dyn Error>> {
-    let (width, height) = state.window_size;
-    if width == 0 || height == 0 {
-        return Err(
-            std::io::Error::other("Cannot capture screenshot at zero-sized viewport").into(),
-        );
-    }
-
-    let byte_len = width as usize * height as usize * 4;
-    let mut pixels = vec![0u8; byte_len];
-    // SAFETY: the current OpenGL context writes RGBA bytes into the owned `pixels`
-    // buffer for the exact viewport rectangle requested.
-    unsafe {
-        state.gl.pixel_store_i32(glow::PACK_ALIGNMENT, 1);
-        state.gl.read_buffer(state.api.screenshot_read_buffer());
-        state.gl.read_pixels(
-            0,
-            0,
-            width as i32,
-            height as i32,
-            glow::RGBA,
-            glow::UNSIGNED_BYTE,
-            PixelPackData::Slice(Some(pixels.as_mut_slice())),
-        );
-    }
-
-    flip_rows_rgba_in_place(width as usize, height as usize, &mut pixels);
-    RgbaImage::from_raw(width, height, pixels)
-        .ok_or_else(|| std::io::Error::other("Failed to build screenshot image").into())
+    state
+        .captured_frame
+        .take()
+        .ok_or_else(|| std::io::Error::other("No captured screenshot frame available").into())
 }
 
 #[inline(always)]

--- a/src/engine/gfx/backends/vulkan.rs
+++ b/src/engine/gfx/backends/vulkan.rs
@@ -2043,7 +2043,7 @@ pub fn draw(
         }
         if let Some((staging, width, height, format)) = screenshot_staging {
             let wait_started = Instant::now();
-            device.queue_wait_idle(state.queue)?;
+            device.wait_for_fences(&[fence], true, u64::MAX)?;
             stats.gpu_wait_us = stats
                 .gpu_wait_us
                 .saturating_add(elapsed_us_since(wait_started));

--- a/src/engine/gfx/backends/wgpu_core.rs
+++ b/src/engine/gfx/backends/wgpu_core.rs
@@ -1227,6 +1227,11 @@ pub fn draw(
     let screenshot_readback = if state.screenshot_requested {
         state.screenshot_requested = false;
         if state.config.usage.contains(wgpu::TextureUsages::COPY_SRC) {
+            let format = state.config.format;
+            debug!(
+                "wgpu screenshot: surface format={:?} size={}x{}",
+                format, state.config.width, state.config.height
+            );
             let width = state.config.width.max(1);
             let height = state.config.height.max(1);
             let bytes_per_row = 4 * width;
@@ -1611,7 +1616,21 @@ fn reconfigure_surface(state: &mut State) {
 }
 
 fn pick_format(caps: &wgpu::SurfaceCapabilities) -> wgpu::TextureFormat {
-    // Avoid sRGB conversion to keep colors consistent across backends.
+    // Prefer 8-bit non-sRGB formats for consistent colors and correct screenshot
+    // readback. The screenshot path assumes 4 bytes/pixel RGBA or BGRA; formats
+    // like Rgb10a2 or Rgba16Float would produce garbled captures.
+    const PREFERRED: &[wgpu::TextureFormat] = &[
+        wgpu::TextureFormat::Bgra8Unorm,
+        wgpu::TextureFormat::Rgba8Unorm,
+        wgpu::TextureFormat::Bgra8UnormSrgb,
+        wgpu::TextureFormat::Rgba8UnormSrgb,
+    ];
+    for &pref in PREFERRED {
+        if caps.formats.contains(&pref) {
+            return pref;
+        }
+    }
+    // Fall back to the first non-sRGB, then the first format overall.
     caps.formats
         .iter()
         .copied()


### PR DESCRIPTION
Fixes #300

## Problem

Screenshots produce incorrect results on most graphics backends:
- **Vulkan**: Works but freezes for ~1 second
- **Vulkan (wgpu)**: Colors are garbled
- **OpenGL**: Screenshot is black
- **OpenGL (wgpu)**: Not addressed (surface lacks COPY_SRC support)

## Fixes

### OpenGL - black screenshot
Read from the `BACK` buffer before `swap_buffers()` instead of the `FRONT` buffer after swap. The front buffer is unreliable on modern compositing window managers (Wayland/KDE). Capture now happens during `draw()`, matching the Vulkan/wgpu pattern.

### Vulkan - ~1 second freeze
Replace `queue_wait_idle()` with `wait_for_fences()` when reading back the screenshot staging buffer. This waits only for the specific submission containing the copy command rather than draining the entire queue.

### wgpu - garbled colors
Restrict `pick_format()` to prefer known 8-bit surface formats (`Bgra8Unorm`, `Rgba8Unorm`, then sRGB variants). The screenshot readback assumes 4 bytes/pixel RGBA/BGRA layout; non-8-bit formats like `Rgb10a2` or `Rgba16Float` would produce incorrect pixel decoding.

### Known limitation
**OpenGL (wgpu)** screenshots remain unsupported - the GL surface does not report `COPY_SRC` capability, which is required by the wgpu readback path. Fixing this would require rendering to an intermediate texture, which is a larger architectural change.