### PR TITLE
refactor(player-options): add numeric_binding! macro

### DIFF
--- a/src/screens/player_options/panes/advanced.rs
+++ b/src/screens/player_options/panes/advanced.rs
@@ -1,7 +1,7 @@
 use super::super::choice;
 use super::super::constants::MINI_INDICATOR_VARIANTS;
-use super::super::row::index_binding;
-use super::super::row::{BitmaskInit, CursorInit, CycleInit, NumericInit};
+use super::super::row::{index_binding, numeric_binding};
+use super::super::row::{BitmaskInit, CursorInit, CycleInit};
 use super::super::state::{
     EarlyDwMask, ErrorBarOptionsMask, FaPlusMask, GameplayExtrasMask, HideMask, LifeBarOptionsMask,
     MeasureCounterOptionsMask, PlayerOptionMasks, ResultsExtrasMask, ScrollMask,
@@ -252,30 +252,20 @@ const CUSTOM_BLUE_FANTASTIC_WINDOW: ChoiceBinding<bool> = ChoiceBinding::<bool> 
     }),
 };
 
-const ERROR_BAR_OFFSET_X: NumericBinding = NumericBinding {
-    parse: parse_i32,
-    apply: |p, v| {
-        p.error_bar_offset_x = v;
-        Outcome::persisted()
-    },
-    persist_for_side: gp::update_error_bar_offset_x_for_side,
-    init: Some(NumericInit {
-        from_profile: |p| p.error_bar_offset_x.clamp(HUD_OFFSET_MIN, HUD_OFFSET_MAX),
-        format: |v| format!("{v}"),
-    }),
-};
-const ERROR_BAR_OFFSET_Y: NumericBinding = NumericBinding {
-    parse: parse_i32,
-    apply: |p, v| {
-        p.error_bar_offset_y = v;
-        Outcome::persisted()
-    },
-    persist_for_side: gp::update_error_bar_offset_y_for_side,
-    init: Some(NumericInit {
-        from_profile: |p| p.error_bar_offset_y.clamp(HUD_OFFSET_MIN, HUD_OFFSET_MAX),
-        format: |v| format!("{v}"),
-    }),
-};
+const ERROR_BAR_OFFSET_X: NumericBinding = numeric_binding!(
+    parse = parse_i32,
+    field = error_bar_offset_x,
+    persist = gp::update_error_bar_offset_x_for_side,
+    clamp = (HUD_OFFSET_MIN, HUD_OFFSET_MAX),
+    suffix = "",
+);
+const ERROR_BAR_OFFSET_Y: NumericBinding = numeric_binding!(
+    parse = parse_i32,
+    field = error_bar_offset_y,
+    persist = gp::update_error_bar_offset_y_for_side,
+    clamp = (HUD_OFFSET_MIN, HUD_OFFSET_MAX),
+    suffix = "",
+);
 
 const SCROLL: BitmaskBinding = BitmaskBinding::HandRolled {
     init: Some(BitmaskInit {

--- a/src/screens/player_options/panes/main.rs
+++ b/src/screens/player_options/panes/main.rs
@@ -1,5 +1,5 @@
 use super::super::choice;
-use super::super::row::index_binding;
+use super::super::row::{index_binding, numeric_binding};
 use super::*;
 use crate::game::profile as gp;
 
@@ -48,117 +48,69 @@ const BACKGROUND_FILTER: NumericBinding = NumericBinding {
     }),
 };
 
-const JUDGMENT_OFFSET_X: NumericBinding = NumericBinding {
-    parse: parse_i32,
-    apply: |p, v| {
-        p.judgment_offset_x = v;
-        Outcome::persisted()
-    },
-    persist_for_side: gp::update_judgment_offset_x_for_side,
-    init: Some(NumericInit {
-        from_profile: |p| p.judgment_offset_x.clamp(HUD_OFFSET_MIN, HUD_OFFSET_MAX),
-        format: |v| format!("{v}"),
-    }),
-};
-const JUDGMENT_OFFSET_Y: NumericBinding = NumericBinding {
-    parse: parse_i32,
-    apply: |p, v| {
-        p.judgment_offset_y = v;
-        Outcome::persisted()
-    },
-    persist_for_side: gp::update_judgment_offset_y_for_side,
-    init: Some(NumericInit {
-        from_profile: |p| p.judgment_offset_y.clamp(HUD_OFFSET_MIN, HUD_OFFSET_MAX),
-        format: |v| format!("{v}"),
-    }),
-};
-const COMBO_OFFSET_X: NumericBinding = NumericBinding {
-    parse: parse_i32,
-    apply: |p, v| {
-        p.combo_offset_x = v;
-        Outcome::persisted()
-    },
-    persist_for_side: gp::update_combo_offset_x_for_side,
-    init: Some(NumericInit {
-        from_profile: |p| p.combo_offset_x.clamp(HUD_OFFSET_MIN, HUD_OFFSET_MAX),
-        format: |v| format!("{v}"),
-    }),
-};
-const COMBO_OFFSET_Y: NumericBinding = NumericBinding {
-    parse: parse_i32,
-    apply: |p, v| {
-        p.combo_offset_y = v;
-        Outcome::persisted()
-    },
-    persist_for_side: gp::update_combo_offset_y_for_side,
-    init: Some(NumericInit {
-        from_profile: |p| p.combo_offset_y.clamp(HUD_OFFSET_MIN, HUD_OFFSET_MAX),
-        format: |v| format!("{v}"),
-    }),
-};
-const NOTEFIELD_OFFSET_X: NumericBinding = NumericBinding {
-    parse: parse_i32,
-    apply: |p, v| {
-        p.note_field_offset_x = v;
-        Outcome::persisted()
-    },
-    persist_for_side: gp::update_notefield_offset_x_for_side,
-    init: Some(NumericInit {
-        from_profile: |p| p.note_field_offset_x.clamp(0, 50),
-        format: |v| format!("{v}"),
-    }),
-};
-const NOTEFIELD_OFFSET_Y: NumericBinding = NumericBinding {
-    parse: parse_i32,
-    apply: |p, v| {
-        p.note_field_offset_y = v;
-        Outcome::persisted()
-    },
-    persist_for_side: gp::update_notefield_offset_y_for_side,
-    init: Some(NumericInit {
-        from_profile: |p| p.note_field_offset_y.clamp(-50, 50),
-        format: |v| format!("{v}"),
-    }),
-};
-const VISUAL_DELAY: NumericBinding = NumericBinding {
-    parse: parse_i32_ms,
-    apply: |p, v| {
-        p.visual_delay_ms = v;
-        Outcome::persisted()
-    },
-    persist_for_side: gp::update_visual_delay_ms_for_side,
-    init: Some(NumericInit {
-        from_profile: |p| p.visual_delay_ms.clamp(-100, 100),
-        format: |v| format!("{v}ms"),
-    }),
-};
-const GLOBAL_OFFSET_SHIFT: NumericBinding = NumericBinding {
-    parse: parse_i32_ms,
-    apply: |p, v| {
-        p.global_offset_shift_ms = v;
-        Outcome::persisted()
-    },
-    persist_for_side: gp::update_global_offset_shift_ms_for_side,
-    init: Some(NumericInit {
-        from_profile: |p| p.global_offset_shift_ms.clamp(-100, 100),
-        format: |v| format!("{v}ms"),
-    }),
-};
-const SPACING: NumericBinding = NumericBinding {
-    parse: parse_i32_percent,
-    apply: |p, v| {
-        p.spacing_percent = v;
-        Outcome::persisted()
-    },
-    persist_for_side: gp::update_spacing_percent_for_side,
-    init: Some(NumericInit {
-        from_profile: |p| {
-            p.spacing_percent
-                .clamp(SPACING_PERCENT_MIN, SPACING_PERCENT_MAX)
-        },
-        format: |v| format!("{v}%"),
-    }),
-};
+const JUDGMENT_OFFSET_X: NumericBinding = numeric_binding!(
+    parse = parse_i32,
+    field = judgment_offset_x,
+    persist = gp::update_judgment_offset_x_for_side,
+    clamp = (HUD_OFFSET_MIN, HUD_OFFSET_MAX),
+    suffix = "",
+);
+const JUDGMENT_OFFSET_Y: NumericBinding = numeric_binding!(
+    parse = parse_i32,
+    field = judgment_offset_y,
+    persist = gp::update_judgment_offset_y_for_side,
+    clamp = (HUD_OFFSET_MIN, HUD_OFFSET_MAX),
+    suffix = "",
+);
+const COMBO_OFFSET_X: NumericBinding = numeric_binding!(
+    parse = parse_i32,
+    field = combo_offset_x,
+    persist = gp::update_combo_offset_x_for_side,
+    clamp = (HUD_OFFSET_MIN, HUD_OFFSET_MAX),
+    suffix = "",
+);
+const COMBO_OFFSET_Y: NumericBinding = numeric_binding!(
+    parse = parse_i32,
+    field = combo_offset_y,
+    persist = gp::update_combo_offset_y_for_side,
+    clamp = (HUD_OFFSET_MIN, HUD_OFFSET_MAX),
+    suffix = "",
+);
+const NOTEFIELD_OFFSET_X: NumericBinding = numeric_binding!(
+    parse = parse_i32,
+    field = note_field_offset_x,
+    persist = gp::update_notefield_offset_x_for_side,
+    clamp = (0, 50),
+    suffix = "",
+);
+const NOTEFIELD_OFFSET_Y: NumericBinding = numeric_binding!(
+    parse = parse_i32,
+    field = note_field_offset_y,
+    persist = gp::update_notefield_offset_y_for_side,
+    clamp = (-50, 50),
+    suffix = "",
+);
+const VISUAL_DELAY: NumericBinding = numeric_binding!(
+    parse = parse_i32_ms,
+    field = visual_delay_ms,
+    persist = gp::update_visual_delay_ms_for_side,
+    clamp = (-100, 100),
+    suffix = "ms",
+);
+const GLOBAL_OFFSET_SHIFT: NumericBinding = numeric_binding!(
+    parse = parse_i32_ms,
+    field = global_offset_shift_ms,
+    persist = gp::update_global_offset_shift_ms_for_side,
+    clamp = (-100, 100),
+    suffix = "ms",
+);
+const SPACING: NumericBinding = numeric_binding!(
+    parse = parse_i32_percent,
+    field = spacing_percent,
+    persist = gp::update_spacing_percent_for_side,
+    clamp = (SPACING_PERCENT_MIN, SPACING_PERCENT_MAX),
+    suffix = "%",
+);
 
 /// Shared boilerplate for a noteskin-style cycle row implemented via
 /// `CustomBinding`: advance the choice index, look up the chosen string, then

--- a/src/screens/player_options/row.rs
+++ b/src/screens/player_options/row.rs
@@ -510,6 +510,58 @@ macro_rules! index_binding {
 
 pub(crate) use index_binding;
 
+/// Build a `NumericBinding` for the common shape: a row whose value is
+/// an `i32` that lives directly on a single `Profile` field, with an
+/// `init` contract that clamps the profile value into a `(min, max)`
+/// range and formats it for choice-list lookup with an optional unit
+/// suffix (e.g. `"ms"`, `"%"`, or `""`).
+///
+/// The macro does *not* cover bindings whose `apply` translates the
+/// `i32` into something other than the field type (e.g.
+/// `BackgroundFilter` which converts `i32 → enum` and back). Construct
+/// those by hand.
+///
+/// # Example
+///
+/// ```ignore
+/// const VISUAL_DELAY: NumericBinding = numeric_binding!(
+///     parse = parse_i32_ms,
+///     field = visual_delay_ms,
+///     persist = gp::update_visual_delay_ms_for_side,
+///     clamp = (-100, 100),
+///     suffix = "ms",
+/// );
+/// ```
+macro_rules! numeric_binding {
+    (
+        parse = $parse:expr,
+        field = $field:ident,
+        persist = $persist:path,
+        clamp = ($min:expr, $max:expr),
+        suffix = $suffix:literal $(,)?
+    ) => {
+        $crate::screens::player_options::row::NumericBinding {
+            parse: $parse,
+            apply: |p, v| {
+                p.$field = v;
+                $crate::screens::player_options::row::Outcome::persisted()
+            },
+            persist_for_side: $persist,
+            init: Some($crate::screens::player_options::row::NumericInit {
+                from_profile: |p| p.$field.clamp($min, $max),
+                // Format string `"{}{}"` is a literal; `$suffix` is a
+                // const-evaluable expression substituted as the second
+                // argument. (Using `concat!("{v}", $suffix)` would not
+                // compile because `format_args!` cannot capture `v`
+                // from a macro-expanded format string.)
+                format: |v| format!("{}{}", v, $suffix),
+            }),
+        }
+    };
+}
+
+pub(crate) use numeric_binding;
+
 /// Build a `BitmaskBinding::Generic` for the common case of a mask row that:
 ///
 /// - Reads/writes a single `bitflags!` mask field on `Profile` (`profile_field`).


### PR DESCRIPTION
## Summary

Adds a `numeric_binding!` macro alongside the existing `index_binding!` and `simple_bitmask_binding!` macros, and migrates 11 of the 12 `NumericBinding` constants in `panes/main.rs` and `panes/advanced.rs` to use it.