### PR TITLE
fix(evaluation): wait for ITL overlay before auto-screenshot

### DIFF
--- a/src/game/scores/groovestats.rs
+++ b/src/game/scores/groovestats.rs
@@ -1191,6 +1191,14 @@ fn spawn_groovestats_submit(job: GrooveStatsSubmitRequest) {
                     continue;
                 }
 
+                groovestats_update_submit_event_ui_if_token(
+                    player.side,
+                    player.chart_hash.as_str(),
+                    player.token,
+                    itl::progress_from_submit(player, player_response),
+                    submit_record_banner(player, player_response),
+                );
+                itl::handle_submit_player_unlocks(player, player_response);
                 let accepted = groovestats_update_submit_ui_status_if_token(
                     player.side,
                     player.chart_hash.as_str(),
@@ -1214,14 +1222,6 @@ fn spawn_groovestats_submit(job: GrooveStatsSubmitRequest) {
                         player.username.as_str(),
                     );
                 }
-                groovestats_update_submit_event_ui_if_token(
-                    player.side,
-                    player.chart_hash.as_str(),
-                    player.token,
-                    itl::progress_from_submit(player, player_response),
-                    submit_record_banner(player, player_response),
-                );
-                itl::handle_submit_player_unlocks(player, player_response);
                 debug!(
                     "{} submit succeeded for {:?} ({}) result='{}'",
                     online::groovestats_service_name(),

--- a/src/screens/evaluation.rs
+++ b/src/screens/evaluation.rs
@@ -2662,6 +2662,16 @@ fn waiting_for_groovestats_submit(state: &State) -> bool {
         .or(state.submit_groovestats_fallback[player_idx]);
         match status {
             None | Some(scores::GrooveStatsSubmitUiStatus::Submitting) => return true,
+            Some(scores::GrooveStatsSubmitUiStatus::Submitted) => {
+                if scores::get_groovestats_submit_itl_progress_for_side(
+                    si.chart.short_hash.as_str(),
+                    si.side,
+                )
+                .is_some()
+                {
+                    return true;
+                }
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
The auto-screenshot on the evaluation screen could fire in the small window between the GrooveStats submit worker flipping the UI status to Submitted and publishing the ITL event payload. In that window`the eval screen observed Submitted with no ITL progress yet, treated the GS phase as finished, found `itl_overlay_visible == false`, and snapped the screenshot just before the ITL widget popped up.

- In `spawn_groovestats_submit` (groovestats.rs)` publish the ITL event UI (overlay progress, record banner) and run unlock side-effects before flipping the submit UI status to Submitted. The status flip is the signal readers wait on` so the ITL globals must be visible first. Success bookkeeping that depends on `accepted` (record_submit_success and score caching) keeps its existing ordering relative to the status flip.
- In `waiting_for_groovestats_submit` (evaluation.rs)` when the cached per-player ITL progress is still None but status reads Submitted` probe `scores::get_groovestats_submit_itl_progress_for_side` to catch the case where the global has been published but `sync_submit_itl_progress`n  hasn't run for this frame yet. Returning true gives the overlay one more frame to open before the auto-screenshot logic considers the screen Ready.

Addresses #269 