### PR TITLE
refactor(player_options): convert BitmaskBinding to enum + declarative BitMapping

### DIFF
--- a/src/screens/player_options/choice.rs
+++ b/src/screens/player_options/choice.rs
@@ -147,32 +147,35 @@ pub(super) fn dispatch_behavior_delta(
 /// Returns true if the dispatcher handled the row (Bitmask behavior), false
 /// otherwise.
 ///
-/// When the binding declares a `writeback` (and `init`), the row is routed
-/// through the generic `toggle_bitmask_row_generic` path; otherwise the
-/// hand-rolled `toggle` fn pointer is invoked.
+/// `BitmaskBinding::Generic` rows route through
+/// `toggle_bitmask_row_generic`; `BitmaskBinding::HandRolled` rows invoke
+/// the bound `toggle` fn pointer directly.
 pub(super) fn dispatch_behavior_toggle(state: &mut State, player_idx: usize, id: RowId) -> bool {
     let Some(RowBehavior::Bitmask(b)) = state.pane().row_map.get(id).map(|r| r.behavior) else {
         return false;
     };
-    if b.writeback.is_some() && b.init.is_some() {
-        toggle_bitmask_row_generic(state, player_idx, id);
-    } else {
-        (b.toggle)(state, player_idx);
+    match b {
+        BitmaskBinding::Generic { .. } => {
+            toggle_bitmask_row_generic(state, player_idx, id);
+        }
+        BitmaskBinding::HandRolled { toggle, .. } => {
+            (toggle)(state, player_idx);
+        }
     }
     true
 }
 
-/// Generic bitmask toggle for `BitmaskBinding`s that declare both `init`
-/// and `writeback`. Verifies the focused row matches `id`, computes the
-/// target bit via `writeback.bit_for_choice`, flips it through
+/// Generic bitmask toggle for `BitmaskBinding::Generic` bindings. Verifies
+/// the focused row matches `id`, computes the target bit via
+/// `writeback.bit_mapping.bit_for_choice`, flips it through
 /// `init.get_active`/`init.set_active`, projects the resulting bits onto
 /// the in-memory profile via `writeback.project_to_profile`, and
 /// (conditionally) persists them for the active side via
 /// `writeback.persist_for_side`. Plays the change-value SFX on success.
 ///
 /// Returns `true` when a toggle was applied; `false` when the row was not
-/// focused, the binding lacked the required contracts, or the choice
-/// index produced no bit.
+/// focused, the binding was not `Generic`, or the choice index produced
+/// no bit.
 pub(super) fn toggle_bitmask_row_generic(
     state: &mut State,
     player_idx: usize,
@@ -189,16 +192,15 @@ pub(super) fn toggle_bitmask_row_generic(
     }
 
     let (init, writeback) = match state.pane().row_map.get(id).map(|r| r.behavior) {
-        Some(RowBehavior::Bitmask(b)) => match (b.init, b.writeback) {
-            (Some(i), Some(w)) => (i, w),
-            _ => return false,
-        },
+        Some(RowBehavior::Bitmask(BitmaskBinding::Generic { init, writeback })) => {
+            (init, writeback)
+        }
         _ => return false,
     };
 
     let row = state.pane().row_map.row(id);
     let choice_index = row.selected_choice_index[idx];
-    let bit = match (writeback.bit_for_choice)(choice_index, row) {
+    let bit = match writeback.bit_mapping.bit_for_choice(choice_index) {
         Some(b) if b != 0 => b,
         _ => return false,
     };

--- a/src/screens/player_options/choice.rs
+++ b/src/screens/player_options/choice.rs
@@ -1,9 +1,6 @@
 use super::*;
 use crate::engine::audio;
-use crate::game::profile::{
-    self as gp, AccelEffectsMask, AppearanceEffectsMask, ErrorBarMask, HoldsMask, InsertMask,
-    PlayerSide, RemoveMask, VisualEffectsMask,
-};
+use crate::game::profile::{self as gp, ErrorBarMask, PlayerSide};
 
 // ============================ Dispatchers ============================
 // Dispatch reads `row.behavior` to decide how to apply input.
@@ -149,11 +146,76 @@ pub(super) fn dispatch_behavior_delta(
 /// `toggle_*_row` helpers already play their own SFX and sync visibility.
 /// Returns true if the dispatcher handled the row (Bitmask behavior), false
 /// otherwise.
+///
+/// When the binding declares a `writeback` (and `init`), the row is routed
+/// through the generic `toggle_bitmask_row_generic` path; otherwise the
+/// hand-rolled `toggle` fn pointer is invoked.
 pub(super) fn dispatch_behavior_toggle(state: &mut State, player_idx: usize, id: RowId) -> bool {
     let Some(RowBehavior::Bitmask(b)) = state.pane().row_map.get(id).map(|r| r.behavior) else {
         return false;
     };
-    (b.toggle)(state, player_idx);
+    if b.writeback.is_some() && b.init.is_some() {
+        toggle_bitmask_row_generic(state, player_idx, id);
+    } else {
+        (b.toggle)(state, player_idx);
+    }
+    true
+}
+
+/// Generic bitmask toggle for `BitmaskBinding`s that declare both `init`
+/// and `writeback`. Verifies the focused row matches `id`, computes the
+/// target bit via `writeback.bit_for_choice`, flips it through
+/// `init.get_active`/`init.set_active`, projects the resulting bits onto
+/// the in-memory profile via `writeback.project_to_profile`, and
+/// (conditionally) persists them for the active side via
+/// `writeback.persist_for_side`. Plays the change-value SFX on success.
+///
+/// Returns `true` when a toggle was applied; `false` when the row was not
+/// focused, the binding lacked the required contracts, or the choice
+/// index produced no bit.
+pub(super) fn toggle_bitmask_row_generic(
+    state: &mut State,
+    player_idx: usize,
+    id: RowId,
+) -> bool {
+    let idx = player_idx.min(PLAYER_SLOTS - 1);
+    let row_index = state.pane().selected_row[idx];
+    let focused_id = match state.pane().row_map.display_order().get(row_index) {
+        Some(&fid) => fid,
+        None => return false,
+    };
+    if focused_id != id {
+        return false;
+    }
+
+    let (init, writeback) = match state.pane().row_map.get(id).map(|r| r.behavior) {
+        Some(RowBehavior::Bitmask(b)) => match (b.init, b.writeback) {
+            (Some(i), Some(w)) => (i, w),
+            _ => return false,
+        },
+        _ => return false,
+    };
+
+    let row = state.pane().row_map.row(id);
+    let choice_index = row.selected_choice_index[idx];
+    let bit = match (writeback.bit_for_choice)(choice_index, row) {
+        Some(b) if b != 0 => b,
+        _ => return false,
+    };
+
+    let cur = (init.get_active)(&state.option_masks[idx]);
+    let new_bits = cur ^ bit;
+    (init.set_active)(&mut state.option_masks[idx], new_bits);
+    let stored = (init.get_active)(&state.option_masks[idx]);
+
+    (writeback.project_to_profile)(&mut state.player_profiles[idx], stored);
+
+    let (should_persist, side) = persist_ctx(idx);
+    if should_persist {
+        (writeback.persist_for_side)(side, stored);
+    }
+
+    audio::play_sfx("assets/sounds/change_value.ogg");
     true
 }
 
@@ -389,365 +451,6 @@ pub(super) fn toggle_hide_row(state: &mut State, player_idx: usize) {
     audio::play_sfx("assets/sounds/change_value.ogg");
 }
 
-pub(super) fn toggle_insert_row(state: &mut State, player_idx: usize) {
-    let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.pane().selected_row[idx];
-    if let Some(row) = state
-        .pane()
-        .row_map
-        .display_order()
-        .get(row_index)
-        .and_then(|&id| state.pane().row_map.get(id))
-    {
-        if row.id != RowId::Insert {
-            return;
-        }
-    } else {
-        return;
-    }
-
-    let choice_index = state
-        .pane()
-        .row_map
-        .row(state.pane().row_map.id_at(row_index))
-        .selected_choice_index[idx];
-    let bit = if choice_index < 7 {
-        1u8 << (choice_index as u8)
-    } else {
-        0
-    };
-    if bit == 0 {
-        return;
-    }
-
-    let mut bits = state.option_masks[idx].insert.bits();
-    if (bits & bit) != 0 {
-        bits &= !bit;
-    } else {
-        bits |= bit;
-    }
-    let mask = InsertMask::from_bits_truncate(bits);
-    state.option_masks[idx].insert = mask;
-    state.player_profiles[idx].insert_active_mask = mask;
-
-    let play_style = crate::game::profile::get_session_play_style();
-    let should_persist = play_style == crate::game::profile::PlayStyle::Versus
-        || idx == session_persisted_player_idx();
-    if should_persist {
-        let side = if idx == P1 {
-            crate::game::profile::PlayerSide::P1
-        } else {
-            crate::game::profile::PlayerSide::P2
-        };
-        crate::game::profile::update_insert_mask_for_side(side, mask);
-    }
-
-    audio::play_sfx("assets/sounds/change_value.ogg");
-}
-
-pub(super) fn toggle_remove_row(state: &mut State, player_idx: usize) {
-    let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.pane().selected_row[idx];
-    if let Some(row) = state
-        .pane()
-        .row_map
-        .display_order()
-        .get(row_index)
-        .and_then(|&id| state.pane().row_map.get(id))
-    {
-        if row.id != RowId::Remove {
-            return;
-        }
-    } else {
-        return;
-    }
-
-    let choice_index = state
-        .pane()
-        .row_map
-        .row(state.pane().row_map.id_at(row_index))
-        .selected_choice_index[idx];
-    let bit = if choice_index < 8 {
-        1u8 << (choice_index as u8)
-    } else {
-        0
-    };
-    if bit == 0 {
-        return;
-    }
-
-    let mut bits = state.option_masks[idx].remove.bits();
-    if (bits & bit) != 0 {
-        bits &= !bit;
-    } else {
-        bits |= bit;
-    }
-    let mask = RemoveMask::from_bits_truncate(bits);
-    state.option_masks[idx].remove = mask;
-    state.player_profiles[idx].remove_active_mask = mask;
-
-    let play_style = crate::game::profile::get_session_play_style();
-    let should_persist = play_style == crate::game::profile::PlayStyle::Versus
-        || idx == session_persisted_player_idx();
-    if should_persist {
-        let side = if idx == P1 {
-            crate::game::profile::PlayerSide::P1
-        } else {
-            crate::game::profile::PlayerSide::P2
-        };
-        crate::game::profile::update_remove_mask_for_side(side, mask);
-    }
-
-    audio::play_sfx("assets/sounds/change_value.ogg");
-}
-
-pub(super) fn toggle_holds_row(state: &mut State, player_idx: usize) {
-    let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.pane().selected_row[idx];
-    if let Some(row) = state
-        .pane()
-        .row_map
-        .display_order()
-        .get(row_index)
-        .and_then(|&id| state.pane().row_map.get(id))
-    {
-        if row.id != RowId::Holds {
-            return;
-        }
-    } else {
-        return;
-    }
-
-    let choice_index = state
-        .pane()
-        .row_map
-        .row(state.pane().row_map.id_at(row_index))
-        .selected_choice_index[idx];
-    let bit = if choice_index
-        < state
-            .pane()
-            .row_map
-            .row(state.pane().row_map.id_at(row_index))
-            .choices
-            .len()
-            .min(u8::BITS as usize)
-    {
-        1u8 << (choice_index as u8)
-    } else {
-        0
-    };
-    if bit == 0 {
-        return;
-    }
-
-    let mut bits = state.option_masks[idx].holds.bits();
-    if (bits & bit) != 0 {
-        bits &= !bit;
-    } else {
-        bits |= bit;
-    }
-    let mask = HoldsMask::from_bits_truncate(bits);
-    state.option_masks[idx].holds = mask;
-    state.player_profiles[idx].holds_active_mask = mask;
-
-    let play_style = crate::game::profile::get_session_play_style();
-    let should_persist = play_style == crate::game::profile::PlayStyle::Versus
-        || idx == session_persisted_player_idx();
-    if should_persist {
-        let side = if idx == P1 {
-            crate::game::profile::PlayerSide::P1
-        } else {
-            crate::game::profile::PlayerSide::P2
-        };
-        crate::game::profile::update_holds_mask_for_side(side, mask);
-    }
-
-    audio::play_sfx("assets/sounds/change_value.ogg");
-}
-
-pub(super) fn toggle_accel_effects_row(state: &mut State, player_idx: usize) {
-    let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.pane().selected_row[idx];
-    if let Some(row) = state
-        .pane()
-        .row_map
-        .display_order()
-        .get(row_index)
-        .and_then(|&id| state.pane().row_map.get(id))
-    {
-        if row.id != RowId::Accel {
-            return;
-        }
-    } else {
-        return;
-    }
-
-    let choice_index = state
-        .pane()
-        .row_map
-        .row(state.pane().row_map.id_at(row_index))
-        .selected_choice_index[idx];
-    let bit = if choice_index
-        < state
-            .pane()
-            .row_map
-            .row(state.pane().row_map.id_at(row_index))
-            .choices
-            .len()
-            .min(u8::BITS as usize)
-    {
-        1u8 << (choice_index as u8)
-    } else {
-        0
-    };
-    if bit == 0 {
-        return;
-    }
-
-    let mut bits = state.option_masks[idx].accel_effects.bits();
-    if (bits & bit) != 0 {
-        bits &= !bit;
-    } else {
-        bits |= bit;
-    }
-    let mask = AccelEffectsMask::from_bits_truncate(bits);
-    state.option_masks[idx].accel_effects = mask;
-    state.player_profiles[idx].accel_effects_active_mask = mask;
-
-    let play_style = crate::game::profile::get_session_play_style();
-    let should_persist = play_style == crate::game::profile::PlayStyle::Versus
-        || idx == session_persisted_player_idx();
-    if should_persist {
-        let side = if idx == P1 {
-            crate::game::profile::PlayerSide::P1
-        } else {
-            crate::game::profile::PlayerSide::P2
-        };
-        crate::game::profile::update_accel_effects_mask_for_side(side, mask);
-    }
-
-    audio::play_sfx("assets/sounds/change_value.ogg");
-}
-
-pub(super) fn toggle_visual_effects_row(state: &mut State, player_idx: usize) {
-    let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.pane().selected_row[idx];
-    if let Some(row) = state
-        .pane()
-        .row_map
-        .display_order()
-        .get(row_index)
-        .and_then(|&id| state.pane().row_map.get(id))
-    {
-        if row.id != RowId::Effect {
-            return;
-        }
-    } else {
-        return;
-    }
-
-    let choice_index = state
-        .pane()
-        .row_map
-        .row(state.pane().row_map.id_at(row_index))
-        .selected_choice_index[idx];
-    let bit = if choice_index < 10 {
-        1u16 << (choice_index as u16)
-    } else {
-        0
-    };
-    if bit == 0 {
-        return;
-    }
-
-    let mut bits = state.option_masks[idx].visual_effects.bits();
-    if (bits & bit) != 0 {
-        bits &= !bit;
-    } else {
-        bits |= bit;
-    }
-    let mask = VisualEffectsMask::from_bits_truncate(bits);
-    state.option_masks[idx].visual_effects = mask;
-    state.player_profiles[idx].visual_effects_active_mask = mask;
-
-    let play_style = crate::game::profile::get_session_play_style();
-    let should_persist = play_style == crate::game::profile::PlayStyle::Versus
-        || idx == session_persisted_player_idx();
-    if should_persist {
-        let side = if idx == P1 {
-            crate::game::profile::PlayerSide::P1
-        } else {
-            crate::game::profile::PlayerSide::P2
-        };
-        crate::game::profile::update_visual_effects_mask_for_side(side, mask);
-    }
-
-    audio::play_sfx("assets/sounds/change_value.ogg");
-}
-
-pub(super) fn toggle_appearance_effects_row(state: &mut State, player_idx: usize) {
-    let idx = player_idx.min(PLAYER_SLOTS - 1);
-    let row_index = state.pane().selected_row[idx];
-    if let Some(row) = state
-        .pane()
-        .row_map
-        .display_order()
-        .get(row_index)
-        .and_then(|&id| state.pane().row_map.get(id))
-    {
-        if row.id != RowId::Appearance {
-            return;
-        }
-    } else {
-        return;
-    }
-
-    let choice_index = state
-        .pane()
-        .row_map
-        .row(state.pane().row_map.id_at(row_index))
-        .selected_choice_index[idx];
-    let bit = if choice_index
-        < state
-            .pane()
-            .row_map
-            .row(state.pane().row_map.id_at(row_index))
-            .choices
-            .len()
-            .min(u8::BITS as usize)
-    {
-        1u8 << (choice_index as u8)
-    } else {
-        0
-    };
-    if bit == 0 {
-        return;
-    }
-
-    let mut bits = state.option_masks[idx].appearance_effects.bits();
-    if (bits & bit) != 0 {
-        bits &= !bit;
-    } else {
-        bits |= bit;
-    }
-    let mask = AppearanceEffectsMask::from_bits_truncate(bits);
-    state.option_masks[idx].appearance_effects = mask;
-    state.player_profiles[idx].appearance_effects_active_mask = mask;
-
-    let play_style = crate::game::profile::get_session_play_style();
-    let should_persist = play_style == crate::game::profile::PlayStyle::Versus
-        || idx == session_persisted_player_idx();
-    if should_persist {
-        let side = if idx == P1 {
-            crate::game::profile::PlayerSide::P1
-        } else {
-            crate::game::profile::PlayerSide::P2
-        };
-        crate::game::profile::update_appearance_effects_mask_for_side(side, mask);
-    }
-
-    audio::play_sfx("assets/sounds/change_value.ogg");
-}
 
 pub(super) fn toggle_life_bar_options_row(state: &mut State, player_idx: usize) {
     let idx = player_idx.min(PLAYER_SLOTS - 1);

--- a/src/screens/player_options/panes/advanced.rs
+++ b/src/screens/player_options/panes/advanced.rs
@@ -1,6 +1,12 @@
+use super::super::choice;
 use super::super::constants::MINI_INDICATOR_VARIANTS;
 use super::super::row::index_binding;
 use super::super::row::{BitmaskInit, CursorInit, CycleInit, NumericInit};
+use super::super::state::{
+    EarlyDwMask, ErrorBarOptionsMask, FaPlusMask, GameplayExtrasMask, HideMask,
+    LifeBarOptionsMask, MeasureCounterOptionsMask, PlayerOptionMasks, ResultsExtrasMask,
+    ScrollMask,
+};
 use super::*;
 use crate::game::profile as gp;
 
@@ -282,21 +288,21 @@ const SCROLL: BitmaskBinding = BitmaskBinding::HandRolled {
             // invariant. We translate per-flag rather than copying ``.0`` so
             // any future divergence is caught here.
             use crate::game::profile::ScrollOption;
-            let mut bits = super::super::state::ScrollMask::empty();
+            let mut bits = ScrollMask::empty();
             if p.scroll_option.contains(ScrollOption::Reverse) {
-                bits.insert(super::super::state::ScrollMask::from_bits_retain(1u8 << 0));
+                bits.insert(ScrollMask::from_bits_retain(1u8 << 0));
             }
             if p.scroll_option.contains(ScrollOption::Split) {
-                bits.insert(super::super::state::ScrollMask::from_bits_retain(1u8 << 1));
+                bits.insert(ScrollMask::from_bits_retain(1u8 << 1));
             }
             if p.scroll_option.contains(ScrollOption::Alternate) {
-                bits.insert(super::super::state::ScrollMask::from_bits_retain(1u8 << 2));
+                bits.insert(ScrollMask::from_bits_retain(1u8 << 2));
             }
             if p.scroll_option.contains(ScrollOption::Cross) {
-                bits.insert(super::super::state::ScrollMask::from_bits_retain(1u8 << 3));
+                bits.insert(ScrollMask::from_bits_retain(1u8 << 3));
             }
             if p.scroll_option.contains(ScrollOption::Centered) {
-                bits.insert(super::super::state::ScrollMask::from_bits_retain(1u8 << 4));
+                bits.insert(ScrollMask::from_bits_retain(1u8 << 4));
             }
             bits.bits() as u32
         },
@@ -307,36 +313,36 @@ const SCROLL: BitmaskBinding = BitmaskBinding::HandRolled {
                 0,
                 "ScrollMask init bits exceed u8 width"
             );
-            m.scroll = super::super::state::ScrollMask::from_bits_retain(b as u8);
+            m.scroll = ScrollMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    toggle: super::super::choice::toggle_scroll_row,
+    toggle: choice::toggle_scroll_row,
 };
 const HIDE: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
-            let mut bits = super::super::state::HideMask::empty();
+            let mut bits = HideMask::empty();
             if p.hide_targets {
-                bits.insert(super::super::state::HideMask::TARGETS);
+                bits.insert(HideMask::TARGETS);
             }
             if p.hide_song_bg {
-                bits.insert(super::super::state::HideMask::BACKGROUND);
+                bits.insert(HideMask::BACKGROUND);
             }
             if p.hide_combo {
-                bits.insert(super::super::state::HideMask::COMBO);
+                bits.insert(HideMask::COMBO);
             }
             if p.hide_lifebar {
-                bits.insert(super::super::state::HideMask::LIFE);
+                bits.insert(HideMask::LIFE);
             }
             if p.hide_score {
-                bits.insert(super::super::state::HideMask::SCORE);
+                bits.insert(HideMask::SCORE);
             }
             if p.hide_danger {
-                bits.insert(super::super::state::HideMask::DANGER);
+                bits.insert(HideMask::DANGER);
             }
             if p.hide_combo_explosions {
-                bits.insert(super::super::state::HideMask::COMBO_EXPLOSIONS);
+                bits.insert(HideMask::COMBO_EXPLOSIONS);
             }
             bits.bits() as u32
         },
@@ -347,24 +353,24 @@ const HIDE: BitmaskBinding = BitmaskBinding::HandRolled {
                 0,
                 "HideMask init bits exceed u8 width"
             );
-            m.hide = super::super::state::HideMask::from_bits_retain(b as u8);
+            m.hide = HideMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    toggle: super::super::choice::toggle_hide_row,
+    toggle: choice::toggle_hide_row,
 };
 const LIFE_BAR_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
-            let mut bits = super::super::state::LifeBarOptionsMask::empty();
+            let mut bits = LifeBarOptionsMask::empty();
             if p.rainbow_max {
-                bits.insert(super::super::state::LifeBarOptionsMask::RAINBOW_MAX);
+                bits.insert(LifeBarOptionsMask::RAINBOW_MAX);
             }
             if p.responsive_colors {
-                bits.insert(super::super::state::LifeBarOptionsMask::RESPONSIVE_COLORS);
+                bits.insert(LifeBarOptionsMask::RESPONSIVE_COLORS);
             }
             if p.show_life_percent {
-                bits.insert(super::super::state::LifeBarOptionsMask::SHOW_LIFE_PERCENT);
+                bits.insert(LifeBarOptionsMask::SHOW_LIFE_PERCENT);
             }
             bits.bits() as u32
         },
@@ -375,27 +381,27 @@ const LIFE_BAR_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
                 0,
                 "LifeBarOptionsMask init bits exceed u8 width",
             );
-            m.life_bar_options = super::super::state::LifeBarOptionsMask::from_bits_retain(b as u8);
+            m.life_bar_options = LifeBarOptionsMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    toggle: super::super::choice::toggle_life_bar_options_row,
+    toggle: choice::toggle_life_bar_options_row,
 };
 const GAMEPLAY_EXTRAS: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
