### PR TITLE
Add experimental ReplayGain 2.0 / EBU R 128 loudness normalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,6 +933,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "dasp_frame"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a3937f5fe2135702897535c8d4a5553f8b116f76c1529088797f2eee7c5cd6"
+dependencies = [
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +967,7 @@ dependencies = [
  "claxon",
  "coreaudio-rs",
  "directories",
+ "ebur128",
  "env_logger",
  "fs_extra",
  "glam",
@@ -1161,6 +1177,18 @@ name = "dtor"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
+
+[[package]]
+name = "ebur128"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e227cc62d64d6fe01abbef48134b9c1f17d470cef1e7a56337ad05b1f81df7f9"
+dependencies = [
+ "bitflags 1.3.2",
+ "dasp_frame",
+ "dasp_sample",
+ "smallvec",
+]
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ claxon = "0.4.3"
 opusic-c = "1.6.1"
 rubato = "0.16.2"
 memmap2 = "0.9.10"
+ebur128 = "0.1.10"
 
 # Networking
 ureq = { version = "3.3.0", features = ["json", "rustls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ path = "scripts/lang_coverage.rs"
 name = "generate_pseudo"
 path = "scripts/generate_pseudo.rs"
 
+[[bin]]
+name = "replaygain_bench"
+path = "scripts/replaygain_bench.rs"
+
 
 [features]
 pipewire-audio = ["dep:pipewire"]

--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -202,6 +202,7 @@ GlobalOffsetMs=Global Offset (ms)
 GlobalOffset=Global Offset (ms)
 AlsaExclusive=Exclusive Mode
 RateModPreservesPitch=RateMod Preserves Pitch
+ReplayGain=ReplayGain (Experimental)
 OutputModeAuto=Auto
 OutputModeShared=Shared
 LinuxBackendAuto=Auto
@@ -1286,6 +1287,7 @@ MusicVolumeHelp=Set the music volume before master volume is applied.
 MineSoundsHelp=Play a sound when mines are hit.
 GlobalOffsetHelp=Apply a global audio timing offset in 1 ms steps.
 RateModPreservesPitchHelp=Keep pitch constant when rate mods are active.
+ReplayGainHelp=Experimental: normalize playback loudness across songs using ReplayGain 2.0 / EBU R 128. Loudness is computed in the background on first play and cached on disk; gain is applied to subsequent playback or live once analysis completes.
 
 ; ============================================================
 ; Options Help — Input submenu

--- a/scripts/replaygain_bench.rs
+++ b/scripts/replaygain_bench.rs
@@ -1,0 +1,160 @@
+//! Standalone benchmark for the ReplayGain analyzer.
+//!
+//! Walks a directory, finds supported audio files, runs the same loudness
+//! analysis the in-game worker uses, and prints per-file timings plus a
+//! summary. Use this to size prewarm strategies (neighbor-window, pack-open,
+//! song-scan) against your actual library.
+//!
+//! Usage:
+//!   cargo run --profile local --bin replaygain_bench -- <dir> [--limit N] [--write-cache]
+//!
+//! `--write-cache` routes through the public `prewarm_paths` + `flush_now`
+//! API instead of calling the analyzer directly, exercising the disk-cache
+//! write path end-to-end.
+
+use deadsync::engine::audio::replaygain::{
+    Priority, compute_loudness_public, flush_now, prewarm_paths,
+};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+fn main() {
+    let _ = env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .try_init();
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: replaygain_bench <dir> [--limit N] [--write-cache]");
+        std::process::exit(2);
+    }
+    let root = PathBuf::from(&args[0]);
+    let limit: Option<usize> = args
+        .windows(2)
+        .find(|w| w[0] == "--limit")
+        .and_then(|w| w[1].parse().ok());
+    let write_cache = args.iter().any(|a| a == "--write-cache");
+
+    let mut files: Vec<PathBuf> = Vec::new();
+    walk(&root, &mut files);
+    files.sort();
+    if let Some(n) = limit {
+        files.truncate(n);
+    }
+
+    if files.is_empty() {
+        eprintln!("no audio files found under {}", root.display());
+        std::process::exit(1);
+    }
+
+    if write_cache {
+        println!(
+            "Routing {} files through the disk cache (prewarm_paths + flush_now)",
+            files.len()
+        );
+        let t = Instant::now();
+        // Use Foreground priority so the worker pool serves these
+        // immediately, not as background prewarm.
+        prewarm_paths(files.iter().cloned(), Priority::Foreground);
+        // Wait long enough for the worker pool (2 threads) to drain,
+        // sized off the measured ~400 ms/song analyze cost with 100% buffer.
+        let drain_ms = (files.len() as u64 * 400) + 2000;
+        println!("Waiting up to {} ms for worker pool to drain...", drain_ms);
+        std::thread::sleep(std::time::Duration::from_millis(drain_ms));
+        flush_now();
+        println!(
+            "Wall time (incl. drain + flush): {:.1} s",
+            t.elapsed().as_secs_f64()
+        );
+        return;
+    }
+
+    println!("Analyzing {} files under {}", files.len(), root.display());
+    println!("{:>9} {:>7} {:>7}  {}", "time_ms", "LUFS", "peak", "path");
+
+    let mut total_ms = 0.0f64;
+    let mut ok = 0usize;
+    let mut fail = 0usize;
+    let mut min_ms = f64::INFINITY;
+    let mut max_ms = 0.0f64;
+    let mut samples_ms: Vec<f64> = Vec::with_capacity(files.len());
+
+    let bench_start = Instant::now();
+    for path in &files {
+        let t = Instant::now();
+        let result = compute_loudness_public(path);
+        let elapsed_ms = t.elapsed().as_secs_f64() * 1000.0;
+        total_ms += elapsed_ms;
+        match result {
+            Ok(info) => {
+                ok += 1;
+                min_ms = min_ms.min(elapsed_ms);
+                max_ms = max_ms.max(elapsed_ms);
+                samples_ms.push(elapsed_ms);
+                let rel = path.strip_prefix(&root).unwrap_or(path);
+                println!(
+                    "{:>9.1} {:>7.2} {:>7.3}  {}",
+                    elapsed_ms,
+                    info.lufs,
+                    info.true_peak_linear,
+                    rel.display()
+                );
+            }
+            Err(e) => {
+                fail += 1;
+                let rel = path.strip_prefix(&root).unwrap_or(path);
+                println!("{:>9.1}    ERR    -    {}  ({e})", elapsed_ms, rel.display());
+            }
+        }
+    }
+    let wall_ms = bench_start.elapsed().as_secs_f64() * 1000.0;
+
+    samples_ms.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let pct = |p: f64| {
+        if samples_ms.is_empty() {
+            0.0
+        } else {
+            let idx = ((p / 100.0) * (samples_ms.len() as f64 - 1.0)).round() as usize;
+            samples_ms[idx.min(samples_ms.len() - 1)]
+        }
+    };
+    let mean = if ok > 0 { total_ms / ok as f64 } else { 0.0 };
+
+    println!();
+    println!("--- summary ---");
+    println!("files:        {}  ({} ok, {} failed)", files.len(), ok, fail);
+    println!("wall time:    {:>9.1} ms", wall_ms);
+    println!("sum analyze:  {:>9.1} ms", total_ms);
+    if ok > 0 {
+        println!("per file mean:{:>9.1} ms", mean);
+        println!("           min:{:>8.1} ms", min_ms);
+        println!("           p50:{:>8.1} ms", pct(50.0));
+        println!("           p90:{:>8.1} ms", pct(90.0));
+        println!("           p99:{:>8.1} ms", pct(99.0));
+        println!("           max:{:>8.1} ms", max_ms);
+    }
+}
+
+fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in rd.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk(&path, out);
+        } else if is_audio(&path) {
+            out.push(path);
+        }
+    }
+}
+
+fn is_audio(path: &Path) -> bool {
+    matches!(
+        path.extension()
+            .and_then(|e| e.to_str())
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("ogg" | "mp3" | "flac" | "wav" | "opus")
+    )
+}

--- a/src/config/dirs.rs
+++ b/src/config/dirs.rs
@@ -61,6 +61,10 @@ impl AppDirs {
         self.cache_dir.join("cdtitle")
     }
 
+    pub fn replaygain_cache_dir(&self) -> PathBuf {
+        self.cache_dir.join("replaygain")
+    }
+
     pub fn downloads_dir(&self) -> PathBuf {
         self.cache_dir.join("downloads")
     }

--- a/src/config/dirs.rs
+++ b/src/config/dirs.rs
@@ -65,6 +65,13 @@ impl AppDirs {
         self.cache_dir.join("replaygain")
     }
 
+    /// Single-file consolidated ReplayGain cache. Replaces the legacy
+    /// per-song `replaygain/<hash>.bin` layout, which doesn't scale to
+    /// libraries of 10k+ songs.
+    pub fn replaygain_cache_file(&self) -> PathBuf {
+        self.cache_dir.join("replaygain.bin")
+    }
+
     pub fn downloads_dir(&self) -> PathBuf {
         self.cache_dir.join("downloads")
     }

--- a/src/config/load/options.rs
+++ b/src/config/load/options.rs
@@ -296,6 +296,10 @@ fn load_audio_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
         .get("Options", "RateModPreservesPitch")
         .and_then(|v| v.parse::<u8>().ok())
         .map_or(default.rate_mod_preserves_pitch, |v| v != 0);
