### PR TITLE
fix(select-music): route P2 Up/Down through handle_pad_dir_p2 in single-player mode

### DIFF
--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -8372,20 +8372,12 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
                 ev.pressed,
                 ev.timestamp,
             ),
-            VirtualAction::p2_up | VirtualAction::p2_menu_up => handle_pad_dir(
-                state,
-                profile::PlayerSide::P2,
-                PadDir::Up,
-                ev.pressed,
-                ev.timestamp,
-            ),
-            VirtualAction::p2_down | VirtualAction::p2_menu_down => handle_pad_dir(
-                state,
-                profile::PlayerSide::P2,
-                PadDir::Down,
-                ev.pressed,
-                ev.timestamp,
-            ),
+            VirtualAction::p2_up | VirtualAction::p2_menu_up => {
+                handle_pad_dir_p2(state, PadDir::Up, ev.pressed, ev.timestamp)
+            }
+            VirtualAction::p2_down | VirtualAction::p2_menu_down => {
+                handle_pad_dir_p2(state, PadDir::Down, ev.pressed, ev.timestamp)
+            }
             VirtualAction::p2_start if ev.pressed => {
                 if try_open_select_music_menu_with_select_start(
                     state,


### PR DESCRIPTION
In non-Versus mode with session side P2, `p2_up`/`p2_down` were dispatched to the generic `handle_pad_dir`, whose Up/Down branch unconditionally uses P1 state (`chord_mask_p1`, `last_steps_nav_dir_p1`, `selected_steps_index`, `preferred_difficulty_index`).

This broke double-tap-to-change-steps for P2 and made chord/steps state diverge from the Versus-mode path, where P2 Up/Down already routes to `handle_pad_dir_p2`.

This PR routes those actions to `handle_pad_dir_p2` so P2-specific fields are used consistently in single-player P2 mode.