### PR TITLE
fix(practice): align lead-in clock with audio silence pad

### DIFF
--- a/src/game/gameplay.rs
+++ b/src/game/gameplay.rs
@@ -5117,6 +5117,7 @@ pub fn start_practice_music(
     judge_start_music_time: f32,
 ) {
     reset_practice_playback(state, judge_start_music_time);
+    state.audio_lead_in_seconds = (-playback_music_time).max(0.0);
     set_current_music_time_ns(state, song_time_ns_from_seconds(playback_music_time));
 
     let Some(music_path) = state.charts[0].music_path.as_ref() else {


### PR DESCRIPTION
## Summary

When entering practice playback near the start of a song (i.e. the cursor sits within `LEAD_IN_SECONDS` of beat 0), the audio plays correctly but the visual notefield momentarily drifts at the very start of every playback, producing a perceptible audio/visual desync. Mid-song practice starts (positive `playback_music_time`) are unaffected.

## Root cause

`start_practice_music` pre-sets `state.current_music_time_ns` to `playback_music_time` (`start_time - LEAD_IN_SECONDS`) but never updates `state.audio_lead_in_seconds`. While the audio decoder thread is still spinning up the silence pad and `MUSIC_TRACK_HAS_STARTED` is `false`, `current_song_clock_snapshot` falls back to `stream_pos_to_music_time`, which computes `(stream_pos - audio_lead_in_seconds) * rate + anchor * (1 - rate)`. With `audio_lead_in_seconds == 0` the fallback returns `0`, the first gameplay tick sees a forward jump just under `STARTUP_MAX_FORWARD_JUMP_NS` (1.0s) and accepts it, and the game clock stays at 0 until the audio mapping catches up, then snaps backward to `-LEAD_IN_SECONDS`. The visible artifact is a momentary notefield desync at the start of any practice playback whose `playback_music_time` is negative.