### PR TITLE
fix(evaluation): allow restart button to retry from eval screen

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4880,7 +4880,10 @@ impl App {
             return Ok(());
         }
         if ev.pressed
-            && self.state.screens.current_screen == CurrentScreen::Gameplay
+            && matches!(
+                self.state.screens.current_screen,
+                CurrentScreen::Gameplay | CurrentScreen::Evaluation
+            )
             && self.state.gameplay_offset_save_prompt.is_none()
             && self.state.session.course_run.is_none()
             && matches!(


### PR DESCRIPTION
## Summary

Closes #348.

The previous fix for #170 (commit 780af1a8) only enabled the Ctrl+R raw-keyboard path on the Evaluation screen. The virtual `p1_restart` / `p2_restart` action (e.g. numpad + on macOS) was still gated to `CurrentScreen::Gameplay` only, so users with restart bound to a key/button couldn't retry from eval.

- Expand the restart-button gate in `route_input_event` to also accept `CurrentScreen::Evaluation`, mirroring the Ctrl+R behavior.
- `prepare_player_options_for_gameplay_restart` already supports the Evaluation path via `restart_payload_from_eval`, so no other plumbing was needed.