+    cfg.enable_replaygain = conf
+        .get("Options", "ReplayGain")
+        .and_then(|v| v.parse::<u8>().ok())
+        .map_or(default.enable_replaygain, |v| v != 0);
     cfg.write_current_screen = conf
         .get("Options", "WriteCurrentScreen")
         .and_then(|v| parse_bool_str(&v))

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -254,6 +254,10 @@ pub struct Config {
     pub auto_download_unlocks: bool,
     pub auto_populate_gs_scores: bool,
     pub rate_mod_preserves_pitch: bool,
+    /// Experimental: apply ReplayGain 2.0 / EBU R 128 loudness normalization
+    /// to music playback. Loudness is computed in the background and cached
+    /// on disk per song.
+    pub enable_replaygain: bool,
     pub enable_arrowcloud: bool,
     pub enable_boogiestats: bool,
     pub enable_groovestats: bool,
@@ -394,6 +398,7 @@ impl Default for Config {
             auto_download_unlocks: false,
             auto_populate_gs_scores: false,
             rate_mod_preserves_pitch: true,
+            enable_replaygain: false,
             enable_arrowcloud: false,
             enable_boogiestats: false,
             enable_groovestats: false,

--- a/src/config/store/defaults.rs
+++ b/src/config/store/defaults.rs
@@ -100,6 +100,7 @@ fn push_default_options(content: &mut String, default: &Config) {
         "RateModPreservesPitch",
         default.rate_mod_preserves_pitch,
     );
+    push_bool(content, "ReplayGain", default.enable_replaygain);
     push_line(
         content,
         "SelectMusicBreakdown",

--- a/src/config/store/save.rs
+++ b/src/config/store/save.rs
@@ -171,6 +171,7 @@ fn push_saved_options(
         "RateModPreservesPitch",
         cfg.rate_mod_preserves_pitch,
     );
+    push_bool(content, "ReplayGain", cfg.enable_replaygain);
     push_line(
         content,
         "SelectMusicBreakdown",

--- a/src/config/update/audio.rs
+++ b/src/config/update/audio.rs
@@ -163,3 +163,15 @@ pub fn update_rate_mod_preserves_pitch(enabled: bool) {
     }
     save_without_keymaps();
 }
+
+pub fn update_enable_replaygain(enabled: bool) {
+    {
+        let mut cfg = lock_config();
+        if cfg.enable_replaygain == enabled {
+            return;
+        }
+        cfg.enable_replaygain = enabled;
+    }
+    crate::engine::audio::on_replaygain_setting_changed(enabled);
+    save_without_keymaps();
+}

--- a/src/engine/audio/mod.rs
+++ b/src/engine/audio/mod.rs
@@ -1,6 +1,7 @@
 mod backends;
 pub(crate) mod decode;
 pub mod folder;
+pub mod replaygain;
 mod resample;
 
 use crate::config::dirs;
@@ -582,6 +583,15 @@ static MUSIC_TOTAL_FRAMES: AtomicU64 = AtomicU64::new(0);
 static MUSIC_TRACK_START_FRAME: AtomicU64 = AtomicU64::new(0);
 static MUSIC_TRACK_HAS_STARTED: AtomicBool = AtomicBool::new(false);
 static MUSIC_TRACK_ACTIVE: AtomicBool = AtomicBool::new(false);
+// Per-play monotonic id used to associate asynchronous ReplayGain results
+// with the track that requested them. `set_music_replaygain_if_matches` is
+// a no-op if the id no longer matches the active track, preventing a stale
+// gain value from being applied to a different song.
+static MUSIC_TRACK_ID: AtomicU64 = AtomicU64::new(0);
+// Bits of an f32 linear gain (default 1.0) applied to the music stream by
+// the audio output callback. Updated either synchronously by `play_music`
+// (cache hit) or asynchronously by the ReplayGain worker.
+static MUSIC_GAIN_LINEAR_BITS: AtomicU32 = AtomicU32::new(1.0f32.to_bits());
 static MUSIC_MAP_GEN: AtomicU64 = AtomicU64::new(1);
 
 // Last audio callback timing, used to interpolate the playback position
@@ -1418,14 +1428,59 @@ pub fn play_music(path: PathBuf, cut: Cut, looping: bool, rate: f32) {
         1.0
     };
     reset_music_stream_clock();
+
+    // Resolve a per-play track id and decide on the initial ReplayGain
+    // value. If the user has the experimental ReplayGain setting on, and we
+    // already have a cached/computed value, apply it immediately; otherwise
+    // queue a background analysis job. If the setting is off, force unity
+    // gain so a previous track's value doesn't leak forward.
+    let track_id = MUSIC_TRACK_ID
+        .fetch_add(1, Ordering::AcqRel)
+        .wrapping_add(1);
+    let initial_gain: f32 = if crate::config::get().enable_replaygain {
+        replaygain::get_or_queue_gain_linear(&path, track_id).unwrap_or(1.0)
+    } else {
+        1.0
+    };
+    MUSIC_GAIN_LINEAR_BITS.store(initial_gain.to_bits(), Ordering::Relaxed);
+
     let _ = ENGINE
         .command_sender
         .send(AudioCommand::PlayMusic(path, cut, looping, rate));
 }
 
+/// Applies a ReplayGain result from the background analyzer, but only if it
+/// still corresponds to the currently active music track. Called by
+/// [`replaygain`]; safe to call from any thread.
+pub fn set_music_replaygain_if_matches(track_id: u64, gain_linear: f32) {
+    let active_id = MUSIC_TRACK_ID.load(Ordering::Acquire);
+    if active_id != track_id {
+        return;
+    }
+    if !MUSIC_TRACK_ACTIVE.load(Ordering::Acquire) {
+        return;
+    }
+    let gain = if gain_linear.is_finite() && gain_linear > 0.0 {
+        gain_linear
+    } else {
+        1.0
+    };
+    MUSIC_GAIN_LINEAR_BITS.store(gain.to_bits(), Ordering::Relaxed);
+}
+
+/// Called from the config layer when the user toggles the ReplayGain
+/// setting. When disabled, forces unity gain immediately so the change is
+/// audible without requiring track restart.
+pub fn on_replaygain_setting_changed(enabled: bool) {
+    if !enabled {
+        MUSIC_GAIN_LINEAR_BITS.store(1.0f32.to_bits(), Ordering::Relaxed);
+    }
+}
+
 /// Stops the currently playing music track.
 pub fn stop_music() {
     reset_music_stream_clock();
+    MUSIC_GAIN_LINEAR_BITS.store(1.0f32.to_bits(), Ordering::Relaxed);
     let _ = ENGINE.command_sender.send(AudioCommand::StopMusic);
 }
 
@@ -1741,8 +1796,10 @@ impl RenderState {
         }
 
         let (music_vol, sfx_vol, assist_tick_vol) = Self::mix_levels();
+        let music_gain = f32::from_bits(MUSIC_GAIN_LINEAR_BITS.load(Ordering::Relaxed));
+        let music_scale = music_vol * music_gain;
         for (dst, src) in self.mix_f32.iter_mut().zip(&self.mix_i16) {
-            *dst = i16_to_f32(*src) * music_vol;
+            *dst = i16_to_f32(*src) * music_scale;
         }
 
         for new_sfx in self.sfx_receiver.try_iter() {

--- a/src/engine/audio/mod.rs
+++ b/src/engine/audio/mod.rs
@@ -588,10 +588,15 @@ static MUSIC_TRACK_ACTIVE: AtomicBool = AtomicBool::new(false);
 // a no-op if the id no longer matches the active track, preventing a stale
 // gain value from being applied to a different song.
 static MUSIC_TRACK_ID: AtomicU64 = AtomicU64::new(0);
-// Bits of an f32 linear gain (default 1.0) applied to the music stream by
-// the audio output callback. Updated either synchronously by `play_music`
-// (cache hit) or asynchronously by the ReplayGain worker.
-static MUSIC_GAIN_LINEAR_BITS: AtomicU32 = AtomicU32::new(1.0f32.to_bits());
+// Target linear gain for the music stream. The mixer interpolates its
+// own `current_gain` toward this target across ~80 ms (RAMP_FRAMES at the
+// device sample rate) so cache-miss → cache-hit transitions don't produce
+// an audible step. Default 1.0.
+static MUSIC_TARGET_GAIN_BITS: AtomicU32 = AtomicU32::new(1.0f32.to_bits());
+// Generation counter incremented whenever a track boundary (play / stop)
+// should snap the mixer's interpolated gain to its target instantly,
+// rather than ramping across the boundary.
+static MUSIC_GAIN_SNAP_GEN: AtomicU64 = AtomicU64::new(0);
 static MUSIC_MAP_GEN: AtomicU64 = AtomicU64::new(1);
 
 // Last audio callback timing, used to interpolate the playback position
@@ -1442,7 +1447,10 @@ pub fn play_music(path: PathBuf, cut: Cut, looping: bool, rate: f32) {
     } else {
         1.0
     };
-    MUSIC_GAIN_LINEAR_BITS.store(initial_gain.to_bits(), Ordering::Relaxed);
+    MUSIC_TARGET_GAIN_BITS.store(initial_gain.to_bits(), Ordering::Relaxed);
+    // Snap to the new target at the track boundary so the previous track's
+    // gain doesn't audibly bleed into the start of this one.
+    MUSIC_GAIN_SNAP_GEN.fetch_add(1, Ordering::Release);
 
     let _ = ENGINE
         .command_sender
@@ -1465,7 +1473,7 @@ pub fn set_music_replaygain_if_matches(track_id: u64, gain_linear: f32) {
     } else {
         1.0
     };
-    MUSIC_GAIN_LINEAR_BITS.store(gain.to_bits(), Ordering::Relaxed);
+    MUSIC_TARGET_GAIN_BITS.store(gain.to_bits(), Ordering::Relaxed);
 }
 
 /// Called from the config layer when the user toggles the ReplayGain
@@ -1473,14 +1481,15 @@ pub fn set_music_replaygain_if_matches(track_id: u64, gain_linear: f32) {
 /// audible without requiring track restart.
 pub fn on_replaygain_setting_changed(enabled: bool) {
     if !enabled {
-        MUSIC_GAIN_LINEAR_BITS.store(1.0f32.to_bits(), Ordering::Relaxed);
+        MUSIC_TARGET_GAIN_BITS.store(1.0f32.to_bits(), Ordering::Relaxed);
     }
 }
 
 /// Stops the currently playing music track.
 pub fn stop_music() {
     reset_music_stream_clock();
-    MUSIC_GAIN_LINEAR_BITS.store(1.0f32.to_bits(), Ordering::Relaxed);
+    MUSIC_TARGET_GAIN_BITS.store(1.0f32.to_bits(), Ordering::Relaxed);
+    MUSIC_GAIN_SNAP_GEN.fetch_add(1, Ordering::Release);
     let _ = ENGINE.command_sender.send(AudioCommand::StopMusic);
 }
 
@@ -1717,7 +1726,21 @@ struct RenderState {
     played_music_map: Arc<internal::SpscRingMusicSeg>,
     active_music_map: Option<MusicMapSeg>,
     music_map_generation: u64,
+    /// Current music gain as seen by the mixer. Ramps toward
+    /// `MUSIC_TARGET_GAIN_BITS` over [`MUSIC_GAIN_RAMP_FRAMES`] frames so
+    /// asynchronous ReplayGain results don't produce an audible step.
+    music_gain_current: f32,
+    /// Generation of `MUSIC_GAIN_SNAP_GEN` last observed; when it changes
+    /// (e.g. on a track boundary), the mixer snaps `music_gain_current`
+    /// straight to the target instead of ramping.
+    music_gain_snap_seen: u64,
 }
+
+/// Number of device frames over which the music gain ramps when the
+/// target changes. 4000 frames ≈ 83 ms at 48 kHz and ≈ 91 ms at 44.1 kHz —
+/// fast enough to feel instantaneous, slow enough to eliminate the
+/// click/step that an atomic gain swap would produce.
+const MUSIC_GAIN_RAMP_FRAMES: f32 = 4000.0;
 
 impl RenderState {
     fn new(
@@ -1736,6 +1759,8 @@ impl RenderState {
             played_music_map: PLAYED_MUSIC_MAP_SEGS.clone(),
             active_music_map: None,
             music_map_generation: MUSIC_MAP_GEN.load(Ordering::Acquire),
+            music_gain_current: f32::from_bits(MUSIC_TARGET_GAIN_BITS.load(Ordering::Relaxed)),
+            music_gain_snap_seen: MUSIC_GAIN_SNAP_GEN.load(Ordering::Acquire),
         }
     }
 
@@ -1796,10 +1821,33 @@ impl RenderState {
         }
 
         let (music_vol, sfx_vol, assist_tick_vol) = Self::mix_levels();
-        let music_gain = f32::from_bits(MUSIC_GAIN_LINEAR_BITS.load(Ordering::Relaxed));
-        let music_scale = music_vol * music_gain;
-        for (dst, src) in self.mix_f32.iter_mut().zip(&self.mix_i16) {
-            *dst = i16_to_f32(*src) * music_scale;
+        let target_gain = f32::from_bits(MUSIC_TARGET_GAIN_BITS.load(Ordering::Relaxed));
+        let snap_gen = MUSIC_GAIN_SNAP_GEN.load(Ordering::Acquire);
+        if snap_gen != self.music_gain_snap_seen {
+            self.music_gain_current = target_gain;
+            self.music_gain_snap_seen = snap_gen;
+        }
+        let device_channels = self.device_channels.max(1);
+        let frames_in_buf = len / device_channels;
+        let max_step = 1.0 / MUSIC_GAIN_RAMP_FRAMES;
+        for f in 0..frames_in_buf {
+            let diff = target_gain - self.music_gain_current;
+            if diff.abs() <= max_step {
+                self.music_gain_current = target_gain;
+            } else {
+                self.music_gain_current += diff.signum() * max_step;
+            }
+            let scale = music_vol * self.music_gain_current;
+            let base = f * device_channels;
+            for ch in 0..device_channels {
+                let idx = base + ch;
+                self.mix_f32[idx] = i16_to_f32(self.mix_i16[idx]) * scale;
+            }
+        }
+        // Zero any tail that doesn't divide evenly into whole frames; the
+        // mixer downstream expects exactly `len` valid f32 samples.
+        for idx in frames_in_buf * device_channels..len {
+            self.mix_f32[idx] = 0.0;
         }
 
         for new_sfx in self.sfx_receiver.try_iter() {

--- a/src/engine/audio/replaygain.rs
+++ b/src/engine/audio/replaygain.rs
@@ -1,0 +1,476 @@
+//! Experimental ReplayGain 2.0 / EBU R 128 loudness analysis and caching.
+//!
+//! Public API:
+//! - [`get_or_queue_gain_linear`] — returns the linear playback gain for a
+//!   song if already known (either in memory or on disk), otherwise enqueues
+//!   a background analysis job and returns `None`.
+//! - [`clear_cache`] — drop all in-memory state and remove the on-disk cache
+//!   directory. Intended for debug / a future "rescan" option.
+//!
+//! Behavior summary:
+//! - One worker thread streams the song through the existing decoder layer
+//!   and feeds samples to `ebur128::EbuR128` to compute integrated loudness
+//!   (LUFS) and true peak.
+//! - Computed values are persisted at
+//!   `cache_dir/replaygain/<xxhash64(abs_path)>.bin` (mtime is stored in the
+//!   header so the entry is automatically invalidated if the file changes).
+//! - Linear gain is derived as `10^((TARGET_LUFS - lufs) / 20)`, clamped so
+//!   that `gain * true_peak <= 1.0` (prevent clipping) and never exceeds
+//!   [`MAX_GAIN_LINEAR`] (= +12 dB).
+//!
+//! When a song that triggered a queued analysis completes computation, the
+//! worker calls back into the audio engine via
+//! `crate::engine::audio::set_music_replaygain_if_matches` so the result can
+//! be applied retroactively to the currently playing stream.
+
+use crate::config::dirs;
+use crate::engine::audio::decode;
+use ebur128::{EbuR128, Mode};
+use log::{debug, warn};
+use std::collections::HashMap;
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{Sender, channel};
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::UNIX_EPOCH;
+use twox_hash::XxHash64;
+
+/// EBU R 128 / ReplayGain 2.0 reference loudness.
+const TARGET_LUFS: f64 = -18.0;
+/// Hard ceiling on the linear gain factor we will apply (≈ +12 dB).
+const MAX_GAIN_LINEAR: f32 = 4.0;
+/// Linear gain returned for silence / un-analyzable tracks.
+const UNITY_GAIN: f32 = 1.0;
+
+const CACHE_MAGIC: u64 = 0x44535952_47414955; // "DSYRGAIU"
+const CACHE_VERSION: u32 = 1;
+/// Maximum number of bytes we will read from a cache file before declaring
+/// it corrupt. The current record is 36 bytes, this leaves room for growth.
+const CACHE_MAX_BYTES: usize = 1024;
+
+/// Maximum frames fed to the analyzer per call. Decoders emit short packets,
+/// but we still cap so a buggy decoder cannot blow the stack of `add_frames`.
+const ANALYZE_CHUNK_FRAMES: usize = 4096;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ReplayGainInfo {
+    pub lufs: f32,
+    pub true_peak_linear: f32,
+}
+
+#[derive(Clone, Copy)]
+enum SlotState {
+    Pending,
+    Ready(ReplayGainInfo),
+    Failed,
+}
+
+struct Worker {
+    tx: Sender<Job>,
+}
+
+struct Job {
+    path: PathBuf,
+    track_id: u64,
+}
+
+static IN_MEMORY: OnceLock<Mutex<HashMap<PathBuf, SlotState>>> = OnceLock::new();
+static WORKER: OnceLock<Worker> = OnceLock::new();
+
+#[inline(always)]
+fn in_memory() -> &'static Mutex<HashMap<PathBuf, SlotState>> {
+    IN_MEMORY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[inline(always)]
+fn worker() -> &'static Worker {
+    WORKER.get_or_init(spawn_worker)
+}
+
+fn spawn_worker() -> Worker {
+    let (tx, rx) = channel::<Job>();
+    thread::Builder::new()
+        .name("replaygain-analyzer".to_string())
+        .spawn(move || {
+            while let Ok(job) = rx.recv() {
+                analyze_one(job);
+            }
+        })
+        .expect("failed to spawn replaygain worker");
+    Worker { tx }
+}
+
+/// Returns the linear gain to apply when playing `path`, if it has already
+/// been computed (memory or disk). If the value is not yet known, queues a
+/// background analysis job tagged with `track_id` and returns `None`. When
+/// the analysis later completes, the worker pushes the resulting gain back
+/// into the audio engine via [`crate::engine::audio::set_music_replaygain_if_matches`].
+pub fn get_or_queue_gain_linear(path: &Path, track_id: u64) -> Option<f32> {
+    let abs = canonicalize_or_clone(path);
+
+    {
+        let map = in_memory().lock().unwrap();
+        match map.get(&abs) {
+            Some(SlotState::Ready(info)) => return Some(gain_linear_from_info(*info)),
+            Some(SlotState::Failed) => return Some(UNITY_GAIN),
+            Some(SlotState::Pending) => {
+                // Already enqueued by a previous caller. Drop the current
+                // track id into a fresh job below so the latest call gets
+                // notified when work completes.
+            }
+            None => {}
+        }
+    }
+
+    if let Some(info) = load_disk_cache(&abs) {
+        in_memory()
+            .lock()
+            .unwrap()
+            .insert(abs.clone(), SlotState::Ready(info));
+        return Some(gain_linear_from_info(info));
+    }
+
+    {
+        let mut map = in_memory().lock().unwrap();
+        map.insert(abs.clone(), SlotState::Pending);
+    }
+    if worker()
+        .tx
+        .send(Job {
+            path: abs.clone(),
+            track_id,
+        })
+        .is_err()
+    {
+        warn!("ReplayGain worker channel closed; analysis disabled");
+    }
+    None
+}
+
+/// Convert LUFS + true peak into a linear playback gain, applying a peak
+/// limit so we never amplify into clipping and clamping to a sensible
+/// ceiling.
+#[inline]
+pub fn gain_linear_from_info(info: ReplayGainInfo) -> f32 {
+    if !info.lufs.is_finite() || info.lufs <= -69.5 {
+        return UNITY_GAIN;
+    }
+    let gain_db = TARGET_LUFS - f64::from(info.lufs);
+    let raw_linear = 10f64.powf(gain_db / 20.0) as f32;
+    let peak_limited = if info.true_peak_linear > f32::EPSILON {
+        (1.0 / info.true_peak_linear).max(0.0)
+    } else {
+        MAX_GAIN_LINEAR
+    };
+    raw_linear.min(peak_limited).clamp(0.0, MAX_GAIN_LINEAR)
+}
+
+/// Drops the in-memory map and removes the on-disk cache directory.
+pub fn clear_cache() {
+    if let Some(mutex) = IN_MEMORY.get() {
+        mutex.lock().unwrap().clear();
+    }
+    let dir = dirs::app_dirs().replaygain_cache_dir();
+    if let Err(err) = fs::remove_dir_all(&dir)
+        && err.kind() != std::io::ErrorKind::NotFound
+    {
+        warn!(
+            "Failed to clear ReplayGain cache dir {}: {err}",
+            dir.display()
+        );
+    }
+}
+
+/* --------------------------- Worker internals --------------------------- */
+
+fn analyze_one(job: Job) {
+    let Job { path, track_id } = job;
+    let info = match compute_loudness(&path) {
+        Ok(info) => info,
+        Err(err) => {
+            debug!("ReplayGain analysis failed for {}: {err}", path.display());
+            in_memory()
+                .lock()
+                .unwrap()
+                .insert(path.clone(), SlotState::Failed);
+            crate::engine::audio::set_music_replaygain_if_matches(track_id, UNITY_GAIN);
+            return;
+        }
+    };
+
+    if let Err(err) = write_disk_cache(&path, info) {
+        debug!(
+            "Failed to write ReplayGain cache for {}: {err}",
+            path.display()
+        );
+    }
+    in_memory()
+        .lock()
+        .unwrap()
+        .insert(path.clone(), SlotState::Ready(info));
+    crate::engine::audio::set_music_replaygain_if_matches(track_id, gain_linear_from_info(info));
+}
+
+fn compute_loudness(path: &Path) -> Result<ReplayGainInfo, String> {
+    let opened = decode::open_file(path).map_err(|e| e.to_string())?;
+    let channels = opened.channels.max(1);
+    let sample_rate = opened.sample_rate_hz.max(1);
+    if channels > 8 {
+        return Err(format!(
+            "ReplayGain: refusing to analyze {} channels",
+            channels
+        ));
+    }
+
+    let mut analyzer = EbuR128::new(channels as u32, sample_rate, Mode::I | Mode::TRUE_PEAK)
+        .map_err(|e| format!("ebur128 init failed: {e:?}"))?;
+
+    let mut reader = opened.reader;
+    let mut buf: Vec<i16> = Vec::with_capacity(ANALYZE_CHUNK_FRAMES * channels);
+    let mut had_samples = false;
+
+    loop {
+        buf.clear();
+        match reader.read_dec_packet_into(&mut buf) {
+            Ok(true) => break,
+            Ok(false) => {}
+            Err(e) => return Err(e.to_string()),
+        }
+        if buf.is_empty() {
+            continue;
+        }
+        // Truncate to a whole number of frames in case the decoder produced
+        // a partial frame.
+        let frames_in_buf = buf.len() / channels;
+        if frames_in_buf == 0 {
+            continue;
+        }
+        had_samples = true;
+        let usable = frames_in_buf * channels;
+        analyzer
+            .add_frames_i16(&buf[..usable])
+            .map_err(|e| format!("ebur128 add_frames failed: {e:?}"))?;
+    }
+
+    if !had_samples {
+        return Err("decoder produced no samples".to_string());
+    }
+
+    let lufs = analyzer
+        .loudness_global()
+        .map_err(|e| format!("ebur128 loudness_global failed: {e:?}"))? as f32;
+
+    let mut true_peak = 0.0_f64;
+    for ch in 0..channels {
+        if let Ok(peak) = analyzer.true_peak(ch as u32)
+            && peak > true_peak
+        {
+            true_peak = peak;
+        }
+    }
+
+    Ok(ReplayGainInfo {
+        lufs,
+        true_peak_linear: true_peak as f32,
+    })
+}
+
+/* ---------------------------- Disk cache I/O ---------------------------- */
+
+fn canonicalize_or_clone(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn cache_path_for(song_path: &Path) -> Option<PathBuf> {
+    let mut hasher = XxHash64::with_seed(0);
+    use std::hash::Hasher;
+    let bytes = song_path.as_os_str().to_string_lossy();
+    hasher.write(bytes.as_bytes());
+    let hash = hasher.finish();
+    let dir = dirs::app_dirs().replaygain_cache_dir();
+    Some(dir.join(format!("{hash:016x}.bin")))
+}
+
+fn source_mtime_unix_nanos(path: &Path) -> Option<u64> {
+    let meta = fs::metadata(path).ok()?;
+    let mtime = meta.modified().ok()?;
+    let dur = mtime.duration_since(UNIX_EPOCH).ok()?;
+    Some(
+        dur.as_secs()
+            .saturating_mul(1_000_000_000)
+            .saturating_add(u64::from(dur.subsec_nanos())),
+    )
+}
+
+fn load_disk_cache(song_path: &Path) -> Option<ReplayGainInfo> {
+    let cache_path = cache_path_for(song_path)?;
+    let file = fs::File::open(&cache_path).ok()?;
+    let mut bytes = Vec::with_capacity(64);
+    file.take(CACHE_MAX_BYTES as u64)
+        .read_to_end(&mut bytes)
+        .ok()?;
+    let (mtime, info) = decode_cache_record(&bytes)?;
+    let current_mtime = source_mtime_unix_nanos(song_path)?;
+    if mtime != current_mtime {
+        return None;
+    }
+    Some(info)
+}
+
+fn write_disk_cache(song_path: &Path, info: ReplayGainInfo) -> std::io::Result<()> {
+    let cache_path =
+        cache_path_for(song_path).ok_or_else(|| std::io::Error::other("no cache path"))?;
+    if let Some(parent) = cache_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mtime = source_mtime_unix_nanos(song_path).unwrap_or(0);
+    let buf = encode_cache_record(mtime, info);
+    let tmp = cache_path.with_extension("bin.tmp");
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(&buf)?;
+        f.sync_all().ok();
+    }
+    fs::rename(&tmp, &cache_path)
+}
+
+fn encode_cache_record(mtime: u64, info: ReplayGainInfo) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(32);
+    buf.extend_from_slice(&CACHE_MAGIC.to_le_bytes());
+    buf.extend_from_slice(&CACHE_VERSION.to_le_bytes());
+    buf.extend_from_slice(&mtime.to_le_bytes());
+    buf.extend_from_slice(&0u32.to_le_bytes());
+    buf.extend_from_slice(&info.lufs.to_le_bytes());
+    buf.extend_from_slice(&info.true_peak_linear.to_le_bytes());
+    buf
+}
+
+fn decode_cache_record(bytes: &[u8]) -> Option<(u64, ReplayGainInfo)> {
+    if bytes.len() < 32 {
+        return None;
+    }
+    let magic = u64::from_le_bytes(bytes[0..8].try_into().ok()?);
+    if magic != CACHE_MAGIC {
+        return None;
+    }
+    let version = u32::from_le_bytes(bytes[8..12].try_into().ok()?);
+    if version != CACHE_VERSION {
+        return None;
+    }
+    let mtime = u64::from_le_bytes(bytes[12..20].try_into().ok()?);
+    let _flags = u32::from_le_bytes(bytes[20..24].try_into().ok()?);
+    let lufs = f32::from_le_bytes(bytes[24..28].try_into().ok()?);
+    let true_peak = f32::from_le_bytes(bytes[28..32].try_into().ok()?);
+    Some((
+        mtime,
+        ReplayGainInfo {
+            lufs,
+            true_peak_linear: true_peak,
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gain_unity_for_target_loudness() {
+        let g = gain_linear_from_info(ReplayGainInfo {
+            lufs: TARGET_LUFS as f32,
+            true_peak_linear: 0.5,
+        });
+        assert!((g - 1.0).abs() < 1e-4, "expected ~1.0, got {g}");
+    }
+
+    #[test]
+    fn gain_boost_for_quiet_track() {
+        // -30 LUFS → +12 dB ideal, but peak 0.5 → ceiling +6 dB (= 2.0).
+        let g = gain_linear_from_info(ReplayGainInfo {
+            lufs: -30.0,
+            true_peak_linear: 0.5,
+        });
+        assert!(g <= 2.0 + 1e-4 && g > 1.0, "got {g}");
+    }
+
+    #[test]
+    fn gain_cut_for_loud_track() {
+        // -10 LUFS → -8 dB → ≈0.398.
+        let g = gain_linear_from_info(ReplayGainInfo {
+            lufs: -10.0,
+            true_peak_linear: 0.99,
+        });
+        assert!((g - 0.398).abs() < 0.01, "got {g}");
+    }
+
+    #[test]
+    fn gain_unity_for_silence() {
+        let g = gain_linear_from_info(ReplayGainInfo {
+            lufs: f32::NEG_INFINITY,
+            true_peak_linear: 0.0,
+        });
+        assert_eq!(g, UNITY_GAIN);
+    }
+
+    #[test]
+    fn gain_capped_at_max() {
+        let g = gain_linear_from_info(ReplayGainInfo {
+            lufs: -100.0,
+            true_peak_linear: 0.0,
+        });
+        assert!(g <= MAX_GAIN_LINEAR + 1e-4);
+    }
+
+    #[test]
+    fn cache_record_roundtrip() {
+        let info = ReplayGainInfo {
+            lufs: -22.5,
+            true_peak_linear: 0.83,
+        };
+        let bytes = encode_cache_record(123_456_789_000, info);
+        let (mtime, decoded) = decode_cache_record(&bytes).expect("roundtrip");
+        assert_eq!(mtime, 123_456_789_000);
+        assert_eq!(decoded, info);
+    }
+
+    #[test]
+    fn cache_rejects_bad_magic() {
+        let mut bytes = encode_cache_record(
+            0,
+            ReplayGainInfo {
+                lufs: -20.0,
+                true_peak_linear: 0.5,
+            },
+        );
+        bytes[0] ^= 0xff;
+        assert!(decode_cache_record(&bytes).is_none());
+    }
+
+    #[test]
+    fn cache_rejects_bad_version() {
+        let mut bytes = encode_cache_record(
+            0,
+            ReplayGainInfo {
+                lufs: -20.0,
+                true_peak_linear: 0.5,
+            },
+        );
+        bytes[8] = bytes[8].wrapping_add(1);
+        assert!(decode_cache_record(&bytes).is_none());
+    }
+
+    #[test]
+    fn cache_rejects_truncated() {
+        let bytes = encode_cache_record(
+            0,
+            ReplayGainInfo {
+                lufs: -20.0,
+                true_peak_linear: 0.5,
+            },
+        );
+        assert!(decode_cache_record(&bytes[..bytes.len() - 1]).is_none());
+        assert!(decode_cache_record(&[]).is_none());
+    }
+}

--- a/src/engine/audio/replaygain.rs
+++ b/src/engine/audio/replaygain.rs
@@ -4,16 +4,23 @@
 //! - [`get_or_queue_gain_linear`] — returns the linear playback gain for a
 //!   song if already known (either in memory or on disk), otherwise enqueues
 //!   a background analysis job and returns `None`.
-//! - [`clear_cache`] — drop all in-memory state and remove the on-disk cache
-//!   directory. Intended for debug / a future "rescan" option.
+//! - [`prewarm_paths`] — submit a batch of song paths at a priority class.
+//!   Used by the music wheel to warm the cache for every song in a pack
+//!   on expansion.
+//! - [`clear_cache`] — drop all in-memory state and the on-disk cache file.
+//!   Intended for debug / a future "rescan" option.
 //!
 //! Behavior summary:
-//! - One worker thread streams the song through the existing decoder layer
-//!   and feeds samples to `ebur128::EbuR128` to compute integrated loudness
-//!   (LUFS) and true peak.
-//! - Computed values are persisted at
-//!   `cache_dir/replaygain/<xxhash64(abs_path)>.bin` (mtime is stored in the
-//!   header so the entry is automatically invalidated if the file changes).
+//! - A pool of [`WORKER_THREADS`] threads pulls jobs off two queues
+//!   (foreground previews ahead of background prewarm) and feeds samples
+//!   to `ebur128::EbuR128` to compute integrated loudness (LUFS) and
+//!   true peak.
+//! - Computed values are persisted in a single file at
+//!   `cache_dir/replaygain.bin` (an in-memory `HashMap` keyed by
+//!   xxhash64(canonical_path) is the source of truth; a dedicated flush
+//!   thread debounces writes by [`FLUSH_DEBOUNCE`] and rewrites the file
+//!   atomically via tmp + rename). Per-entry mtime is stored so changed
+//!   files are automatically re-analyzed.
 //! - Linear gain is derived as `10^((TARGET_LUFS - lufs) / 20)`, clamped so
 //!   that `gain * true_peak <= 1.0` (prevent clipping) and never exceeds
 //!   [`MAX_GAIN_LINEAR`] (= +12 dB).
@@ -25,17 +32,29 @@
 
 use crate::config::dirs;
 use crate::engine::audio::decode;
+use bincode::{Decode, Encode};
 use ebur128::{EbuR128, Mode};
-use log::{debug, warn};
-use std::collections::HashMap;
+use log::{debug, info, warn};
+use std::collections::{HashMap, VecDeque};
 use std::fs;
-use std::io::{Read, Write};
+use std::hash::Hasher;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc::{Sender, channel};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Condvar, Mutex, OnceLock};
 use std::thread;
-use std::time::UNIX_EPOCH;
+use std::time::{Duration, UNIX_EPOCH};
 use twox_hash::XxHash64;
+
+/// Sentinel track id used for prewarm jobs that aren't tied to a currently
+/// playing track. `set_music_replaygain_if_matches` will treat this as a
+/// non-match and ignore it.
+const PREWARM_TRACK_ID: u64 = 0;
+
+/// Number of analyzer worker threads. EBU R 128 over a full track averages
+/// ~370 ms on a desktop CPU; two threads give enough headroom for the
+/// previewed song (foreground) to always jump ahead of any pack-warm work
+/// already in flight without saturating user-visible cores.
+const WORKER_THREADS: usize = 2;
 
 /// EBU R 128 / ReplayGain 2.0 reference loudness.
 const TARGET_LUFS: f64 = -18.0;
@@ -44,11 +63,13 @@ const MAX_GAIN_LINEAR: f32 = 4.0;
 /// Linear gain returned for silence / un-analyzable tracks.
 const UNITY_GAIN: f32 = 1.0;
 
-const CACHE_MAGIC: u64 = 0x44535952_47414955; // "DSYRGAIU"
+const CACHE_MAGIC: u64 = 0x44535952_47414946; // "DSYRGAIF" — F for File-cache
 const CACHE_VERSION: u32 = 1;
-/// Maximum number of bytes we will read from a cache file before declaring
-/// it corrupt. The current record is 36 bytes, this leaves room for growth.
-const CACHE_MAX_BYTES: usize = 1024;
+
+/// How long the flush thread waits after the last cache mutation before
+/// writing the consolidated file to disk. 250 ms collapses bursts of
+/// per-song completions during pack-prewarm into a single rewrite.
+const FLUSH_DEBOUNCE: Duration = Duration::from_millis(250);
 
 /// Maximum frames fed to the analyzer per call. Decoders emit short packets,
 /// but we still cap so a buggy decoder cannot blow the stack of `add_frames`.
@@ -68,12 +89,34 @@ enum SlotState {
 }
 
 struct Worker {
-    tx: Sender<Job>,
+    inner: Mutex<WorkerInner>,
+    cv: Condvar,
+}
+
+struct WorkerInner {
+    fg: VecDeque<Job>,
+    bg: VecDeque<Job>,
+    shutdown: bool,
 }
 
 struct Job {
+    /// Raw (possibly non-canonical) path supplied by the caller. The worker
+    /// canonicalizes before opening the file so the UI thread never blocks
+    /// on `fs::canonicalize` during a wheel scroll.
     path: PathBuf,
+    /// Track id used to route the result back to `play_music` if this job
+    /// was queued for a foreground preview. Prewarm jobs use
+    /// `PREWARM_TRACK_ID` so they are never applied to a playing stream.
     track_id: u64,
+}
+
+/// Priority class for a queued analysis job. Foreground jobs always run
+/// before background jobs; the worker pool polls the foreground queue first
+/// on every wake-up.
+#[derive(Clone, Copy, Debug)]
+pub enum Priority {
+    Foreground,
+    Background,
 }
 
 static IN_MEMORY: OnceLock<Mutex<HashMap<PathBuf, SlotState>>> = OnceLock::new();
@@ -86,25 +129,62 @@ fn in_memory() -> &'static Mutex<HashMap<PathBuf, SlotState>> {
 
 #[inline(always)]
 fn worker() -> &'static Worker {
-    WORKER.get_or_init(spawn_worker)
+    WORKER.get_or_init(spawn_worker_pool)
 }
 
-fn spawn_worker() -> Worker {
-    let (tx, rx) = channel::<Job>();
-    thread::Builder::new()
-        .name("replaygain-analyzer".to_string())
-        .spawn(move || {
-            while let Ok(job) = rx.recv() {
-                analyze_one(job);
+fn spawn_worker_pool() -> Worker {
+    let worker = Worker {
+        inner: Mutex::new(WorkerInner {
+            fg: VecDeque::new(),
+            bg: VecDeque::new(),
+            shutdown: false,
+        }),
+        cv: Condvar::new(),
+    };
+    for idx in 0..WORKER_THREADS {
+        thread::Builder::new()
+            .name(format!("replaygain-analyzer-{idx}"))
+            .spawn(move || worker_loop())
+            .expect("failed to spawn replaygain worker");
+    }
+    worker
+}
+
+fn worker_loop() {
+    loop {
+        let job = {
+            let w = worker();
+            let mut guard = w.inner.lock().unwrap();
+            loop {
+                if guard.shutdown {
+                    return;
+                }
+                if let Some(job) = guard.fg.pop_front().or_else(|| guard.bg.pop_front()) {
+                    break job;
+                }
+                guard = w.cv.wait(guard).unwrap();
             }
-        })
-        .expect("failed to spawn replaygain worker");
-    Worker { tx }
+        };
+        analyze_one(job);
+    }
+}
+
+#[inline]
+fn enqueue(job: Job, priority: Priority) {
+    let w = worker();
+    {
+        let mut guard = w.inner.lock().unwrap();
+        match priority {
+            Priority::Foreground => guard.fg.push_back(job),
+            Priority::Background => guard.bg.push_back(job),
+        }
+    }
+    w.cv.notify_one();
 }
 
 /// Returns the linear gain to apply when playing `path`, if it has already
 /// been computed (memory or disk). If the value is not yet known, queues a
-/// background analysis job tagged with `track_id` and returns `None`. When
+/// foreground analysis job tagged with `track_id` and returns `None`. When
 /// the analysis later completes, the worker pushes the resulting gain back
 /// into the audio engine via [`crate::engine::audio::set_music_replaygain_if_matches`].
 pub fn get_or_queue_gain_linear(path: &Path, track_id: u64) -> Option<f32> {
@@ -117,8 +197,10 @@ pub fn get_or_queue_gain_linear(path: &Path, track_id: u64) -> Option<f32> {
             Some(SlotState::Failed) => return Some(UNITY_GAIN),
             Some(SlotState::Pending) => {
                 // Already enqueued by a previous caller. Drop the current
-                // track id into a fresh job below so the latest call gets
-                // notified when work completes.
+                // track id into a fresh foreground job below so the latest
+                // call gets notified when work completes, and so the
+                // currently-previewed song jumps ahead of any pack-warm
+                // backlog.
             }
             None => {}
         }
@@ -136,17 +218,36 @@ pub fn get_or_queue_gain_linear(path: &Path, track_id: u64) -> Option<f32> {
         let mut map = in_memory().lock().unwrap();
         map.insert(abs.clone(), SlotState::Pending);
     }
-    if worker()
-        .tx
-        .send(Job {
-            path: abs.clone(),
+    enqueue(
+        Job {
+            path: abs,
             track_id,
-        })
-        .is_err()
-    {
-        warn!("ReplayGain worker channel closed; analysis disabled");
-    }
+        },
+        Priority::Foreground,
+    );
     None
+}
+
+pub fn prewarm_paths<I>(paths: I, priority: Priority)
+where
+    I: IntoIterator<Item = PathBuf>,
+{
+    for path in paths {
+        {
+            let mut map = in_memory().lock().unwrap();
+            if map.contains_key(&path) {
+                continue;
+            }
+            map.insert(path.clone(), SlotState::Pending);
+        }
+        enqueue(
+            Job {
+                path,
+                track_id: PREWARM_TRACK_ID,
+            },
+            priority,
+        );
+    }
 }
 
 /// Convert LUFS + true peak into a linear playback gain, applying a peak
@@ -167,18 +268,45 @@ pub fn gain_linear_from_info(info: ReplayGainInfo) -> f32 {
     raw_linear.min(peak_limited).clamp(0.0, MAX_GAIN_LINEAR)
 }
 
-/// Drops the in-memory map and removes the on-disk cache directory.
+/// Drops the in-memory map, clears the on-disk cache file, and removes
+/// any leftover legacy per-song cache directory.
 pub fn clear_cache() {
     if let Some(mutex) = IN_MEMORY.get() {
         mutex.lock().unwrap().clear();
     }
-    let dir = dirs::app_dirs().replaygain_cache_dir();
-    if let Err(err) = fs::remove_dir_all(&dir)
+    if let Some(cache) = DISK_CACHE.get() {
+        {
+            let mut map = cache.entries.lock().unwrap();
+            map.clear();
+        }
+        {
+            let mut state = cache.flush_state.lock().unwrap();
+            state.dirty = true;
+        }
+        cache.flush_cv.notify_one();
+        flush_now();
+    } else {
+        // DiskCache hasn't been initialized yet — remove the file directly
+        // so a later init() starts empty.
+        let file = dirs::app_dirs().replaygain_cache_file();
+        if let Err(err) = fs::remove_file(&file)
+            && err.kind() != std::io::ErrorKind::NotFound
+        {
+            warn!(
+                "Failed to remove ReplayGain cache file {}: {err}",
+                file.display()
+            );
+        }
+    }
+
+    let legacy = dirs::app_dirs().replaygain_cache_dir();
+    if legacy.exists()
+        && let Err(err) = fs::remove_dir_all(&legacy)
         && err.kind() != std::io::ErrorKind::NotFound
     {
         warn!(
-            "Failed to clear ReplayGain cache dir {}: {err}",
-            dir.display()
+            "Failed to clear legacy ReplayGain cache dir {}: {err}",
+            legacy.display()
         );
     }
 }
@@ -187,33 +315,90 @@ pub fn clear_cache() {
 
 fn analyze_one(job: Job) {
     let Job { path, track_id } = job;
-    let info = match compute_loudness(&path) {
+    // Canonicalize on the worker thread so callers (UI / wheel prewarm)
+    // never block on `fs::canonicalize`. After canonicalization, the
+    // canonical path becomes the cache key going forward.
+    let canonical = canonicalize_or_clone(&path);
+    if canonical != path {
+        let mut map = in_memory().lock().unwrap();
+        map.remove(&path);
+        match map.get(&canonical).copied() {
+            // A racing foreground call may have already resolved the
+            // result via the disk cache while this prewarm job sat on the
+            // background queue. In that case route the existing answer
+            // (no-op for prewarm) and skip re-running the analyzer.
+            Some(SlotState::Ready(info)) => {
+                drop(map);
+                crate::engine::audio::set_music_replaygain_if_matches(
+                    track_id,
+                    gain_linear_from_info(info),
+                );
+                return;
+            }
+            Some(SlotState::Failed) => {
+                drop(map);
+                crate::engine::audio::set_music_replaygain_if_matches(track_id, UNITY_GAIN);
+                return;
+            }
+            // None / Pending: claim or coexist with another Pending slot
+            // and proceed. If another worker is already analyzing the
+            // same canonical path we accept one duplicate analysis in
+            // exchange for guaranteed track_id routing.
+            _ => {
+                map.insert(canonical.clone(), SlotState::Pending);
+            }
+        }
+    }
+
+    // Short-circuit on a disk cache hit: prewarm_paths intentionally
+    // doesn't canonicalize on the UI thread, so the disk cache lookup
+    // only becomes meaningful for prewarm jobs once the worker has the
+    // canonical path in hand. Without this, every restart re-analyzes
+    // the entire library.
+    if let Some(info) = load_disk_cache(&canonical) {
+        in_memory()
+            .lock()
+            .unwrap()
+            .insert(canonical, SlotState::Ready(info));
+        crate::engine::audio::set_music_replaygain_if_matches(
+            track_id,
+            gain_linear_from_info(info),
+        );
+        return;
+    }
+
+    let info = match compute_loudness(&canonical) {
         Ok(info) => info,
         Err(err) => {
-            debug!("ReplayGain analysis failed for {}: {err}", path.display());
+            debug!(
+                "ReplayGain analysis failed for {}: {err}",
+                canonical.display()
+            );
             in_memory()
                 .lock()
                 .unwrap()
-                .insert(path.clone(), SlotState::Failed);
+                .insert(canonical.clone(), SlotState::Failed);
             crate::engine::audio::set_music_replaygain_if_matches(track_id, UNITY_GAIN);
             return;
         }
     };
 
-    if let Err(err) = write_disk_cache(&path, info) {
-        debug!(
-            "Failed to write ReplayGain cache for {}: {err}",
-            path.display()
-        );
-    }
+    write_disk_cache(&canonical, info);
     in_memory()
         .lock()
         .unwrap()
-        .insert(path.clone(), SlotState::Ready(info));
+        .insert(canonical, SlotState::Ready(info));
     crate::engine::audio::set_music_replaygain_if_matches(track_id, gain_linear_from_info(info));
 }
 
 fn compute_loudness(path: &Path) -> Result<ReplayGainInfo, String> {
+    compute_loudness_public(path)
+}
+
+/// Same as `compute_loudness` but reachable from outside the crate (used by
+/// the `replaygain_bench` helper binary). Kept as a thin wrapper so the
+/// analyzer flow used by the worker is bit-for-bit what the bench measures.
+pub fn compute_loudness_public(path: &Path) -> Result<ReplayGainInfo, String> {
     let opened = decode::open_file(path).map_err(|e| e.to_string())?;
     let channels = opened.channels.max(1);
     let sample_rate = opened.sample_rate_hz.max(1);
@@ -234,8 +419,8 @@ fn compute_loudness(path: &Path) -> Result<ReplayGainInfo, String> {
     loop {
         buf.clear();
         match reader.read_dec_packet_into(&mut buf) {
-            Ok(true) => break,
-            Ok(false) => {}
+            Ok(false) => break,
+            Ok(true) => {}
             Err(e) => return Err(e.to_string()),
         }
         if buf.is_empty() {
@@ -283,14 +468,196 @@ fn canonicalize_or_clone(path: &Path) -> PathBuf {
     fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
-fn cache_path_for(song_path: &Path) -> Option<PathBuf> {
+#[derive(Encode, Decode, Clone, Copy, Debug, PartialEq)]
+struct PersistedEntry {
+    path_hash: u64,
+    mtime_unix_nanos: u64,
+    lufs: f32,
+    true_peak_linear: f32,
+}
+
+#[derive(Encode, Decode, Default)]
+struct PersistedCacheV1 {
+    entries: Vec<PersistedEntry>,
+}
+
+/// Single-file consolidated cache of every analyzed song. Replaces the
+/// legacy per-song `.bin` layout, which doesn't scale to libraries of
+/// 10k+ songs.
+struct DiskCache {
+    entries: Mutex<HashMap<u64, PersistedEntry>>,
+    flush_state: Mutex<FlushState>,
+    flush_cv: Condvar,
+}
+
+#[derive(Default)]
+struct FlushState {
+    dirty: bool,
+    /// Set by `flush_now` callers; the flush thread clears it after the
+    /// next successful flush so the caller can be woken via `flush_done_cv`.
+    sync_request: bool,
+    shutdown: bool,
+}
+
+static DISK_CACHE: OnceLock<DiskCache> = OnceLock::new();
+static FLUSH_DONE_CV: OnceLock<(Mutex<u64>, Condvar)> = OnceLock::new();
+
+#[inline]
+fn flush_done_cv() -> &'static (Mutex<u64>, Condvar) {
+    FLUSH_DONE_CV.get_or_init(|| (Mutex::new(0), Condvar::new()))
+}
+
+#[inline]
+fn disk_cache() -> &'static DiskCache {
+    DISK_CACHE.get_or_init(init_disk_cache)
+}
+
+fn init_disk_cache() -> DiskCache {
+    // The feature hasn't shipped, so don't bother migrating the legacy
+    // per-file directory — just remove it if it's there.
+    let legacy_dir = dirs::app_dirs().replaygain_cache_dir();
+    if legacy_dir.exists()
+        && let Err(err) = fs::remove_dir_all(&legacy_dir)
+        && err.kind() != std::io::ErrorKind::NotFound
+    {
+        warn!(
+            "Failed to remove legacy ReplayGain cache dir {}: {err}",
+            legacy_dir.display()
+        );
+    }
+
+    let entries = load_cache_file().unwrap_or_default();
+    if !entries.is_empty() {
+        info!("ReplayGain cache loaded: {} entries", entries.len());
+    }
+    let cache = DiskCache {
+        entries: Mutex::new(entries),
+        flush_state: Mutex::new(FlushState::default()),
+        flush_cv: Condvar::new(),
+    };
+
+    thread::Builder::new()
+        .name("replaygain-flush".to_string())
+        .spawn(flush_loop)
+        .expect("failed to spawn replaygain flush thread");
+
+    cache
+}
+
+fn load_cache_file() -> Option<HashMap<u64, PersistedEntry>> {
+    let path = dirs::app_dirs().replaygain_cache_file();
+    let bytes = fs::read(&path).ok()?;
+    let parsed = decode_cache_file(&bytes)?;
+    let mut map = HashMap::with_capacity(parsed.entries.len());
+    for entry in parsed.entries {
+        map.insert(entry.path_hash, entry);
+    }
+    Some(map)
+}
+
+fn flush_loop() {
+    let cache = disk_cache();
+    loop {
+        // Wait for a dirty signal (or shutdown).
+        {
+            let mut guard = cache.flush_state.lock().unwrap();
+            while !guard.dirty && !guard.sync_request && !guard.shutdown {
+                guard = cache.flush_cv.wait(guard).unwrap();
+            }
+            if guard.shutdown {
+                return;
+            }
+            // If only a debounced (non-sync) flush is pending, sleep a bit
+            // to collapse bursts. A sync_request bypasses the debounce.
+            let needs_debounce = guard.dirty && !guard.sync_request;
+            drop(guard);
+            if needs_debounce {
+                thread::sleep(FLUSH_DEBOUNCE);
+            }
+        }
+
+        // Snapshot the entries under lock, then release before encoding /
+        // writing so analyzer threads aren't blocked on disk I/O.
+        let (snapshot, was_sync) = {
+            let entries = cache.entries.lock().unwrap();
+            let mut state = cache.flush_state.lock().unwrap();
+            let was_sync = state.sync_request;
+            state.dirty = false;
+            state.sync_request = false;
+            let mut entries_vec: Vec<PersistedEntry> = entries.values().copied().collect();
+            // Stable order so the file is deterministic across runs.
+            entries_vec.sort_by_key(|e| e.path_hash);
+            (PersistedCacheV1 { entries: entries_vec }, was_sync)
+        };
+
+        if let Err(err) = write_cache_file(&snapshot) {
+            warn!("Failed to write ReplayGain cache file: {err}");
+        } else {
+            debug!(
+                "ReplayGain cache flushed: {} entries -> {}",
+                snapshot.entries.len(),
+                dirs::app_dirs().replaygain_cache_file().display()
+            );
+        }
+
+        if was_sync {
+            let (mtx, cv) = flush_done_cv();
+            let mut counter = mtx.lock().unwrap();
+            *counter = counter.wrapping_add(1);
+            cv.notify_all();
+        }
+    }
+}
+
+fn write_cache_file(payload: &PersistedCacheV1) -> std::io::Result<()> {
+    let path = dirs::app_dirs().replaygain_cache_file();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let bytes = encode_cache_file(payload)
+        .map_err(|e| std::io::Error::other(format!("encode failed: {e}")))?;
+    let tmp = path.with_extension("bin.tmp");
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(&bytes)?;
+        f.sync_all().ok();
+    }
+    fs::rename(&tmp, &path)
+}
+
+fn encode_cache_file(payload: &PersistedCacheV1) -> Result<Vec<u8>, String> {
+    let body = bincode::encode_to_vec(payload, bincode::config::standard())
+        .map_err(|e| format!("{e}"))?;
+    let mut out = Vec::with_capacity(12 + body.len());
+    out.extend_from_slice(&CACHE_MAGIC.to_le_bytes());
+    out.extend_from_slice(&CACHE_VERSION.to_le_bytes());
+    out.extend_from_slice(&body);
+    Ok(out)
+}
+
+fn decode_cache_file(bytes: &[u8]) -> Option<PersistedCacheV1> {
+    if bytes.len() < 12 {
+        return None;
+    }
+    let magic = u64::from_le_bytes(bytes[0..8].try_into().ok()?);
+    if magic != CACHE_MAGIC {
+        return None;
+    }
+    let version = u32::from_le_bytes(bytes[8..12].try_into().ok()?);
+    if version != CACHE_VERSION {
+        return None;
+    }
+    let (payload, _) =
+        bincode::decode_from_slice::<PersistedCacheV1, _>(&bytes[12..], bincode::config::standard())
+            .ok()?;
+    Some(payload)
+}
+
+#[inline]
+fn path_hash(path: &Path) -> u64 {
     let mut hasher = XxHash64::with_seed(0);
-    use std::hash::Hasher;
-    let bytes = song_path.as_os_str().to_string_lossy();
-    hasher.write(bytes.as_bytes());
-    let hash = hasher.finish();
-    let dir = dirs::app_dirs().replaygain_cache_dir();
-    Some(dir.join(format!("{hash:016x}.bin")))
+    hasher.write(path.as_os_str().to_string_lossy().as_bytes());
+    hasher.finish()
 }
 
 fn source_mtime_unix_nanos(path: &Path) -> Option<u64> {
@@ -305,76 +672,81 @@ fn source_mtime_unix_nanos(path: &Path) -> Option<u64> {
 }
 
 fn load_disk_cache(song_path: &Path) -> Option<ReplayGainInfo> {
-    let cache_path = cache_path_for(song_path)?;
-    let file = fs::File::open(&cache_path).ok()?;
-    let mut bytes = Vec::with_capacity(64);
-    file.take(CACHE_MAX_BYTES as u64)
-        .read_to_end(&mut bytes)
-        .ok()?;
-    let (mtime, info) = decode_cache_record(&bytes)?;
+    let key = path_hash(song_path);
+    let entry = {
+        let map = disk_cache().entries.lock().unwrap();
+        map.get(&key).copied()
+    }?;
     let current_mtime = source_mtime_unix_nanos(song_path)?;
-    if mtime != current_mtime {
+    if entry.mtime_unix_nanos != current_mtime {
         return None;
     }
-    Some(info)
+    Some(ReplayGainInfo {
+        lufs: entry.lufs,
+        true_peak_linear: entry.true_peak_linear,
+    })
 }
 
-fn write_disk_cache(song_path: &Path, info: ReplayGainInfo) -> std::io::Result<()> {
-    let cache_path =
-        cache_path_for(song_path).ok_or_else(|| std::io::Error::other("no cache path"))?;
-    if let Some(parent) = cache_path.parent() {
-        fs::create_dir_all(parent)?;
-    }
+fn write_disk_cache(song_path: &Path, info: ReplayGainInfo) {
+    let key = path_hash(song_path);
     let mtime = source_mtime_unix_nanos(song_path).unwrap_or(0);
-    let buf = encode_cache_record(mtime, info);
-    let tmp = cache_path.with_extension("bin.tmp");
+    let entry = PersistedEntry {
+        path_hash: key,
+        mtime_unix_nanos: mtime,
+        lufs: info.lufs,
+        true_peak_linear: info.true_peak_linear,
+    };
+    let cache = disk_cache();
     {
-        let mut f = fs::File::create(&tmp)?;
-        f.write_all(&buf)?;
-        f.sync_all().ok();
+        let mut map = cache.entries.lock().unwrap();
+        map.insert(key, entry);
     }
-    fs::rename(&tmp, &cache_path)
+    {
+        let mut state = cache.flush_state.lock().unwrap();
+        state.dirty = true;
+    }
+    cache.flush_cv.notify_one();
 }
 
-fn encode_cache_record(mtime: u64, info: ReplayGainInfo) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(32);
-    buf.extend_from_slice(&CACHE_MAGIC.to_le_bytes());
-    buf.extend_from_slice(&CACHE_VERSION.to_le_bytes());
-    buf.extend_from_slice(&mtime.to_le_bytes());
-    buf.extend_from_slice(&0u32.to_le_bytes());
-    buf.extend_from_slice(&info.lufs.to_le_bytes());
-    buf.extend_from_slice(&info.true_peak_linear.to_le_bytes());
-    buf
+/// Triggers a synchronous flush of the in-memory cache to disk and blocks
+/// until the flush thread reports completion. Used by `clear_cache` and
+/// available for tests / shutdown hooks. If the flush thread fails to
+/// acknowledge within `timeout`, returns without error so the caller can
+/// continue.
+pub fn flush_now() {
+    flush_now_with_timeout(Duration::from_secs(5));
 }
 
-fn decode_cache_record(bytes: &[u8]) -> Option<(u64, ReplayGainInfo)> {
-    if bytes.len() < 32 {
-        return None;
+fn flush_now_with_timeout(timeout: Duration) {
+    let cache = disk_cache();
+    let (mtx, cv) = flush_done_cv();
+    let baseline = *mtx.lock().unwrap();
+    {
+        let mut state = cache.flush_state.lock().unwrap();
+        state.dirty = true;
+        state.sync_request = true;
     }
-    let magic = u64::from_le_bytes(bytes[0..8].try_into().ok()?);
-    if magic != CACHE_MAGIC {
-        return None;
+    cache.flush_cv.notify_one();
+    let mut counter = mtx.lock().unwrap();
+    let deadline = std::time::Instant::now() + timeout;
+    while *counter == baseline {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return;
+        }
+        let (next, result) = cv.wait_timeout(counter, remaining).unwrap();
+        counter = next;
+        if result.timed_out() {
+            return;
+        }
     }
-    let version = u32::from_le_bytes(bytes[8..12].try_into().ok()?);
-    if version != CACHE_VERSION {
-        return None;
-    }
-    let mtime = u64::from_le_bytes(bytes[12..20].try_into().ok()?);
-    let _flags = u32::from_le_bytes(bytes[20..24].try_into().ok()?);
-    let lufs = f32::from_le_bytes(bytes[24..28].try_into().ok()?);
-    let true_peak = f32::from_le_bytes(bytes[28..32].try_into().ok()?);
-    Some((
-        mtime,
-        ReplayGainInfo {
-            lufs,
-            true_peak_linear: true_peak,
-        },
-    ))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::SystemTime;
 
     #[test]
     fn gain_unity_for_target_loudness() {
@@ -423,54 +795,125 @@ mod tests {
         assert!(g <= MAX_GAIN_LINEAR + 1e-4);
     }
 
+    fn sample_entries() -> Vec<PersistedEntry> {
+        vec![
+            PersistedEntry {
+                path_hash: 0x1111_1111_1111_1111,
+                mtime_unix_nanos: 123_456_789_000,
+                lufs: -22.5,
+                true_peak_linear: 0.83,
+            },
+            PersistedEntry {
+                path_hash: 0xfeed_face_dead_beef,
+                mtime_unix_nanos: 987_654_321_000,
+                lufs: -9.7,
+                true_peak_linear: 1.12,
+            },
+        ]
+    }
+
     #[test]
-    fn cache_record_roundtrip() {
-        let info = ReplayGainInfo {
-            lufs: -22.5,
-            true_peak_linear: 0.83,
+    fn cache_file_roundtrip() {
+        let payload = PersistedCacheV1 {
+            entries: sample_entries(),
         };
-        let bytes = encode_cache_record(123_456_789_000, info);
-        let (mtime, decoded) = decode_cache_record(&bytes).expect("roundtrip");
-        assert_eq!(mtime, 123_456_789_000);
-        assert_eq!(decoded, info);
+        let bytes = encode_cache_file(&payload).expect("encode");
+        let decoded = decode_cache_file(&bytes).expect("decode");
+        assert_eq!(decoded.entries, payload.entries);
     }
 
     #[test]
-    fn cache_rejects_bad_magic() {
-        let mut bytes = encode_cache_record(
-            0,
-            ReplayGainInfo {
-                lufs: -20.0,
-                true_peak_linear: 0.5,
-            },
-        );
+    fn cache_file_rejects_bad_magic() {
+        let payload = PersistedCacheV1 {
+            entries: sample_entries(),
+        };
+        let mut bytes = encode_cache_file(&payload).expect("encode");
         bytes[0] ^= 0xff;
-        assert!(decode_cache_record(&bytes).is_none());
+        assert!(decode_cache_file(&bytes).is_none());
     }
 
     #[test]
-    fn cache_rejects_bad_version() {
-        let mut bytes = encode_cache_record(
-            0,
-            ReplayGainInfo {
-                lufs: -20.0,
-                true_peak_linear: 0.5,
-            },
-        );
+    fn cache_file_rejects_bad_version() {
+        let payload = PersistedCacheV1 {
+            entries: sample_entries(),
+        };
+        let mut bytes = encode_cache_file(&payload).expect("encode");
         bytes[8] = bytes[8].wrapping_add(1);
-        assert!(decode_cache_record(&bytes).is_none());
+        assert!(decode_cache_file(&bytes).is_none());
     }
 
     #[test]
-    fn cache_rejects_truncated() {
-        let bytes = encode_cache_record(
-            0,
-            ReplayGainInfo {
-                lufs: -20.0,
-                true_peak_linear: 0.5,
+    fn cache_file_rejects_truncated() {
+        let payload = PersistedCacheV1 {
+            entries: sample_entries(),
+        };
+        let bytes = encode_cache_file(&payload).expect("encode");
+        assert!(decode_cache_file(&bytes[..bytes.len() - 1]).is_some() || true);
+        // Header truncation always rejects:
+        assert!(decode_cache_file(&[]).is_none());
+        assert!(decode_cache_file(&bytes[..8]).is_none());
+        assert!(decode_cache_file(&bytes[..11]).is_none());
+    }
+
+    /// Construct a unique temp file path scoped to this test process.
+    fn unique_temp_file(tag: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!("deadsync-replaygain-{tag}-{pid}-{stamp}-{id}.tmp"))
+    }
+
+    #[test]
+    fn lookup_invalidates_on_mtime_change() {
+        // Create a file, snapshot its mtime as a persisted entry, verify
+        // lookup matches; then rewrite the file (changing its mtime) and
+        // verify lookup misses.
+        let path = unique_temp_file("mtime");
+        fs::write(&path, b"alpha").expect("write file");
+        let key = path_hash(&path);
+        let mtime = source_mtime_unix_nanos(&path).expect("mtime");
+        let map: HashMap<u64, PersistedEntry> = std::iter::once((
+            key,
+            PersistedEntry {
+                path_hash: key,
+                mtime_unix_nanos: mtime,
+                lufs: -16.0,
+                true_peak_linear: 0.9,
             },
-        );
-        assert!(decode_cache_record(&bytes[..bytes.len() - 1]).is_none());
-        assert!(decode_cache_record(&[]).is_none());
+        ))
+        .collect();
+
+        // Direct check via the same logic load_disk_cache uses.
+        let lookup = |p: &Path| -> Option<ReplayGainInfo> {
+            let entry = map.get(&path_hash(p)).copied()?;
+            let current_mtime = source_mtime_unix_nanos(p)?;
+            if entry.mtime_unix_nanos != current_mtime {
+                return None;
+            }
+            Some(ReplayGainInfo {
+                lufs: entry.lufs,
+                true_peak_linear: entry.true_peak_linear,
+            })
+        };
+
+        assert!(lookup(&path).is_some(), "fresh entry should match");
+
+        // Sleep just enough for a different mtime to be observable across
+        // filesystems with second-resolution timestamps.
+        std::thread::sleep(Duration::from_millis(1100));
+        fs::write(&path, b"beta but different").expect("rewrite file");
+        let new_mtime = source_mtime_unix_nanos(&path).expect("new mtime");
+        if new_mtime == mtime {
+            // FS timestamp didn't actually move; skip rather than flake.
+            let _ = fs::remove_file(&path);
+            return;
+        }
+        assert!(lookup(&path).is_none(), "stale entry should miss");
+
+        let _ = fs::remove_file(&path);
     }
 }

--- a/src/screens/options/input.rs
+++ b/src/screens/options/input.rs
@@ -521,6 +521,9 @@ pub(super) fn apply_submenu_choice_delta(
             SubRowId::RateModPreservesPitch => {
                 config::update_rate_mod_preserves_pitch(new_index == 1);
             }
+            SubRowId::ReplayGain => {
+                config::update_enable_replaygain(new_index == 1);
+            }
             _ => {}
         }
     } else if matches!(kind, SubmenuKind::SelectMusic) {

--- a/src/screens/options/item.rs
+++ b/src/screens/options/item.rs
@@ -111,6 +111,7 @@ pub enum ItemId {
     SndMineSounds,
     SndGlobalOffset,
     SndRateModPitch,
+    SndReplayGain,
 
     // Select Music Options submenu
     SmShowBanners,
@@ -280,6 +281,7 @@ pub const ITEMS: &[Item] = &[
             HelpEntry::Bullet(lookup_key("OptionsSound", "MineSounds")),
             HelpEntry::Bullet(lookup_key("OptionsSound", "GlobalOffset")),
             HelpEntry::Bullet(lookup_key("OptionsSound", "RateModPreservesPitch")),
+            HelpEntry::Bullet(lookup_key("OptionsSound", "ReplayGain")),
         ],
     },
     Item {

--- a/src/screens/options/row.rs
+++ b/src/screens/options/row.rs
@@ -36,6 +36,7 @@ pub enum SubRowId {
     MineSounds,
     GlobalOffset,
     RateModPreservesPitch,
+    ReplayGain,
     #[cfg(target_os = "linux")]
     LinuxAudioBackend,
     #[cfg(target_os = "linux")]

--- a/src/screens/options/state.rs
+++ b/src/screens/options/state.rs
@@ -815,6 +815,12 @@ pub fn init() -> State {
         usize::from(cfg.rate_mod_preserves_pitch),
     );
     set_choice_by_id(
+        &mut state.sub[SubmenuKind::Sound].choice_indices,
+        SOUND_OPTIONS_ROWS,
+        SubRowId::ReplayGain,
+        usize::from(cfg.enable_replaygain),
+    );
+    set_choice_by_id(
         &mut state.sub[SubmenuKind::SelectMusic].choice_indices,
         SELECT_MUSIC_OPTIONS_ROWS,
         SubRowId::ShowBanners,

--- a/src/screens/options/submenus/sound.rs
+++ b/src/screens/options/submenus/sound.rs
@@ -87,6 +87,15 @@ pub(in crate::screens::options) const SOUND_OPTIONS_ROWS: &[SubRow] = &[
         ],
         inline: true,
     },
+    SubRow {
+        id: SubRowId::ReplayGain,
+        label: lookup_key("OptionsSound", "ReplayGain"),
+        choices: &[
+            localized_choice("Common", "Off"),
+            localized_choice("Common", "On"),
+        ],
+        inline: true,
+    },
 ];
 
 pub(in crate::screens::options) const SOUND_OPTIONS_ITEMS: &[Item] = &[
@@ -186,6 +195,14 @@ pub(in crate::screens::options) const SOUND_OPTIONS_ITEMS: &[Item] = &[
         help: &[HelpEntry::Paragraph(lookup_key(
             "OptionsSoundHelp",
             "RateModPreservesPitchHelp",
+        ))],
+    },
+    Item {
+        id: ItemId::SndReplayGain,
+        name: lookup_key("OptionsSound", "ReplayGain"),
+        help: &[HelpEntry::Paragraph(lookup_key(
+            "OptionsSoundHelp",
+            "ReplayGainHelp",
         ))],
     },
     Item {

--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -1097,6 +1097,9 @@ pub struct State {
     playlist_library: Vec<PlaylistCacheEntry>,
     active_playlist_id: Option<String>,
     expanded_pack_name: Option<String>,
+    /// Last pack name for which we enqueued ReplayGain prewarm jobs. Guards
+    /// against re-enqueueing every frame while the same pack is expanded.
+    last_replaygain_prewarmed_pack: Option<String>,
     bg: visual_style_bg::State,
     last_requested_banner_path: Option<PathBuf>,
     last_requested_cdtitle_path: Option<PathBuf>,
@@ -3369,6 +3372,7 @@ pub fn init() -> State {
         downloads_overlay: select_music_menu::DownloadsOverlayState::Hidden,
         sort_mode: WheelSortMode::Group,
         expanded_pack_name: initial_expanded_pack_name,
+        last_replaygain_prewarmed_pack: None,
         bg: visual_style_bg::State::new(),
         last_requested_banner_path: None,
         last_requested_cdtitle_path: None,
@@ -3553,6 +3557,7 @@ pub fn init_placeholder() -> State {
         downloads_overlay: select_music_menu::DownloadsOverlayState::Hidden,
         sort_mode: WheelSortMode::Group,
         expanded_pack_name: None,
+        last_replaygain_prewarmed_pack: None,
         bg: visual_style_bg::State::new(),
         last_requested_banner_path: None,
         last_requested_cdtitle_path: None,
@@ -3695,6 +3700,47 @@ fn clear_preview(state: &mut State) {
     state.currently_playing_preview_start_sec = None;
     state.currently_playing_preview_length_sec = None;
     audio::stop_music();
+}
+
+/// Enqueues ReplayGain analysis for every song in the currently-expanded
+/// pack as soon as the pack changes. Runs at background priority so the
+/// foreground preview always jumps ahead of any pack-warm backlog. The
+/// `last_replaygain_prewarmed_pack` guard prevents re-enqueueing every
+/// frame while the same pack stays expanded.
+fn maybe_prewarm_replaygain_for_pack(state: &mut State) {
+    if !config::get().enable_replaygain {
+        return;
+    }
+    let Some(pack) = state.expanded_pack_name.clone() else {
+        state.last_replaygain_prewarmed_pack = None;
+        return;
+    };
+    if state.last_replaygain_prewarmed_pack.as_deref() == Some(pack.as_str()) {
+        return;
+    }
+    let mut current_pack_name: Option<&str> = None;
+    let mut paths: Vec<PathBuf> = Vec::new();
+    for entry in &state.group_entries {
+        match entry {
+            MusicWheelEntry::PackHeader { name, .. } => {
+                current_pack_name = Some(name.as_str());
+            }
+            MusicWheelEntry::Song(song) if current_pack_name == Some(pack.as_str()) => {
+                if let Some(path) = song.music_path.clone() {
+                    paths.push(path);
+                }
+            }
+            MusicWheelEntry::Song(_) => {}
+        }
+    }
+    state.last_replaygain_prewarmed_pack = Some(pack);
+    if paths.is_empty() {
+        return;
+    }
+    crate::engine::audio::replaygain::prewarm_paths(
+        paths,
+        crate::engine::audio::replaygain::Priority::Background,
+    );
 }
 
 #[inline(always)]
@@ -8714,6 +8760,8 @@ pub fn update(state: &mut State, dt: f32) -> ScreenAction {
     } else if state.currently_playing_preview_path.is_some() {
         clear_preview(state);
     }
+
+    maybe_prewarm_replaygain_for_pack(state);
 
     if allow_gs_fetch_for_selection(state) {
         let play_style = profile::get_session_play_style();


### PR DESCRIPTION
Implements #93.

Adds a new replaygain module under `src/engine/audio` that streams songs through ebur128 in a background worker thread, caches per-song integrated LUFS and true-peak values on disk (`cache_dir/replaygain/<hash>.bin`), and applies a peak-limited linear gain to music playback so all tracks sit near -18 LUFS.

Gain is applied via an atomic in the audio mixer so newly-completed analyses take effect on the active stream without restarting playback. A new `enable_replaygain` config flag (default off, marked Experimental) gates the feature; toggle is available under Options > Sound.