### PR TITLE
feat(evaluation): add TestInput pane (SL Pane6 parity)

### DIFF
--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -996,6 +996,8 @@ BpmRange={min} - {max} bpm
 BpmWithRate={base} ({rate}x Music Rate)
 DifficultyFormat={style} / {difficulty}
 TotalLabel=Total
+TestInputTitle=Test Input
+TestInputInstructions=Use this to diagnose pad problems you may have had during gameplay.
 
 ; ============================================================
 ; Evaluation Summary screen

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4852,6 +4852,9 @@ impl App {
                         .select_music_state
                         .test_input_overlay_visible
                 }
+                CurrentScreen::Evaluation => crate::screens::evaluation::test_input_pane_active(
+                    &self.state.screens.evaluation_state,
+                ),
                 _ => false,
             };
             if !allow_gameplay_arrow {
@@ -6257,6 +6260,10 @@ impl App {
                 }
             }
         } else if self.state.screens.current_screen == CurrentScreen::Evaluation {
+            crate::screens::evaluation::handle_raw_key_event(
+                &mut self.state.screens.evaluation_state,
+                &raw_key,
+            );
             if App::raw_keyboard_restart_screen(self.state.screens.current_screen)
                 && raw_key.pressed
                 && !raw_key.repeat
@@ -8025,6 +8032,11 @@ impl ApplicationHandler<UserEvent> for App {
                 } else if self.state.screens.current_screen == CurrentScreen::SelectMusic {
                     crate::screens::select_music::handle_raw_pad_event(
                         &mut self.state.screens.select_music_state,
+                        &ev,
+                    );
+                } else if self.state.screens.current_screen == CurrentScreen::Evaluation {
+                    crate::screens::evaluation::handle_raw_pad_event(
+                        &mut self.state.screens.evaluation_state,
                         &ev,
                     );
                 }

--- a/src/engine/present/dsl.rs
+++ b/src/engine/present/dsl.rs
@@ -661,6 +661,9 @@ impl SpriteBuilder {
     pub fn wrapwidthpixels(&mut self, _w: f32) {}
 
     #[inline(always)]
+    pub fn vertspacing(&mut self, _s: f32) {}
+
+    #[inline(always)]
     pub fn maxwidth(&mut self, _w: f32) {}
 
     #[inline(always)]
@@ -812,6 +815,7 @@ pub struct TextBuilder {
     fit_w: Option<f32>,
     fit_h: Option<f32>,
     wrap_width_pixels: Option<i32>,
+    line_spacing: Option<i32>,
     max_w: Option<f32>,
     max_h: Option<f32>,
     saw_max_w: bool,
@@ -847,6 +851,7 @@ impl TextBuilder {
             fit_w: None,
             fit_h: None,
             wrap_width_pixels: None,
+            line_spacing: None,
             max_w: None,
             max_h: None,
             saw_max_w: false,
@@ -1013,6 +1018,13 @@ impl TextBuilder {
     pub fn wrapwidthpixels(&mut self, w: f32) {
         let wrap = w as i32;
         self.wrap_width_pixels = (wrap >= 0).then_some(wrap);
+    }
+
+    #[inline(always)]
+    pub fn vertspacing(&mut self, spacing: f32) {
+        // Mirrors SM5 `BitmapText:vertspacing(n)` — overrides the font's
+        // default line spacing (i.e. the distance between successive lines).
+        self.line_spacing = Some(spacing as i32);
     }
 
     #[inline(always)]
@@ -1223,7 +1235,7 @@ impl TextBuilder {
             scale: [self.sx, self.sy],
             fit_width: self.fit_w,
             fit_height: self.fit_h,
-            line_spacing: None,
+            line_spacing: self.line_spacing,
             wrap_width_pixels: self.wrap_width_pixels,
             max_width: self.max_w,
             max_height: self.max_h,
@@ -1641,6 +1653,9 @@ macro_rules! __dsl_apply_one {
     }};
     (wrapwidthpixels ($w:expr) $mods:ident $tw:ident $cur:ident $site:ident) => {{
         $mods.wrapwidthpixels(($w) as f32);
+    }};
+    (vertspacing ($s:expr) $mods:ident $tw:ident $cur:ident $site:ident) => {{
+        $mods.vertspacing(($s) as f32);
     }};
     // --- NEW: max constraints for text -------------------------------
     (maxwidth ($w:expr) $mods:ident $tw:ident $cur:ident $site:ident) => {{

--- a/src/screens/components/evaluation/mod.rs
+++ b/src/screens/components/evaluation/mod.rs
@@ -11,6 +11,8 @@ pub mod pane_stats;
 pub mod pane_timing;
 mod utils;
 
+pub(crate) use utils::pane_origin_x as test_input_pane_origin_x;
+
 pub use event_progress::build_itl_event_overlay;
 pub use event_progress::build_itl_progress_box;
 pub use pane_column::build_column_judgments_pane;

--- a/src/screens/components/evaluation/pane_percentage.rs
+++ b/src/screens/components/evaluation/pane_percentage.rs
@@ -42,6 +42,7 @@ pub(crate) fn build_pane_percentage_display(
             | EvalPane::GrooveStatsEx
             | EvalPane::Itl
             | EvalPane::ArrowCloud
+            | EvalPane::TestInput
     ) {
         return vec![];
     }
@@ -83,6 +84,7 @@ pub(crate) fn build_pane_percentage_display(
         EvalPane::GrooveStatsEx => {}
         EvalPane::Itl => {}
         EvalPane::ArrowCloud => {}
+        EvalPane::TestInput => {}
         EvalPane::Column => {
             // Pane3 percentage container: small and not mirrored.
             frame_x = pane_origin_x - 115.0;

--- a/src/screens/components/evaluation/utils.rs
+++ b/src/screens/components/evaluation/utils.rs
@@ -6,7 +6,7 @@ const MONTH_ABBR: [&str; 12] = [
 ];
 
 #[inline(always)]
-pub(super) fn pane_origin_x(controller: profile::PlayerSide) -> f32 {
+pub(crate) fn pane_origin_x(controller: profile::PlayerSide) -> f32 {
     match controller {
         profile::PlayerSide::P1 => screen_center_x() - 155.0,
         profile::PlayerSide::P2 => screen_center_x() + 155.0,

--- a/src/screens/components/shared/test_input.rs
+++ b/src/screens/components/shared/test_input.rs
@@ -542,18 +542,43 @@ fn push_pad(
     show_player_label: bool,
     z: f32,
 ) {
-    let arrow_h_offset = 67.0_f32;
-    let arrow_v_offset = 68.0_f32;
-    let buttons_y = pad_y + 160.0;
-    let start_y = pad_y + 146.0;
-    let select_y = pad_y + 175.0;
-    let menu_y = pad_y + 160.0;
-    let menu_x_offset = 37.0_f32;
+    push_pad_scaled(
+        actors,
+        state,
+        slot,
+        pad_x,
+        pad_y,
+        show_menu_buttons,
+        show_player_label,
+        z,
+        1.0,
+    );
+}
+
+fn push_pad_scaled(
+    actors: &mut Vec<Actor>,
+    state: &State,
+    slot: PlayerSlot,
+    pad_x: f32,
+    pad_y: f32,
+    show_menu_buttons: bool,
+    show_player_label: bool,
+    z: f32,
+    scale: f32,
+) {
+    let arrow_h_offset = 67.0_f32 * scale;
+    let arrow_v_offset = 68.0_f32 * scale;
+    let sprite_zoom = 0.8_f32 * scale;
+    let buttons_y = pad_y + 160.0 * scale;
+    let start_y = pad_y + 146.0 * scale;
+    let select_y = pad_y + 175.0 * scale;
+    let menu_y = pad_y + 160.0 * scale;
+    let menu_x_offset = 37.0_f32 * scale;
 
     actors.push(act!(sprite("test_input/dance.png"):
         align(0.5, 0.5):
         xy(pad_x, pad_y):
-        zoom(0.8):
+        zoom(sprite_zoom):
         z(z)
     ));
 
@@ -564,8 +589,8 @@ fn push_pad(
         };
         actors.push(act!(text:
             align(0.5, 0.5):
-            xy(pad_x, pad_y - 130.0):
-            zoom(0.7):
+            xy(pad_x, pad_y - 130.0 * scale):
+            zoom(0.7 * scale):
             font(current_machine_font_key(FontRole::Header)):
             settext(label):
             horizalign(center):
@@ -576,28 +601,28 @@ fn push_pad(
     actors.push(act!(sprite("test_input/highlight.png"):
         align(0.5, 0.5):
         xy(pad_x, pad_y - arrow_v_offset):
-        zoom(0.8):
+        zoom(sprite_zoom):
         diffuse(1.0, 1.0, 1.0, held_alpha(state, slot, LogicalButton::Up)):
         z(z + 1.0)
     ));
     actors.push(act!(sprite("test_input/highlight.png"):
         align(0.5, 0.5):
         xy(pad_x, pad_y + arrow_v_offset):
-        zoom(0.8):
+        zoom(sprite_zoom):
         diffuse(1.0, 1.0, 1.0, held_alpha(state, slot, LogicalButton::Down)):
         z(z + 1.0)
     ));
     actors.push(act!(sprite("test_input/highlight.png"):
         align(0.5, 0.5):
         xy(pad_x - arrow_h_offset, pad_y):
-        zoom(0.8):
+        zoom(sprite_zoom):
         diffuse(1.0, 1.0, 1.0, held_alpha(state, slot, LogicalButton::Left)):
         z(z + 1.0)
     ));
     actors.push(act!(sprite("test_input/highlight.png"):
         align(0.5, 0.5):
         xy(pad_x + arrow_h_offset, pad_y):
-        zoom(0.8):
+        zoom(sprite_zoom):
         diffuse(1.0, 1.0, 1.0, held_alpha(state, slot, LogicalButton::Right)):
         z(z + 1.0)
     ));
@@ -606,30 +631,31 @@ fn push_pad(
         return;
     }
 
+    let button_zoom = 0.5_f32 * scale;
     actors.push(act!(sprite("test_input/buttons.png"):
         align(0.5, 0.5):
         xy(pad_x, buttons_y):
-        zoom(0.5):
+        zoom(button_zoom):
         z(z)
     ));
     actors.push(act!(sprite("test_input/highlightgreen.png"):
         align(0.5, 0.5):
         xy(pad_x, start_y):
-        zoom(0.5):
+        zoom(button_zoom):
         diffuse(1.0, 1.0, 1.0, held_alpha(state, slot, LogicalButton::Start)):
         z(z + 1.0)
     ));
     actors.push(act!(sprite("test_input/highlightred.png"):
         align(0.5, 0.5):
         xy(pad_x, select_y):
-        zoom(0.5):
+        zoom(button_zoom):
         diffuse(1.0, 1.0, 1.0, held_alpha(state, slot, LogicalButton::Select)):
         z(z + 1.0)
     ));
     actors.push(act!(sprite("test_input/highlightarrow.png"):
         align(0.5, 0.5):
         xy(pad_x - menu_x_offset, menu_y):
-        zoom(0.5):
+        zoom(button_zoom):
         rotationz(180.0):
         diffuse(1.0, 1.0, 1.0, held_alpha(state, slot, LogicalButton::MenuLeft)):
         z(z + 1.0)
@@ -637,7 +663,7 @@ fn push_pad(
     actors.push(act!(sprite("test_input/highlightarrow.png"):
         align(0.5, 0.5):
         xy(pad_x + menu_x_offset, menu_y):
-        zoom(0.5):
+        zoom(button_zoom):
         diffuse(1.0, 1.0, 1.0, held_alpha(state, slot, LogicalButton::MenuRight)):
         z(z + 1.0)
     ));
@@ -1075,6 +1101,178 @@ pub fn build_test_input_screen_content(state: &State, active_color_index: i32) -
     ));
 
     push_polling_readout(&mut actors, state, 30.0);
+
+    actors
+}
+
+/// Build a TestInput pad for use inside an evaluation pane (SL ScreenEvaluation Pane6 parity).
+///
+/// `scale` scales the entire pad uniformly (1.0 = full size; SL Pane6 uses ~0.8).
+pub fn build_evaluation_pad(
+    state: &State,
+    slot: PlayerSlot,
+    pad_x: f32,
+    pad_y: f32,
+    scale: f32,
+) -> Vec<Actor> {
+    let mut actors = Vec::with_capacity(6);
+    push_pad_scaled(
+        &mut actors,
+        state,
+        slot,
+        pad_x,
+        pad_y,
+        false,
+        false,
+        100.0,
+        scale,
+    );
+    actors
+}
+
+/// Approximate visual half-width of a pad rendered by `build_evaluation_pad` at the given scale.
+/// Useful for laying out neighboring elements (e.g., gaps between two pads in Double play).
+pub fn evaluation_pad_half_width(scale: f32) -> f32 {
+    eval_panel_layout::PAD_NATURAL_WIDTH * 0.5 * scale
+}
+
+mod eval_panel_layout {
+    // Panel size (logical px).
+    pub const PANEL_WIDTH: f32 = 288.889;
+    pub const PANEL_HEIGHT: f32 = 177.778;
+
+    // Pad: top-left corner of the pad's bounding box, panel-local, y-down.
+    pub const PAD_LOGICAL_SCALE: f32 = 0.8222;
+    pub const PAD_X: f32 = 126.667;
+    pub const PAD_Y: f32 = -5.111;
+
+    // Text block.
+    pub const TEXT_LEFT_X: f32 = 3.111;
+    pub const TEXT_BLOCK_WIDTH: f32 = 100.0;
+    pub const TITLE_TOP_Y: f32 = 17.778;
+    pub const DIVIDER_OFFSET: f32 = 23.111;
+    pub const BODY_OFFSET: f32 = 28.889;
+
+    /// If true, the title is horizontally centered within the text block;
+    /// otherwise it's left-aligned to TEXT_LEFT_X.
+    pub const TITLE_CENTERED: bool = true;
+
+    pub const TITLE_ZOOM: f32 = 1.0889;
+    pub const BODY_ZOOM: f32 = 0.7778;
+
+    pub const BODY_LINE_SPACING: i32 = 20;
+
+    /// Pad natural full width at PAD_LOGICAL_SCALE = 1.0, in logical px.
+    /// This is `(arrow_h_offset + half_arrow_sprite) * 2` from `push_pad_scaled`.
+    pub const PAD_NATURAL_WIDTH: f32 = (67.0 + 27.0) * 2.0;
+    /// Pad natural full height at PAD_LOGICAL_SCALE = 1.0, in logical px.
+    pub const PAD_NATURAL_HEIGHT: f32 = (68.0 + 27.0) * 2.0;
+}
+
+/// Visual size of the unscaled panel in logical pixels (width, height at
+/// scale 1.0).
+pub fn evaluation_panel_size() -> (f32, f32) {
+    (
+        eval_panel_layout::PANEL_WIDTH,
+        eval_panel_layout::PANEL_HEIGHT,
+    )
+}
+
+/// Build the TestInput evaluation panel anchored at its **top-left corner**.
+///
+/// `(anchor_x, anchor_y)` is the screen-space position of the panel's
+/// top-left corner. `scale` uniformly scales the entire panel.
+pub fn build_evaluation_panel(
+    state: &State,
+    slot: PlayerSlot,
+    anchor_x: f32,
+    anchor_y: f32,
+    scale: f32,
+    title_font: &'static str,
+    title: std::sync::Arc<str>,
+    body_font: &'static str,
+    instructions: std::sync::Arc<str>,
+) -> Vec<Actor> {
+    use eval_panel_layout::*;
+    let mut actors = Vec::with_capacity(10);
+
+    // Convert a panel-local (x_right, y_down) point in logical px to screen-space actor coords.
+    let map = |local_x: f32, local_y_from_top: f32| -> (f32, f32) {
+        (
+            anchor_x + local_x * scale,
+            anchor_y + local_y_from_top * scale,
+        )
+    };
+
+    let (pad_x, pad_y) = {
+        // PAD_X/PAD_Y refer to the pad's top-left (panel-local, y-down);
+        // convert to the pad's center for push_pad_scaled.
+        let pad_box_w = PAD_NATURAL_WIDTH * PAD_LOGICAL_SCALE;
+        let pad_box_h = PAD_NATURAL_HEIGHT * PAD_LOGICAL_SCALE;
+        let cx_local = PAD_X + pad_box_w * 0.5;
+        let cy_local = PAD_Y + pad_box_h * 0.5;
+        map(cx_local, cy_local)
+    };
+    let pad_scale = PAD_LOGICAL_SCALE * scale;
+    push_pad_scaled(
+        &mut actors,
+        state,
+        slot,
+        pad_x,
+        pad_y,
+        false,
+        false,
+        100.0,
+        pad_scale,
+    );
+
+    let (text_x, title_y) = map(TEXT_LEFT_X, TITLE_TOP_Y);
+    let (_, divider_y) = map(TEXT_LEFT_X, TITLE_TOP_Y + DIVIDER_OFFSET);
+    let (_, body_y) = map(TEXT_LEFT_X, TITLE_TOP_Y + BODY_OFFSET);
+    let block_w = TEXT_BLOCK_WIDTH * scale;
+    let title_zoom = TITLE_ZOOM * scale;
+    let body_zoom = BODY_ZOOM * scale;
+
+    if TITLE_CENTERED {
+        let title_center_x = text_x + block_w * 0.5;
+        actors.push(act!(text:
+            font(title_font):
+            settext(title):
+            align(0.5, 0.0):
+            xy(title_center_x, title_y):
+            zoom(title_zoom):
+            horizalign(center):
+            z(100.0)
+        ));
+    } else {
+        actors.push(act!(text:
+            font(title_font):
+            settext(title):
+            align(0.0, 0.0):
+            xy(text_x, title_y):
+            zoom(title_zoom):
+            horizalign(left):
+            z(100.0)
+        ));
+    }
+    actors.push(act!(quad:
+        align(0.0, 0.0):
+        xy(text_x, divider_y):
+        zoomto(block_w, 2.0_f32.max(scale * 2.0)):
+        diffuse(1.0, 1.0, 1.0, 0.33):
+        z(100.0)
+    ));
+    actors.push(act!(text:
+        font(body_font):
+        settext(instructions):
+        align(0.0, 0.0):
+        xy(text_x, body_y):
+        zoom(body_zoom):
+        horizalign(left):
+        wrapwidthpixels(TEXT_BLOCK_WIDTH / BODY_ZOOM):
+        vertspacing(BODY_LINE_SPACING):
+        z(100.0)
+    ));
 
     actors
 }

--- a/src/screens/evaluation.rs
+++ b/src/screens/evaluation.rs
@@ -12,7 +12,7 @@ use crate::screens::components::shared::screen_bar::{
 use crate::screens::components::{
     evaluation::{self as eval_panes, eval_grades},
     shared::{
-        banner as shared_banner, lobby_hud, mode_pads, screen_bar, timers, transitions,
+        banner as shared_banner, lobby_hud, mode_pads, screen_bar, test_input, timers, transitions,
         visual_style_bg,
     },
 };
@@ -39,7 +39,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
-use crate::engine::input::{InputEvent, VirtualAction};
+use crate::engine::input::{InputEvent, PadEvent, RawKeyboardEvent, VirtualAction};
 use crate::game::profile;
 use crate::game::profile::ScatterWindow;
 use crate::screens::ScreenAction;
@@ -1249,6 +1249,7 @@ mod tests {
             EvalPane::ArrowCloud,
             EvalPane::Timing,
             EvalPane::TimingEx,
+            EvalPane::TestInput,
         ];
 
         for window in cycle.windows(2) {
@@ -1286,6 +1287,7 @@ mod tests {
             EvalPane::ArrowCloud,
             EvalPane::Timing,
             EvalPane::TimingEx,
+            EvalPane::TestInput,
         ];
 
         for window in cycle.windows(2) {
@@ -1315,6 +1317,7 @@ mod tests {
             EvalPane::Timing,
             EvalPane::TimingEx,
             EvalPane::TimingHardEx,
+            EvalPane::TestInput,
         ];
 
         for window in cycle.windows(2) {
@@ -1378,6 +1381,7 @@ pub(crate) enum EvalPane {
     Timing,
     TimingEx,
     TimingHardEx,
+    TestInput,
 }
 
 #[inline(always)]
@@ -1422,6 +1426,7 @@ fn eval_pane_cycle(
     has_gs: bool,
     has_itl: bool,
     has_arrowcloud: bool,
+    has_test_input: bool,
 ) -> Vec<EvalPane> {
     let mut panes = Vec::with_capacity(13);
     panes.push(EvalPane::Standard);
@@ -1449,7 +1454,18 @@ fn eval_pane_cycle(
     if has_hard_ex {
         panes.push(EvalPane::TimingHardEx);
     }
+    if has_test_input {
+        panes.push(EvalPane::TestInput);
+    }
     panes
+}
+
+#[inline(always)]
+fn eval_has_test_input_pane() -> bool {
+    // SL parity: ScreenEvaluation Pane6 is gated on OnlyDedicatedMenuButtons so
+    // that pad arrows can't accidentally cycle panes while the player is testing
+    // their inputs and get stuck on the TestInput pane.
+    crate::config::get().only_dedicated_menu_buttons
 }
 
 #[inline(always)]
@@ -1462,7 +1478,14 @@ fn eval_pane_shift(
     has_itl: bool,
     has_arrowcloud: bool,
 ) -> EvalPane {
-    let panes = eval_pane_cycle(has_hard_ex, has_qr, has_gs, has_itl, has_arrowcloud);
+    let panes = eval_pane_cycle(
+        has_hard_ex,
+        has_qr,
+        has_gs,
+        has_itl,
+        has_arrowcloud,
+        eval_has_test_input_pane(),
+    );
     let Some(cur_idx) = panes.iter().position(|&candidate| candidate == pane) else {
         return panes.first().copied().unwrap_or(EvalPane::Standard);
     };
@@ -1556,6 +1579,7 @@ pub struct State {
     menu_lr_chord: screen_input::MenuLrChordTracker,
     menu_lr_undo: [i8; MAX_PLAYERS],
     favorite_code: crate::screens::favorite_code::FavoriteCodeTracker,
+    test_input_state: test_input::State,
 }
 
 impl Clone for State {
@@ -1595,6 +1619,7 @@ impl Clone for State {
             menu_lr_chord: self.menu_lr_chord,
             menu_lr_undo: self.menu_lr_undo,
             favorite_code: self.favorite_code.clone(),
+            test_input_state: self.test_input_state.clone(),
         }
     }
 }
@@ -2154,6 +2179,7 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
         menu_lr_chord: screen_input::MenuLrChordTracker::default(),
         menu_lr_undo: [0; MAX_PLAYERS],
         favorite_code: Default::default(),
+        test_input_state: test_input::State::default(),
     }
 }
 
@@ -2234,6 +2260,7 @@ pub fn init_from_score_info(
         menu_lr_chord: screen_input::MenuLrChordTracker::default(),
         menu_lr_undo: [0; MAX_PLAYERS],
         favorite_code: Default::default(),
+        test_input_state: test_input::State::default(),
     }
 }
 
@@ -2485,6 +2512,14 @@ pub fn retry_submissions(state: &State) -> bool {
         retried |= scores::retry_arrowcloud_submit(si.chart.short_hash.as_str(), si.side);
     }
     retried
+}
+
+/// Returns true if any controller currently has the TestInput pane active.
+pub fn test_input_pane_active(state: &State) -> bool {
+    state
+        .active_pane
+        .iter()
+        .any(|&pane| matches!(pane, EvalPane::TestInput))
 }
 
 #[inline(always)]
@@ -2780,7 +2815,30 @@ fn barely_marker_sample(si: &ScoreInfo) -> Option<(f32, f32)> {
     Some((t, min_life))
 }
 
+pub fn handle_raw_pad_event(state: &mut State, pad_event: &PadEvent) {
+    test_input::apply_raw_pad_event(&mut state.test_input_state, pad_event);
+}
+
+pub fn handle_raw_key_event(state: &mut State, key_event: &RawKeyboardEvent) {
+    test_input::apply_raw_key_event(&mut state.test_input_state, key_event);
+}
+
 pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
+    // Feed virtual input through the test_input state so the highlight feedback on the
+    // EvalPane::TestInput pad reflects MENU buttons / Start / Select while the pane is active.
+    let _ = test_input::apply_virtual_input(&mut state.test_input_state, ev);
+
+    // When the TestInput pane is active and OnlyDedicatedMenuButtons is on, gameplay
+    // arrow presses are routed here purely to drive the pad's highlight feedback —
+    // they must NOT also trigger pane cycling, favorite-code tracking, or other
+    // arrow-driven side effects. Short-circuit before the rest of the handler.
+    if ev.action.is_gameplay_arrow()
+        && crate::config::get().only_dedicated_menu_buttons
+        && test_input_pane_active(state)
+    {
+        return ScreenAction::None;
+    }
+
     let chord_side = if crate::config::get().three_key_navigation {
         state.menu_lr_chord.update(ev)
     } else {
@@ -3823,6 +3881,65 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                         asset_manager,
                         state.screen_elapsed,
                     ));
+                }
+                EvalPane::TestInput => {
+                    // Centered, uniformly scaled TestInput panel (text on left, pad on right).
+                    let pane_ox =
+                        crate::screens::components::evaluation::test_input_pane_origin_x(
+                            controller,
+                        );
+                    let panel_scale = 1.0_f32;
+                    let (panel_w, panel_h) = test_input::evaluation_panel_size();
+                    let panel_w_scaled = panel_w * panel_scale;
+                    let panel_h_scaled = panel_h * panel_scale;
+
+                    // Center the panel horizontally in the per-controller pane,
+                    // and vertically around screen_center_y + 50 (matches the other panes' visible area).
+                    let panel_center_x = pane_ox;
+                    let panel_center_y = screen_center_y() + 50.0;
+                    let anchor_x = panel_center_x - panel_w_scaled * 0.5;
+                    let anchor_y = panel_center_y - panel_h_scaled * 0.5;
+
+                    let title_font = current_machine_font_key(FontRole::Normal);
+                    let body_font = current_machine_font_key(FontRole::Normal);
+                    let title = tr("Evaluation", "TestInputTitle");
+                    let instructions = tr("Evaluation", "TestInputInstructions");
+
+                    if play_style == profile::PlayStyle::Double {
+                        let pad_scale = 0.75_f32 * panel_scale;
+                        let pad_half = test_input::evaluation_pad_half_width(pad_scale);
+                        let gap = pad_half + 6.0;
+                        actors.extend(test_input::build_evaluation_pad(
+                            &state.test_input_state,
+                            test_input::PlayerSlot::P1,
+                            pane_ox - gap,
+                            panel_center_y,
+                            pad_scale,
+                        ));
+                        actors.extend(test_input::build_evaluation_pad(
+                            &state.test_input_state,
+                            test_input::PlayerSlot::P2,
+                            pane_ox + gap,
+                            panel_center_y,
+                            pad_scale,
+                        ));
+                    } else {
+                        let slot = match controller {
+                            profile::PlayerSide::P1 => test_input::PlayerSlot::P1,
+                            profile::PlayerSide::P2 => test_input::PlayerSlot::P2,
+                        };
+                        actors.extend(test_input::build_evaluation_panel(
+                            &state.test_input_state,
+                            slot,
+                            anchor_x,
+                            anchor_y,
+                            panel_scale,
+                            title_font,
+                            title,
+                            body_font,
+                            instructions,
+                        ));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adds a TestInput pane to ScreenEvaluation matching Simply Love's Pane6.

## Changes
- New `EvalPane::TestInput` appended to the pane cycle, gated on `OnlyDedicatedMenuButtons` (matches SL behavior so pad arrows can't trap players on the pane).
- Self-contained `build_evaluation_panel` in `shared/test_input` renders a localized **Test Input** title, divider, wrapped instructions, and a scaled pad anchored at a top-left coordinate.
- Routes raw pad/key events and virtual gameplay arrows on the evaluation screen into the `test_input` state so pad highlights light up only while the TestInput pane is active.
- Adds `vertspacing(...)` to the actor DSL so wrapped body text can use tighter line spacing.
- New `en.ini` strings under `[Evaluation]`: `TestInputTitle`, `TestInputInstructions`.

Addresses #361 