### PR TITLE
Use 60s timeout for GrooveStats requests

### DIFF
--- a/src/engine/network.rs
+++ b/src/engine/network.rs
@@ -8,6 +8,9 @@ use std::time::Duration;
 
 pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
+// Match Simply Love / ITGmania's GrooveStats request timeout (60s).
+pub const GROOVESTATS_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AgentConfig {
     pub timeout: Duration,
@@ -77,15 +80,34 @@ pub fn build_agent(config: AgentConfig) -> ureq::Agent {
 // one connection pool instead of opening fresh sockets/TLS sessions per request.
 static DEFAULT_AGENT: LazyLock<ureq::Agent> = LazyLock::new(|| build_agent(AgentConfig::default()));
 
+// Dedicated agent for GrooveStats (and BoogieStats) requests, configured with the
+// longer 60s timeout used by Simply Love / ITGmania.
+static GROOVESTATS_AGENT: LazyLock<ureq::Agent> = LazyLock::new(|| {
+    build_agent(AgentConfig {
+        timeout: GROOVESTATS_REQUEST_TIMEOUT,
+    })
+});
+
 pub fn get_agent() -> ureq::Agent {
     DEFAULT_AGENT.clone()
+}
+
+pub fn get_groovestats_agent() -> ureq::Agent {
+    GROOVESTATS_AGENT.clone()
 }
 
 pub fn get_json<T>(url: &str) -> Result<T, NetworkError>
 where
     T: DeserializeOwned,
 {
-    let response = get_agent()
+    get_json_with(&get_agent(), url)
+}
+
+pub fn get_json_with<T>(agent: &ureq::Agent, url: &str) -> Result<T, NetworkError>
+where
+    T: DeserializeOwned,
+{
+    let response = agent
         .get(url)
         .call()
         .map_err(|error| request_error(error.to_string()))?;

--- a/src/game/online/groovestats.rs
+++ b/src/game/online/groovestats.rs
@@ -135,7 +135,7 @@ fn perform_check() {
     let service_name = service_name();
     debug!("Performing {service_name} connectivity check...");
 
-    match network::get_json::<ApiResponse>(&new_session_url()) {
+    match network::get_json_with::<ApiResponse>(&network::get_groovestats_agent(), &new_session_url()) {
         Ok(data) => {
             if !data.services_result.eq_ignore_ascii_case("OK") {
                 warn!("{service_name} servicesResult != OK.");

--- a/src/game/scores.rs
+++ b/src/game/scores.rs
@@ -2872,7 +2872,7 @@ fn fetch_player_leaderboards_internal(
 
     let max_entries = max_entries.max(1);
     let max_entries_str = max_entries.to_string();
-    let agent = network::get_agent();
+    let agent = network::get_groovestats_agent();
     let api_url = online::groovestats_player_leaderboards_url();
     let response = agent
         .get(&api_url)
@@ -4106,7 +4106,12 @@ fn fetch_player_score_from_endpoint(
         .into());
     }
 
-    let agent = network::get_agent();
+    let agent = match endpoint {
+        ScoreImportEndpoint::GrooveStats | ScoreImportEndpoint::BoogieStats => {
+            network::get_groovestats_agent()
+        }
+        ScoreImportEndpoint::ArrowCloud => network::get_agent(),
+    };
     let api_url = endpoint.player_leaderboards_url();
     let response = agent
         .get(&api_url)

--- a/src/game/scores/groovestats.rs
+++ b/src/game/scores/groovestats.rs
@@ -922,7 +922,7 @@ fn submit_groovestats_request(
     job: &GrooveStatsSubmitRequest,
 ) -> Result<GrooveStatsSubmitApiResponse, GrooveStatsSubmitError> {
     let service_name = online::groovestats_service_name();
-    let mut request = network::get_agent()
+    let mut request = network::get_groovestats_agent()
         .post(&online::groovestats_score_submit_url())
         .header("Content-Type", "application/json");
     for (name, value) in &job.headers {


### PR DESCRIPTION
Match Simply Love / ITGmania, which use a 60-second timeout for GrooveStats API calls (see `Themes/Simply Love/Scripts/SL-Helpers-GrooveStats.lua`).

Adds a dedicated `ureq` agent for GrooveStats and BoogieStats traffic — the connectivity check, score submit, and player-leaderboard fetches — while leaving the existing 10s default in place for downloads, ArrowCloud, and other unrelated callers.