### PR TITLE
fix(evaluation): scale graphs to played chart end (#383)

### DIFF
--- a/src/screens/evaluation.rs
+++ b/src/screens/evaluation.rs
@@ -1721,7 +1721,27 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
                 }
             };
             let graph_first_second = 0.0_f32.min(gs.timing.get_time_for_beat(0.0));
-            let graph_last_second = gs.song.total_length_seconds as f32;
+            let chart_last_second = {
+                let mut latest_ns: i64 = i64::MIN;
+                for (idx, &t_ns) in note_times.iter().enumerate() {
+                    if !crate::game::gameplay::song_time_ns_invalid(t_ns) && t_ns > latest_ns {
+                        latest_ns = t_ns;
+                    }
+                    if let Some(end_ns) = hold_end_times.get(idx).copied().flatten()
+                        && !crate::game::gameplay::song_time_ns_invalid(end_ns)
+                        && end_ns > latest_ns
+                    {
+                        latest_ns = end_ns;
+                    }
+                }
+                if latest_ns == i64::MIN {
+                    (gs.song.total_length_seconds.max(0) as f32).max(graph_first_second + 0.001)
+                } else {
+                    crate::game::gameplay::song_time_ns_to_seconds(latest_ns)
+                        .max(graph_first_second + 0.001)
+                }
+            };
+            let graph_last_second = chart_last_second;
 
             let score_percent = judgment::calculate_itg_score_percent_from_counts(
                 &p.scoring_counts,
@@ -1926,7 +1946,7 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
 
             density_graph_mesh[player_idx] = {
                 const GRAPH_H: f32 = 64.0;
-                let last_second = si.song.total_length_seconds.max(0) as f32;
+                let last_second = si.graph_last_second.max(si.graph_first_second + 0.001);
                 let verts = crate::engine::present::density::build_density_histogram_mesh(
                     &si.chart.measure_nps_vec,
                     si.chart.max_nps,


### PR DESCRIPTION
Closes #383.

## Problem

On the evaluation screen, the scatterplot of judgments visibly ends well before the right edge of the graph frame, while the density histogram (drawn in the same frame) appears to fill the width. See the screenshot in the issue.

## Root cause

Both meshes were scaled by `gs.song.total_length_seconds`, which is the **song-wide** max across all charts in the song (`rssp`'s `summary.total_length` is `max chart length across entries`). When the played chart ends earlier than the longest chart in the song, scatter points at the last played note map to `x ≈ (T_last_played / T_song_max) * width < width`, so the scatter looks truncated.

The density mesh hid the issue: `src/engine/present/density.rs:146-152` appends a synthetic right-edge column when the last measure has notes, so density always reaches the right edge regardless of `last_second`. The scatter has no such trick.

## Fix

`src/screens/evaluation.rs`:

1. Compute `graph_last_second` from the **played chart's** actual content — `max(note_time_cache_ns, hold_end_time_cache_ns)` for that player's note range — instead of `gs.song.total_length_seconds`. Fall back to `total_length_seconds` if no valid note/hold times exist (e.g., empty chart).
2. Make the density mesh consume `si.graph_last_second` instead of independently reading `si.song.total_length_seconds`, so both meshes stay aligned.

Both graphs now fill `graph_width` for the actual played chart, and the scatter no longer appears cut off.