### PR TITLE
feat(gameplay): add DelayedBack option for instant song exit (#403)

### DIFF
--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -300,6 +300,9 @@ CenteredP1Notefield=Centered P1 Notefield
 ZmodRatingBox=Zmod Rating Box
 ShowDecimalInBPM=Show Decimal in BPM
 BpmDecimal=Show Decimal in BPM
+DelayedBack=Back Button
+DelayedBackInstant=Instant
+DelayedBackHold=Hold
 AutoScreenshot=Auto Screenshot
 
 ; ============================================================
@@ -1388,6 +1391,7 @@ BgBrightnessHelp=Adjust the background brightness during gameplay.
 CenteredP1NotefieldHelp=Center the active single-player notefield during gameplay.
 ZmodRatingBoxHelp=Show the zmod-style difficulty text label with the rating box in gameplay/eval.
 BpmDecimalHelp=Show one decimal place for live gameplay BPM when BPM is non-integer.
+DelayedBackHelp=Choose how the BACK button exits a song.\nHold: must hold BACK for ~1 second (default, matches ITGmania).\nInstant: BACK exits the song immediately on first press.
 AutoScreenshotHelp=Automatically screenshot the Evaluation screen.\nUse Left/Right to pick a condition, then Start to toggle it.\nPBs: personal bests. Fails: failed scores.\nClears: non-PB clears. Quads: 100%. Quints: perfect EX.
 
 ; ============================================================

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1184,6 +1184,11 @@ pub struct SessionState {
     course_individual_stage_indices: Vec<usize>,
     combo_carry: [u32; crate::game::gameplay::MAX_PLAYERS],
     gameplay_restart_count: u32,
+    /// SL/zmod parity: when a restart key is pressed mid-gameplay, the gameplay
+    /// state runs its fast Cancel exit. This flag intercepts the resulting
+    /// `NavigateNoFade(SelectMusic)` and redirects it back to Gameplay so the
+    /// player skips the long out-transition.
+    restart_pending: bool,
     course_run: Option<CourseRunState>,
     course_eval_pages: Vec<evaluation::State>,
     course_eval_page_index: usize,
@@ -1580,6 +1585,7 @@ impl SessionState {
             course_individual_stage_indices: Vec::new(),
             combo_carry,
             gameplay_restart_count: 0,
+            restart_pending: false,
             course_run: None,
             course_eval_pages: Vec::new(),
             course_eval_page_index: 0,
@@ -3848,6 +3854,16 @@ impl App {
         event_loop: &ActiveEventLoop,
     ) -> Result<(), Box<dyn Error>> {
         let action = match action {
+            // SL/zmod parity: a restart-triggered Cancel exit returns
+            // `NavigateNoFade(SelectMusic)`. Redirect it to Gameplay so the
+            // player skips the trip through SelectMusic.
+            ScreenAction::NavigateNoFade(CurrentScreen::SelectMusic)
+                if self.state.session.restart_pending
+                    && self.state.screens.current_screen == CurrentScreen::Gameplay =>
+            {
+                self.state.session.restart_pending = false;
+                ScreenAction::NavigateNoFade(CurrentScreen::Gameplay)
+            }
             ScreenAction::Navigate(CurrentScreen::Evaluation)
                 if self.should_chain_course_to_next_stage() =>
             {
@@ -4576,20 +4592,37 @@ impl App {
     }
 
     fn try_gameplay_restart(&mut self, event_loop: &ActiveEventLoop, label: &str) -> bool {
-        if self.prepare_player_options_for_gameplay_restart() {
-            let restart_count = self.state.session.gameplay_restart_count.saturating_add(1);
-            if let Err(e) =
-                self.handle_action(ScreenAction::Navigate(CurrentScreen::Gameplay), event_loop)
-            {
-                log::error!("Failed to restart Gameplay with {label}: {e}");
-            } else {
-                self.state.session.gameplay_restart_count = restart_count;
-            }
-            true
-        } else {
+        if !self.prepare_player_options_for_gameplay_restart() {
             log::warn!("Ignored {label} restart: no restartable stage state.");
-            false
+            return false;
         }
+        let restart_count = self.state.session.gameplay_restart_count.saturating_add(1);
+
+        // SL/zmod parity: if we're already in Gameplay, run the fast Cancel
+        // exit (~0.5s) instead of the full ~1.5s gameplay out-transition.
+        // The Cancel navigation is intercepted in `handle_action` and
+        // redirected back to Gameplay, which uses a shortened in-transition.
+        if self.state.screens.current_screen == CurrentScreen::Gameplay
+            && let Some(gs) = self.state.screens.gameplay_state.as_mut()
+        {
+            let already_exiting = gs.exit_transition.is_some();
+            crate::game::gameplay::begin_restart_exit(gs);
+            if !already_exiting && gs.exit_transition.is_some() {
+                self.state.session.gameplay_restart_count = restart_count;
+                self.state.session.restart_pending = true;
+            }
+            return true;
+        }
+
+        // Fallback (e.g. Ctrl+R from Evaluation): use the standard navigation.
+        if let Err(e) =
+            self.handle_action(ScreenAction::Navigate(CurrentScreen::Gameplay), event_loop)
+        {
+            log::error!("Failed to restart Gameplay with {label}: {e}");
+        } else {
+            self.state.session.gameplay_restart_count = restart_count;
+        }
+        true
     }
 
     fn should_chain_course_to_next_stage(&self) -> bool {
@@ -7266,6 +7299,7 @@ impl App {
             crate::engine::audio::stop_music();
             if prev != CurrentScreen::Gameplay {
                 self.state.session.gameplay_restart_count = 0;
+                self.state.session.restart_pending = false;
             }
             let mut course_display_carry = None;
             let course_display_totals = self

--- a/src/app/screen_nav.rs
+++ b/src/app/screen_nav.rs
@@ -522,6 +522,7 @@ impl App {
             CurrentScreen::Gameplay => gameplay::in_transition(
                 self.state.screens.gameplay_state.as_ref(),
                 &self.asset_manager,
+                self.state.session.gameplay_restart_count > 0,
             ),
             CurrentScreen::Practice => gameplay::in_transition(
                 self.state
@@ -530,6 +531,7 @@ impl App {
                     .as_ref()
                     .map(|state| &state.gameplay),
                 &self.asset_manager,
+                false,
             ),
             CurrentScreen::Options => options::in_transition(),
             CurrentScreen::Credits => credits::in_transition(),

--- a/src/config/load/options.rs
+++ b/src/config/load/options.rs
@@ -473,6 +473,10 @@ fn load_runtime_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
         .get("Options", "ArcadeOptionsNavigation")
         .and_then(|v| parse_loose_bool_str(&v))
         .unwrap_or(default.arcade_options_navigation);
+    cfg.delayed_back = conf
+        .get("Options", "DelayedBack")
+        .and_then(|v| parse_loose_bool_str(&v))
+        .unwrap_or(default.delayed_back);
     cfg.three_key_navigation = conf
         .get("Options", "ThreeKeyNavigation")
         .and_then(|v| parse_loose_bool_str(&v))

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -162,6 +162,9 @@ pub struct Config {
     pub select_music_preview_loop: bool,
     /// zmod parity: enable keyboard-only shortcuts like Ctrl+R restart in gameplay/evaluation.
     pub keyboard_features: bool,
+    /// ITGmania parity (`DelayedBack`): when `true`, the BACK button must be held to
+    /// exit a song; when `false`, BACK exits instantly on first press.
+    pub delayed_back: bool,
     /// Simply Love visual style used by shared menu art.
     pub visual_style: VisualStyle,
     /// Enable or disable animated gameplay background videos.
@@ -343,6 +346,7 @@ impl Default for Config {
             machine_preferred_play_mode: MachinePreferredPlayMode::Regular,
             machine_font: MachineFont::Wendy,
             machine_bar_color: MachineBarColor::Default,
+            delayed_back: true,
             machine_enable_replays: true,
             machine_allow_per_player_global_offsets: false,
             machine_pack_ini_offsets: false,

--- a/src/config/store/defaults.rs
+++ b/src/config/store/defaults.rs
@@ -252,6 +252,7 @@ fn push_default_options(content: &mut String, default: &Config) {
         "ArcadeOptionsNavigation",
         default.arcade_options_navigation,
     );
+    push_bool(content, "DelayedBack", default.delayed_back);
     push_bool(content, "ThreeKeyNavigation", default.three_key_navigation);
     push_bool(content, "UseFSRs", default.use_fsrs);
     push_line(content, "LightsDriver", default.lights_driver.as_str());

--- a/src/config/store/save.rs
+++ b/src/config/store/save.rs
@@ -315,6 +315,7 @@ fn push_saved_options(
         "ArcadeOptionsNavigation",
         cfg.arcade_options_navigation,
     );
+    push_bool(content, "DelayedBack", cfg.delayed_back);
     push_bool(content, "ThreeKeyNavigation", cfg.three_key_navigation);
     push_bool(content, "UseFSRs", cfg.use_fsrs);
     push_line(content, "LightsDriver", cfg.lights_driver.as_str());

--- a/src/config/update/machine.rs
+++ b/src/config/update/machine.rs
@@ -38,6 +38,17 @@ pub fn update_arcade_options_navigation(enabled: bool) {
     save_without_keymaps();
 }
 
+pub fn update_delayed_back(enabled: bool) {
+    {
+        let mut cfg = lock_config();
+        if cfg.delayed_back == enabled {
+            return;
+        }
+        cfg.delayed_back = enabled;
+    }
+    save_without_keymaps();
+}
+
 pub fn update_three_key_navigation(enabled: bool) {
     let dedicated = {
         let mut cfg = lock_config();

--- a/src/game/gameplay.rs
+++ b/src/game/gameplay.rs
@@ -4649,7 +4649,9 @@ fn begin_exit_transition(state: &mut State, kind: ExitTransitionKind) {
         kind,
         started_at: Instant::now(),
     });
-    audio::stop_music();
+    if audio::is_initialized() {
+        audio::stop_music();
+    }
 }
 
 pub fn danger_overlay_rgba(state: &State, player: usize) -> Option<[f32; 4]> {
@@ -8577,9 +8579,10 @@ fn update_danger_fx(state: &mut State) {
 #[cfg(test)]
 mod tests {
     use super::{
-        COMBO_BREAK_ON_IMMEDIATE_HOLD_LET_GO, DisplayClockDiagRing, FinalizedRowOutcome,
-        FrameStableDisplayClock, GAMEPLAY_INPUT_BACKLOG_WARN, HELD_MISS_TOTAL_DURATION,
-        HeldMissRenderInfo, HoldJudgmentRenderInfo, HoldToExitKey, INSERT_MASK_BIT_MINES, MAX_COLS,
+        COMBO_BREAK_ON_IMMEDIATE_HOLD_LET_GO, DisplayClockDiagRing, ExitTransitionKind,
+        FinalizedRowOutcome, FrameStableDisplayClock, GAMEPLAY_INPUT_BACKLOG_WARN,
+        HELD_MISS_TOTAL_DURATION, HeldMissRenderInfo, HoldJudgmentRenderInfo, HoldToExitKey,
+        INSERT_MASK_BIT_MINES, MAX_COLS,
         MAX_PLAYERS, REPLAY_EDGE_RATE_PER_SEC, RowEntry, ScrollEffects, ScrollSpeedSetting,
         SongClockSnapshot, TIMING_WINDOW_SECONDS_HOLD, TickMode, TurnRng,
         active_hold_counts_as_pressed, add_provisional_early_score, advance_hold_last_held,
@@ -9346,6 +9349,76 @@ return Def.ActorFrame{}
                 assert_eq!(state.hold_to_exit_key, Some(HoldToExitKey::Back));
                 assert_eq!(state.hold_to_exit_start, hold_start);
                 assert_eq!(state.hold_to_exit_aborted_at, None);
+            },
+        );
+    }
+
+    #[test]
+    fn delayed_back_false_exits_song_on_first_press() {
+        with_session(
+            profile::PlayStyle::Single,
+            profile::PlayerSide::P1,
+            true,
+            false,
+            || {
+                let prev = crate::config::get().delayed_back;
+                crate::config::update_delayed_back(false);
+
+                let state_profiles = [profile::Profile::default(), profile::Profile::default()];
+                let mut state = regression_state(state_profiles);
+
+                handle_input(&mut state, &test_input_event(VirtualAction::p1_back));
+
+                let exit = state.exit_transition;
+                let hold_key = state.hold_to_exit_key;
+
+                crate::config::update_delayed_back(prev);
+
+                assert!(
+                    exit.is_some(),
+                    "exit_transition should be armed immediately when delayed_back is false"
+                );
+                assert_eq!(
+                    exit.unwrap().kind,
+                    ExitTransitionKind::Cancel,
+                    "BACK should trigger a Cancel exit transition"
+                );
+                assert_eq!(
+                    hold_key, None,
+                    "hold_to_exit_key should remain unset in instant-back mode"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn delayed_back_true_preserves_hold_arming() {
+        with_session(
+            profile::PlayStyle::Single,
+            profile::PlayerSide::P1,
+            true,
+            false,
+            || {
+                let prev = crate::config::get().delayed_back;
+                crate::config::update_delayed_back(true);
+
+                let state_profiles = [profile::Profile::default(), profile::Profile::default()];
+                let mut state = regression_state(state_profiles);
+
+                handle_input(&mut state, &test_input_event(VirtualAction::p1_back));
+
+                let hold_key = state.hold_to_exit_key;
+                let hold_start = state.hold_to_exit_start;
+                let exit = state.exit_transition;
+
+                crate::config::update_delayed_back(prev);
+
+                assert_eq!(hold_key, Some(HoldToExitKey::Back));
+                assert!(hold_start.is_some());
+                assert!(
+                    exit.is_none(),
+                    "exit_transition should not fire until the hold elapses"
+                );
             },
         );
     }

--- a/src/game/gameplay.rs
+++ b/src/game/gameplay.rs
@@ -175,6 +175,11 @@ pub(crate) use self::time::{
 
 // Simply Love ScreenGameplay in/default.lua keeps intro cover actors alive for 2.0s.
 pub const TRANSITION_IN_DURATION: f32 = 2.0;
+/// SL/zmod parity: when re-entering Gameplay as a restart, skip the splode +
+/// stage-text in-transition (`ScreenGameplay in/default.lua` calls
+/// `Hide` immediately when `SL.Global.GameplayReloadCheck` is true). Use a
+/// short fade-from-black so the new gameplay frame doesn't pop in.
+pub const TRANSITION_IN_RESTART_DURATION: f32 = 0.2;
 // Simply Love ScreenGameplay out.lua: sleep(0.5), linear(1.0).
 pub const TRANSITION_OUT_DELAY: f32 = 0.5;
 pub const TRANSITION_OUT_FADE_DURATION: f32 = 1.0;
@@ -4652,6 +4657,14 @@ fn begin_exit_transition(state: &mut State, kind: ExitTransitionKind) {
     if audio::is_initialized() {
         audio::stop_music();
     }
+}
+
+/// SL/zmod parity: trigger the fast Cancel exit fade (~0.5s) used by BACK,
+/// so an in-progress song can hand off to the next gameplay entry without
+/// playing the long ~1.5s gameplay out-transition. The app shell intercepts
+/// the resulting `Cancel` navigation and re-enters Gameplay.
+pub fn begin_restart_exit(state: &mut State) {
+    begin_exit_transition(state, ExitTransitionKind::Cancel);
 }
 
 pub fn danger_overlay_rgba(state: &State, player: usize) -> Option<[f32; 4]> {
@@ -9420,6 +9433,41 @@ return Def.ActorFrame{}
                     "exit_transition should not fire until the hold elapses"
                 );
             },
+        );
+    }
+
+    #[test]
+    fn begin_restart_exit_arms_cancel_transition_like_back_out() {
+        let state_profiles = [profile::Profile::default(), profile::Profile::default()];
+        let mut state = regression_state(state_profiles);
+        assert!(state.exit_transition.is_none());
+
+        super::begin_restart_exit(&mut state);
+
+        let exit = state
+            .exit_transition
+            .expect("begin_restart_exit should arm an exit_transition");
+        assert_eq!(
+            exit.kind,
+            ExitTransitionKind::Cancel,
+            "restart should reuse the fast Cancel out-fade for SL/zmod parity"
+        );
+    }
+
+    #[test]
+    fn begin_restart_exit_is_idempotent_when_already_exiting() {
+        let state_profiles = [profile::Profile::default(), profile::Profile::default()];
+        let mut state = regression_state(state_profiles);
+
+        // Pretend a give-up exit is already in flight.
+        super::begin_exit_transition(&mut state, ExitTransitionKind::Out);
+        let original = state.exit_transition.expect("primed exit");
+
+        super::begin_restart_exit(&mut state);
+        let after = state.exit_transition.expect("still exiting");
+        assert_eq!(
+            after.kind, original.kind,
+            "begin_restart_exit must not overwrite an in-flight exit transition"
         );
     }
 

--- a/src/game/gameplay/input.rs
+++ b/src/game/gameplay/input.rs
@@ -1,3 +1,4 @@
+use crate::config;
 use crate::engine::audio;
 use crate::engine::input::{
     INPUT_SLOT_INVALID, InputEdge, InputEvent, InputSource, Lane, VirtualAction, lane_from_action,
@@ -10,14 +11,15 @@ use std::time::Instant;
 
 use super::{
     ASSIST_TICK_SFX_PATH, ActiveInputSlot, COMBO_HUNDRED_MILESTONE_DURATION,
-    COMBO_THOUSAND_MILESTONE_DURATION, ComboMilestoneKind, GAMEPLAY_INPUT_BACKLOG_WARN,
-    GAMEPLAY_INPUT_LATENCY_WARN_US, GameplayAction, GameplayUpdatePhaseTimings,
-    HELD_MISS_TOTAL_DURATION, HOLD_JUDGMENT_TOTAL_DURATION, HoldToExitKey, INVALID_SONG_TIME_NS,
-    MAX_ACTIVE_INPUT_SLOTS, MINE_EXPLOSION_DURATION, RECEPTOR_GLOW_DURATION,
-    REPLAY_EDGE_FLOOR_PER_LANE, REPLAY_EDGE_RATE_PER_SEC, RecordedLaneEdge, SongClockSnapshot,
-    SongTimeNs, State, TickMode, abort_hold_to_exit, add_elapsed_us, current_music_time_s,
-    elapsed_us_between, gameplay_input_log_enabled, integrate_active_hold_to_time, judge_a_lift,
-    judge_a_tap, live_autoplay_enabled, music_time_ns_from_song_clock, record_step_calories,
+    COMBO_THOUSAND_MILESTONE_DURATION, ComboMilestoneKind, ExitTransitionKind,
+    GAMEPLAY_INPUT_BACKLOG_WARN, GAMEPLAY_INPUT_LATENCY_WARN_US, GameplayAction,
+    GameplayUpdatePhaseTimings, HELD_MISS_TOTAL_DURATION, HOLD_JUDGMENT_TOTAL_DURATION,
+    HoldToExitKey, INVALID_SONG_TIME_NS, MAX_ACTIVE_INPUT_SLOTS, MINE_EXPLOSION_DURATION,
+    RECEPTOR_GLOW_DURATION, REPLAY_EDGE_FLOOR_PER_LANE, REPLAY_EDGE_RATE_PER_SEC,
+    RecordedLaneEdge, SongClockSnapshot, SongTimeNs, State, TickMode, abort_hold_to_exit,
+    add_elapsed_us, begin_exit_transition, current_music_time_s, elapsed_us_between,
+    gameplay_input_log_enabled, integrate_active_hold_to_time, judge_a_lift, judge_a_tap,
+    live_autoplay_enabled, music_time_ns_from_song_clock, record_step_calories,
     refresh_roll_life_on_step, single_runtime_player_is_p2, song_time_ns_invalid,
     song_time_ns_to_seconds,
 };
@@ -563,18 +565,26 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> GameplayAction {
         }
         VirtualAction::p1_back if p1_menu_active => {
             if ev.pressed {
-                state.hold_to_exit_key = Some(HoldToExitKey::Back);
-                state.hold_to_exit_start = Some(ev.timestamp);
-                state.hold_to_exit_aborted_at = None;
+                if !config::get().delayed_back {
+                    begin_exit_transition(state, ExitTransitionKind::Cancel);
+                } else {
+                    state.hold_to_exit_key = Some(HoldToExitKey::Back);
+                    state.hold_to_exit_start = Some(ev.timestamp);
+                    state.hold_to_exit_aborted_at = None;
+                }
             } else if state.hold_to_exit_key == Some(HoldToExitKey::Back) {
                 abort_hold_to_exit(state, ev.timestamp);
             }
         }
         VirtualAction::p2_back if p2_menu_active => {
             if ev.pressed {
-                state.hold_to_exit_key = Some(HoldToExitKey::Back);
-                state.hold_to_exit_start = Some(ev.timestamp);
-                state.hold_to_exit_aborted_at = None;
+                if !config::get().delayed_back {
+                    begin_exit_transition(state, ExitTransitionKind::Cancel);
+                } else {
+                    state.hold_to_exit_key = Some(HoldToExitKey::Back);
+                    state.hold_to_exit_start = Some(ev.timestamp);
+                    state.hold_to_exit_aborted_at = None;
+                }
             } else if state.hold_to_exit_key == Some(HoldToExitKey::Back) {
                 abort_hold_to_exit(state, ev.timestamp);
             }

--- a/src/screens/gameplay.rs
+++ b/src/screens/gameplay.rs
@@ -53,9 +53,10 @@ pub struct ActorViewOverride {
 use crate::game::gameplay::{
     self as gameplay_core, CourseDisplayCarry, CourseDisplayTotals, GameplayAction, GameplayExit,
     LeadInTiming, MAX_PLAYERS, ReplayInputEdge, ReplayOffsetSnapshot, TRANSITION_IN_DURATION,
-    TRANSITION_OUT_DELAY, TRANSITION_OUT_DURATION, TRANSITION_OUT_FADE_DURATION,
-    effective_visibility_effects_for_player, handle_input as gameplay_handle_input,
-    timing_tick_status_line, toggle_flash_text, update as gameplay_update,
+    TRANSITION_IN_RESTART_DURATION, TRANSITION_OUT_DELAY, TRANSITION_OUT_DURATION,
+    TRANSITION_OUT_FADE_DURATION, effective_visibility_effects_for_player,
+    handle_input as gameplay_handle_input, timing_tick_status_line, toggle_flash_text,
+    update as gameplay_update,
 };
 
 pub struct DensityGraphRenderState {
@@ -998,7 +999,26 @@ pub fn prewarm_text_layout(
 }
 
 // --- TRANSITIONS ---
-pub fn in_transition(state: Option<&State>, asset_manager: &AssetManager) -> (Vec<Actor>, f32) {
+pub fn in_transition(
+    state: Option<&State>,
+    asset_manager: &AssetManager,
+    is_restart: bool,
+) -> (Vec<Actor>, f32) {
+    if is_restart {
+        // SL/zmod parity: on a song restart, skip the splode + stage-text
+        // splash and run only a brief fade-from-black so the first gameplay
+        // frame doesn't pop in. The "RESTART N" label still appears in the
+        // gameplay footer overlay.
+        let actor = act!(quad:
+            align(0.0, 0.0): xy(0.0, 0.0):
+            zoomto(screen_width(), screen_height()):
+            diffuse(0.0, 0.0, 0.0, 1.0):
+            z(1100):
+            linear(TRANSITION_IN_RESTART_DURATION): alpha(0.0):
+            linear(0.0): visible(false)
+        );
+        return (vec![actor], TRANSITION_IN_RESTART_DURATION);
+    }
     let text = state
         .map(|gs| gs.stage_intro_text.clone())
         .unwrap_or_else(|| Arc::from("EVENT"));
@@ -7867,8 +7887,12 @@ pub fn push_actors(
             }
         }
         // Simply Love parity: keep Stage/Event text visible at the footer after intro animation ends.
-        if !state.stage_intro_text.is_empty()
-            && state.total_elapsed_in_screen >= INTRO_TEXT_SETTLE_SECONDS
+        // On a song restart we skip the splode/text in-transition entirely, so make the footer
+        // label appear immediately rather than waiting `INTRO_TEXT_SETTLE_SECONDS` of dead time.
+        let intro_text = state.stage_intro_text.as_ref();
+        let is_restart_label = intro_text.starts_with("RESTART ");
+        if !intro_text.is_empty()
+            && (is_restart_label || state.total_elapsed_in_screen >= INTRO_TEXT_SETTLE_SECONDS)
         {
             let text_x = intro_text_target_x(
                 state,

--- a/src/screens/options/input.rs
+++ b/src/screens/options/input.rs
@@ -458,6 +458,9 @@ pub(super) fn apply_submenu_choice_delta(
             config::update_zmod_rating_box_text(new_index == 1);
         } else if row.id == SubRowId::BpmDecimal {
             config::update_show_bpm_decimal(new_index == 1);
+        } else if row.id == SubRowId::DelayedBack {
+            // Choice 0 = Instant (delayed_back = false), 1 = Hold (delayed_back = true).
+            config::update_delayed_back(new_index == 1);
         }
     } else if matches!(kind, SubmenuKind::Sound) {
         let row = &rows[row_index];

--- a/src/screens/options/item.rs
+++ b/src/screens/options/item.rs
@@ -94,6 +94,7 @@ pub enum ItemId {
     GpCenteredP1,
     GpZmodRatingBox,
     GpBpmDecimal,
+    GpDelayedBack,
     GpAutoScreenshot,
 
     // Sound Options submenu

--- a/src/screens/options/row.rs
+++ b/src/screens/options/row.rs
@@ -83,6 +83,7 @@ pub enum SubRowId {
     CenteredP1Notefield,
     ZmodRatingBox,
     BpmDecimal,
+    DelayedBack,
     AutoScreenshot,
     // Select Music Options
     ShowBanners,

--- a/src/screens/options/state.rs
+++ b/src/screens/options/state.rs
@@ -763,6 +763,12 @@ pub fn init() -> State {
     set_choice_by_id(
         &mut state.sub[SubmenuKind::Gameplay].choice_indices,
         GAMEPLAY_OPTIONS_ROWS,
+        SubRowId::DelayedBack,
+        usize::from(cfg.delayed_back),
+    );
+    set_choice_by_id(
+        &mut state.sub[SubmenuKind::Gameplay].choice_indices,
+        GAMEPLAY_OPTIONS_ROWS,
         SubRowId::AutoScreenshot,
         auto_screenshot_cursor_index(cfg.auto_screenshot_eval),
     );

--- a/src/screens/options/submenus/gameplay.rs
+++ b/src/screens/options/submenus/gameplay.rs
@@ -47,6 +47,15 @@ pub(in crate::screens::options) const GAMEPLAY_OPTIONS_ROWS: &[SubRow] = &[
         inline: true,
     },
     SubRow {
+        id: SubRowId::DelayedBack,
+        label: lookup_key("OptionsGameplay", "DelayedBack"),
+        choices: &[
+            localized_choice("OptionsGameplay", "DelayedBackInstant"),
+            localized_choice("OptionsGameplay", "DelayedBackHold"),
+        ],
+        inline: true,
+    },
+    SubRow {
         id: SubRowId::AutoScreenshot,
         label: lookup_key("OptionsGameplay", "AutoScreenshot"),
         choices: &[
@@ -91,6 +100,14 @@ pub(in crate::screens::options) const GAMEPLAY_OPTIONS_ITEMS: &[Item] = &[
         help: &[HelpEntry::Paragraph(lookup_key(
             "OptionsGameplayHelp",
             "BpmDecimalHelp",
+        ))],
+    },
+    Item {
+        id: ItemId::GpDelayedBack,
+        name: lookup_key("OptionsGameplay", "DelayedBack"),
+        help: &[HelpEntry::Paragraph(lookup_key(
+            "OptionsGameplayHelp",
+            "DelayedBackHelp",
         ))],
     },
     Item {


### PR DESCRIPTION
Implements ITGmania `DelayedBack` parity **plus** Simply Love / SL-zmod snappy restart behavior (closes #403).

## 1. Instant BACK (ITGmania `DelayedBack`)
- New **Operator Menu → Gameplay Options → Back Button** toggle: `Hold` (default, current 1 s hold) or `Instant`.
- When `Instant`, BACK exits the song immediately on first press.
- Mirrors ITGmania's `PrefsManager` `DelayedBack` preference.

## 2. Snappy restart (Simply Love / SL-zmod parity)
Researched `D:\github\Simply-Love-SM5` and `D:\github\SL-zmod` (`ScreenGameplay in/default.lua`, `ScreenGameplay underlay/default.lua`). SL/zmod use `SL.Global.GameplayReloadCheck` to make restart **skip the splode/stage-text in-transition** and use the same fast `:begin_backing_out()` out-fade as BACK.

Restart key in Gameplay (`p1_restart` / `p2_restart` / Ctrl+R) now:
- Triggers the fast Cancel out-fade (~0.5 s) instead of the full ~1.5 s gameplay out-transition.
- Sets `session.restart_pending` so the resulting `NavigateNoFade(SelectMusic)` is redirected back to `Gameplay` in `handle_action`.
- Uses a new short in-transition (`TRANSITION_IN_RESTART_DURATION = 0.2 s`, plain black fade-from-black) — no splode, no stage-text settle delay.
- Shows the `RESTART N` footer label immediately (skips the `INTRO_TEXT_SETTLE_SECONDS` gate when the intro text is a restart label).

**End-to-end visible restart wait: ~3.5 s → ~0.7–1.0 s.**

## Restart / single-button cab restart (no code change)
Already supported: `VirtualAction::p1_restart` / `p2_restart` fire on first press (`src/app/mod.rs:4996`). Users bind a button via the existing key-mappings UI; cabinet-friendly out of the box.