-            let mut bits = super::super::state::GameplayExtrasMask::empty();
+            let mut bits = GameplayExtrasMask::empty();
             if p.column_flash_on_miss {
-                bits.insert(super::super::state::GameplayExtrasMask::FLASH_COLUMN_FOR_MISS);
+                bits.insert(GameplayExtrasMask::FLASH_COLUMN_FOR_MISS);
             }
             if p.nps_graph_at_top {
-                bits.insert(super::super::state::GameplayExtrasMask::DENSITY_GRAPH_AT_TOP);
+                bits.insert(GameplayExtrasMask::DENSITY_GRAPH_AT_TOP);
             }
             if p.column_cues {
-                bits.insert(super::super::state::GameplayExtrasMask::COLUMN_CUES);
+                bits.insert(GameplayExtrasMask::COLUMN_CUES);
             }
             if p.display_scorebox {
-                bits.insert(super::super::state::GameplayExtrasMask::DISPLAY_SCOREBOX);
+                bits.insert(GameplayExtrasMask::DISPLAY_SCOREBOX);
             }
             bits.bits() as u32
         },
@@ -406,11 +412,11 @@ const GAMEPLAY_EXTRAS: BitmaskBinding = BitmaskBinding::HandRolled {
                 0,
                 "GameplayExtrasMask init bits exceed u8 width",
             );
-            m.gameplay_extras = super::super::state::GameplayExtrasMask::from_bits_retain(b as u8);
+            m.gameplay_extras = GameplayExtrasMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    toggle: super::super::choice::toggle_gameplay_extras_row,
+    toggle: choice::toggle_gameplay_extras_row,
 };
 const ERROR_BAR: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
@@ -436,17 +442,17 @@ const ERROR_BAR: BitmaskBinding = BitmaskBinding::HandRolled {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    toggle: super::super::choice::toggle_error_bar_row,
+    toggle: choice::toggle_error_bar_row,
 };
 const ERROR_BAR_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
-            let mut bits = super::super::state::ErrorBarOptionsMask::empty();
+            let mut bits = ErrorBarOptionsMask::empty();
             if p.error_bar_up {
-                bits.insert(super::super::state::ErrorBarOptionsMask::MOVE_UP);
+                bits.insert(ErrorBarOptionsMask::MOVE_UP);
             }
             if p.error_bar_multi_tick {
-                bits.insert(super::super::state::ErrorBarOptionsMask::MULTI_TICK);
+                bits.insert(ErrorBarOptionsMask::MULTI_TICK);
             }
             bits.bits() as u32
         },
@@ -458,30 +464,30 @@ const ERROR_BAR_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
                 "ErrorBarOptionsMask init bits exceed u8 width",
             );
             m.error_bar_options =
-                super::super::state::ErrorBarOptionsMask::from_bits_retain(b as u8);
+                ErrorBarOptionsMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    toggle: super::super::choice::toggle_error_bar_options_row,
+    toggle: choice::toggle_error_bar_options_row,
 };
 const MEASURE_COUNTER_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
-            let mut bits = super::super::state::MeasureCounterOptionsMask::empty();
+            let mut bits = MeasureCounterOptionsMask::empty();
             if p.measure_counter_left {
-                bits.insert(super::super::state::MeasureCounterOptionsMask::MOVE_LEFT);
+                bits.insert(MeasureCounterOptionsMask::MOVE_LEFT);
             }
             if p.measure_counter_up {
-                bits.insert(super::super::state::MeasureCounterOptionsMask::MOVE_UP);
+                bits.insert(MeasureCounterOptionsMask::MOVE_UP);
             }
             if p.measure_counter_vert {
-                bits.insert(super::super::state::MeasureCounterOptionsMask::VERTICAL_LOOKAHEAD);
+                bits.insert(MeasureCounterOptionsMask::VERTICAL_LOOKAHEAD);
             }
             if p.broken_run {
-                bits.insert(super::super::state::MeasureCounterOptionsMask::BROKEN_RUN_TOTAL);
+                bits.insert(MeasureCounterOptionsMask::BROKEN_RUN_TOTAL);
             }
             if p.run_timer {
-                bits.insert(super::super::state::MeasureCounterOptionsMask::RUN_TIMER);
+                bits.insert(MeasureCounterOptionsMask::RUN_TIMER);
             }
             bits.bits() as u32
         },
@@ -493,42 +499,42 @@ const MEASURE_COUNTER_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
                 "MeasureCounterOptionsMask init bits exceed u8 width",
             );
             m.measure_counter_options =
-                super::super::state::MeasureCounterOptionsMask::from_bits_retain(b as u8);
+                MeasureCounterOptionsMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    toggle: super::super::choice::toggle_measure_counter_options_row,
+    toggle: choice::toggle_measure_counter_options_row,
 };
 fn fa_plus_bits_from_profile(p: &gp::Profile) -> u32 {
-    let mut bits = super::super::state::FaPlusMask::empty();
+    let mut bits = FaPlusMask::empty();
     if p.show_fa_plus_window {
-        bits.insert(super::super::state::FaPlusMask::WINDOW);
+        bits.insert(FaPlusMask::WINDOW);
     }
     if p.show_ex_score {
-        bits.insert(super::super::state::FaPlusMask::EX_SCORE);
+        bits.insert(FaPlusMask::EX_SCORE);
     }
     if p.show_hard_ex_score {
-        bits.insert(super::super::state::FaPlusMask::HARD_EX_SCORE);
+        bits.insert(FaPlusMask::HARD_EX_SCORE);
     }
     if p.show_fa_plus_pane {
-        bits.insert(super::super::state::FaPlusMask::PANE);
+        bits.insert(FaPlusMask::PANE);
     }
     if p.fa_plus_10ms_blue_window {
-        bits.insert(super::super::state::FaPlusMask::BLUE_WINDOW_10MS);
+        bits.insert(FaPlusMask::BLUE_WINDOW_10MS);
     }
     if p.split_15_10ms {
-        bits.insert(super::super::state::FaPlusMask::SPLIT_15_10MS);
+        bits.insert(FaPlusMask::SPLIT_15_10MS);
     }
     bits.bits() as u32
 }
 
-fn set_fa_plus_bits(m: &mut super::super::state::PlayerOptionMasks, b: u32) {
+fn set_fa_plus_bits(m: &mut PlayerOptionMasks, b: u32) {
     debug_assert_eq!(
         b & !(u8::MAX as u32),
         0,
         "FaPlusMask init bits exceed u8 width"
     );
-    m.fa_plus = super::super::state::FaPlusMask::from_bits_retain(b as u8);
+    m.fa_plus = FaPlusMask::from_bits_retain(b as u8);
 }
 
 const FA_PLUS_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
@@ -538,7 +544,7 @@ const FA_PLUS_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
         set_active: set_fa_plus_bits,
         cursor: CursorInit::Fixed(0),
     }),
-    toggle: super::super::choice::toggle_fa_plus_row,
+    toggle: choice::toggle_fa_plus_row,
 };
 
 const FA_PLUS_WINDOW_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
@@ -548,17 +554,17 @@ const FA_PLUS_WINDOW_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
         set_active: set_fa_plus_bits,
         cursor: CursorInit::FirstActiveBit,
     }),
-    toggle: super::super::choice::toggle_fa_plus_row,
+    toggle: choice::toggle_fa_plus_row,
 };
 const EARLY_DW_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
-            let mut bits = super::super::state::EarlyDwMask::empty();
+            let mut bits = EarlyDwMask::empty();
             if p.hide_early_dw_judgments {
-                bits.insert(super::super::state::EarlyDwMask::HIDE_JUDGMENTS);
+                bits.insert(EarlyDwMask::HIDE_JUDGMENTS);
             }
             if p.hide_early_dw_flash {
-                bits.insert(super::super::state::EarlyDwMask::HIDE_FLASH);
+                bits.insert(EarlyDwMask::HIDE_FLASH);
             }
             bits.bits() as u32
         },
@@ -569,21 +575,21 @@ const EARLY_DW_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
                 0,
                 "EarlyDwMask init bits exceed u8 width"
             );
