### PR TITLE
refactor(practice): unify menus behind MenuDef and localize screen chrome

### DIFF
--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -1446,6 +1446,64 @@ KernelTypeHelp=Choose the kernel shape used for the post-processing convolution.
 FullSpectrogramHelp=Allow the full-spectrogram fingerprint path when null-or-die decides it is appropriate.\nThis may use more memory or work for some charts.
 
 ; ============================================================
+; Practice Mode — Main menu rows, Help menu rows, sidebar,
+; flash messages, and right-side info panel.
+; ============================================================
+[Practice]
+TitlePracticeMode=PRACTICE MODE
+MenuPlayWholeSong=Play whole song
+MenuPlayCurrentToEnd=Play current beat to end
+MenuPlaySelection=Play selection
+MenuSetSelectionStart=Set selection start
+MenuSetSelectionEnd=Set selection end
+MenuEditorOptions=Editor options
+MenuExit=Exit Edit Mode
+HelpHoldUpDown=Hold Up/Down: Move by current snap
+HelpSemicolonApostrophe=Semicolon/Apostrophe: Move one measure
+HelpCtrlUpDown=Ctrl+Up/Down: Change zoom
+HelpHomeEnd=Home/End: Move to start/end of steps
+HelpLeftRight=Left/Right: Select note snap
+HelpSpace=Space: Set area marker
+HelpShiftNavigate=Shift+Navigate: Select area
+HelpP=P: Play selection
+HelpEscEnter=Esc/Enter/Start/Back: Main Menu
+HelpSidebarNavigatingTitle=Navigating
+HelpSidebarNavigatingBody=Up/Down:\n     Move One Beat\nSemicolon/Apostrophe:\n     Move One Measure\nCtrl+Up/Down:\n     Change Zoom\nHome/End:\n     Move to Start/End of Steps\nLeft/Right:\n     Select Note Snap
+HelpSidebarMenusTitle=Available Menus
+HelpSidebarMenusBody=Escape\\Enter:\n     Main Menu\nF1:\n     Open Help Menu
+HelpSidebarMiscTitle=Misc.
+HelpSidebarMiscBody=Space:\n     Set area marker\nShift+Navigate:\n     Select area
+FlashZoomChanged=Zoom changed
+FlashAreaMarkerStartSet=Area marker start set
+FlashAreaMarkerEndSet=Area marker end set
+FlashInvalidSelectionStart=Invalid selection start
+FlashSelectionStartSet=Selection start set
+FlashInvalidSelectionEnd=Invalid selection end
+FlashSelectionEndSet=Selection end set
+FlashSelectionCleared=Selection cleared
+InfoCurrentBeat=Current beat:  {beat}
+InfoCurrentSecond=Current second:  {sec}
+InfoSnapTo=Snap to: {snap}
+InfoDifficulty=Difficulty:  {difficulty} {meter}
+InfoSelectionBeatRange=Selection beat:  {start}-{stop}
+InfoSelectionBeatStart=Selection beat:  {start} ...
+InfoSelectionBeatEnd=Selection beat:  ...-{stop}
+InfoMainTitle=Main title
+InfoSubtitle=Subtitle
+InfoDescription=Description
+InfoChartName=Chart name
+InfoStepAuthor=Step author
+InfoChartStyle=Chart style
+InfoNumSteps=Num steps: {count}
+InfoNumJumps=Num jumps: {count}
+InfoNumHands=Num hands: {count}
+InfoNumHolds=Num holds: {count}
+InfoNumMines=Num mines: {count}
+InfoNumRolls=Num rolls: {count}
+InfoNumLifts=Num lifts: {count}
+InfoNumFakes=Num fakes: {count}
+
+; ============================================================
 ; Options Help — Sync Pack submenu
 ; ============================================================
 [OptionsSyncPackHelp]

--- a/src/screens/practice.rs
+++ b/src/screens/practice.rs
@@ -1,4 +1,5 @@
 use crate::act;
+use crate::assets::i18n::{self, LookupKey, lookup_key};
 use crate::assets::{AssetManager, FontRole, current_machine_font_key};
 use crate::engine::audio;
 use crate::engine::input::{InputEvent, RawKeyboardEvent, VirtualAction};
