### PR TITLE
feat(select_music): prompt profile select on mid-set join

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5189,6 +5189,15 @@ impl App {
         }
         if screen == CurrentScreen::SelectMusic {
             self.apply_select_music_join(join_side);
+            // Per Simply-Love-SM5#741: when the Select Profile screen is on,
+            // prompt the late-joining player with the profile-select widget
+            // instead of silently leaving them as Guest.
+            if config::get().machine_show_select_profile {
+                crate::screens::select_music::open_late_join_profile_overlay(
+                    &mut self.state.screens.select_music_state,
+                    join_side,
+                );
+            }
         }
 
         crate::engine::audio::play_sfx("assets/sounds/start.ogg");

--- a/src/screens/components/shared/profile_boxes.rs
+++ b/src/screens/components/shared/profile_boxes.rs
@@ -462,6 +462,42 @@ pub fn set_joined(state: &mut State, p1_joined: bool, p2_joined: bool) {
     );
 }
 
+/// Configure the overlay for a late-join scenario: the existing player is
+/// pre-readied with their current profile, and only `joining_side` needs to
+/// pick a profile. Used when a second player presses Start mid-set on a
+/// screen with an embedded profile-select overlay.
+pub fn enter_late_join(state: &mut State, joining_side: profile::PlayerSide) {
+    match joining_side {
+        profile::PlayerSide::P1 => {
+            state.p1_joined = true;
+            state.p1_ready = false;
+            state.p1_join_pulse_t = 0.0;
+            state.p2_joined = true;
+            state.p2_ready = true;
+            state.p2_join_pulse_t = JOIN_PULSE_DURATION;
+        }
+        profile::PlayerSide::P2 => {
+            state.p1_joined = true;
+            state.p1_ready = true;
+            state.p1_join_pulse_t = JOIN_PULSE_DURATION;
+            state.p2_joined = true;
+            state.p2_ready = false;
+            state.p2_join_pulse_t = 0.0;
+        }
+    }
+
+    state.p1_preview_noteskin = preview_noteskin_for_choice(
+        &mut state.noteskin_cache,
+        &state.choices,
+        state.p1_selected_index,
+    );
+    state.p2_preview_noteskin = preview_noteskin_for_choice(
+        &mut state.noteskin_cache,
+        &state.choices,
+        state.p2_selected_index,
+    );
+}
+
 pub fn update(state: &mut State, dt: f32) {
     const BPM: f32 = 120.0;
     let dt = dt.max(0.0);

--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -1093,6 +1093,7 @@ pub struct State {
     pub test_input_overlay_visible: bool,
     test_input_overlay: test_input::State,
     profile_switch_overlay: Option<profile_boxes::State>,
+    profile_switch_overlay_is_late_join: bool,
     pending_replay: Option<select_music_menu::ReplayStartPayload>,
     select_music_menu: select_music_menu::State,
     leaderboard: select_music_menu::LeaderboardOverlayState,
@@ -3389,6 +3390,7 @@ pub fn init() -> State {
         test_input_overlay_visible: false,
         test_input_overlay: test_input::State::default(),
         profile_switch_overlay: None,
+        profile_switch_overlay_is_late_join: false,
         pending_replay: None,
         select_music_menu: select_music_menu::State::Hidden,
         leaderboard: select_music_menu::LeaderboardOverlayState::Hidden,
@@ -3574,6 +3576,7 @@ pub fn init_placeholder() -> State {
         test_input_overlay_visible: false,
         test_input_overlay: test_input::State::default(),
         profile_switch_overlay: None,
+        profile_switch_overlay_is_late_join: false,
         pending_replay: None,
         select_music_menu: select_music_menu::State::Hidden,
         leaderboard: select_music_menu::LeaderboardOverlayState::Hidden,
@@ -4288,6 +4291,41 @@ fn show_profile_switch_overlay(state: &mut State) {
         profile::is_session_side_joined(profile::PlayerSide::P2),
     );
     state.profile_switch_overlay = Some(overlay);
+    state.profile_switch_overlay_is_late_join = false;
+}
+
+/// Open the profile-select overlay for a player who pressed Start mid-set to
+/// late-join the session. The already-joined player is pre-readied with their
+/// current profile; only `joining_side` needs to pick a profile. If the
+/// joining player cancels, `handle_profile_switch_overlay_input` will revert
+/// the late-join via `cancel_late_join_profile_overlay`.
+pub fn open_late_join_profile_overlay(state: &mut State, joining_side: profile::PlayerSide) {
+    profile::set_fast_profile_switch_from_select_music(false);
+    clear_preview(state);
+    state.select_music_menu = select_music_menu::State::Hidden;
+    state.song_search = select_music_menu::SongSearchState::Hidden;
+    state.leaderboard = select_music_menu::LeaderboardOverlayState::Hidden;
+    state.downloads_overlay = select_music_menu::DownloadsOverlayState::Hidden;
+    state.replay_overlay = select_music_menu::ReplayOverlayState::Hidden;
+    state.lobby_overlay = lobby_overlay::OverlayState::Hidden;
+    state.sync_overlay = SyncOverlayState::Hidden;
+    pack_sync::hide_overlay(state);
+    hide_test_input_overlay(state);
+    clear_menu_chord(state);
+    clear_p1_ud_chord(state);
+    clear_p2_ud_chord(state);
+    clear_overlay_nav_hold(state);
+    clear_nav_hold(state);
+    state.last_steps_nav_dir_p1 = None;
+    state.last_steps_nav_time_p1 = None;
+    state.last_steps_nav_dir_p2 = None;
+    state.last_steps_nav_time_p2 = None;
+
+    let mut overlay = profile_boxes::init();
+    overlay.active_color_index = state.active_color_index;
+    profile_boxes::enter_late_join(&mut overlay, joining_side);
+    state.profile_switch_overlay = Some(overlay);
+    state.profile_switch_overlay_is_late_join = true;
 }
 
 #[inline(always)]
@@ -7777,16 +7815,39 @@ fn handle_profile_switch_overlay_input(state: &mut State, ev: &InputEvent) -> Sc
     match profile_boxes::handle_input(overlay, ev) {
         ScreenAction::SelectProfiles { p1, p2 } => {
             state.profile_switch_overlay = None;
+            state.profile_switch_overlay_is_late_join = false;
             profile::set_fast_profile_switch_from_select_music(true);
             ScreenAction::SelectProfiles { p1, p2 }
         }
         ScreenAction::Navigate(_) => {
+            let was_late_join = state.profile_switch_overlay_is_late_join;
             state.profile_switch_overlay = None;
-            restore_select_music_menu_after_profile_overlay(state);
+            state.profile_switch_overlay_is_late_join = false;
+            if was_late_join {
+                // Cancelled mid-set join: revert to the single-player session
+                // state so the late-joiner is fully unjoined again. No menu
+                // to restore — the overlay was opened directly from a Start
+                // press, not from the quick menu.
+                cancel_late_join_session();
+                audio::play_sfx("assets/sounds/unjoin.ogg");
+            } else {
+                restore_select_music_menu_after_profile_overlay(state);
+            }
             ScreenAction::None
         }
         _ => ScreenAction::None,
     }
+}
+
+/// Revert the session to single-player after a late-join was cancelled from
+/// the profile-switch overlay. Mirrors the inverse of `try_handle_late_join`.
+fn cancel_late_join_session() {
+    let staying_side = profile::get_session_player_side();
+    match staying_side {
+        profile::PlayerSide::P1 => profile::set_session_joined(true, false),
+        profile::PlayerSide::P2 => profile::set_session_joined(false, true),
+    }
+    profile::set_session_play_style(profile::PlayStyle::Single);
 }
 
 fn handle_test_input_overlay_input(state: &mut State, ev: &InputEvent) -> ScreenAction {

--- a/src/screens/select_profile.rs
+++ b/src/screens/select_profile.rs
@@ -22,6 +22,11 @@ pub fn set_joined(state: &mut State, p1_joined: bool, p2_joined: bool) {
 }
 
 #[inline(always)]
+pub fn enter_late_join(state: &mut State, joining_side: crate::game::profile::PlayerSide) {
+    profile_boxes::enter_late_join(state, joining_side);
+}
+
+#[inline(always)]
 pub fn update(state: &mut State, dt: f32) {
     profile_boxes::update(state, dt);
 }


### PR DESCRIPTION
Closes #395.

When a second player presses Start to late-join during the music wheel, they're currently dropped in with whatever profile was still parked on that slot (typically Guest). Per Simply-Love-SM5#741, when "Select Profile Screen is on" the late-joining player should instead see the profile-select widget so they can pick their own profile.

## Approach

Reuse the existing `profile_switch_overlay` (a `profile_boxes::State`) on SelectMusic instead of building new UI. After `try_handle_late_join` finalizes the join (Versus + Guest assignment so the screen is in a coherent state), it opens the overlay scoped to the joining side when `cfg.machine_show_select_profile` is true:

- A new `profile_boxes::enter_late_join(state, joining_side)` helper marks the existing player joined+ready (their current profile already loaded) and the joining side joined-but-not-ready with a join pulse.
- `select_music::open_late_join_profile_overlay` wires it up and sets a new `profile_switch_overlay_is_late_join` flag on `State`.
- Confirming flows through the existing `ScreenAction::SelectProfiles` fast-profile-switch path -- no new plumbing in the app shell.
- Cancelling (back/select) calls `cancel_late_join_session`, which reverts the joined mask back to the original single-player side and resets the play style to Single, then plays `unjoin.ogg`. This is needed because the overlay was opened directly from a Start press, not from the quick menu, so there is no SortMenu to restore.

## Scope

SelectMusic only, gated on `machine_show_select_profile`. The other late-join screens (SelectColor / SelectStyle / SelectPlayMode / SelectCourse) keep today's silent auto-Guest behavior.