-            m.early_dw = super::super::state::EarlyDwMask::from_bits_retain(b as u8);
+            m.early_dw = EarlyDwMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    toggle: super::super::choice::toggle_early_dw_row,
+    toggle: choice::toggle_early_dw_row,
 };
 const RESULTS_EXTRAS: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
-            let mut bits = super::super::state::ResultsExtrasMask::empty();
+            let mut bits = ResultsExtrasMask::empty();
             if p.track_early_judgments {
-                bits.insert(super::super::state::ResultsExtrasMask::TRACK_EARLY_JUDGMENTS);
+                bits.insert(ResultsExtrasMask::TRACK_EARLY_JUDGMENTS);
             }
             if p.scale_scatterplot {
-                bits.insert(super::super::state::ResultsExtrasMask::SCALE_SCATTERPLOT);
+                bits.insert(ResultsExtrasMask::SCALE_SCATTERPLOT);
             }
             bits.bits() as u32
         },
@@ -594,16 +600,16 @@ const RESULTS_EXTRAS: BitmaskBinding = BitmaskBinding::HandRolled {
                 0,
                 "ResultsExtrasMask init bits exceed u8 width",
             );
-            m.results_extras = super::super::state::ResultsExtrasMask::from_bits_retain(b as u8);
+            m.results_extras = ResultsExtrasMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    toggle: super::super::choice::toggle_results_extras_row,
+    toggle: choice::toggle_results_extras_row,
 };
 
 const ACTION_ON_MISSED_TARGET: CustomBinding = CustomBinding {
     apply: |state, player_idx, row_id, delta, wrap| {
-        if super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
+        if choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
             .is_none()
         {
             return Outcome::NONE;
@@ -615,7 +621,7 @@ const ACTION_ON_MISSED_TARGET: CustomBinding = CustomBinding {
 const MINI_INDICATOR: CustomBinding = CustomBinding {
     apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
+            choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };
@@ -628,7 +634,7 @@ const MINI_INDICATOR: CustomBinding = CustomBinding {
         state.player_profiles[player_idx].mini_indicator = mini_indicator;
         state.player_profiles[player_idx].subtractive_scoring = subtractive_scoring;
         state.player_profiles[player_idx].pacemaker = pacemaker;
-        let (should_persist, side) = super::super::choice::persist_ctx(player_idx);
+        let (should_persist, side) = choice::persist_ctx(player_idx);
         if should_persist {
             let profile_ref = &state.player_profiles[player_idx];
             gp::update_mini_indicator_for_side(side, mini_indicator);
@@ -647,7 +653,7 @@ const MINI_INDICATOR: CustomBinding = CustomBinding {
 const JUDGMENT_TILT_INTENSITY: CustomBinding = CustomBinding {
     apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
+            choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };
@@ -666,7 +672,7 @@ const JUDGMENT_TILT_INTENSITY: CustomBinding = CustomBinding {
         let mult =
             round_to_step(mult, TILT_INTENSITY_STEP).clamp(TILT_INTENSITY_MIN, TILT_INTENSITY_MAX);
         state.player_profiles[player_idx].tilt_multiplier = mult;
-        let (should_persist, side) = super::super::choice::persist_ctx(player_idx);
+        let (should_persist, side) = choice::persist_ctx(player_idx);
         if should_persist {
             gp::update_tilt_multiplier_for_side(side, mult);
         }
@@ -682,7 +688,7 @@ fn chosen_tilt_threshold_ms(
     wrap: NavWrap,
 ) -> Option<u32> {
     let new_index =
-        super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)?;
+        choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)?;
     let choice = state
         .pane()
         .row_map
@@ -714,7 +720,7 @@ const JUDGMENT_TILT_MIN_THRESHOLD: CustomBinding = CustomBinding {
             (min_ms, max_ms)
         };
         set_tilt_threshold_row(state, player_idx, RowId::JudgmentTiltMaxThreshold, max_ms);
-        let (should_persist, side) = super::super::choice::persist_ctx(player_idx);
+        let (should_persist, side) = choice::persist_ctx(player_idx);
         if should_persist {
             gp::update_tilt_thresholds_for_side(side, min_ms, max_ms);
         }
@@ -736,7 +742,7 @@ const JUDGMENT_TILT_MAX_THRESHOLD: CustomBinding = CustomBinding {
             (min_ms, max_ms)
         };
         set_tilt_threshold_row(state, player_idx, RowId::JudgmentTiltMinThreshold, min_ms);
-        let (should_persist, side) = super::super::choice::persist_ctx(player_idx);
+        let (should_persist, side) = choice::persist_ctx(player_idx);
         if should_persist {
             gp::update_tilt_thresholds_for_side(side, min_ms, max_ms);
         }
@@ -747,13 +753,13 @@ const JUDGMENT_TILT_MAX_THRESHOLD: CustomBinding = CustomBinding {
 const MEASURE_COUNTER_LOOKAHEAD: CustomBinding = CustomBinding {
     apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
+            choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };
         let lookahead = (new_index as u8).min(4);
         state.player_profiles[player_idx].measure_counter_lookahead = lookahead;
-        let (should_persist, side) = super::super::choice::persist_ctx(player_idx);
+        let (should_persist, side) = choice::persist_ctx(player_idx);
         if should_persist {
             gp::update_measure_counter_lookahead_for_side(side, lookahead);
         }
@@ -764,7 +770,7 @@ const MEASURE_COUNTER_LOOKAHEAD: CustomBinding = CustomBinding {
 const CUSTOM_BLUE_FANTASTIC_WINDOW_MS: CustomBinding = CustomBinding {
     apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
+            choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };
@@ -782,7 +788,7 @@ const CUSTOM_BLUE_FANTASTIC_WINDOW_MS: CustomBinding = CustomBinding {
         };
         let ms = gp::clamp_custom_fantastic_window_ms(raw);
         state.player_profiles[player_idx].custom_fantastic_window_ms = ms;
-        let (should_persist, side) = super::super::choice::persist_ctx(player_idx);
+        let (should_persist, side) = choice::persist_ctx(player_idx);
         if should_persist {
             gp::update_custom_fantastic_window_ms_for_side(side, ms);
         }

--- a/src/screens/player_options/panes/advanced.rs
+++ b/src/screens/player_options/panes/advanced.rs
@@ -312,6 +312,7 @@ const SCROLL: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
+    writeback: None,
 };
 const HIDE: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_hide_row,
@@ -352,6 +353,7 @@ const HIDE: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
+    writeback: None,
 };
 const LIFE_BAR_OPTIONS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_life_bar_options_row,
@@ -380,6 +382,7 @@ const LIFE_BAR_OPTIONS: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
+    writeback: None,
 };
 const GAMEPLAY_EXTRAS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_gameplay_extras_row,
@@ -411,6 +414,7 @@ const GAMEPLAY_EXTRAS: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
+    writeback: None,
 };
 const ERROR_BAR: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_error_bar_row,
@@ -437,6 +441,7 @@ const ERROR_BAR: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
+    writeback: None,
 };
 const ERROR_BAR_OPTIONS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_error_bar_options_row,
@@ -463,6 +468,7 @@ const ERROR_BAR_OPTIONS: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
+    writeback: None,
 };
 const MEASURE_COUNTER_OPTIONS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_measure_counter_options_row,
@@ -498,6 +504,7 @@ const MEASURE_COUNTER_OPTIONS: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
+    writeback: None,
 };
 fn fa_plus_bits_from_profile(p: &gp::Profile) -> u32 {
     let mut bits = super::super::state::FaPlusMask::empty();
@@ -539,6 +546,7 @@ const FA_PLUS_OPTIONS: BitmaskBinding = BitmaskBinding {
         set_active: set_fa_plus_bits,
         cursor: CursorInit::Fixed(0),
     }),
+    writeback: None,
 };
 
 const FA_PLUS_WINDOW_OPTIONS: BitmaskBinding = BitmaskBinding {
@@ -549,6 +557,7 @@ const FA_PLUS_WINDOW_OPTIONS: BitmaskBinding = BitmaskBinding {
         set_active: set_fa_plus_bits,
         cursor: CursorInit::FirstActiveBit,
     }),
+    writeback: None,
 };
 const EARLY_DW_OPTIONS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_early_dw_row,
@@ -574,6 +583,7 @@ const EARLY_DW_OPTIONS: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
+    writeback: None,
 };
 const RESULTS_EXTRAS: BitmaskBinding = BitmaskBinding {
     toggle: super::super::choice::toggle_results_extras_row,
@@ -599,6 +609,7 @@ const RESULTS_EXTRAS: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
+    writeback: None,
 };
 
 const ACTION_ON_MISSED_TARGET: CustomBinding = CustomBinding {
@@ -1271,6 +1282,7 @@ mod bitmask_binding_init_tests {
             behavior: RowBehavior::Bitmask(BitmaskBinding {
                 toggle: |_, _| {},
                 init: None,
+                writeback: None,
             }),
             name,
             choices: choices.iter().map(ToString::to_string).collect(),
@@ -1392,6 +1404,7 @@ mod bitmask_binding_init_tests {
         let init_less = BitmaskBinding {
             toggle: |_, _| {},
             init: None,
+            writeback: None,
         };
         let applied = init_bitmask_row_from_binding(&mut row, &init_less, &profile, &mut masks, 0);
         assert!(!applied, "init-less binding must short-circuit");

--- a/src/screens/player_options/panes/advanced.rs
+++ b/src/screens/player_options/panes/advanced.rs
@@ -272,8 +272,7 @@ const ERROR_BAR_OFFSET_Y: NumericBinding = NumericBinding {
     }),
 };
 
-const SCROLL: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_scroll_row,
+const SCROLL: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
             // The Scroll row's choice indices are fixed by build order
@@ -312,10 +311,9 @@ const SCROLL: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    writeback: None,
+    toggle: super::super::choice::toggle_scroll_row,
 };
-const HIDE: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_hide_row,
+const HIDE: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
             let mut bits = super::super::state::HideMask::empty();
@@ -353,10 +351,9 @@ const HIDE: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    writeback: None,
+    toggle: super::super::choice::toggle_hide_row,
 };
-const LIFE_BAR_OPTIONS: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_life_bar_options_row,
+const LIFE_BAR_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
             let mut bits = super::super::state::LifeBarOptionsMask::empty();
@@ -382,10 +379,9 @@ const LIFE_BAR_OPTIONS: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    writeback: None,
+    toggle: super::super::choice::toggle_life_bar_options_row,
 };
-const GAMEPLAY_EXTRAS: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_gameplay_extras_row,
+const GAMEPLAY_EXTRAS: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
             let mut bits = super::super::state::GameplayExtrasMask::empty();
@@ -414,10 +410,9 @@ const GAMEPLAY_EXTRAS: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    writeback: None,
+    toggle: super::super::choice::toggle_gameplay_extras_row,
 };
-const ERROR_BAR: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_error_bar_row,
+const ERROR_BAR: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
             // Profile already stores the desired mask; if it's empty (e.g.
@@ -441,10 +436,9 @@ const ERROR_BAR: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    writeback: None,
+    toggle: super::super::choice::toggle_error_bar_row,
 };
-const ERROR_BAR_OPTIONS: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_error_bar_options_row,
+const ERROR_BAR_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
             let mut bits = super::super::state::ErrorBarOptionsMask::empty();
@@ -468,10 +462,9 @@ const ERROR_BAR_OPTIONS: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    writeback: None,
+    toggle: super::super::choice::toggle_error_bar_options_row,
 };
-const MEASURE_COUNTER_OPTIONS: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_measure_counter_options_row,
+const MEASURE_COUNTER_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
             let mut bits = super::super::state::MeasureCounterOptionsMask::empty();
@@ -504,7 +497,7 @@ const MEASURE_COUNTER_OPTIONS: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    writeback: None,
+    toggle: super::super::choice::toggle_measure_counter_options_row,
 };
 fn fa_plus_bits_from_profile(p: &gp::Profile) -> u32 {
     let mut bits = super::super::state::FaPlusMask::empty();
@@ -538,29 +531,26 @@ fn set_fa_plus_bits(m: &mut super::super::state::PlayerOptionMasks, b: u32) {
     m.fa_plus = super::super::state::FaPlusMask::from_bits_retain(b as u8);
 }
 
-const FA_PLUS_OPTIONS: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_fa_plus_row,
+const FA_PLUS_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: fa_plus_bits_from_profile,
         get_active: |m| (m.fa_plus.bits() & 0b0000_1111) as u32,
         set_active: set_fa_plus_bits,
         cursor: CursorInit::Fixed(0),
     }),
-    writeback: None,
+    toggle: super::super::choice::toggle_fa_plus_row,
 };
 
-const FA_PLUS_WINDOW_OPTIONS: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_fa_plus_row,
+const FA_PLUS_WINDOW_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: fa_plus_bits_from_profile,
         get_active: |m| ((m.fa_plus.bits() >> 4) & 0b0000_0011) as u32,
         set_active: set_fa_plus_bits,
         cursor: CursorInit::FirstActiveBit,
     }),
-    writeback: None,
+    toggle: super::super::choice::toggle_fa_plus_row,
 };
-const EARLY_DW_OPTIONS: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_early_dw_row,
+const EARLY_DW_OPTIONS: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
             let mut bits = super::super::state::EarlyDwMask::empty();
@@ -583,10 +573,9 @@ const EARLY_DW_OPTIONS: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    writeback: None,
+    toggle: super::super::choice::toggle_early_dw_row,
 };
