### PR TITLE
feat(sounds): folder-based custom sound packs (#375)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,36 @@ A `save` directory is created inside the data directory to store your personal d
 *   To enable online features with **GrooveStats**, edit `<data dir>/save/profiles/00000000/groovestats.ini` and add your API key and username. This allows the game to fetch your online scores.
 *   You can also change your in-game display name in `<data dir>/save/profiles/00000000/profile.ini`.
 
+### Custom sound packs
+
+DeadSync supports zmod-style "drop in a folder, play a random one" custom
+sounds. The bundled `assets/sounds/` directory ships several folders that
+you can fill with your own `.ogg` files; the data-directory overlay
+(`{data dir}/assets/sounds/...`) is honored as well, so you don't have to
+modify the install. Files whose name starts with `_` are ignored.
+
+| Folder | Plays when |
+|---|---|
+| `assets/sounds/evaluation_pass/` | Any joined player clears (passes) on the Evaluation screen |
+| `assets/sounds/evaluation_fail/` | All joined players failed on the Evaluation screen |
+| `assets/sounds/evaluation_pb/` | GrooveStats submit response reports a Personal Best |
+| `assets/sounds/evaluation_wr/` | GrooveStats submit response reports a World Record (rank 1) |
+| `assets/sounds/song_start/` | Gameplay starts (first try; not on restart) |
+| `assets/sounds/song_start/restart/` | Gameplay restarts. Naming is `{n}.ogg` (1.ogg, 2.ogg, ...). Falls back to `restart.ogg` for any restart count without a matching file |
+
+`{n}` in `song_start/restart/` is the restart count since the last fresh
+entry into Gameplay; it resets to zero on `SelectMusic → Gameplay` and
+between course songs.
+
+Custom per-style menu music works the same way: drop `.ogg` files into
+`assets/music/menu/{style}/` (one of `hearts`, `arrows`, `bears`,
+`ducks`, `cats`, `spooky`, `gay`, `stars`, `thonk`, `technique`, `srpg9`)
+and the menu music for that visual style will randomly pick from your
+files. If the folder is empty the bundled per-style track plays.
+
+The whole feature is gated by `CustomSoundsEnabled` in `deadsync.ini`
+(default `1`). Set it to `0` to disable all folder-based sound triggers.
+
 ## Data Directories
 
 By default, DeadSync stores user data outside the install directory so that upgrading the game doesn't risk overwriting your config, saves, or scores. Linux and FreeBSD use a single `~/.deadsync` root; Windows and macOS use platform-native locations.

--- a/assets/music/menu/Instructions.txt
+++ b/assets/music/menu/Instructions.txt
@@ -1,0 +1,12 @@
+Drop `.ogg` files in any of these subfolders (one per visual style) to
+override the bundled menu music with your own.
+
+When the matching `{style}/` folder contains one or more `.ogg` files, a
+random one is chosen each time menu music starts; if the folder is empty
+or missing, the bundled per-style file is used instead.
+
+Folder names match the lowercase visual-style identifier:
+    hearts, arrows, bears, ducks, cats, spooky, gay, stars,
+    thonk, technique, srpg9
+
+Files starting with `_` are ignored.

--- a/assets/sounds/evaluation_fail/Instructions.txt
+++ b/assets/sounds/evaluation_fail/Instructions.txt
@@ -1,0 +1,7 @@
+Place `.ogg` files in this folder to play one at random when the player
+fails a chart on the Evaluation screen.
+
+Multiple files: a random one is chosen per play.
+Files starting with `_` are ignored.
+
+Enable / disable the whole feature with `CustomSoundsEnabled` in options.ini.

--- a/assets/sounds/evaluation_pass/Instructions.txt
+++ b/assets/sounds/evaluation_pass/Instructions.txt
@@ -1,0 +1,7 @@
+Place `.ogg` files in this folder to play one at random when the player
+clears (passes) a chart on the Evaluation screen.
+
+Multiple files: a random one is chosen per play.
+Files starting with `_` are ignored.
+
+Enable / disable the whole feature with `CustomSoundsEnabled` in options.ini.

--- a/assets/sounds/evaluation_pb/Instructions.txt
+++ b/assets/sounds/evaluation_pb/Instructions.txt
@@ -1,0 +1,8 @@
+Place `.ogg` files in this folder to play one at random when the
+GrooveStats submit response indicates the player earned a Personal Best
+on the Evaluation screen.
+
+Multiple files: a random one is chosen per play.
+Files starting with `_` are ignored.
+
+Enable / disable the whole feature with `CustomSoundsEnabled` in options.ini.

--- a/assets/sounds/evaluation_wr/Instructions.txt
+++ b/assets/sounds/evaluation_wr/Instructions.txt
@@ -1,0 +1,8 @@
+Place `.ogg` files in this folder to play one at random when the
+GrooveStats submit response indicates the player earned a World Record
+(rank 1) on the Evaluation screen.
+
+Multiple files: a random one is chosen per play.
+Files starting with `_` are ignored.
+
+Enable / disable the whole feature with `CustomSoundsEnabled` in options.ini.

--- a/assets/sounds/song_start/Instructions.txt
+++ b/assets/sounds/song_start/Instructions.txt
@@ -1,0 +1,9 @@
+Place `.ogg` files in this folder to play one at random when gameplay
+starts (the first time a chart is played, not on restart).
+
+Multiple files: a random one is chosen per play.
+Files starting with `_` are ignored.
+
+Enable / disable the whole feature with `CustomSoundsEnabled` in options.ini.
+
+See `restart/Instructions.txt` for the per-restart count behavior.

--- a/assets/sounds/song_start/restart/Instructions.txt
+++ b/assets/sounds/song_start/restart/Instructions.txt
@@ -1,0 +1,12 @@
+Place `.ogg` files in this folder named after restart counts:
+
+    1.ogg     - played on the first restart
+    2.ogg     - played on the second restart
+    3.ogg     - played on the third restart
+    ...
+    restart.ogg  - fallback when no `{count}.ogg` file exists
+
+If neither `{count}.ogg` nor `restart.ogg` is present, no sound plays
+on restart.
+
+Enable / disable the whole feature with `CustomSoundsEnabled` in options.ini.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4603,6 +4603,19 @@ impl App {
             self.state.session.course_run.is_some();
         self.state.screens.evaluation_state.auto_advance_seconds = None;
 
+        // Pass / Fail SFX (zmod parity, issue #375). Based on the per-stage
+        // result that was just captured into `eval_snapshot` — the
+        // course-summary replacement below would only run on the very last
+        // course stage, and the per-stage pass/fail is still the right cue
+        // for the player at that moment.
+        let failed = crate::screens::evaluation::all_joined_players_failed(&eval_snapshot);
+        let folder = if failed {
+            "assets/sounds/evaluation_fail"
+        } else {
+            "assets/sounds/evaluation_pass"
+        };
+        crate::engine::audio::folder::play_random_sfx(folder);
+
         if let Some(course_run) = self.state.session.course_run.as_mut() {
             if course_run.next_stage_index >= course_run.stages.len() {
                 let score_hash = course_run.score_hash.clone();
@@ -6506,8 +6519,7 @@ impl App {
         if target_menu_music {
             if !prev_menu_music {
                 commands.push(Command::PlayMusic {
-                    path: dirs::app_dirs()
-                        .resolve_asset_path(visual_styles::menu_music_asset_path()),
+                    path: visual_styles::menu_music_resolved_path(),
                     looped: true,
                     volume: 1.0,
                 });
@@ -7488,6 +7500,21 @@ impl App {
                 self.state.screens.gameplay_state = Some(gs);
                 if let Some(gs) = self.state.screens.gameplay_state.as_mut() {
                     crate::screens::gameplay::on_enter(gs);
+                }
+                // Song Start / Restart SFX (zmod parity, issue #375). At this
+                // point `gameplay_restart_count` has already been zeroed for
+                // fresh entries (line above) and preserved for in-screen
+                // restarts (`try_gameplay_restart` incremented it before we
+                // arrived).
+                let restart_count = self.state.session.gameplay_restart_count;
+                if restart_count == 0 {
+                    crate::engine::audio::folder::play_random_sfx("assets/sounds/song_start");
+                } else {
+                    crate::engine::audio::folder::play_indexed_sfx(
+                        "assets/sounds/song_start/restart",
+                        restart_count,
+                        "restart.ogg",
+                    );
                 }
                 if let Some(course) = self.state.session.course_run.as_mut() {
                     course.next_stage_index = course.next_stage_index.saturating_add(1);

--- a/src/app/screen_nav.rs
+++ b/src/app/screen_nav.rs
@@ -186,7 +186,7 @@ impl App {
         if target_menu_music {
             if !prev_menu_music {
                 crate::engine::audio::play_music(
-                    dirs::app_dirs().resolve_asset_path(visual_styles::menu_music_asset_path()),
+                    visual_styles::menu_music_resolved_path(),
                     crate::engine::audio::Cut::default(),
                     true,
                     1.0,

--- a/src/assets/visual_styles.rs
+++ b/src/assets/visual_styles.rs
@@ -130,6 +130,22 @@ pub fn menu_music_asset_path() -> &'static str {
     for_style(current_style()).menu_music
 }
 
+/// Returns the absolute path to the menu music file that should play for the
+/// current visual style. If the user has dropped one or more `.ogg` files
+/// into `{data_dir}/assets/music/menu/{style}/` (lowercase style name) a
+/// random one of those is returned; otherwise the bundled per-style file
+/// from [`menu_music_asset_path`] is used. Folder override + bundled file
+/// satisfy issue #375 without requiring users to overwrite anything inside
+/// the bundle.
+pub fn menu_music_resolved_path() -> std::path::PathBuf {
+    let style = current_style();
+    let folder_rel = format!("assets/music/menu/{}", style.as_str().to_ascii_lowercase());
+    if let Some(p) = crate::engine::audio::folder::random_music_path(&folder_rel) {
+        return p;
+    }
+    crate::config::dirs::app_dirs().resolve_asset_path(menu_music_asset_path())
+}
+
 #[inline(always)]
 pub fn select_color_aspect(style: VisualStyle) -> f32 {
     let size = for_style(style).select_color_size;

--- a/src/config/load/options.rs
+++ b/src/config/load/options.rs
@@ -246,6 +246,10 @@ fn load_audio_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
         .get("Options", "MenuMusic")
         .and_then(|v| v.parse::<u8>().ok())
         .map_or(default.menu_music, |v| v != 0);
+    cfg.custom_sounds_enabled = conf
+        .get("Options", "CustomSoundsEnabled")
+        .and_then(|v| v.parse::<u8>().ok())
+        .map_or(default.custom_sounds_enabled, |v| v != 0);
     cfg.music_volume = conf
         .get("Options", "MusicVolume")
         .and_then(|v| v.parse().ok())

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -239,6 +239,7 @@ pub struct Config {
     pub visual_delay_seconds: f32,
     pub master_volume: u8,
     pub menu_music: bool,
+    pub custom_sounds_enabled: bool,
     pub music_volume: u8,
     // ITGmania PrefsManager "MusicWheelSwitchSpeed" (default 15).
     pub music_wheel_switch_speed: u8,
@@ -381,6 +382,7 @@ impl Default for Config {
             visual_delay_seconds: 0.0,
             master_volume: 90,
             menu_music: true,
+            custom_sounds_enabled: true,
             music_volume: 100,
             music_wheel_switch_speed: 15,
             assist_tick_volume: 100,

--- a/src/config/store/defaults.rs
+++ b/src/config/store/defaults.rs
@@ -87,6 +87,7 @@ fn push_default_options(content: &mut String, default: &Config) {
     push_line(content, "VisualDelaySeconds", default.visual_delay_seconds);
     push_line(content, "MasterVolume", default.master_volume);
     push_bool(content, "MenuMusic", default.menu_music);
+    push_bool(content, "CustomSoundsEnabled", default.custom_sounds_enabled);
     push_bool(content, "MineHitSound", default.mine_hit_sound);
     push_line(content, "MusicVolume", default.music_volume);
     push_line(

--- a/src/config/store/save.rs
+++ b/src/config/store/save.rs
@@ -158,6 +158,7 @@ fn push_saved_options(
     push_line(content, "VisualDelaySeconds", cfg.visual_delay_seconds);
     push_line(content, "MasterVolume", cfg.master_volume);
     push_bool(content, "MenuMusic", cfg.menu_music);
+    push_bool(content, "CustomSoundsEnabled", cfg.custom_sounds_enabled);
     push_bool(content, "MineHitSound", cfg.mine_hit_sound);
     push_line(content, "MusicVolume", cfg.music_volume);
     push_line(

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -37,6 +37,15 @@ fn clamp_null_or_die_magic_offset_uses_tenths() {
 }
 
 #[test]
+fn config_default_enables_custom_sounds() {
+    let cfg = Config::default();
+    assert!(
+        cfg.custom_sounds_enabled,
+        "custom_sounds_enabled should default to true so the bundled folders are active out of the box"
+    );
+}
+
+#[test]
 fn parse_keycode_common_keys() {
     let cases = [
         ("KeyCode::Enter", KeyCode::Enter),

--- a/src/engine/audio/folder.rs
+++ b/src/engine/audio/folder.rs
@@ -1,0 +1,348 @@
+//! Folder-based random sound effect helpers.
+//!
+//! Mirrors the Simply Love / Zmod "drop ogg files in a folder, play a random
+//! one" convention. The directory contents are listed once per resolved path
+//! and cached for the life of the process. Files whose stem starts with an
+//! underscore are excluded (matches the `_silent.redir` / theme override
+//! convention used by SL/SM5).
+//!
+//! Resolution goes through [`crate::config::dirs::app_dirs`], so a user-supplied
+//! `{data_dir}/assets/sounds/<folder>/...` overlay is automatically picked up
+//! on top of the bundled `assets/` directory.
+
+use crate::config::{self, dirs};
+use log::{debug, warn};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::SystemTime;
+
+static FOLDER_LISTINGS: OnceLock<Mutex<HashMap<PathBuf, Vec<PathBuf>>>> = OnceLock::new();
+
+#[inline(always)]
+fn listings() -> &'static Mutex<HashMap<PathBuf, Vec<PathBuf>>> {
+    FOLDER_LISTINGS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[inline(always)]
+fn is_ogg(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("ogg"))
+}
+
+#[inline(always)]
+fn is_skipped_stem(path: &Path) -> bool {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .is_some_and(|stem| stem.starts_with('_'))
+}
+
+fn list_ogg_files_uncached(dir: &Path) -> Vec<PathBuf> {
+    let read = match std::fs::read_dir(dir) {
+        Ok(r) => r,
+        Err(e) => {
+            // Missing directory is normal (the user hasn't dropped anything in
+            // yet) so we log at debug, not warn.
+            debug!("Custom sound dir unavailable {}: {e}", dir.display());
+            return Vec::new();
+        }
+    };
+    let mut out: Vec<PathBuf> = read
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.is_file() && is_ogg(path) && !is_skipped_stem(path))
+        .collect();
+    out.sort();
+    out
+}
+
+fn cached_listing(dir: &Path) -> Vec<PathBuf> {
+    let key: PathBuf = dir.to_path_buf();
+    {
+        let map = listings().lock().unwrap();
+        if let Some(v) = map.get(&key) {
+            return v.clone();
+        }
+    }
+    let files = list_ogg_files_uncached(dir);
+    let mut map = listings().lock().unwrap();
+    map.entry(key).or_insert(files).clone()
+}
+
+/// Invalidates the cached listing for a resolved directory. Tests use this to
+/// avoid leakage between cases. Not currently exposed to the rest of the app
+/// because the listing is assumed to be stable for the life of the process.
+#[cfg(test)]
+fn invalidate_cache(dir: &Path) {
+    let mut map = listings().lock().unwrap();
+    map.remove(dir);
+}
+
+#[inline(always)]
+fn time_based_index(len: usize) -> usize {
+    if len <= 1 {
+        return 0;
+    }
+    let nanos = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let mut state = nanos.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    state ^= state << 13;
+    state ^= state >> 7;
+    state ^= state << 17;
+    (state as usize) % len
+}
+
+/// Returns true when the folder feature is enabled in config.
+#[inline(always)]
+fn enabled() -> bool {
+    config::get().custom_sounds_enabled
+}
+
+/// Picks a random `.ogg` file from the directory referenced by `rel_dir`
+/// (an `assets/`-relative path, e.g. `"assets/sounds/evaluation_pass"`).
+/// Pure resolver: ignores the `custom_sounds_enabled` flag so the caller can
+/// distinguish "no files" from "feature disabled". Returns `None` when the
+/// directory is missing or contains no eligible `.ogg` files.
+pub fn random_sfx_in(rel_dir: &str) -> Option<PathBuf> {
+    pick_random_in(&dirs::app_dirs().resolve_asset_path(rel_dir))
+}
+
+/// Same as [`random_sfx_in`] but takes a fully resolved directory.
+pub fn pick_random_in(dir: &Path) -> Option<PathBuf> {
+    let listing = cached_listing(dir);
+    if listing.is_empty() {
+        return None;
+    }
+    let idx = time_based_index(listing.len());
+    listing.get(idx).cloned()
+}
+
+/// Picks an indexed `.ogg` file (`{index}.ogg`) from the directory referenced
+/// by `rel_dir`, falling back to `fallback_name` (e.g. `"restart.ogg"`) when
+/// the indexed file is missing. Returns `None` if neither exists.
+pub fn indexed_sfx_in(rel_dir: &str, index: u32, fallback_name: &str) -> Option<PathBuf> {
+    let dir = dirs::app_dirs().resolve_asset_path(rel_dir);
+    pick_indexed_in(&dir, index, fallback_name)
+}
+
+/// Same as [`indexed_sfx_in`] but takes a fully resolved directory.
+pub fn pick_indexed_in(dir: &Path, index: u32, fallback_name: &str) -> Option<PathBuf> {
+    let indexed = dir.join(format!("{index}.ogg"));
+    if indexed.is_file() {
+        return Some(indexed);
+    }
+    let fallback = dir.join(fallback_name);
+    if fallback.is_file() {
+        return Some(fallback);
+    }
+    None
+}
+
+/// Plays a random `.ogg` from `rel_dir` via [`super::play_sfx`]. No-op when
+/// the [`config::Config::custom_sounds_enabled`] flag is off or the folder
+/// is empty.
+pub fn play_random_sfx(rel_dir: &str) {
+    if !enabled() {
+        return;
+    }
+    if let Some(path) = random_sfx_in(rel_dir) {
+        let path_str = path.to_string_lossy().into_owned();
+        super::play_sfx(&path_str);
+    } else {
+        debug!("No custom SFX picked for {rel_dir}");
+    }
+}
+
+/// Plays the indexed `.ogg` (or fallback) from `rel_dir` via [`super::play_sfx`].
+/// No-op when [`config::Config::custom_sounds_enabled`] is off.
+pub fn play_indexed_sfx(rel_dir: &str, index: u32, fallback_name: &str) {
+    if !enabled() {
+        return;
+    }
+    if let Some(path) = indexed_sfx_in(rel_dir, index, fallback_name) {
+        let path_str = path.to_string_lossy().into_owned();
+        super::play_sfx(&path_str);
+    } else {
+        debug!("No custom SFX for {rel_dir} index {index} (fallback {fallback_name})");
+    }
+}
+
+/// Resolves a music path from a folder (or single file). If `rel_path` points
+/// to a directory containing one or more eligible `.ogg` files, a random one
+/// is returned; if it points to a file, that file is returned as-is;
+/// otherwise returns `None`. Independent of `custom_sounds_enabled` because
+/// it powers the per-visual-style menu music selection, not the SFX folder
+/// feature.
+pub fn random_music_path(rel_path: &str) -> Option<PathBuf> {
+    let resolved = dirs::app_dirs().resolve_asset_path(rel_path);
+    if resolved.is_dir() {
+        let picked = pick_random_in(&resolved);
+        if picked.is_none() {
+            warn!(
+                "Menu music folder {} is empty; falling back to no music",
+                resolved.display()
+            );
+        }
+        picked
+    } else if resolved.is_file() {
+        Some(resolved)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    struct TmpDir {
+        path: PathBuf,
+    }
+
+    impl TmpDir {
+        fn new(label: &str) -> Self {
+            let mut path = std::env::temp_dir();
+            let nanos = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_nanos() as u64)
+                .unwrap_or(0);
+            let n = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+            path.push(format!(
+                "deadsync-folder-{label}-{nanos:x}-{n:x}-{}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).expect("create tempdir");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TmpDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn write(path: &Path, name: &str) -> PathBuf {
+        let p = path.join(name);
+        fs::write(&p, b"").expect("write fixture");
+        p
+    }
+
+    #[test]
+    fn pick_random_in_returns_none_for_missing_dir() {
+        let dir = TmpDir::new("missing");
+        let missing = dir.path().join("does_not_exist");
+        invalidate_cache(&missing);
+        assert!(pick_random_in(&missing).is_none());
+    }
+
+    #[test]
+    fn pick_random_in_returns_none_for_empty_dir() {
+        let dir = TmpDir::new("empty");
+        invalidate_cache(dir.path());
+        assert!(pick_random_in(dir.path()).is_none());
+    }
+
+    #[test]
+    fn pick_random_in_single_file_returns_it() {
+        let dir = TmpDir::new("single");
+        let only = write(dir.path(), "alpha.ogg");
+        invalidate_cache(dir.path());
+        let picked = pick_random_in(dir.path()).expect("pick");
+        assert_eq!(picked, only);
+    }
+
+    #[test]
+    fn pick_random_in_returns_one_of_listed_oggs() {
+        let dir = TmpDir::new("multi");
+        let a = write(dir.path(), "a.ogg");
+        let b = write(dir.path(), "b.ogg");
+        invalidate_cache(dir.path());
+        let picked = pick_random_in(dir.path()).expect("pick");
+        assert!(picked == a || picked == b, "{picked:?} not in fixture");
+    }
+
+    #[test]
+    fn pick_random_in_ignores_non_ogg() {
+        let dir = TmpDir::new("nonogg");
+        write(dir.path(), "ignored.wav");
+        write(dir.path(), "ignored.txt");
+        let ogg = write(dir.path(), "kept.ogg");
+        invalidate_cache(dir.path());
+        let picked = pick_random_in(dir.path()).expect("pick");
+        assert_eq!(picked, ogg);
+    }
+
+    #[test]
+    fn pick_random_in_ignores_underscore_prefixed() {
+        let dir = TmpDir::new("underscore");
+        write(dir.path(), "_silent.ogg");
+        let kept = write(dir.path(), "kept.ogg");
+        invalidate_cache(dir.path());
+        let picked = pick_random_in(dir.path()).expect("pick");
+        assert_eq!(picked, kept);
+    }
+
+    #[test]
+    fn pick_random_in_extension_check_is_case_insensitive() {
+        let dir = TmpDir::new("case");
+        let upper = write(dir.path(), "upper.OGG");
+        invalidate_cache(dir.path());
+        let picked = pick_random_in(dir.path()).expect("pick");
+        assert_eq!(picked, upper);
+    }
+
+    #[test]
+    fn pick_indexed_in_returns_indexed_when_present() {
+        let dir = TmpDir::new("indexed");
+        write(dir.path(), "1.ogg");
+        write(dir.path(), "2.ogg");
+        write(dir.path(), "restart.ogg");
+        let picked = pick_indexed_in(dir.path(), 1, "restart.ogg").expect("pick");
+        assert_eq!(picked, dir.path().join("1.ogg"));
+        let picked = pick_indexed_in(dir.path(), 2, "restart.ogg").expect("pick");
+        assert_eq!(picked, dir.path().join("2.ogg"));
+    }
+
+    #[test]
+    fn pick_indexed_in_falls_back_when_index_missing() {
+        let dir = TmpDir::new("fallback");
+        write(dir.path(), "1.ogg");
+        write(dir.path(), "restart.ogg");
+        let picked = pick_indexed_in(dir.path(), 5, "restart.ogg").expect("pick");
+        assert_eq!(picked, dir.path().join("restart.ogg"));
+    }
+
+    #[test]
+    fn pick_indexed_in_none_when_nothing_matches() {
+        let dir = TmpDir::new("none");
+        write(dir.path(), "other.ogg");
+        assert!(pick_indexed_in(dir.path(), 5, "restart.ogg").is_none());
+    }
+
+    #[test]
+    fn cached_listing_reuses_first_result() {
+        let dir = TmpDir::new("cache");
+        write(dir.path(), "a.ogg");
+        invalidate_cache(dir.path());
+
+        let first = cached_listing(dir.path());
+        // Add a new file after caching; the cached value should still be
+        // returned because the listing is process-stable by design.
+        write(dir.path(), "b.ogg");
+        let second = cached_listing(dir.path());
+        assert_eq!(first, second);
+    }
+}
+

--- a/src/engine/audio/mod.rs
+++ b/src/engine/audio/mod.rs
@@ -1,5 +1,6 @@
 mod backends;
 pub(crate) mod decode;
+pub mod folder;
 mod resample;
 
 use crate::config::dirs;

--- a/src/screens/evaluation.rs
+++ b/src/screens/evaluation.rs
@@ -1546,6 +1546,7 @@ pub struct State {
     pub auto_screenshot_taken: bool,
     pub itl_overlay_visible: bool,
     itl_overlay_shown: bool,
+    submit_record_sfx_played: bool,
     submit_groovestats_fallback: [Option<scores::GrooveStatsSubmitUiStatus>; MAX_PLAYERS],
     submit_arrowcloud_fallback: [Option<scores::ArrowCloudSubmitUiStatus>; MAX_PLAYERS],
     lobby_disconnect_hold_p1: Option<Instant>,
@@ -1585,6 +1586,7 @@ impl Clone for State {
             auto_screenshot_taken: self.auto_screenshot_taken,
             itl_overlay_visible: self.itl_overlay_visible,
             itl_overlay_shown: self.itl_overlay_shown,
+            submit_record_sfx_played: self.submit_record_sfx_played,
             submit_groovestats_fallback: self.submit_groovestats_fallback,
             submit_arrowcloud_fallback: self.submit_arrowcloud_fallback,
             lobby_disconnect_hold_p1: self.lobby_disconnect_hold_p1,
@@ -2144,6 +2146,7 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
         auto_screenshot_taken: false,
         itl_overlay_visible: false,
         itl_overlay_shown: false,
+        submit_record_sfx_played: false,
         submit_groovestats_fallback: std::array::from_fn(|_| None),
         submit_arrowcloud_fallback: std::array::from_fn(|_| None),
         lobby_disconnect_hold_p1: None,
@@ -2224,6 +2227,7 @@ pub fn init_from_score_info(
         auto_screenshot_taken: false,
         itl_overlay_visible: false,
         itl_overlay_shown: false,
+        submit_record_sfx_played: false,
         submit_groovestats_fallback: std::array::from_fn(|_| None),
         submit_arrowcloud_fallback: std::array::from_fn(|_| None),
         lobby_disconnect_hold_p1: None,
@@ -2264,6 +2268,46 @@ fn sync_submit_itl_progress(state: &mut State) {
         state.itl_overlay_visible = true;
         state.itl_overlay_shown = true;
     }
+}
+
+/// Fires a one-shot PB / WR sound effect (zmod parity, issue #375) when the
+/// GrooveStats submit response first lands with a record banner. Triggers
+/// once per evaluation visit; subsequent retries or repeated banners do not
+/// re-fire the SFX.
+fn sync_submit_record_sfx(state: &mut State) {
+    if state.submit_record_sfx_played {
+        return;
+    }
+    let mut best: Option<scores::GrooveStatsSubmitRecordBanner> = None;
+    for player_idx in 0..MAX_PLAYERS {
+        let Some(si) = state.score_info[player_idx].as_ref() else {
+            continue;
+        };
+        let Some(banner) = scores::get_groovestats_submit_record_banner_for_side(
+            si.chart.short_hash.as_str(),
+            si.side,
+        ) else {
+            continue;
+        };
+        // WorldRecord{,Ex} beats PersonalBest if any joined player earned it.
+        best = Some(match (best, banner) {
+            (Some(scores::GrooveStatsSubmitRecordBanner::WorldRecord), _)
+            | (Some(scores::GrooveStatsSubmitRecordBanner::WorldRecordEx), _) => best.unwrap(),
+            (_, scores::GrooveStatsSubmitRecordBanner::WorldRecord)
+            | (_, scores::GrooveStatsSubmitRecordBanner::WorldRecordEx) => banner,
+            _ => best.unwrap_or(banner),
+        });
+    }
+    let Some(banner) = best else {
+        return;
+    };
+    let folder = match banner {
+        scores::GrooveStatsSubmitRecordBanner::WorldRecord
+        | scores::GrooveStatsSubmitRecordBanner::WorldRecordEx => "assets/sounds/evaluation_wr",
+        scores::GrooveStatsSubmitRecordBanner::PersonalBest => "assets/sounds/evaluation_pb",
+    };
+    crate::engine::audio::folder::play_random_sfx(folder);
+    state.submit_record_sfx_played = true;
 }
 
 fn sync_missing_submit_status_fallbacks(state: &mut State) {
@@ -2330,6 +2374,7 @@ pub fn update(state: &mut State, dt: f32) {
     }
     sync_submit_itl_progress(state);
     sync_missing_submit_status_fallbacks(state);
+    sync_submit_record_sfx(state);
     scores::tick_groovestats_auto_retries();
     scores::tick_arrowcloud_auto_retries();
     for controller_idx in 0..MAX_PLAYERS {
@@ -2509,7 +2554,7 @@ fn eval_grade_for_result(
     }
 }
 
-fn all_joined_players_failed(state: &State) -> bool {
+pub(crate) fn all_joined_players_failed(state: &State) -> bool {
     let play_style = profile::get_session_play_style();
     let side_to_idx = |side: profile::PlayerSide| match (play_style, side) {
         (profile::PlayStyle::Versus, profile::PlayerSide::P1) => 0,


### PR DESCRIPTION
Closes #375.

## Summary

Adds Zmod-style "drop ogg files in a folder, play a random one" custom sound support. Resolution goes through the existing data-dir overlay, so users can drop their own oggs into `{data dir}/assets/sounds/<folder>/...` without modifying anything in the bundle.

## Reference behavior

ITGmania itself only ships the primitives (`FILEMAN:GetDirListing`, `SOUND:PlayOnce`); the folder-of-random-oggs convention is theme-level code, identical between Zmod and stock Simply Love SM5 (`Scripts/Z-NewFunctions.lua` `findFiles` helper + `Sounds/Evaluation Pass/`, `Evaluation Fail/`, `Evaluation PB/`, `Evaluation WR/`, `Song Start/`, `Song Start/Restart/` folders).

## What's added

| Trigger | Folder | Selection |
|---|---|---|
| Eval enter, any joined player clears | `assets/sounds/evaluation_pass/` | Random `.ogg` |
| Eval enter, all joined players failed | `assets/sounds/evaluation_fail/` | Random `.ogg` |
| GS submit response says PB | `assets/sounds/evaluation_pb/` | Random `.ogg` |
| GS submit response says WR (rank 1) | `assets/sounds/evaluation_wr/` | Random `.ogg` |
| Gameplay entry, first try | `assets/sounds/song_start/` | Random `.ogg` |
| Gameplay entry, restart | `assets/sounds/song_start/restart/` | `{n}.ogg`, falls back to `restart.ogg` |
| Per-visual-style menu music | `assets/music/menu/{style}/` | Random `.ogg`; falls back to bundled file when folder is empty |

Files whose name starts with `_` are ignored (matches the SL/SM5 convention for `_silent.redir` etc.).

## Config

Single new flag in `deadsync.ini`:

```
CustomSoundsEnabled=1
```

Defaults to **on**. Gates only the SFX-folder triggers. The per-visual-style menu music override is independent and always enabled because it composes with the existing per-style fallback (the bundled track plays when no override files exist).