@@ -11,6 +12,7 @@ use crate::game::gameplay::{self as gameplay_core, effective_spacing_multiplier_
 use crate::game::{profile, scroll::ScrollSpeedSetting};
 use crate::screens::gameplay as gameplay_screen;
 use crate::screens::{Screen, ScreenAction};
+use std::sync::Arc;
 use winit::keyboard::KeyCode;
 
 const LEAD_IN_SECONDS: f32 = 1.0;
@@ -40,6 +42,7 @@ const EDIT_MARKER_SOUND: &str = "assets/sounds/screen_edit_marker.ogg";
 const EDIT_SNAP_SOUND: &str = "assets/sounds/screen_edit_snap.ogg";
 const EDIT_INVALID_SOUND: &str = "assets/sounds/common_invalid.ogg";
 const EDIT_SCROLL_SPEEDS: [f32; 7] = [1.0, 1.5, 2.0, 3.0, 4.0, 6.0, 8.0];
+const FLASH_DURATION_SECS: f32 = 0.75;
 
 #[derive(Clone, Copy, Debug)]
 enum Mode {
@@ -83,53 +86,82 @@ pub struct State {
     cursor_hold_down_count: u8,
     cursor_hold_delay_left: f32,
     cursor_hold_repeat_left: f32,
-    flash: Option<(&'static str, f32)>,
+    flash: Option<(String, f32)>,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 struct MenuState {
-    kind: MenuKind,
+    def: &'static MenuDef,
     selected: usize,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum MenuKind {
-    Main,
-    Help,
+type MenuAction = fn(&mut State) -> ScreenAction;
+
+struct MenuRow {
+    label: LookupKey,
+    /// `None` means the row is display-only; activating it just closes the menu.
+    action: Option<MenuAction>,
 }
 
-#[derive(Clone, Copy, Debug)]
-enum MenuItem {
-    PlayWholeSong,
-    PlayCurrentToEnd,
-    PlaySelection,
-    SetSelectionStart,
-    SetSelectionEnd,
-    EditorOptions,
-    Exit,
+struct MenuDef {
+    rows: &'static [MenuRow],
 }
 
-const MAIN_MENU_ITEMS: [MenuItem; 7] = [
-    MenuItem::PlayWholeSong,
-    MenuItem::PlayCurrentToEnd,
-    MenuItem::PlaySelection,
-    MenuItem::SetSelectionStart,
-    MenuItem::SetSelectionEnd,
-    MenuItem::EditorOptions,
-    MenuItem::Exit,
-];
+impl MenuDef {
+    fn first_actionable_row(&self) -> usize {
+        self.rows
+            .iter()
+            .position(|r| r.action.is_some())
+            .unwrap_or(0)
+    }
+}
 
-const HELP_MENU_ITEMS: [&str; 9] = [
-    "Hold Up/Down: Move by current snap",
-    "Semicolon/Apostrophe: Move one measure",
-    "Ctrl+Up/Down: Change zoom",
-    "Home/End: Move to start/end of steps",
-    "Left/Right: Select note snap",
-    "Space: Set area marker",
-    "Shift+Navigate: Select area",
-    "P: Play selection",
-    "Esc/Enter/Start/Back: Main Menu",
-];
+const MAIN_MENU: MenuDef = MenuDef {
+    rows: &[
+        MenuRow {
+            label: lookup_key("Practice", "MenuPlayWholeSong"),
+            action: Some(action_play_whole_song),
+        },
+        MenuRow {
+            label: lookup_key("Practice", "MenuPlayCurrentToEnd"),
+            action: Some(action_play_current_to_end),
+        },
+        MenuRow {
+            label: lookup_key("Practice", "MenuPlaySelection"),
+            action: Some(action_play_selection),
+        },
+        MenuRow {
+            label: lookup_key("Practice", "MenuSetSelectionStart"),
+            action: Some(action_set_selection_start),
+        },
+        MenuRow {
+            label: lookup_key("Practice", "MenuSetSelectionEnd"),
+            action: Some(action_set_selection_end),
+        },
+        MenuRow {
+            label: lookup_key("Practice", "MenuEditorOptions"),
+            action: Some(action_editor_options),
+        },
+        MenuRow {
+            label: lookup_key("Practice", "MenuExit"),
+            action: Some(action_exit_practice),
+        },
+    ],
+};
+
+const HELP_MENU: MenuDef = MenuDef {
+    rows: &[
+        MenuRow { label: lookup_key("Practice", "HelpHoldUpDown"), action: None },
+        MenuRow { label: lookup_key("Practice", "HelpSemicolonApostrophe"), action: None },
+        MenuRow { label: lookup_key("Practice", "HelpCtrlUpDown"), action: None },
+        MenuRow { label: lookup_key("Practice", "HelpHomeEnd"), action: None },
+        MenuRow { label: lookup_key("Practice", "HelpLeftRight"), action: None },
+        MenuRow { label: lookup_key("Practice", "HelpSpace"), action: None },
+        MenuRow { label: lookup_key("Practice", "HelpShiftNavigate"), action: None },
+        MenuRow { label: lookup_key("Practice", "HelpP"), action: None },
+        MenuRow { label: lookup_key("Practice", "HelpEscEnter"), action: None },
+    ],
+};
 
 const SNAP_LABELS: [&str; 9] = [
     "4th", "8th", "12th", "16th", "24th", "32nd", "48th", "64th", "192nd",
@@ -458,8 +490,8 @@ fn open_main_menu(state: &mut State) {
         audio::play_sfx("assets/sounds/start.ogg");
     }
     state.menu = Some(MenuState {
-        kind: MenuKind::Main,
-        selected: first_enabled_menu_row(MenuKind::Main),
+        def: &MAIN_MENU,
+        selected: MAIN_MENU.first_actionable_row(),
     });
 }
 
@@ -469,7 +501,7 @@ fn open_help_menu(state: &mut State) {
         audio::play_sfx("assets/sounds/start.ogg");
     }
     state.menu = Some(MenuState {
-        kind: MenuKind::Help,
+        def: &HELP_MENU,
         selected: 0,
     });
 }
@@ -483,16 +515,13 @@ fn step_menu(state: &mut State, delta: isize) {
     let Some(menu) = state.menu else {
         return;
     };
-    let len = menu_len(menu.kind) as isize;
-    let mut selected = menu.selected;
-    for _ in 0..len {
-        selected = (selected as isize + delta).rem_euclid(len) as usize;
-        if menu_row_enabled(menu.kind, selected) {
-            break;
-        }
+    let len = menu.def.rows.len() as isize;
+    if len == 0 {
+        return;
     }
+    let selected = (menu.selected as isize + delta).rem_euclid(len) as usize;
     state.menu = Some(MenuState {
-        kind: menu.kind,
+        def: menu.def,
         selected,
     });
     audio::play_sfx("assets/sounds/change.ogg");
@@ -502,68 +531,52 @@ fn activate_menu_item(state: &mut State) -> ScreenAction {
     let Some(menu) = state.menu else {
         return ScreenAction::None;
     };
-    if menu.kind == MenuKind::Help {
+    let Some(row) = menu.def.rows.get(menu.selected) else {
+        return ScreenAction::None;
+    };
+    let Some(action) = row.action else {
+        // Display-only row (e.g. Help): treat Enter as close.
         close_menu(state);
         return ScreenAction::None;
-    }
-    if !menu_row_enabled(menu.kind, menu.selected) {
-        audio::play_sfx("assets/sounds/change.ogg");
-        return ScreenAction::None;
-    }
-    let item = MAIN_MENU_ITEMS[menu.selected.min(MAIN_MENU_ITEMS.len() - 1)];
+    };
     state.menu = None;
     clear_cursor_hold_inputs(state);
     audio::play_sfx("assets/sounds/start.ogg");
-    match item {
-        MenuItem::PlayWholeSong => {
-            start_playback(state, MIN_CURSOR_BEAT, max_play_beat(state));
-            ScreenAction::None
-        }
-        MenuItem::PlayCurrentToEnd => {
-            start_playback(state, state.cursor_beat, max_play_beat(state));
-            ScreenAction::None
-        }
-        MenuItem::PlaySelection => {
-            start_selection_like_itg(state);
-            ScreenAction::None
-        }
-        MenuItem::SetSelectionStart => {
-            set_selection_start(state);
-            ScreenAction::None
-        }
-        MenuItem::SetSelectionEnd => {
-            set_selection_end(state);
-            ScreenAction::None
-        }
-        MenuItem::EditorOptions => ScreenAction::Navigate(Screen::PlayerOptions),
-        MenuItem::Exit => ScreenAction::Navigate(Screen::SelectMusic),
-    }
+    action(state)
 }
 
-fn menu_len(kind: MenuKind) -> usize {
-    match kind {
-        MenuKind::Main => MAIN_MENU_ITEMS.len(),
-        MenuKind::Help => HELP_MENU_ITEMS.len(),
-    }
+fn action_play_whole_song(state: &mut State) -> ScreenAction {
+    start_playback(state, MIN_CURSOR_BEAT, max_play_beat(state));
+    ScreenAction::None
 }
 
-fn first_enabled_menu_row(kind: MenuKind) -> usize {
-    (0..menu_len(kind))
-        .find(|&idx| menu_row_enabled(kind, idx))
-        .unwrap_or(0)
+fn action_play_current_to_end(state: &mut State) -> ScreenAction {
+    let cursor = state.cursor_beat;
+    start_playback(state, cursor, max_play_beat(state));
+    ScreenAction::None
 }
 
-fn menu_row_enabled(kind: MenuKind, idx: usize) -> bool {
-    match kind {
-        MenuKind::Main => MAIN_MENU_ITEMS
-            .get(idx)
-            .is_some_and(|item| menu_item_enabled(*item)),
-        MenuKind::Help => true,
-    }
+fn action_play_selection(state: &mut State) -> ScreenAction {
+    start_selection_like_itg(state);
+    ScreenAction::None
 }
 
-const fn menu_item_enabled(_item: MenuItem) -> bool {
-    true
+fn action_set_selection_start(state: &mut State) -> ScreenAction {
+    set_selection_start(state);
+    ScreenAction::None
+}
+
+fn action_set_selection_end(state: &mut State) -> ScreenAction {
+    set_selection_end(state);
+    ScreenAction::None
+}
+
+fn action_editor_options(_state: &mut State) -> ScreenAction {
+    ScreenAction::Navigate(Screen::PlayerOptions)
+}
+
+fn action_exit_practice(_state: &mut State) -> ScreenAction {
+    ScreenAction::Navigate(Screen::SelectMusic)
 }
 
 fn practice_nav_mode() -> PracticeNavMode {
@@ -877,8 +890,15 @@ fn change_edit_scroll_speed(state: &mut State, delta: isize) {
         return;
     }
     state.edit_scroll_speed_index = next;
-    state.flash = Some(("Zoom changed", 0.75));
+    set_flash_tr(state, "FlashZoomChanged");
     audio::play_sfx(EDIT_MARKER_SOUND);
+}
+
+fn set_flash_tr(state: &mut State, key: &str) {
+    state.flash = Some((
+        i18n::tr("Practice", key).to_string(),
+        FLASH_DURATION_SECS,
+    ));
 }
 
 fn seek_chart_note(state: &mut State, dir: i32) {
@@ -913,21 +933,21 @@ fn set_area_marker(state: &mut State) {
     match (state.selection_anchor, state.selection_end) {
         (None, None) => {
             state.selection_anchor = Some(state.cursor_beat);
-            state.flash = Some(("Area marker start set", 0.75));
+            set_flash_tr(state, "FlashAreaMarkerStartSet");
         }
         (Some(begin), None) => {
             if same_beat(begin, state.cursor_beat) {
                 clear_selection(state);
             } else {
                 set_marker_range(state, begin, state.cursor_beat);
-                state.flash = Some(("Area marker end set", 0.75));
+                set_flash_tr(state, "FlashAreaMarkerEndSet");
             }
         }
         _ => {
             state.selection_anchor = Some(state.cursor_beat);
             state.selection_end = None;
             state.shift_anchor = None;
-            state.flash = Some(("Area marker start set", 0.75));
+            set_flash_tr(state, "FlashAreaMarkerStartSet");
         }
     }
 }
@@ -937,12 +957,12 @@ fn set_selection_start(state: &mut State) {
         .selection_end
         .is_some_and(|end| state.cursor_beat >= end)
     {
-        state.flash = Some(("Invalid selection start", 0.75));
+        set_flash_tr(state, "FlashInvalidSelectionStart");
         audio::play_sfx(EDIT_INVALID_SOUND);
         return;
     }
     state.selection_anchor = Some(state.cursor_beat);
-    state.flash = Some(("Selection start set", 0.75));
+    set_flash_tr(state, "FlashSelectionStartSet");
     audio::play_sfx(EDIT_MARKER_SOUND);
 }
 
@@ -951,12 +971,12 @@ fn set_selection_end(state: &mut State) {
         .selection_anchor
         .is_some_and(|start| state.cursor_beat <= start)
     {
-        state.flash = Some(("Invalid selection end", 0.75));
+        set_flash_tr(state, "FlashInvalidSelectionEnd");
         audio::play_sfx(EDIT_INVALID_SOUND);
         return;
     }
     state.selection_end = Some(state.cursor_beat);
-    state.flash = Some(("Selection end set", 0.75));
+    set_flash_tr(state, "FlashSelectionEndSet");
     audio::play_sfx(EDIT_MARKER_SOUND);
 }
 
@@ -964,7 +984,7 @@ fn clear_selection(state: &mut State) {
     state.selection_anchor = None;
     state.selection_end = None;
     state.shift_anchor = None;
-    state.flash = Some(("Selection cleared", 0.75));
+    set_flash_tr(state, "FlashSelectionCleared");
 }
 
 fn set_marker_range(state: &mut State, a: f32, b: f32) {
@@ -1225,7 +1245,7 @@ fn append_edit_overlay(state: &State, actors: &mut Vec<Actor>) {
     let pc = practice_player_color(state);
     actors.push(act!(text:
         font(current_machine_font_key(FontRole::Header)):
-        settext("PRACTICE MODE"):
+        settext(i18n::tr("Practice", "TitlePracticeMode")):
         align(1.0, 0.5):
         xy(screen_width() - 35.0, 10.0):
         zoom(EDIT_HELP_HEADER_ZOOM):
@@ -1243,22 +1263,22 @@ fn append_edit_overlay(state: &State, actors: &mut Vec<Actor>) {
     let status = edit_info_text(state);
     append_help_section(
         actors,
-        "Navigating",
-        "Up/Down:\n     Move One Beat\nSemicolon/Apostrophe:\n     Move One Measure\nCtrl+Up/Down:\n     Change Zoom\nHome/End:\n     Move to Start/End of Steps\nLeft/Right:\n     Select Note Snap",
+        i18n::tr("Practice", "HelpSidebarNavigatingTitle"),
+        i18n::tr("Practice", "HelpSidebarNavigatingBody"),
         0.0,
         pc,
     );
     append_help_section(
         actors,
-        "Available Menus",
-        "Escape\\Enter:\n     Main Menu\nF1:\n     Open Help Menu",
+        i18n::tr("Practice", "HelpSidebarMenusTitle"),
+        i18n::tr("Practice", "HelpSidebarMenusBody"),
         EDIT_HELP_MENU_Y,
         pc,
     );
     append_help_section(
         actors,
-        "Misc.",
-        "Space:\n     Set area marker\nShift+Navigate:\n     Select area",
+        i18n::tr("Practice", "HelpSidebarMiscTitle"),
+        i18n::tr("Practice", "HelpSidebarMiscBody"),
         EDIT_HELP_MISC_Y,
         pc,
     );
@@ -1272,11 +1292,12 @@ fn append_edit_overlay(state: &State, actors: &mut Vec<Actor>) {
         shadowlength(1.0):
         z(3000)
     ));
-    if let Some((text, remaining)) = state.flash {
+    if let Some((text, remaining)) = state.flash.as_ref() {
         let alpha = remaining.clamp(0.0, 1.0);
+        let label = text.clone();
         actors.push(act!(text:
             font("miso"):
-            settext(text):
+            settext(label):
             align(0.5, 0.5):
             xy(screen_width() * 0.5, screen_height() - 80.0):
             zoom(0.9):
@@ -1296,43 +1317,118 @@ fn edit_info_text(state: &State) -> String {
     let song = &state.gameplay.song;
     let current_second = gameplay_core::music_time_for_beat(&state.gameplay, state.cursor_beat);
     let difficulty = color::difficulty_display_name_for_song(&chart.difficulty, &song.title, true);
-    let mut status = format!(
-        "Current beat:  {:.3}\nCurrent second:  {:.6}\nSnap to: {}\n",
-        state.cursor_beat, current_second, SNAP_LABELS[state.snap_index]
-    );
+    let snap = SNAP_LABELS[state.snap_index];
+    let mut status = String::new();
+    status.push_str(&i18n::tr_fmt(
+        "Practice",
+        "InfoCurrentBeat",
+        &[("beat", &format!("{:.3}", state.cursor_beat))],
+    ));
+    status.push('\n');
+    status.push_str(&i18n::tr_fmt(
+        "Practice",
+        "InfoCurrentSecond",
+        &[("sec", &format!("{current_second:.6}"))],
+    ));
+    status.push('\n');
+    status.push_str(&i18n::tr_fmt(
+        "Practice",
+        "InfoSnapTo",
+        &[("snap", snap)],
+    ));
+    status.push('\n');
     if let Some(selection) = selection_info_text(state) {
         status.push_str(&selection);
         status.push('\n');
     }
-    status.push_str(&format!("Difficulty:  {} {}\n\n", difficulty, chart.meter));
-    push_info_line(&mut status, "Main title", &song.title);
-    push_info_line(&mut status, "Subtitle", &song.subtitle);
-    push_info_line(&mut status, "Description", &chart.description);
-    push_info_line(&mut status, "Chart name", &chart.chart_name);
-    push_info_line(&mut status, "Step author", &chart.step_artist);
-    push_info_line(&mut status, "Chart style", &chart.chart_type);
-    status.push('\n');
-    status.push_str(&format!(
-        "Num steps: {}\nNum jumps: {}\nNum hands: {}\nNum holds: {}\nNum mines: {}\nNum rolls: {}\nNum lifts: {}\nNum fakes: {}",
-        chart.stats.total_steps,
-        chart.stats.jumps,
-        chart.stats.hands,
-        state.gameplay.holds_total[0],
-        state.gameplay.mines_total[0],
-        state.gameplay.rolls_total[0],
-        chart.stats.lifts,
-        chart.stats.fakes,
+    status.push_str(&i18n::tr_fmt(
+        "Practice",
+        "InfoDifficulty",
+        &[
+            ("difficulty", difficulty),
+            ("meter", &chart.meter.to_string()),
+        ],
     ));
+    status.push_str("\n\n");
+    push_info_line(
+        &mut status,
+        &i18n::tr("Practice", "InfoMainTitle"),
+        &song.title,
+    );
+    push_info_line(
+        &mut status,
+        &i18n::tr("Practice", "InfoSubtitle"),
+        &song.subtitle,
+    );
+    push_info_line(
+        &mut status,
+        &i18n::tr("Practice", "InfoDescription"),
+        &chart.description,
+    );
+    push_info_line(
+        &mut status,
+        &i18n::tr("Practice", "InfoChartName"),
+        &chart.chart_name,
+    );
+    push_info_line(
+        &mut status,
+        &i18n::tr("Practice", "InfoStepAuthor"),
+        &chart.step_artist,
+    );
+    push_info_line(
+        &mut status,
+        &i18n::tr("Practice", "InfoChartStyle"),
+        &chart.chart_type,
+    );
+    status.push('\n');
+    let stat_lines: [(&str, String); 8] = [
+        ("InfoNumSteps", chart.stats.total_steps.to_string()),
+        ("InfoNumJumps", chart.stats.jumps.to_string()),
+        ("InfoNumHands", chart.stats.hands.to_string()),
+        ("InfoNumHolds", state.gameplay.holds_total[0].to_string()),
+        ("InfoNumMines", state.gameplay.mines_total[0].to_string()),
+        ("InfoNumRolls", state.gameplay.rolls_total[0].to_string()),
+        ("InfoNumLifts", chart.stats.lifts.to_string()),
+        ("InfoNumFakes", chart.stats.fakes.to_string()),
+    ];
+    for (idx, (key, count)) in stat_lines.iter().enumerate() {
+        if idx > 0 {
+            status.push('\n');
+        }
+        status.push_str(&i18n::tr_fmt("Practice", key, &[("count", count)]));
+    }
     status
 }
 
 fn selection_info_text(state: &State) -> Option<String> {
     match (state.selection_anchor, state.selection_end) {
-        (Some(start), Some(stop)) if stop > start => {
-            Some(format!("Selection beat:  {start:.3}-{stop:.3}"))
-        }
-        (Some(start), None) => Some(format!("Selection beat:  {start:.3} ...")),
-        (None, Some(stop)) => Some(format!("Selection beat:  ...-{stop:.3}")),
+        (Some(start), Some(stop)) if stop > start => Some(
+            i18n::tr_fmt(
+                "Practice",
+                "InfoSelectionBeatRange",
+                &[
+                    ("start", &format!("{start:.3}")),
+                    ("stop", &format!("{stop:.3}")),
+                ],
+            )
+            .to_string(),
+        ),
+        (Some(start), None) => Some(
+            i18n::tr_fmt(
+                "Practice",
+                "InfoSelectionBeatStart",
+                &[("start", &format!("{start:.3}"))],
+            )
+            .to_string(),
+        ),
+        (None, Some(stop)) => Some(
+            i18n::tr_fmt(
+                "Practice",
+                "InfoSelectionBeatEnd",
+                &[("stop", &format!("{stop:.3}"))],
+            )
+            .to_string(),
+        ),
         _ => None,
     }
 }
@@ -1361,40 +1457,17 @@ fn append_main_menu(state: &State, actors: &mut Vec<Actor>) {
     let Some(menu) = state.menu else {
         return;
     };
-    let row_count = menu_len(menu.kind);
+    let row_count = menu.def.rows.len();
     let selected_color = practice_player_color(state);
-    for idx in 0..row_count {
+    for (idx, row) in menu.def.rows.iter().enumerate() {
         append_menu_row(
             actors,
             idx,
             row_count,
             menu.selected == idx,
-            menu_row_enabled(menu.kind, idx),
-            menu_row_label(menu.kind, idx),
+            row.label.get(),
             selected_color,
         );
-    }
-}
-
-const fn menu_item_label(item: MenuItem) -> &'static str {
-    match item {
-        MenuItem::PlayWholeSong => "Play whole song",
-        MenuItem::PlayCurrentToEnd => "Play current beat to end",
-        MenuItem::PlaySelection => "Play selection",
-        MenuItem::SetSelectionStart => "Set selection start",
-        MenuItem::SetSelectionEnd => "Set selection end",
-        MenuItem::EditorOptions => "Editor options",
-        MenuItem::Exit => "Exit Edit Mode",
-    }
-}
-
-fn menu_row_label(kind: MenuKind, idx: usize) -> &'static str {
-    match kind {
-        MenuKind::Main => MAIN_MENU_ITEMS
-            .get(idx)
-            .map(|item| menu_item_label(*item))
-            .unwrap_or(""),
-        MenuKind::Help => HELP_MENU_ITEMS.get(idx).copied().unwrap_or(""),
     }
 }
 
@@ -1403,16 +1476,13 @@ fn append_menu_row(
     idx: usize,
     row_count: usize,
     selected: bool,
-    enabled: bool,
-    label: &'static str,
+    label: Arc<str>,
     selected_color: [f32; 4],
 ) {
     let y = menu_row_y(idx, row_count);
     let bg_x = screen_center_x();
     let bg_w = widescale(543.0, 720.0);
-    let (bg, fg) = if !enabled {
-        ([0.015, 0.015, 0.015, 0.95], [0.65, 0.0, 0.0, 1.0])
-    } else if selected {
+    let (bg, fg) = if selected {
         ([0.161, 0.196, 0.22, 0.95], selected_color)
     } else {
         ([0.027, 0.063, 0.086, 0.95], [1.0, 1.0, 1.0, 1.0])
@@ -1448,8 +1518,8 @@ fn menu_row_y(idx: usize, row_count: usize) -> f32 {
 
 fn append_help_section(
     actors: &mut Vec<Actor>,
-    label: &'static str,
-    body: &'static str,
+    label: Arc<str>,
+    body: Arc<str>,
     y: f32,
     player_color: [f32; 4],
 ) {
@@ -1484,11 +1554,54 @@ fn append_help_section(
 #[cfg(test)]
 mod tests {
     use super::{
-        CursorHoldDir, PracticeNavMode, edit_cursor_hold_dir_for_action_in_mode,
-        edit_snap_delta_for_action_in_mode, menu_step_delta_for_action_in_mode,
-        practice_nav_mode_from_config,
+        CursorHoldDir, HELP_MENU, MAIN_MENU, MenuDef, PracticeNavMode,
+        edit_cursor_hold_dir_for_action_in_mode, edit_snap_delta_for_action_in_mode,
+        menu_step_delta_for_action_in_mode, practice_nav_mode_from_config,
     };
+    use crate::assets::i18n;
     use crate::engine::input::VirtualAction;
+
+    /// Every i18n key the practice screen looks up at runtime, outside of the
+    /// menu definitions (which already have their own coverage tests). Keep
+    /// this in sync with call sites — the test below proves each key resolves.
+    const PRACTICE_RUNTIME_KEYS: &[&str] = &[
+        "TitlePracticeMode",
+        "HelpSidebarNavigatingTitle",
+        "HelpSidebarNavigatingBody",
+        "HelpSidebarMenusTitle",
+        "HelpSidebarMenusBody",
+        "HelpSidebarMiscTitle",
+        "HelpSidebarMiscBody",
+        "FlashZoomChanged",
+        "FlashAreaMarkerStartSet",
+        "FlashAreaMarkerEndSet",
+        "FlashInvalidSelectionStart",
+        "FlashSelectionStartSet",
+        "FlashInvalidSelectionEnd",
+        "FlashSelectionEndSet",
+        "FlashSelectionCleared",
+        "InfoCurrentBeat",
+        "InfoCurrentSecond",
+        "InfoSnapTo",
+        "InfoDifficulty",
+        "InfoSelectionBeatRange",
+        "InfoSelectionBeatStart",
+        "InfoSelectionBeatEnd",
+        "InfoMainTitle",
+        "InfoSubtitle",
+        "InfoDescription",
+        "InfoChartName",
+        "InfoStepAuthor",
+        "InfoChartStyle",
+        "InfoNumSteps",
+        "InfoNumJumps",
+        "InfoNumHands",
+        "InfoNumHolds",
+        "InfoNumMines",
+        "InfoNumRolls",
+        "InfoNumLifts",
+        "InfoNumFakes",
+    ];
 
     #[test]
     fn practice_nav_mode_follows_dedicated_menu_config() {
@@ -1568,5 +1681,76 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn help_menu_rows_have_no_actions_main_menu_rows_all_have_actions() {
+        assert!(
+            HELP_MENU.rows.iter().all(|r| r.action.is_none()),
+            "help rows are display-only"
+        );
+        assert!(
+            MAIN_MENU.rows.iter().all(|r| r.action.is_some()),
+            "every main row must dispatch an action"
+        );
+    }
+
+    #[test]
+    fn help_menu_labels_resolve_through_i18n() {
+        i18n::init_for_tests();
+        assert_menu_labels_localized(&HELP_MENU);
+    }
+
+    #[test]
+    fn main_menu_labels_resolve_through_i18n() {
+        i18n::init_for_tests();
+        assert_menu_labels_localized(&MAIN_MENU);
+    }
+
+    #[test]
+    fn all_practice_runtime_keys_resolve_through_i18n() {
+        i18n::init_for_tests();
+        for key in PRACTICE_RUNTIME_KEYS {
+            let resolved = i18n::tr("Practice", key);
+            assert_ne!(
+                resolved.as_ref(),
+                format!("Practice.{key}").as_str(),
+                "missing i18n entry for Practice.{key}"
+            );
+        }
+    }
+
+    #[test]
+    fn placeholder_keys_substitute_named_args() {
+        i18n::init_for_tests();
+        let beat = i18n::tr_fmt("Practice", "InfoCurrentBeat", &[("beat", "3.000")]);
+        assert!(
+            beat.contains("3.000") && !beat.contains("{beat}"),
+            "InfoCurrentBeat did not substitute placeholder: {beat}"
+        );
+        let range = i18n::tr_fmt(
+            "Practice",
+            "InfoSelectionBeatRange",
+            &[("start", "1.000"), ("stop", "2.000")],
+        );
+        assert!(
+            range.contains("1.000")
+                && range.contains("2.000")
+                && !range.contains("{start}")
+                && !range.contains("{stop}"),
+            "InfoSelectionBeatRange did not substitute placeholders: {range}"
+        );
+    }
+
+    fn assert_menu_labels_localized(def: &MenuDef) {
+        for row in def.rows {
+            let resolved = row.label.get();
+            let fallback = format!("{}.{}", row.label.section, row.label.key);
+            assert_ne!(
+                resolved.as_ref(),
+                fallback.as_str(),
+                "missing i18n entry for {fallback}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Pure structural refactor of the Practice screen, no user-facing behavior change.

- Collapses the parallel `MenuKind` / `MenuItem` / `MAIN_MENU_ITEMS` / `HELP_MENU_ITEMS` plumbing into a single data-driven `MenuDef` of `MenuRow`s. Each row carries a typed i18n `LookupKey` label plus an optional `MenuAction`; display-only rows (the F1 help) use `None` and Enter just closes the menu.
- Drops the `menu_len` / `menu_row_enabled` / `first_enabled_menu_row` / `menu_item_enabled` / `menu_item_label` / `menu_row_label` dispatch tax and the dead disabled-row visuals that came with it. Adding a new menu now needs only a new `const MenuDef` + action fns; adding a row is a single struct literal.
- Routes all Practice screen chrome through a new `[Practice]` section in `en.ini`: the title, both menus' labels, the left-side help sidebar (titles + bodies), the eight existing flash messages (via a new `set_flash_tr` helper + `FLASH_DURATION_SECS` constant), and the right-side info panel (via `tr_fmt` with named placeholders so translators can reorder).

## Tests

Adds tests asserting that every menu row label and every runtime-looked-up key resolves through i18n (i.e. doesn't fall back to `Section.Key`), so future drift between code and en.ini fails CI. All 8 practice-module tests pass.