-const RESULTS_EXTRAS: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_results_extras_row,
+const RESULTS_EXTRAS: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {
         from_profile: |p| {
             let mut bits = super::super::state::ResultsExtrasMask::empty();
@@ -609,7 +598,7 @@ const RESULTS_EXTRAS: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
-    writeback: None,
+    toggle: super::super::choice::toggle_results_extras_row,
 };
 
 const ACTION_ON_MISSED_TARGET: CustomBinding = CustomBinding {
@@ -1279,10 +1268,9 @@ mod bitmask_binding_init_tests {
     fn make_bitmask_row(id: RowId, name: LookupKey, choices: &[&str]) -> Row {
         Row {
             id,
-            behavior: RowBehavior::Bitmask(BitmaskBinding {
-                toggle: |_, _| {},
+            behavior: RowBehavior::Bitmask(BitmaskBinding::HandRolled {
                 init: None,
-                writeback: None,
+                toggle: |_, _| {},
             }),
             name,
             choices: choices.iter().map(ToString::to_string).collect(),
@@ -1401,10 +1389,9 @@ mod bitmask_binding_init_tests {
         row.selected_choice_index = [3, 4];
         let mut masks = PlayerOptionMasks::default();
         let profile = Profile::default();
-        let init_less = BitmaskBinding {
-            toggle: |_, _| {},
+        let init_less = BitmaskBinding::HandRolled {
             init: None,
-            writeback: None,
+            toggle: |_, _| {},
         };
         let applied = init_bitmask_row_from_binding(&mut row, &init_less, &profile, &mut masks, 0);
         assert!(!applied, "init-less binding must short-circuit");

--- a/src/screens/player_options/panes/main.rs
+++ b/src/screens/player_options/panes/main.rs
@@ -1,3 +1,4 @@
+use super::super::choice;
 use super::super::row::index_binding;
 use super::*;
 use crate::game::profile as gp;
@@ -172,7 +173,7 @@ fn apply_noteskin_delta(
     apply: fn(&mut State, usize, &str, bool, gp::PlayerSide),
 ) -> Outcome {
     let Some(new_index) =
-        super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
+        choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
     else {
         return Outcome::NONE;
     };
@@ -183,7 +184,7 @@ fn apply_noteskin_delta(
         .and_then(|r| r.choices.get(new_index))
         .cloned()
         .unwrap_or_default();
-    let (should_persist, side) = super::super::choice::persist_ctx(player_idx);
+    let (should_persist, side) = choice::persist_ctx(player_idx);
     apply(state, player_idx, &choice, should_persist, side);
     Outcome::persisted()
 }
@@ -350,7 +351,7 @@ const SPEED_MOD: CustomBinding = CustomBinding {
 const TYPE_OF_SPEED_MOD: CustomBinding = CustomBinding {
     apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
+            choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };
@@ -398,7 +399,7 @@ const TYPE_OF_SPEED_MOD: CustomBinding = CustomBinding {
 const MINI: CustomBinding = CustomBinding {
     apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
+            choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };
@@ -415,7 +416,7 @@ const MINI: CustomBinding = CustomBinding {
             return Outcome::persisted();
         };
         state.player_profiles[player_idx].mini_percent = val;
-        let (should_persist, side) = super::super::choice::persist_ctx(player_idx);
+        let (should_persist, side) = choice::persist_ctx(player_idx);
         if should_persist {
             gp::update_mini_percent_for_side(side, val);
         }
@@ -426,7 +427,7 @@ const MINI: CustomBinding = CustomBinding {
 const JUDGMENT_FONT: CustomBinding = CustomBinding {
     apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
+            choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };
@@ -435,7 +436,7 @@ const JUDGMENT_FONT: CustomBinding = CustomBinding {
             .map(|choice| gp::JudgmentGraphic::new(&choice.key))
             .unwrap_or_default();
         state.player_profiles[player_idx].judgment_graphic = setting;
-        let (should_persist, side) = super::super::choice::persist_ctx(player_idx);
+        let (should_persist, side) = choice::persist_ctx(player_idx);
         if should_persist {
             gp::update_judgment_graphic_for_side(
                 side,
@@ -449,7 +450,7 @@ const JUDGMENT_FONT: CustomBinding = CustomBinding {
 const HOLD_JUDGMENT: CustomBinding = CustomBinding {
     apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
+            choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };
@@ -458,7 +459,7 @@ const HOLD_JUDGMENT: CustomBinding = CustomBinding {
             .map(|choice| gp::HoldJudgmentGraphic::new(&choice.key))
             .unwrap_or_default();
         state.player_profiles[player_idx].hold_judgment_graphic = setting;
-        let (should_persist, side) = super::super::choice::persist_ctx(player_idx);
+        let (should_persist, side) = choice::persist_ctx(player_idx);
         if should_persist {
             gp::update_hold_judgment_graphic_for_side(
                 side,
@@ -474,7 +475,7 @@ const HOLD_JUDGMENT: CustomBinding = CustomBinding {
 const STEPCHART: CustomBinding = CustomBinding {
     apply: |state, player_idx, row_id, delta, wrap| {
         let Some(new_index) =
-            super::super::choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
+            choice::cycle_choice_index(state, player_idx, row_id, delta, wrap)
         else {
             return Outcome::NONE;
         };

--- a/src/screens/player_options/panes/mod.rs
+++ b/src/screens/player_options/panes/mod.rs
@@ -288,7 +288,7 @@ fn init_opted_in_bitmask_rows(
         let RowBehavior::Bitmask(binding) = row.behavior else {
             continue;
         };
-        if binding.init.is_none() {
+        if binding.init().is_none() {
             continue;
         }
         let row = row_map.get_mut(id).expect("row was just observed");

--- a/src/screens/player_options/panes/uncommon.rs
+++ b/src/screens/player_options/panes/uncommon.rs
@@ -1,5 +1,5 @@
 use super::super::row::index_binding;
-use super::super::row::{BitmaskInit, BitmaskWriteback, CursorInit};
+use super::super::row::{BitMapping, BitmaskInit, BitmaskWriteback, CursorInit};
 use super::*;
 use crate::game::profile as gp;
 use crate::game::profile::{
@@ -21,32 +21,8 @@ const HIDE_LIGHT_TYPE: ChoiceBinding<usize> = index_binding!(
     false
 );
 
-/// Bit selector used by every uncommon-pane mask row except `Insert`: pick
-/// the bit at `choice_index` if it fits in the row's choice list, capped at
-/// `u8::BITS` to mirror the legacy `toggle_*_row` widths.
-#[inline]
-fn bit_choices_min_u8(choice_index: usize, row: &Row) -> Option<u32> {
-    let width = row.choices.len().min(u8::BITS as usize);
-    if choice_index < width {
-        Some(1u32 << choice_index)
-    } else {
-        None
-    }
-}
-
-/// Fixed-width bit selector. `Insert` clamps to 7, `Effect` to 10, etc.
-#[inline]
-fn bit_fixed<const N: usize>(choice_index: usize, _row: &Row) -> Option<u32> {
-    if choice_index < N {
-        Some(1u32 << choice_index)
-    } else {
-        None
-    }
-}
-
-const INSERT: BitmaskBinding = BitmaskBinding {
-    toggle: |_, _| {},
-    init: Some(BitmaskInit {
+const INSERT: BitmaskBinding = BitmaskBinding::Generic {
+    init: BitmaskInit {
         from_profile: |p| p.insert_active_mask.bits() as u32,
         get_active: |m| m.insert.bits() as u32,
         set_active: |m, b| {
@@ -58,20 +34,19 @@ const INSERT: BitmaskBinding = BitmaskBinding {
             m.insert = InsertMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::FirstActiveBit,
-    }),
-    writeback: Some(BitmaskWriteback {
+    },
+    writeback: BitmaskWriteback {
         project_to_profile: |p, b| {
             p.insert_active_mask = InsertMask::from_bits_truncate(b as u8);
         },
         persist_for_side: |s, b| {
             gp::update_insert_mask_for_side(s, InsertMask::from_bits_truncate(b as u8));
         },
-        bit_for_choice: bit_fixed::<7>,
-    }),
+        bit_mapping: BitMapping::Sequential { width: 7 },
+    },
 };
-const REMOVE: BitmaskBinding = BitmaskBinding {
-    toggle: |_, _| {},
-    init: Some(BitmaskInit {
+const REMOVE: BitmaskBinding = BitmaskBinding::Generic {
+    init: BitmaskInit {
         from_profile: |p| p.remove_active_mask.bits() as u32,
         get_active: |m| m.remove.bits() as u32,
         set_active: |m, b| {
@@ -83,20 +58,19 @@ const REMOVE: BitmaskBinding = BitmaskBinding {
             m.remove = RemoveMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::FirstActiveBit,
-    }),
-    writeback: Some(BitmaskWriteback {
+    },
+    writeback: BitmaskWriteback {
         project_to_profile: |p, b| {
             p.remove_active_mask = RemoveMask::from_bits_truncate(b as u8);
         },
         persist_for_side: |s, b| {
             gp::update_remove_mask_for_side(s, RemoveMask::from_bits_truncate(b as u8));
         },
-        bit_for_choice: bit_fixed::<8>,
-    }),
+        bit_mapping: BitMapping::Sequential { width: 8 },
+    },
 };
-const HOLDS: BitmaskBinding = BitmaskBinding {
-    toggle: |_, _| {},
-    init: Some(BitmaskInit {
+const HOLDS: BitmaskBinding = BitmaskBinding::Generic {
+    init: BitmaskInit {
         from_profile: |p| p.holds_active_mask.bits() as u32,
         get_active: |m| m.holds.bits() as u32,
         set_active: |m, b| {
@@ -108,20 +82,19 @@ const HOLDS: BitmaskBinding = BitmaskBinding {
             m.holds = HoldsMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::FirstActiveBit,
-    }),
-    writeback: Some(BitmaskWriteback {
+    },
+    writeback: BitmaskWriteback {
         project_to_profile: |p, b| {
             p.holds_active_mask = HoldsMask::from_bits_truncate(b as u8);
         },
         persist_for_side: |s, b| {
             gp::update_holds_mask_for_side(s, HoldsMask::from_bits_truncate(b as u8));
         },
-        bit_for_choice: bit_choices_min_u8,
-    }),
+        bit_mapping: BitMapping::Sequential { width: 5 },
+    },
 };
-const ACCEL: BitmaskBinding = BitmaskBinding {
-    toggle: |_, _| {},
-    init: Some(BitmaskInit {
+const ACCEL: BitmaskBinding = BitmaskBinding::Generic {
+    init: BitmaskInit {
         from_profile: |p| p.accel_effects_active_mask.bits() as u32,
         get_active: |m| m.accel_effects.bits() as u32,
         set_active: |m, b| {
@@ -133,8 +106,8 @@ const ACCEL: BitmaskBinding = BitmaskBinding {
             m.accel_effects = AccelEffectsMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::FirstActiveBit,
-    }),
-    writeback: Some(BitmaskWriteback {
+    },
+    writeback: BitmaskWriteback {
         project_to_profile: |p, b| {
             p.accel_effects_active_mask = AccelEffectsMask::from_bits_truncate(b as u8);
         },
@@ -144,12 +117,11 @@ const ACCEL: BitmaskBinding = BitmaskBinding {
                 AccelEffectsMask::from_bits_truncate(b as u8),
             );
         },
-        bit_for_choice: bit_choices_min_u8,
-    }),
+        bit_mapping: BitMapping::Sequential { width: 5 },
+    },
 };
-const EFFECT: BitmaskBinding = BitmaskBinding {
-    toggle: |_, _| {},
-    init: Some(BitmaskInit {
+const EFFECT: BitmaskBinding = BitmaskBinding::Generic {
+    init: BitmaskInit {
         from_profile: |p| p.visual_effects_active_mask.bits() as u32,
         get_active: |m| m.visual_effects.bits() as u32,
         set_active: |m, b| {
@@ -161,8 +133,8 @@ const EFFECT: BitmaskBinding = BitmaskBinding {
             m.visual_effects = VisualEffectsMask::from_bits_retain(b as u16);
         },
         cursor: CursorInit::FirstActiveBit,
-    }),
-    writeback: Some(BitmaskWriteback {
+    },
+    writeback: BitmaskWriteback {
         project_to_profile: |p, b| {
             p.visual_effects_active_mask = VisualEffectsMask::from_bits_truncate(b as u16);
         },
@@ -172,12 +144,11 @@ const EFFECT: BitmaskBinding = BitmaskBinding {
                 VisualEffectsMask::from_bits_truncate(b as u16),
             );
         },
-        bit_for_choice: bit_fixed::<10>,
-    }),
+        bit_mapping: BitMapping::Sequential { width: 10 },
+    },
 };
-const APPEARANCE: BitmaskBinding = BitmaskBinding {
-    toggle: |_, _| {},
-    init: Some(BitmaskInit {
+const APPEARANCE: BitmaskBinding = BitmaskBinding::Generic {
+    init: BitmaskInit {
         from_profile: |p| p.appearance_effects_active_mask.bits() as u32,
         get_active: |m| m.appearance_effects.bits() as u32,
         set_active: |m, b| {
@@ -189,8 +160,8 @@ const APPEARANCE: BitmaskBinding = BitmaskBinding {
             m.appearance_effects = AppearanceEffectsMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::FirstActiveBit,
-    }),
-    writeback: Some(BitmaskWriteback {
+    },
+    writeback: BitmaskWriteback {
         project_to_profile: |p, b| {
             p.appearance_effects_active_mask = AppearanceEffectsMask::from_bits_truncate(b as u8);
         },
@@ -200,8 +171,8 @@ const APPEARANCE: BitmaskBinding = BitmaskBinding {
                 AppearanceEffectsMask::from_bits_truncate(b as u8),
             );
         },
-        bit_for_choice: bit_choices_min_u8,
-    }),
+        bit_mapping: BitMapping::Sequential { width: 5 },
+    },
 };
 
 pub(super) fn build_uncommon_rows(return_screen: Screen) -> RowMap {

--- a/src/screens/player_options/panes/uncommon.rs
+++ b/src/screens/player_options/panes/uncommon.rs
@@ -1,5 +1,5 @@
 use super::super::row::index_binding;
-use super::super::row::{BitmaskInit, CursorInit};
+use super::super::row::{BitmaskInit, BitmaskWriteback, CursorInit};
 use super::*;
 use crate::game::profile as gp;
 use crate::game::profile::{
@@ -21,8 +21,31 @@ const HIDE_LIGHT_TYPE: ChoiceBinding<usize> = index_binding!(
     false
 );
 
+/// Bit selector used by every uncommon-pane mask row except `Insert`: pick
+/// the bit at `choice_index` if it fits in the row's choice list, capped at
+/// `u8::BITS` to mirror the legacy `toggle_*_row` widths.
+#[inline]
+fn bit_choices_min_u8(choice_index: usize, row: &Row) -> Option<u32> {
+    let width = row.choices.len().min(u8::BITS as usize);
+    if choice_index < width {
+        Some(1u32 << choice_index)
+    } else {
+        None
+    }
+}
+
+/// Fixed-width bit selector. `Insert` clamps to 7, `Effect` to 10, etc.
+#[inline]
+fn bit_fixed<const N: usize>(choice_index: usize, _row: &Row) -> Option<u32> {
+    if choice_index < N {
+        Some(1u32 << choice_index)
+    } else {
+        None
+    }
+}
+
 const INSERT: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_insert_row,
+    toggle: |_, _| {},
     init: Some(BitmaskInit {
         from_profile: |p| p.insert_active_mask.bits() as u32,
         get_active: |m| m.insert.bits() as u32,
@@ -36,9 +59,18 @@ const INSERT: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
+    writeback: Some(BitmaskWriteback {
+        project_to_profile: |p, b| {
+            p.insert_active_mask = InsertMask::from_bits_truncate(b as u8);
+        },
+        persist_for_side: |s, b| {
+            gp::update_insert_mask_for_side(s, InsertMask::from_bits_truncate(b as u8));
+        },
+        bit_for_choice: bit_fixed::<7>,
+    }),
 };
 const REMOVE: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_remove_row,
+    toggle: |_, _| {},
     init: Some(BitmaskInit {
         from_profile: |p| p.remove_active_mask.bits() as u32,
         get_active: |m| m.remove.bits() as u32,
@@ -52,9 +84,18 @@ const REMOVE: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
+    writeback: Some(BitmaskWriteback {
+        project_to_profile: |p, b| {
+            p.remove_active_mask = RemoveMask::from_bits_truncate(b as u8);
+        },
+        persist_for_side: |s, b| {
+            gp::update_remove_mask_for_side(s, RemoveMask::from_bits_truncate(b as u8));
+        },
+        bit_for_choice: bit_fixed::<8>,
+    }),
 };
 const HOLDS: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_holds_row,
+    toggle: |_, _| {},
     init: Some(BitmaskInit {
         from_profile: |p| p.holds_active_mask.bits() as u32,
         get_active: |m| m.holds.bits() as u32,
@@ -68,9 +109,18 @@ const HOLDS: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
+    writeback: Some(BitmaskWriteback {
+        project_to_profile: |p, b| {
+            p.holds_active_mask = HoldsMask::from_bits_truncate(b as u8);
+        },
+        persist_for_side: |s, b| {
+            gp::update_holds_mask_for_side(s, HoldsMask::from_bits_truncate(b as u8));
+        },
+        bit_for_choice: bit_choices_min_u8,
+    }),
 };
 const ACCEL: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_accel_effects_row,
+    toggle: |_, _| {},
     init: Some(BitmaskInit {
         from_profile: |p| p.accel_effects_active_mask.bits() as u32,
         get_active: |m| m.accel_effects.bits() as u32,
@@ -84,9 +134,21 @@ const ACCEL: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
+    writeback: Some(BitmaskWriteback {
+        project_to_profile: |p, b| {
+            p.accel_effects_active_mask = AccelEffectsMask::from_bits_truncate(b as u8);
+        },
+        persist_for_side: |s, b| {
+            gp::update_accel_effects_mask_for_side(
+                s,
+                AccelEffectsMask::from_bits_truncate(b as u8),
+            );
+        },
+        bit_for_choice: bit_choices_min_u8,
+    }),
 };
 const EFFECT: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_visual_effects_row,
+    toggle: |_, _| {},
     init: Some(BitmaskInit {
         from_profile: |p| p.visual_effects_active_mask.bits() as u32,
         get_active: |m| m.visual_effects.bits() as u32,
@@ -100,9 +162,21 @@ const EFFECT: BitmaskBinding = BitmaskBinding {
         },
         cursor: CursorInit::FirstActiveBit,
     }),
+    writeback: Some(BitmaskWriteback {
+        project_to_profile: |p, b| {
+            p.visual_effects_active_mask = VisualEffectsMask::from_bits_truncate(b as u16);
+        },
+        persist_for_side: |s, b| {
+            gp::update_visual_effects_mask_for_side(
+                s,
+                VisualEffectsMask::from_bits_truncate(b as u16),
+            );
+        },
+        bit_for_choice: bit_fixed::<10>,
+    }),
 };
 const APPEARANCE: BitmaskBinding = BitmaskBinding {
-    toggle: super::super::choice::toggle_appearance_effects_row,
+    toggle: |_, _| {},
     init: Some(BitmaskInit {
         from_profile: |p| p.appearance_effects_active_mask.bits() as u32,
         get_active: |m| m.appearance_effects.bits() as u32,
@@ -115,6 +189,18 @@ const APPEARANCE: BitmaskBinding = BitmaskBinding {
             m.appearance_effects = AppearanceEffectsMask::from_bits_retain(b as u8);
         },
         cursor: CursorInit::FirstActiveBit,
+    }),
+    writeback: Some(BitmaskWriteback {
+        project_to_profile: |p, b| {
+            p.appearance_effects_active_mask = AppearanceEffectsMask::from_bits_truncate(b as u8);
+        },
+        persist_for_side: |s, b| {
+            gp::update_appearance_effects_mask_for_side(
+                s,
+                AppearanceEffectsMask::from_bits_truncate(b as u8),
+            );
+        },
+        bit_for_choice: bit_choices_min_u8,
     }),
 };
 

--- a/src/screens/player_options/panes/uncommon.rs
+++ b/src/screens/player_options/panes/uncommon.rs
@@ -1,5 +1,4 @@
-use super::super::row::index_binding;
-use super::super::row::{BitMapping, BitmaskInit, BitmaskWriteback, CursorInit};
+use super::super::row::{index_binding, simple_bitmask_binding};
 use super::*;
 use crate::game::profile as gp;
 use crate::game::profile::{
@@ -21,159 +20,54 @@ const HIDE_LIGHT_TYPE: ChoiceBinding<usize> = index_binding!(
     false
 );
 
-const INSERT: BitmaskBinding = BitmaskBinding::Generic {
-    init: BitmaskInit {
-        from_profile: |p| p.insert_active_mask.bits() as u32,
-        get_active: |m| m.insert.bits() as u32,
-        set_active: |m, b| {
-            debug_assert_eq!(
-                b & !(u8::MAX as u32),
-                0,
-                "InsertMask init bits exceed u8 width"
-            );
-            m.insert = InsertMask::from_bits_retain(b as u8);
-        },
-        cursor: CursorInit::FirstActiveBit,
-    },
-    writeback: BitmaskWriteback {
-        project_to_profile: |p, b| {
-            p.insert_active_mask = InsertMask::from_bits_truncate(b as u8);
-        },
-        persist_for_side: |s, b| {
-            gp::update_insert_mask_for_side(s, InsertMask::from_bits_truncate(b as u8));
-        },
-        bit_mapping: BitMapping::Sequential { width: 7 },
-    },
-};
-const REMOVE: BitmaskBinding = BitmaskBinding::Generic {
-    init: BitmaskInit {
-        from_profile: |p| p.remove_active_mask.bits() as u32,
-        get_active: |m| m.remove.bits() as u32,
-        set_active: |m, b| {
-            debug_assert_eq!(
-                b & !(u8::MAX as u32),
-                0,
-                "RemoveMask init bits exceed u8 width"
-            );
-            m.remove = RemoveMask::from_bits_retain(b as u8);
-        },
-        cursor: CursorInit::FirstActiveBit,
-    },
-    writeback: BitmaskWriteback {
-        project_to_profile: |p, b| {
-            p.remove_active_mask = RemoveMask::from_bits_truncate(b as u8);
-        },
-        persist_for_side: |s, b| {
-            gp::update_remove_mask_for_side(s, RemoveMask::from_bits_truncate(b as u8));
-        },
-        bit_mapping: BitMapping::Sequential { width: 8 },
-    },
-};
-const HOLDS: BitmaskBinding = BitmaskBinding::Generic {
-    init: BitmaskInit {
-        from_profile: |p| p.holds_active_mask.bits() as u32,
-        get_active: |m| m.holds.bits() as u32,
-        set_active: |m, b| {
-            debug_assert_eq!(
-                b & !(u8::MAX as u32),
-                0,
-                "HoldsMask init bits exceed u8 width"
-            );
-            m.holds = HoldsMask::from_bits_retain(b as u8);
-        },
-        cursor: CursorInit::FirstActiveBit,
-    },
-    writeback: BitmaskWriteback {
-        project_to_profile: |p, b| {
-            p.holds_active_mask = HoldsMask::from_bits_truncate(b as u8);
-        },
-        persist_for_side: |s, b| {
-            gp::update_holds_mask_for_side(s, HoldsMask::from_bits_truncate(b as u8));
-        },
-        bit_mapping: BitMapping::Sequential { width: 5 },
-    },
-};
-const ACCEL: BitmaskBinding = BitmaskBinding::Generic {
-    init: BitmaskInit {
-        from_profile: |p| p.accel_effects_active_mask.bits() as u32,
-        get_active: |m| m.accel_effects.bits() as u32,
-        set_active: |m, b| {
-            debug_assert_eq!(
-                b & !(u8::MAX as u32),
-                0,
-                "AccelEffectsMask init bits exceed u8 width",
-            );
-            m.accel_effects = AccelEffectsMask::from_bits_retain(b as u8);
-        },
-        cursor: CursorInit::FirstActiveBit,
-    },
-    writeback: BitmaskWriteback {
-        project_to_profile: |p, b| {
-            p.accel_effects_active_mask = AccelEffectsMask::from_bits_truncate(b as u8);
-        },
-        persist_for_side: |s, b| {
-            gp::update_accel_effects_mask_for_side(
-                s,
-                AccelEffectsMask::from_bits_truncate(b as u8),
-            );
-        },
-        bit_mapping: BitMapping::Sequential { width: 5 },
-    },
-};
-const EFFECT: BitmaskBinding = BitmaskBinding::Generic {
-    init: BitmaskInit {
-        from_profile: |p| p.visual_effects_active_mask.bits() as u32,
-        get_active: |m| m.visual_effects.bits() as u32,
-        set_active: |m, b| {
-            debug_assert_eq!(
-                b & !(u16::MAX as u32),
-                0,
-                "VisualEffectsMask init bits exceed u16 width",
-            );
-            m.visual_effects = VisualEffectsMask::from_bits_retain(b as u16);
-        },
-        cursor: CursorInit::FirstActiveBit,
-    },
-    writeback: BitmaskWriteback {
-        project_to_profile: |p, b| {
-            p.visual_effects_active_mask = VisualEffectsMask::from_bits_truncate(b as u16);
-        },
-        persist_for_side: |s, b| {
-            gp::update_visual_effects_mask_for_side(
-                s,
-                VisualEffectsMask::from_bits_truncate(b as u16),
-            );
-        },
-        bit_mapping: BitMapping::Sequential { width: 10 },
-    },
-};
-const APPEARANCE: BitmaskBinding = BitmaskBinding::Generic {
-    init: BitmaskInit {
-        from_profile: |p| p.appearance_effects_active_mask.bits() as u32,
-        get_active: |m| m.appearance_effects.bits() as u32,
-        set_active: |m, b| {
-            debug_assert_eq!(
-                b & !(u8::MAX as u32),
-                0,
-                "AppearanceEffectsMask init bits exceed u8 width",
-            );
-            m.appearance_effects = AppearanceEffectsMask::from_bits_retain(b as u8);
-        },
-        cursor: CursorInit::FirstActiveBit,
-    },
-    writeback: BitmaskWriteback {
-        project_to_profile: |p, b| {
-            p.appearance_effects_active_mask = AppearanceEffectsMask::from_bits_truncate(b as u8);
-        },
-        persist_for_side: |s, b| {
-            gp::update_appearance_effects_mask_for_side(
-                s,
-                AppearanceEffectsMask::from_bits_truncate(b as u8),
-            );
-        },
-        bit_mapping: BitMapping::Sequential { width: 5 },
-    },
-};
+const INSERT: BitmaskBinding = simple_bitmask_binding!(
+    mask = InsertMask,
+    bits = u8,
+    state_field = insert,
+    profile_field = insert_active_mask,
+    persist = gp::update_insert_mask_for_side,
+    width = 7,
+);
+const REMOVE: BitmaskBinding = simple_bitmask_binding!(
+    mask = RemoveMask,
+    bits = u8,
+    state_field = remove,
+    profile_field = remove_active_mask,
+    persist = gp::update_remove_mask_for_side,
+    width = 8,
+);
+const HOLDS: BitmaskBinding = simple_bitmask_binding!(
+    mask = HoldsMask,
+    bits = u8,
+    state_field = holds,
+    profile_field = holds_active_mask,
+    persist = gp::update_holds_mask_for_side,
+    width = 5,
+);
+const ACCEL: BitmaskBinding = simple_bitmask_binding!(
+    mask = AccelEffectsMask,
+    bits = u8,
+    state_field = accel_effects,
+    profile_field = accel_effects_active_mask,
+    persist = gp::update_accel_effects_mask_for_side,
+    width = 5,
+);
+const EFFECT: BitmaskBinding = simple_bitmask_binding!(
+    mask = VisualEffectsMask,
+    bits = u16,
+    state_field = visual_effects,
+    profile_field = visual_effects_active_mask,
+    persist = gp::update_visual_effects_mask_for_side,
+    width = 10,
+);
+const APPEARANCE: BitmaskBinding = simple_bitmask_binding!(
+    mask = AppearanceEffectsMask,
+    bits = u8,
+    state_field = appearance_effects,
+    profile_field = appearance_effects_active_mask,
+    persist = gp::update_appearance_effects_mask_for_side,
+    width = 5,
+);
 
 pub(super) fn build_uncommon_rows(return_screen: Screen) -> RowMap {
     let mut b = RowBuilder::new();

--- a/src/screens/player_options/row.rs
+++ b/src/screens/player_options/row.rs
@@ -510,6 +510,76 @@ macro_rules! index_binding {
 
 pub(crate) use index_binding;
 
+/// Build a `BitmaskBinding::Generic` for the common case of a mask row that:
+///
+/// - Reads/writes a single `bitflags!` mask field on `Profile` (`profile_field`).
+/// - Reads/writes the matching field on `PlayerOptionMasks` (`state_field`).
+/// - Persists via a `(PlayerSide, MaskType) -> ()` updater (`persist`).
+/// - Exposes choices `0..width` mapped 1:1 to bits `0..width`
+///   (`BitMapping::Sequential { width }`).
+/// - Initializes its cursor at the first active bit.
+///
+/// The macro expands to a `BitmaskBinding::Generic { init, writeback }` const
+/// expression, suitable for `const FOO: BitmaskBinding = ...`. The bit width
+/// appears literally at the call site, so "what is the bitmapping for this
+/// row?" is answered by reading one declaration.
+///
+/// For rows that need fan-out, derived state, visibility sync, or a non-FAB
+/// cursor (e.g. `FAPlusOptions` with `CursorInit::Fixed(0)`), construct the
+/// binding by hand instead of using this macro.
+///
+/// # Example
+///
+/// ```ignore
+/// const INSERT: BitmaskBinding = simple_bitmask_binding!(
+///     mask = InsertMask,
+///     bits = u8,
+///     state_field = insert,
+///     profile_field = insert_active_mask,
+///     persist = gp::update_insert_mask_for_side,
+///     width = 7,
+/// );
+/// ```
+macro_rules! simple_bitmask_binding {
+    (
+        mask = $mask_ty:ty,
+        bits = $bits_ty:ty,
+        state_field = $state_field:ident,
+        profile_field = $profile_field:ident,
+        persist = $persist:path,
+        width = $width:expr $(,)?
+    ) => {
+        $crate::screens::player_options::row::BitmaskBinding::Generic {
+            init: $crate::screens::player_options::row::BitmaskInit {
+                from_profile: |p| p.$profile_field.bits() as u32,
+                get_active: |m| m.$state_field.bits() as u32,
+                set_active: |m, b| {
+                    debug_assert_eq!(
+                        b & !(<$bits_ty>::MAX as u32),
+                        0,
+                        concat!(stringify!($mask_ty), " init bits exceed storage width"),
+                    );
+                    m.$state_field = <$mask_ty>::from_bits_retain(b as $bits_ty);
+                },
+                cursor: $crate::screens::player_options::row::CursorInit::FirstActiveBit,
+            },
+            writeback: $crate::screens::player_options::row::BitmaskWriteback {
+                project_to_profile: |p, b| {
+                    p.$profile_field = <$mask_ty>::from_bits_truncate(b as $bits_ty);
+                },
+                persist_for_side: |s, b| {
+                    $persist(s, <$mask_ty>::from_bits_truncate(b as $bits_ty));
+                },
+                bit_mapping: $crate::screens::player_options::row::BitMapping::Sequential {
+                    width: $width,
+                },
+            },
+        }
+    };
+}
+
+pub(crate) use simple_bitmask_binding;
+
 // ============================== RowMap =================================
 
 pub struct RowMap {

--- a/src/screens/player_options/row.rs
+++ b/src/screens/player_options/row.rs
@@ -178,15 +178,54 @@ pub struct ChoiceBinding<T: Copy + 'static> {
 ///      preserved, matching legacy direct-assignment semantics).
 ///    - `cursor: CursorInit::FirstActiveBit` for normal rows, or
 ///      `CursorInit::Fixed(0)` for pinned-cursor rows like FA+ Options.
-/// 4. Write the matching `toggle_my_row` helper in `choice.rs`.
+/// 4. Either:
+///    - Add a `writeback: Some(BitmaskWriteback { ... })` so the generic
+///      `toggle_bitmask_row_generic` in `choice.rs` handles input. This
+///      is the preferred path for "clean" rows that just project a single
+///      mask field onto the profile and persist for one side. Set
+///      `toggle: |_, _| {}` (a noop); it is unused when `writeback` is
+///      `Some`.
+///    - Or write a hand-rolled `toggle_my_row` helper in `choice.rs` and
+///      point `toggle` at it (used for rows that fan out to multiple
+///      profile fields, recompute derived values, or call
+///      `sync_selected_rows_with_visibility`).
 #[derive(Clone, Copy, Debug)]
 pub struct BitmaskBinding {
+    /// Hand-rolled toggle. Called by `dispatch_behavior_toggle` only when
+    /// `writeback` is `None`. For `writeback`-driven bindings, set this to
+    /// `|_, _| {}`.
     pub toggle: fn(&mut State, usize),
     /// Opt-in init contract. When `Some`, a row's initial mask bits and
     /// cursor position are derived directly from a `Profile` via the
     /// helpers in `BitmaskInit`. Every production binding currently opts
     /// in; `None` is reserved for synthetic bindings used in tests.
     pub init: Option<BitmaskInit>,
+    /// Opt-in declarative toggle contract. When `Some`, the input
+    /// dispatcher routes the focused row's toggle through
+    /// `toggle_bitmask_row_generic`, which uses `init.get_active`/
+    /// `init.set_active` to flip a bit and then calls these callbacks to
+    /// project the new bits onto the in-memory profile and (conditionally)
+    /// persist them for the given side. `init` must also be `Some` for
+    /// `writeback` to take effect.
+    pub writeback: Option<BitmaskWriteback>,
+}
+
+/// Declarative writeback contract for a `BitmaskBinding`. Together with
+/// `BitmaskInit`, this lets the generic toggle fully replace a hand-rolled
+/// `toggle_*_row` for "clean" bitmask rows that have no fan-out and no
+/// visibility-sync side effects.
+#[derive(Clone, Copy, Debug)]
+pub struct BitmaskWriteback {
+    /// Project the row's bits onto the in-memory profile. Implementations
+    /// typically reconstruct the typed mask via `from_bits_truncate`.
+    pub project_to_profile: fn(&mut Profile, u32),
+    /// Persist the row's bits for the given side. Called only when
+    /// `persist_ctx` says the active player_idx should write through.
+    pub persist_for_side: fn(PlayerSide, u32),
+    /// Map the focused row's selected choice index to the bit to toggle,
+    /// or `None` if the index is out of the row's bit width. Returning a
+    /// nonzero `Some(bit)` causes a toggle; `None` or `Some(0)` is a noop.
+    pub bit_for_choice: fn(usize, &Row) -> Option<u32>,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/screens/player_options/row.rs
+++ b/src/screens/player_options/row.rs
@@ -169,8 +169,24 @@ pub struct ChoiceBinding<T: Copy + 'static> {
 ///    and a field on `PlayerOptionMasks`.
 /// 2. Build the row in the appropriate pane's `build_*_rows` (or its row
 ///    catalogue) with `behavior: RowBehavior::Bitmask(MY_BINDING)`.
-/// 3. Declare `const MY_BINDING: BitmaskBinding` in that pane's module
-///    (e.g. `panes/advanced.rs`) with `init: Some(BitmaskInit { ... })`:
+/// 3. Declare `const MY_BINDING: BitmaskBinding` in that pane's module.
+///    Pick one of two variants:
+///
+///    a. `BitmaskBinding::Generic { init, writeback }` — preferred for
+///    "clean" rows that project a single mask field onto the profile
+///    and persist for one side with no fan-out, no derived recomputes,
+///    and no visibility sync. The generic `toggle_bitmask_row_generic`
+///    in `choice.rs` drives input; `writeback.bit_mapping` declares
+///    how choice indices map to bits.
+///
+///    b. `BitmaskBinding::HandRolled { init, toggle }` — for rows whose
+///    toggle fans out to multiple profile fields, recomputes derived
+///    state, or calls `sync_selected_rows_with_visibility`. `toggle`
+///    is a hand-rolled `toggle_*_row` fn in `choice.rs`. `init` is
+///    optional; production bindings always supply it, and `None` is
+///    reserved for synthetic bindings in tests.
+///
+/// 4. `BitmaskInit` shape:
 ///    - `from_profile` reads the relevant profile fields and emits
 ///      `mask.bits() as u32`.
 ///    - `set_active` uses `from_bits_retain` plus a `debug_assert_eq!`
@@ -178,42 +194,42 @@ pub struct ChoiceBinding<T: Copy + 'static> {
 ///      preserved, matching legacy direct-assignment semantics).
 ///    - `cursor: CursorInit::FirstActiveBit` for normal rows, or
 ///      `CursorInit::Fixed(0)` for pinned-cursor rows like FA+ Options.
-/// 4. Either:
-///    - Add a `writeback: Some(BitmaskWriteback { ... })` so the generic
-///      `toggle_bitmask_row_generic` in `choice.rs` handles input. This
-///      is the preferred path for "clean" rows that just project a single
-///      mask field onto the profile and persist for one side. Set
-///      `toggle: |_, _| {}` (a noop); it is unused when `writeback` is
-///      `Some`.
-///    - Or write a hand-rolled `toggle_my_row` helper in `choice.rs` and
-///      point `toggle` at it (used for rows that fan out to multiple
-///      profile fields, recompute derived values, or call
-///      `sync_selected_rows_with_visibility`).
 #[derive(Clone, Copy, Debug)]
-pub struct BitmaskBinding {
-    /// Hand-rolled toggle. Called by `dispatch_behavior_toggle` only when
-    /// `writeback` is `None`. For `writeback`-driven bindings, set this to
-    /// `|_, _| {}`.
-    pub toggle: fn(&mut State, usize),
-    /// Opt-in init contract. When `Some`, a row's initial mask bits and
-    /// cursor position are derived directly from a `Profile` via the
-    /// helpers in `BitmaskInit`. Every production binding currently opts
-    /// in; `None` is reserved for synthetic bindings used in tests.
-    pub init: Option<BitmaskInit>,
-    /// Opt-in declarative toggle contract. When `Some`, the input
-    /// dispatcher routes the focused row's toggle through
-    /// `toggle_bitmask_row_generic`, which uses `init.get_active`/
-    /// `init.set_active` to flip a bit and then calls these callbacks to
-    /// project the new bits onto the in-memory profile and (conditionally)
-    /// persist them for the given side. `init` must also be `Some` for
-    /// `writeback` to take effect.
-    pub writeback: Option<BitmaskWriteback>,
+pub enum BitmaskBinding {
+    /// Generic, fully-declarative bitmask binding. The generic toggle
+    /// dispatcher uses `init` + `writeback` to flip a bit and persist it
+    /// without any per-row code. `Row::bitmask` debug-asserts that
+    /// `choices.len() == writeback.bit_mapping.required_choices()`.
+    Generic {
+        init: BitmaskInit,
+        writeback: BitmaskWriteback,
+    },
+    /// Hand-rolled bitmask binding. The dispatcher invokes `toggle`
+    /// directly. `init` is optional but expected for production rows so
+    /// that `init_bitmask_row_from_binding` can derive the initial cursor
+    /// and mask bits from the player's profile.
+    HandRolled {
+        init: Option<BitmaskInit>,
+        toggle: fn(&mut State, usize),
+    },
 }
 
-/// Declarative writeback contract for a `BitmaskBinding`. Together with
-/// `BitmaskInit`, this lets the generic toggle fully replace a hand-rolled
-/// `toggle_*_row` for "clean" bitmask rows that have no fan-out and no
-/// visibility-sync side effects.
+impl BitmaskBinding {
+    /// Borrow the optional `BitmaskInit`, regardless of variant.
+    /// `Generic` always has init; `HandRolled` may or may not.
+    #[inline]
+    pub fn init(&self) -> Option<&BitmaskInit> {
+        match self {
+            BitmaskBinding::Generic { init, .. } => Some(init),
+            BitmaskBinding::HandRolled { init, .. } => init.as_ref(),
+        }
+    }
+}
+
+/// Declarative writeback contract for a `BitmaskBinding::Generic`.
+/// Together with `BitmaskInit`, this lets the generic toggle fully replace
+/// a hand-rolled `toggle_*_row` for "clean" bitmask rows that have no
+/// fan-out and no visibility-sync side effects.
 #[derive(Clone, Copy, Debug)]
 pub struct BitmaskWriteback {
     /// Project the row's bits onto the in-memory profile. Implementations
@@ -222,10 +238,72 @@ pub struct BitmaskWriteback {
     /// Persist the row's bits for the given side. Called only when
     /// `persist_ctx` says the active player_idx should write through.
     pub persist_for_side: fn(PlayerSide, u32),
-    /// Map the focused row's selected choice index to the bit to toggle,
-    /// or `None` if the index is out of the row's bit width. Returning a
-    /// nonzero `Some(bit)` causes a toggle; `None` or `Some(0)` is a noop.
-    pub bit_for_choice: fn(usize, &Row) -> Option<u32>,
+    /// Declarative choice-index-to-bit mapping. The generic toggle
+    /// resolves the focused row's selected choice index through this
+    /// mapping; out-of-range indices yield `None` and produce a no-op.
+    pub bit_mapping: BitMapping,
+}
+
+/// Declarative mapping from a row's choice index to the bit to toggle.
+///
+/// Replaces an earlier `fn(usize, &Row) -> Option<u32>` callback so the
+/// bit width of a row is visible at the binding declaration site rather
+/// than hidden behind code. `Row::bitmask` debug-asserts that the row's
+/// `choices.len()` matches the mapping's `required_choices()`.
+#[derive(Clone, Copy, Debug)]
+pub enum BitMapping {
+    /// `choice_index i` maps to `1 << i` for `i < width`. Use for rows
+    /// where each choice corresponds to bit `i` of the mask.
+    Sequential { width: u8 },
+    /// `choice_index i` maps to `1 << (offset + i)` for `i < width`. Use
+    /// for child rows that share a mask with a parent and expose a
+    /// contiguous sub-range of bits.
+    #[allow(dead_code)]
+    SequentialOffset { offset: u8, width: u8 },
+    /// `choice_index i` maps to `bits[i]`. Use for rows whose choices
+    /// don't correspond to a contiguous bit range.
+    #[allow(dead_code)]
+    Explicit(&'static [u32]),
+}
+
+impl BitMapping {
+    /// Resolve the bit (as u32) for the given row choice index, or `None`
+    /// if the index is out of range. Returning `None` (or `Some(0)`)
+    /// causes the generic toggle to no-op.
+    #[inline]
+    pub fn bit_for_choice(self, choice_index: usize) -> Option<u32> {
+        match self {
+            BitMapping::Sequential { width } => {
+                if choice_index < width as usize {
+                    Some(1u32 << choice_index)
+                } else {
+                    None
+                }
+            }
+            BitMapping::SequentialOffset { offset, width } => {
+                if choice_index < width as usize {
+                    Some(1u32 << (offset as usize + choice_index))
+                } else {
+                    None
+                }
+            }
+            BitMapping::Explicit(bits) => bits.get(choice_index).copied(),
+        }
+    }
+
+    /// The number of choices a row using this mapping must declare.
+    /// Enforced by a debug assertion at `Row::bitmask` construction so
+    /// "row has more choices than the mask exposes" cannot silently
+    /// drop bits, and "row has fewer choices than the mask exposes"
+    /// cannot silently leave bits unreachable.
+    #[inline]
+    pub fn required_choices(self) -> usize {
+        match self {
+            BitMapping::Sequential { width } => width as usize,
+            BitMapping::SequentialOffset { width, .. } => width as usize,
+            BitMapping::Explicit(bits) => bits.len(),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -290,7 +368,7 @@ pub fn init_bitmask_row_from_binding(
     masks: &mut PlayerOptionMasks,
     player_idx: usize,
 ) -> bool {
-    let Some(init) = binding.init.as_ref() else {
+    let Some(init) = binding.init() else {
         return false;
     };
     let bits = (init.from_profile)(profile);
@@ -574,6 +652,12 @@ impl Row {
     }
 
     /// Construct a `RowBehavior::Bitmask` row.
+    ///
+    /// For `BitmaskBinding::Generic` bindings, debug-asserts that the
+    /// number of choices matches the writeback's bit-mapping width. This
+    /// catches drift between the declared bit width and the choice list
+    /// at row-construction time rather than silently dropping bits at
+    /// toggle time.
     pub fn bitmask(
         id: RowId,
         name: LookupKey,
@@ -581,6 +665,17 @@ impl Row {
         binding: BitmaskBinding,
         choices: Vec<String>,
     ) -> Self {
+        if let BitmaskBinding::Generic { writeback, .. } = &binding {
+            let required = writeback.bit_mapping.required_choices();
+            debug_assert_eq!(
+                choices.len(),
+                required,
+                "bitmask row {:?}: choices.len()={} but bit_mapping requires {}",
+                id,
+                choices.len(),
+                required,
+            );
+        }
         Self::base(id, RowBehavior::Bitmask(binding), name, help, choices)
     }
 

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -534,6 +534,7 @@ pub(super) mod tests {
                 },
                 cursor: CursorInit::FirstActiveBit,
             }),
+            writeback: None,
         };
         let mut advanced_rows = test_row_map(vec![test_bitmask_row(
             RowId::Scroll,
@@ -625,6 +626,7 @@ pub(super) mod tests {
                 },
                 cursor: CursorInit::FirstActiveBit,
             }),
+            writeback: None,
         };
         let mut hide_rows = test_row_map(vec![test_bitmask_row(
             RowId::Hide,
@@ -694,6 +696,7 @@ pub(super) mod tests {
                 },
                 cursor: CursorInit::Fixed(0),
             }),
+            writeback: None,
         };
         let mut fa_plus_rows = test_row_map(vec![test_bitmask_row(
             RowId::FAPlusOptions,
@@ -759,6 +762,7 @@ pub(super) mod tests {
                 },
                 cursor: CursorInit::FirstActiveBit,
             }),
+            writeback: None,
         };
         let mut rows = test_row_map(vec![test_bitmask_row(
             RowId::GameplayExtras,
@@ -1020,6 +1024,7 @@ pub(super) mod tests {
             behavior: super::RowBehavior::Bitmask(super::BitmaskBinding {
                 toggle: super::choice::toggle_scroll_row,
                 init: None,
+                writeback: None,
             }),
             name: lookup_key("PlayerOptions", "Scroll"),
             choices: ["Reverse", "Split", "Alternate", "Cross", "Centered"]
@@ -1368,6 +1373,7 @@ pub(super) mod tests {
             behavior: super::RowBehavior::Bitmask(super::BitmaskBinding {
                 toggle: super::choice::toggle_scroll_row,
                 init: None,
+                writeback: None,
             }),
             name: lookup_key("PlayerOptions", "Scroll"),
             choices: ["Reverse", "Split", "Alternate", "Cross", "Centered"]

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -2041,4 +2041,371 @@ pub(super) mod tests {
             "Row {id:?}: variant at cursor {idx} = {actual:?}, expected {expected:?}"
         );
     }
+
+    use crate::game::profile::{
+        AccelEffectsMask, AppearanceEffectsMask, HoldsMask, InsertMask, RemoveMask,
+        VisualEffectsMask,
+    };
+    use super::BitmaskWriteback;
+
+    fn install_bitmask_row(
+        state: &mut super::State,
+        id: RowId,
+        binding: BitmaskBinding,
+        choices: &[&str],
+        choice_index: usize,
+    ) -> usize {
+        let row = test_bitmask_row(id, lookup_key("PlayerOptions", "Insert"), choices, binding);
+        state.pane_mut().row_map.display_order.push(id);
+        state.pane_mut().row_map.insert(row);
+        let row_index = state.pane().row_map.display_order().len() - 1;
+        state.pane_mut().row_map.get_mut(id).unwrap().selected_choice_index = [choice_index, choice_index];
+        state.pane_mut().selected_row[P1] = row_index;
+        row_index
+    }
+
+    #[test]
+    fn generic_toggle_insert_row_sets_bit_and_profile() {
+        ensure_i18n();
+        let (mut state, asset_manager) = setup_state();
+
+        let binding = BitmaskBinding {
+            toggle: |_, _| {},
+            init: Some(BitmaskInit {
+                from_profile: |p| p.insert_active_mask.bits() as u32,
+                get_active: |m| m.insert.bits() as u32,
+                set_active: |m, b| m.insert = InsertMask::from_bits_retain(b as u8),
+                cursor: CursorInit::FirstActiveBit,
+            }),
+            writeback: Some(BitmaskWriteback {
+                project_to_profile: |p, b| {
+                    p.insert_active_mask = InsertMask::from_bits_truncate(b as u8);
+                },
+                persist_for_side: |s, b| {
+                    profile::update_insert_mask_for_side(
+                        s,
+                        InsertMask::from_bits_truncate(b as u8),
+                    );
+                },
+                bit_for_choice: |i, _| if i < 7 { Some(1u32 << i) } else { None },
+            }),
+        };
+        install_bitmask_row(
+            &mut state,
+            RowId::Insert,
+            binding,
+            &["W", "B", "Q", "M", "S", "E", "T"],
+            2,
+        );
+        state.option_masks[P1].insert = InsertMask::empty();
+        state.player_profiles[P1].insert_active_mask = InsertMask::empty();
+
+        let active = session_active_players();
+        handle_start_event(&mut state, &asset_manager, active, P1);
+
+        assert_eq!(
+            state.option_masks[P1].insert.bits(),
+            1u8 << 2,
+            "Insert bit at choice index 2 should be set"
+        );
+        assert_eq!(
+            state.player_profiles[P1].insert_active_mask.bits(),
+            1u8 << 2,
+            "Insert profile should mirror the mask"
+        );
+
+        // Toggle again to clear.
+        handle_start_event(&mut state, &asset_manager, active, P1);
+        assert_eq!(state.option_masks[P1].insert, InsertMask::empty());
+        assert_eq!(
+            state.player_profiles[P1].insert_active_mask,
+            InsertMask::empty()
+        );
+    }
+
+    #[test]
+    fn generic_toggle_insert_row_ignores_out_of_width_choice() {
+        // Insert clamps to choice_index < 7. A row with 7 choices and a
+        // selected index of 7 (impossible in practice; defensive) must
+        // produce no toggle.
+        ensure_i18n();
+        let (mut state, asset_manager) = setup_state();
+
+        let binding = BitmaskBinding {
+            toggle: |_, _| {},
+            init: Some(BitmaskInit {
+                from_profile: |p| p.insert_active_mask.bits() as u32,
+                get_active: |m| m.insert.bits() as u32,
+                set_active: |m, b| m.insert = InsertMask::from_bits_retain(b as u8),
+                cursor: CursorInit::FirstActiveBit,
+            }),
+            writeback: Some(BitmaskWriteback {
+                project_to_profile: |p, b| {
+                    p.insert_active_mask = InsertMask::from_bits_truncate(b as u8);
+                },
+                persist_for_side: |s, b| {
+                    profile::update_insert_mask_for_side(
+                        s,
+                        InsertMask::from_bits_truncate(b as u8),
+                    );
+                },
+                bit_for_choice: |i, _| if i < 7 { Some(1u32 << i) } else { None },
+            }),
+        };
+        // 8 choices, cursor at index 7 — out of width.
+        install_bitmask_row(
+            &mut state,
+            RowId::Insert,
+            binding,
+            &["a", "b", "c", "d", "e", "f", "g", "h"],
+            7,
+        );
+        state.option_masks[P1].insert = InsertMask::empty();
+
+        let active = session_active_players();
+        handle_start_event(&mut state, &asset_manager, active, P1);
+
+        assert_eq!(
+            state.option_masks[P1].insert,
+            InsertMask::empty(),
+            "out-of-width choice index must not toggle a bit"
+        );
+    }
+
+    #[test]
+    fn generic_toggle_remove_row_sets_bit_and_profile() {
+        ensure_i18n();
+        let (mut state, asset_manager) = setup_state();
+        let binding = BitmaskBinding {
+            toggle: |_, _| {},
+            init: Some(BitmaskInit {
+                from_profile: |p| p.remove_active_mask.bits() as u32,
+                get_active: |m| m.remove.bits() as u32,
+                set_active: |m, b| m.remove = RemoveMask::from_bits_retain(b as u8),
+                cursor: CursorInit::FirstActiveBit,
+            }),
+            writeback: Some(BitmaskWriteback {
+                project_to_profile: |p, b| {
+                    p.remove_active_mask = RemoveMask::from_bits_truncate(b as u8);
+                },
+                persist_for_side: |s, b| {
+                    profile::update_remove_mask_for_side(
+                        s,
+                        RemoveMask::from_bits_truncate(b as u8),
+                    );
+                },
+                bit_for_choice: |i, _| if i < 8 { Some(1u32 << i) } else { None },
+            }),
+        };
+        install_bitmask_row(
+            &mut state,
+            RowId::Remove,
+            binding,
+            &["L", "M", "H", "J", "Hands", "Q", "Lifts", "Fakes"],
+            5,
+        );
+        state.option_masks[P1].remove = RemoveMask::empty();
+        state.player_profiles[P1].remove_active_mask = RemoveMask::empty();
+
+        let active = session_active_players();
+        handle_start_event(&mut state, &asset_manager, active, P1);
+
+        assert_eq!(state.option_masks[P1].remove.bits(), 1u8 << 5);
+        assert_eq!(state.player_profiles[P1].remove_active_mask.bits(), 1u8 << 5);
+    }
+
+    #[test]
+    fn generic_toggle_holds_row_sets_bit_and_profile() {
+        ensure_i18n();
+        let (mut state, asset_manager) = setup_state();
+        let binding = BitmaskBinding {
+            toggle: |_, _| {},
+            init: Some(BitmaskInit {
+                from_profile: |p| p.holds_active_mask.bits() as u32,
+                get_active: |m| m.holds.bits() as u32,
+                set_active: |m, b| m.holds = HoldsMask::from_bits_retain(b as u8),
+                cursor: CursorInit::FirstActiveBit,
+            }),
+            writeback: Some(BitmaskWriteback {
+                project_to_profile: |p, b| {
+                    p.holds_active_mask = HoldsMask::from_bits_truncate(b as u8);
+                },
+                persist_for_side: |s, b| {
+                    profile::update_holds_mask_for_side(
+                        s,
+                        HoldsMask::from_bits_truncate(b as u8),
+                    );
+                },
+                bit_for_choice: |i, r| {
+                    let w = r.choices.len().min(8);
+                    if i < w { Some(1u32 << i) } else { None }
+                },
+            }),
+        };
+        // Holds in production has 5 choices; bit_for_choice clamps to choices.len().min(8).
+        install_bitmask_row(
+            &mut state,
+            RowId::Holds,
+            binding,
+            &["Planted", "Floored", "Twister", "NoRolls", "ToRolls"],
+            3,
+        );
+        state.option_masks[P1].holds = HoldsMask::empty();
+        state.player_profiles[P1].holds_active_mask = HoldsMask::empty();
+
+        let active = session_active_players();
+        handle_start_event(&mut state, &asset_manager, active, P1);
+
+        assert_eq!(state.option_masks[P1].holds.bits(), 1u8 << 3);
+        assert_eq!(state.player_profiles[P1].holds_active_mask.bits(), 1u8 << 3);
+    }
+
+    #[test]
+    fn generic_toggle_accel_row_sets_bit_and_profile() {
+        ensure_i18n();
+        let (mut state, asset_manager) = setup_state();
+        let binding = BitmaskBinding {
+            toggle: |_, _| {},
+            init: Some(BitmaskInit {
+                from_profile: |p| p.accel_effects_active_mask.bits() as u32,
+                get_active: |m| m.accel_effects.bits() as u32,
+                set_active: |m, b| m.accel_effects = AccelEffectsMask::from_bits_retain(b as u8),
+                cursor: CursorInit::FirstActiveBit,
+            }),
+            writeback: Some(BitmaskWriteback {
+                project_to_profile: |p, b| {
+                    p.accel_effects_active_mask = AccelEffectsMask::from_bits_truncate(b as u8);
+                },
+                persist_for_side: |s, b| {
+                    profile::update_accel_effects_mask_for_side(
+                        s,
+                        AccelEffectsMask::from_bits_truncate(b as u8),
+                    );
+                },
+                bit_for_choice: |i, r| {
+                    let w = r.choices.len().min(8);
+                    if i < w { Some(1u32 << i) } else { None }
+                },
+            }),
+        };
+        install_bitmask_row(
+            &mut state,
+            RowId::Accel,
+            binding,
+            &["Boost", "Brake", "Wave", "Expand", "Boomerang"],
+            1,
+        );
+        state.option_masks[P1].accel_effects = AccelEffectsMask::empty();
+        state.player_profiles[P1].accel_effects_active_mask = AccelEffectsMask::empty();
+
+        let active = session_active_players();
+        handle_start_event(&mut state, &asset_manager, active, P1);
+
+        assert_eq!(state.option_masks[P1].accel_effects.bits(), 1u8 << 1);
+        assert_eq!(
+            state.player_profiles[P1].accel_effects_active_mask.bits(),
+            1u8 << 1
+        );
+    }
+
+    #[test]
+    fn generic_toggle_visual_effects_row_sets_bit_and_profile() {
+        ensure_i18n();
+        let (mut state, asset_manager) = setup_state();
+        let binding = BitmaskBinding {
+            toggle: |_, _| {},
+            init: Some(BitmaskInit {
+                from_profile: |p| p.visual_effects_active_mask.bits() as u32,
+                get_active: |m| m.visual_effects.bits() as u32,
+                set_active: |m, b| {
+                    m.visual_effects = VisualEffectsMask::from_bits_retain(b as u16)
+                },
+                cursor: CursorInit::FirstActiveBit,
+            }),
+            writeback: Some(BitmaskWriteback {
+                project_to_profile: |p, b| {
+                    p.visual_effects_active_mask = VisualEffectsMask::from_bits_truncate(b as u16);
+                },
+                persist_for_side: |s, b| {
+                    profile::update_visual_effects_mask_for_side(
+                        s,
+                        VisualEffectsMask::from_bits_truncate(b as u16),
+                    );
+                },
+                bit_for_choice: |i, _| if i < 10 { Some(1u32 << i) } else { None },
+            }),
+        };
+        install_bitmask_row(
+            &mut state,
+            RowId::Effect,
+            binding,
+            &[
+                "Drunk", "Dizzy", "Confusion", "Big", "Flip", "Invert", "Tornado", "Tipsy",
+                "Bumpy", "Beat",
+            ],
+            9,
+        );
+        state.option_masks[P1].visual_effects = VisualEffectsMask::empty();
+        state.player_profiles[P1].visual_effects_active_mask = VisualEffectsMask::empty();
+
+        let active = session_active_players();
+        handle_start_event(&mut state, &asset_manager, active, P1);
+
+        assert_eq!(state.option_masks[P1].visual_effects.bits(), 1u16 << 9);
+        assert_eq!(
+            state.player_profiles[P1].visual_effects_active_mask.bits(),
+            1u16 << 9
+        );
+    }
+
+    #[test]
+    fn generic_toggle_appearance_row_sets_bit_and_profile() {
+        ensure_i18n();
+        let (mut state, asset_manager) = setup_state();
+        let binding = BitmaskBinding {
+            toggle: |_, _| {},
+            init: Some(BitmaskInit {
+                from_profile: |p| p.appearance_effects_active_mask.bits() as u32,
+                get_active: |m| m.appearance_effects.bits() as u32,
+                set_active: |m, b| {
+                    m.appearance_effects = AppearanceEffectsMask::from_bits_retain(b as u8)
+                },
+                cursor: CursorInit::FirstActiveBit,
+            }),
+            writeback: Some(BitmaskWriteback {
+                project_to_profile: |p, b| {
+                    p.appearance_effects_active_mask =
+                        AppearanceEffectsMask::from_bits_truncate(b as u8);
+                },
+                persist_for_side: |s, b| {
+                    profile::update_appearance_effects_mask_for_side(
+                        s,
+                        AppearanceEffectsMask::from_bits_truncate(b as u8),
+                    );
+                },
+                bit_for_choice: |i, r| {
+                    let w = r.choices.len().min(8);
+                    if i < w { Some(1u32 << i) } else { None }
+                },
+            }),
+        };
+        install_bitmask_row(
+            &mut state,
+            RowId::Appearance,
+            binding,
+            &["Hidden", "Sudden", "Stealth", "Blink", "RVanish"],
+            4,
+        );
+        state.option_masks[P1].appearance_effects = AppearanceEffectsMask::empty();
+        state.player_profiles[P1].appearance_effects_active_mask = AppearanceEffectsMask::empty();
+
+        let active = session_active_players();
+        handle_start_event(&mut state, &asset_manager, active, P1);
+
+        assert_eq!(state.option_masks[P1].appearance_effects.bits(), 1u8 << 4);
+        assert_eq!(
+            state.player_profiles[P1].appearance_effects_active_mask.bits(),
+            1u8 << 4
+        );
+    }
 }

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 
 #[cfg(test)]
 pub(super) mod tests {
+    use super::super::{choice, panes};
     use super::{
         BitmaskBinding, BitmaskInit, ChoiceBinding, CursorInit, CycleInit, ErrorBarMask,
         FaPlusMask, GameplayExtrasMask, GameplayExtrasMoreMask, HUD_OFFSET_MAX, HUD_OFFSET_MIN,
@@ -533,7 +534,7 @@ pub(super) mod tests {
                 },
                 cursor: CursorInit::FirstActiveBit,
             }),
-            toggle: super::super::choice::toggle_scroll_row,
+            toggle: choice::toggle_scroll_row,
         };
         let mut advanced_rows = test_row_map(vec![test_bitmask_row(
             RowId::Scroll,
@@ -549,20 +550,20 @@ pub(super) mod tests {
         )]);
 
         let mut main = PlayerOptionMasks::default();
-        super::super::panes::apply_profile_defaults(&mut main_rows, &profile, P1, &mut main);
+        panes::apply_profile_defaults(&mut main_rows, &profile, P1, &mut main);
         // Main alone: Scroll row absent, mask comes back empty (the bug source).
         assert_eq!(main.scroll, ScrollMask::empty());
 
         // Accumulated across all three panes (the fix): Reverse + Cross preserved.
         let mut combined = PlayerOptionMasks::default();
-        super::super::panes::apply_profile_defaults(&mut main_rows, &profile, P1, &mut combined);
-        super::super::panes::apply_profile_defaults(
+        panes::apply_profile_defaults(&mut main_rows, &profile, P1, &mut combined);
+        panes::apply_profile_defaults(
             &mut advanced_rows,
             &profile,
             P1,
             &mut combined,
         );
-        super::super::panes::apply_profile_defaults(
+        panes::apply_profile_defaults(
             &mut uncommon_rows,
             &profile,
             P1,
@@ -624,7 +625,7 @@ pub(super) mod tests {
                 },
                 cursor: CursorInit::FirstActiveBit,
             }),
-            toggle: super::super::choice::toggle_hide_row,
+            toggle: choice::toggle_hide_row,
         };
         let mut hide_rows = test_row_map(vec![test_bitmask_row(
             RowId::Hide,
@@ -636,7 +637,7 @@ pub(super) mod tests {
         )]);
 
         let mut masks = PlayerOptionMasks::default();
-        super::super::panes::apply_profile_defaults(&mut hide_rows, &profile, P1, &mut masks);
+        panes::apply_profile_defaults(&mut hide_rows, &profile, P1, &mut masks);
 
         assert_eq!(
             masks.hide,
@@ -693,7 +694,7 @@ pub(super) mod tests {
                 },
                 cursor: CursorInit::Fixed(0),
             }),
-            toggle: super::super::choice::toggle_fa_plus_row,
+            toggle: choice::toggle_fa_plus_row,
         };
         let mut fa_plus_rows = test_row_map(vec![test_bitmask_row(
             RowId::FAPlusOptions,
@@ -703,7 +704,7 @@ pub(super) mod tests {
         )]);
 
         let mut masks = PlayerOptionMasks::default();
-        super::super::panes::apply_profile_defaults(&mut fa_plus_rows, &profile, P1, &mut masks);
+        panes::apply_profile_defaults(&mut fa_plus_rows, &profile, P1, &mut masks);
 
         assert_eq!(
             masks.fa_plus,
@@ -758,7 +759,7 @@ pub(super) mod tests {
                 },
                 cursor: CursorInit::FirstActiveBit,
             }),
-            toggle: super::super::choice::toggle_gameplay_extras_row,
+            toggle: choice::toggle_gameplay_extras_row,
         };
         let mut rows = test_row_map(vec![test_bitmask_row(
             RowId::GameplayExtras,
@@ -768,7 +769,7 @@ pub(super) mod tests {
         )]);
 
         let mut masks = PlayerOptionMasks::default();
-        super::super::panes::apply_profile_defaults(&mut rows, &profile, P1, &mut masks);
+        panes::apply_profile_defaults(&mut rows, &profile, P1, &mut masks);
 
         assert!(
             masks
@@ -1796,7 +1797,7 @@ pub(super) mod tests {
             state.fixed_stepchart.as_ref(),
         );
         let mut masks = PlayerOptionMasks::default();
-        super::super::panes::apply_profile_defaults(&mut row_map, &profile, P1, &mut masks);
+        panes::apply_profile_defaults(&mut row_map, &profile, P1, &mut masks);
 
         // Cycle rows: assert the selected variant matches the profile value.
         assert_variant_at_cursor(
@@ -1856,7 +1857,7 @@ pub(super) mod tests {
             state.fixed_stepchart.as_ref(),
         );
         let mut masks = PlayerOptionMasks::default();
-        super::super::panes::apply_profile_defaults(&mut row_map, &profile, P1, &mut masks);
+        panes::apply_profile_defaults(&mut row_map, &profile, P1, &mut masks);
 
         assert_choice_at_cursor(
             &row_map,
@@ -1913,7 +1914,7 @@ pub(super) mod tests {
             state.fixed_stepchart.as_ref(),
         );
         let mut masks = PlayerOptionMasks::default();
-        super::super::panes::apply_profile_defaults(&mut row_map, &profile, P1, &mut masks);
+        panes::apply_profile_defaults(&mut row_map, &profile, P1, &mut masks);
 
         assert_variant_at_cursor(
             &row_map,

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -505,8 +505,7 @@ pub(super) mod tests {
             &["Exit"],
             [0, 0],
         )]);
-        let scroll_binding = BitmaskBinding {
-            toggle: super::super::choice::toggle_scroll_row,
+        let scroll_binding = BitmaskBinding::HandRolled {
             init: Some(BitmaskInit {
                 from_profile: |p| {
                     use crate::game::profile::ScrollOption;
@@ -534,7 +533,7 @@ pub(super) mod tests {
                 },
                 cursor: CursorInit::FirstActiveBit,
             }),
-            writeback: None,
+            toggle: super::super::choice::toggle_scroll_row,
         };
         let mut advanced_rows = test_row_map(vec![test_bitmask_row(
             RowId::Scroll,
@@ -592,8 +591,7 @@ pub(super) mod tests {
         profile.hide_targets = false;
         profile.hide_song_bg = true;
 
-        let hide_binding = BitmaskBinding {
-            toggle: super::super::choice::toggle_hide_row,
+        let hide_binding = BitmaskBinding::HandRolled {
             init: Some(BitmaskInit {
                 from_profile: |p| {
                     let mut bits = HideMask::empty();
@@ -626,7 +624,7 @@ pub(super) mod tests {
                 },
                 cursor: CursorInit::FirstActiveBit,
             }),
-            writeback: None,
+            toggle: super::super::choice::toggle_hide_row,
         };
         let mut hide_rows = test_row_map(vec![test_bitmask_row(
             RowId::Hide,
@@ -665,8 +663,7 @@ pub(super) mod tests {
         profile.show_fa_plus_window = false;
         profile.show_ex_score = true;
 
-        let fa_plus_binding = BitmaskBinding {
-            toggle: super::super::choice::toggle_fa_plus_row,
+        let fa_plus_binding = BitmaskBinding::HandRolled {
             init: Some(BitmaskInit {
                 from_profile: |p| {
                     let mut bits = FaPlusMask::empty();
@@ -696,7 +693,7 @@ pub(super) mod tests {
                 },
                 cursor: CursorInit::Fixed(0),
             }),
-            writeback: None,
+            toggle: super::super::choice::toggle_fa_plus_row,
         };
         let mut fa_plus_rows = test_row_map(vec![test_bitmask_row(
             RowId::FAPlusOptions,
@@ -737,8 +734,7 @@ pub(super) mod tests {
         // No GameplayExtrasMore row exists (orphan; see the
         // `every_row_id_is_constructed_by_some_pane` test) — we still expect
         // the derived mask bits to be populated.
-        let gameplay_extras_binding = BitmaskBinding {
-            toggle: super::super::choice::toggle_gameplay_extras_row,
+        let gameplay_extras_binding = BitmaskBinding::HandRolled {
             init: Some(BitmaskInit {
                 from_profile: |p| {
                     let mut bits = GameplayExtrasMask::empty();
@@ -762,7 +758,7 @@ pub(super) mod tests {
                 },
                 cursor: CursorInit::FirstActiveBit,
             }),
-            writeback: None,
+            toggle: super::super::choice::toggle_gameplay_extras_row,
         };
         let mut rows = test_row_map(vec![test_bitmask_row(
             RowId::GameplayExtras,
@@ -1021,10 +1017,9 @@ pub(super) mod tests {
         // Insert a Scroll row directly since it lives in the Advanced pane.
         let scroll_row = Row {
             id: RowId::Scroll,
-            behavior: super::RowBehavior::Bitmask(super::BitmaskBinding {
-                toggle: super::choice::toggle_scroll_row,
+            behavior: super::RowBehavior::Bitmask(super::BitmaskBinding::HandRolled {
                 init: None,
-                writeback: None,
+                toggle: super::choice::toggle_scroll_row,
             }),
             name: lookup_key("PlayerOptions", "Scroll"),
             choices: ["Reverse", "Split", "Alternate", "Cross", "Centered"]
@@ -1370,10 +1365,9 @@ pub(super) mod tests {
         // to the Main row_map directly for this isolated test).
         let scroll_row = Row {
             id: RowId::Scroll,
-            behavior: super::RowBehavior::Bitmask(super::BitmaskBinding {
-                toggle: super::choice::toggle_scroll_row,
+            behavior: super::RowBehavior::Bitmask(super::BitmaskBinding::HandRolled {
                 init: None,
-                writeback: None,
+                toggle: super::choice::toggle_scroll_row,
             }),
             name: lookup_key("PlayerOptions", "Scroll"),
             choices: ["Reverse", "Split", "Alternate", "Cross", "Centered"]
@@ -2046,7 +2040,7 @@ pub(super) mod tests {
         AccelEffectsMask, AppearanceEffectsMask, HoldsMask, InsertMask, RemoveMask,
         VisualEffectsMask,
     };
-    use super::BitmaskWriteback;
+    use super::{BitMapping, BitmaskWriteback};
 
     fn install_bitmask_row(
         state: &mut super::State,
@@ -2069,15 +2063,14 @@ pub(super) mod tests {
         ensure_i18n();
         let (mut state, asset_manager) = setup_state();
 
-        let binding = BitmaskBinding {
-            toggle: |_, _| {},
-            init: Some(BitmaskInit {
+        let binding = BitmaskBinding::Generic {
+            init: BitmaskInit {
                 from_profile: |p| p.insert_active_mask.bits() as u32,
                 get_active: |m| m.insert.bits() as u32,
                 set_active: |m, b| m.insert = InsertMask::from_bits_retain(b as u8),
                 cursor: CursorInit::FirstActiveBit,
-            }),
-            writeback: Some(BitmaskWriteback {
+            },
+            writeback: BitmaskWriteback {
                 project_to_profile: |p, b| {
                     p.insert_active_mask = InsertMask::from_bits_truncate(b as u8);
                 },
@@ -2087,8 +2080,8 @@ pub(super) mod tests {
                         InsertMask::from_bits_truncate(b as u8),
                     );
                 },
-                bit_for_choice: |i, _| if i < 7 { Some(1u32 << i) } else { None },
-            }),
+                bit_mapping: BitMapping::Sequential { width: 7 },
+            },
         };
         install_bitmask_row(
             &mut state,
@@ -2131,15 +2124,14 @@ pub(super) mod tests {
         ensure_i18n();
         let (mut state, asset_manager) = setup_state();
 
-        let binding = BitmaskBinding {
-            toggle: |_, _| {},
-            init: Some(BitmaskInit {
+        let binding = BitmaskBinding::Generic {
+            init: BitmaskInit {
                 from_profile: |p| p.insert_active_mask.bits() as u32,
                 get_active: |m| m.insert.bits() as u32,
                 set_active: |m, b| m.insert = InsertMask::from_bits_retain(b as u8),
                 cursor: CursorInit::FirstActiveBit,
-            }),
-            writeback: Some(BitmaskWriteback {
+            },
+            writeback: BitmaskWriteback {
                 project_to_profile: |p, b| {
                     p.insert_active_mask = InsertMask::from_bits_truncate(b as u8);
                 },
@@ -2149,8 +2141,8 @@ pub(super) mod tests {
                         InsertMask::from_bits_truncate(b as u8),
                     );
                 },
-                bit_for_choice: |i, _| if i < 7 { Some(1u32 << i) } else { None },
-            }),
+                bit_mapping: BitMapping::Sequential { width: 7 },
+            },
         };
         // 8 choices, cursor at index 7 — out of width.
         install_bitmask_row(
@@ -2176,15 +2168,14 @@ pub(super) mod tests {
     fn generic_toggle_remove_row_sets_bit_and_profile() {
         ensure_i18n();
         let (mut state, asset_manager) = setup_state();
-        let binding = BitmaskBinding {
-            toggle: |_, _| {},
-            init: Some(BitmaskInit {
+        let binding = BitmaskBinding::Generic {
+            init: BitmaskInit {
                 from_profile: |p| p.remove_active_mask.bits() as u32,
                 get_active: |m| m.remove.bits() as u32,
                 set_active: |m, b| m.remove = RemoveMask::from_bits_retain(b as u8),
                 cursor: CursorInit::FirstActiveBit,
-            }),
-            writeback: Some(BitmaskWriteback {
+            },
+            writeback: BitmaskWriteback {
                 project_to_profile: |p, b| {
                     p.remove_active_mask = RemoveMask::from_bits_truncate(b as u8);
                 },
@@ -2194,8 +2185,8 @@ pub(super) mod tests {
                         RemoveMask::from_bits_truncate(b as u8),
                     );
                 },
-                bit_for_choice: |i, _| if i < 8 { Some(1u32 << i) } else { None },
-            }),
+                bit_mapping: BitMapping::Sequential { width: 8 },
+            },
         };
         install_bitmask_row(
             &mut state,
@@ -2218,15 +2209,14 @@ pub(super) mod tests {
     fn generic_toggle_holds_row_sets_bit_and_profile() {
         ensure_i18n();
         let (mut state, asset_manager) = setup_state();
-        let binding = BitmaskBinding {
-            toggle: |_, _| {},
-            init: Some(BitmaskInit {
+        let binding = BitmaskBinding::Generic {
+            init: BitmaskInit {
                 from_profile: |p| p.holds_active_mask.bits() as u32,
                 get_active: |m| m.holds.bits() as u32,
                 set_active: |m, b| m.holds = HoldsMask::from_bits_retain(b as u8),
                 cursor: CursorInit::FirstActiveBit,
-            }),
-            writeback: Some(BitmaskWriteback {
+            },
+            writeback: BitmaskWriteback {
                 project_to_profile: |p, b| {
                     p.holds_active_mask = HoldsMask::from_bits_truncate(b as u8);
                 },
@@ -2236,13 +2226,10 @@ pub(super) mod tests {
                         HoldsMask::from_bits_truncate(b as u8),
                     );
                 },
-                bit_for_choice: |i, r| {
-                    let w = r.choices.len().min(8);
-                    if i < w { Some(1u32 << i) } else { None }
-                },
-            }),
+                bit_mapping: BitMapping::Sequential { width: 5 },
+            },
         };
-        // Holds in production has 5 choices; bit_for_choice clamps to choices.len().min(8).
+        // Holds in production has 5 choices; bit_mapping is Sequential { width: 5 }.
         install_bitmask_row(
             &mut state,
             RowId::Holds,
@@ -2264,15 +2251,14 @@ pub(super) mod tests {
     fn generic_toggle_accel_row_sets_bit_and_profile() {
         ensure_i18n();
         let (mut state, asset_manager) = setup_state();
-        let binding = BitmaskBinding {
-            toggle: |_, _| {},
-            init: Some(BitmaskInit {
+        let binding = BitmaskBinding::Generic {
+            init: BitmaskInit {
                 from_profile: |p| p.accel_effects_active_mask.bits() as u32,
                 get_active: |m| m.accel_effects.bits() as u32,
                 set_active: |m, b| m.accel_effects = AccelEffectsMask::from_bits_retain(b as u8),
                 cursor: CursorInit::FirstActiveBit,
-            }),
-            writeback: Some(BitmaskWriteback {
+            },
+            writeback: BitmaskWriteback {
                 project_to_profile: |p, b| {
                     p.accel_effects_active_mask = AccelEffectsMask::from_bits_truncate(b as u8);
                 },
@@ -2282,11 +2268,8 @@ pub(super) mod tests {
                         AccelEffectsMask::from_bits_truncate(b as u8),
                     );
                 },
-                bit_for_choice: |i, r| {
-                    let w = r.choices.len().min(8);
-                    if i < w { Some(1u32 << i) } else { None }
-                },
-            }),
+                bit_mapping: BitMapping::Sequential { width: 5 },
+            },
         };
         install_bitmask_row(
             &mut state,
@@ -2312,17 +2295,16 @@ pub(super) mod tests {
     fn generic_toggle_visual_effects_row_sets_bit_and_profile() {
         ensure_i18n();
         let (mut state, asset_manager) = setup_state();
-        let binding = BitmaskBinding {
-            toggle: |_, _| {},
-            init: Some(BitmaskInit {
+        let binding = BitmaskBinding::Generic {
+            init: BitmaskInit {
                 from_profile: |p| p.visual_effects_active_mask.bits() as u32,
                 get_active: |m| m.visual_effects.bits() as u32,
                 set_active: |m, b| {
                     m.visual_effects = VisualEffectsMask::from_bits_retain(b as u16)
                 },
                 cursor: CursorInit::FirstActiveBit,
-            }),
-            writeback: Some(BitmaskWriteback {
+            },
+            writeback: BitmaskWriteback {
                 project_to_profile: |p, b| {
                     p.visual_effects_active_mask = VisualEffectsMask::from_bits_truncate(b as u16);
                 },
@@ -2332,8 +2314,8 @@ pub(super) mod tests {
                         VisualEffectsMask::from_bits_truncate(b as u16),
                     );
                 },
-                bit_for_choice: |i, _| if i < 10 { Some(1u32 << i) } else { None },
-            }),
+                bit_mapping: BitMapping::Sequential { width: 10 },
+            },
         };
         install_bitmask_row(
             &mut state,
@@ -2362,17 +2344,16 @@ pub(super) mod tests {
     fn generic_toggle_appearance_row_sets_bit_and_profile() {
         ensure_i18n();
         let (mut state, asset_manager) = setup_state();
-        let binding = BitmaskBinding {
-            toggle: |_, _| {},
-            init: Some(BitmaskInit {
+        let binding = BitmaskBinding::Generic {
+            init: BitmaskInit {
                 from_profile: |p| p.appearance_effects_active_mask.bits() as u32,
                 get_active: |m| m.appearance_effects.bits() as u32,
                 set_active: |m, b| {
                     m.appearance_effects = AppearanceEffectsMask::from_bits_retain(b as u8)
                 },
                 cursor: CursorInit::FirstActiveBit,
-            }),
-            writeback: Some(BitmaskWriteback {
+            },
+            writeback: BitmaskWriteback {
                 project_to_profile: |p, b| {
                     p.appearance_effects_active_mask =
                         AppearanceEffectsMask::from_bits_truncate(b as u8);
@@ -2383,11 +2364,8 @@ pub(super) mod tests {
                         AppearanceEffectsMask::from_bits_truncate(b as u8),
                     );
                 },
-                bit_for_choice: |i, r| {
-                    let w = r.choices.len().min(8);
-                    if i < w { Some(1u32 << i) } else { None }
-                },
-            }),
+                bit_mapping: BitMapping::Sequential { width: 5 },
+            },
         };
         install_bitmask_row(
             &mut state,


### PR DESCRIPTION
## Summary

Refactor of the player-options bitmask binding API. Drives the 6 uncommon-pane mask rows (Insert, Remove, Holds, Accel, Effect, Appearance) through a single declarative path and tightens the binding contract so invalid states are unrepresentable.

