### PR TITLE
Add post-Select-Profile ArrowCloud QR Login screen

### DIFF
--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -474,6 +474,23 @@ ArrowCloudSubmitFails=Submit Fails
 ; ============================================================
 ; Score Import Options submenu
 ; ============================================================
+[ArrowCloudLogin]
+Title=Sign in to ArrowCloud
+NoPlayerJoined=No player joined.
+ContinueHint=Press &START; to continue
+SkipHint=Press &START; to skip
+Player1=Player 1
+Player2=Player 2
+PanelHeader={side} - {name}
+GuestHint=Load a profile on\n{side} to sign in.
+Contacting=Contacting ArrowCloud...
+QrUnavailable=QR Unavailable
+Code=Code: {code}
+SignInComplete=Sign-in complete.
+KeySaved=Key saved to profile.
+SignInFailed=Sign-in failed:\n{reason}
+AlreadySignedInBadge=Currently signed in — scan to switch account
+
 [OptionsScoreImport]
 APIEndpoint=API Endpoint
 ScoreImportEndpoint=API Endpoint

--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -470,6 +470,10 @@ AutoDownloadUnlocks=Auto Download Unlocks
 SeparateUnlocksByPlayer=Separate Unlocks By Player
 EnableArrowCloud=Enable ArrowCloud
 ArrowCloudSubmitFails=Submit Fails
+ArrowCloudQRLogin=QR Login
+ArrowCloudQRLoginAlways=Always
+ArrowCloudQRLoginSometimes=Sometimes
+ArrowCloudQRLoginDisabled=Never
 
 ; ============================================================
 ; Score Import Options submenu
@@ -1537,6 +1541,7 @@ AutoDownloadUnlocksHelp=Automatically download unlock packs returned by GrooveSt
 SeparateUnlocksByPlayerHelp=Download unlock packs into per-player folders instead of a shared event folder.\nMatches Simply Love's SeparateUnlocksByPlayer preference.
 EnableArrowCloudHelp=Enable connection to ArrowCloud services.
 ArrowCloudSubmitFailsHelp=When Yes, failed stages are still submitted to ArrowCloud.\nDefault: No.
+ArrowCloudQRLoginHelp=When to show the ArrowCloud QR-login screen after picking a profile.\n\nAlways: always show it.\nSometimes: only when a joined player has no saved API key.\nNever: never auto-show. You can still link a profile manually from Manage Local Profiles.
 
 ; ============================================================
 ; Options Help — Online Scoring submenu

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -249,6 +249,7 @@ const fn light_mode_for_screen(screen: CurrentScreen) -> LightMode {
         | CurrentScreen::Mappings
         | CurrentScreen::Input
         | CurrentScreen::SelectProfile
+        | CurrentScreen::ArrowCloudLogin
         | CurrentScreen::SelectColor
         | CurrentScreen::SelectStyle
         | CurrentScreen::SelectPlayMode
@@ -1163,6 +1164,7 @@ pub struct ScreensState {
     init_state: init::State,
     select_profile_state: select_profile::State,
     select_color_state: select_color::State,
+    arrowcloud_login_state: crate::screens::arrowcloud_login::State,
     select_style_state: select_style::State,
     select_play_mode_state: select_mode::State,
     profile_load_state: profile_load::State,
@@ -3050,6 +3052,9 @@ impl ScreensState {
         select_color_state.bg_from_index = color_index;
         select_color_state.bg_to_index = color_index;
 
+        let mut arrowcloud_login_state = crate::screens::arrowcloud_login::init();
+        arrowcloud_login_state.active_color_index = color_index;
+
         let mut select_music_state = select_music::init_placeholder();
         select_music_state.active_color_index = color_index;
         select_music_state.preferred_difficulty_index = preferred_difficulty_index;
@@ -3115,6 +3120,7 @@ impl ScreensState {
             init_state,
             select_profile_state,
             select_color_state,
+            arrowcloud_login_state,
             select_style_state,
             select_play_mode_state,
             profile_load_state,
@@ -3187,6 +3193,13 @@ impl ScreensState {
             }
             CurrentScreen::SelectColor => {
                 select_color::update(&mut self.select_color_state, delta_time);
+                (None, false)
+            }
+            CurrentScreen::ArrowCloudLogin => {
+                crate::screens::arrowcloud_login::update(
+                    &mut self.arrowcloud_login_state,
+                    delta_time,
+                );
                 (None, false)
             }
             CurrentScreen::SelectStyle => (
@@ -4270,9 +4283,21 @@ impl App {
                         self.handle_navigation_action(CurrentScreen::SelectMusic);
                     }
                 } else {
+                    // After profile selection, Simply Love optionally routes
+                    // through ScreenGrooveStatsLogin before SelectColor.
+                    // Mirror that here for ArrowCloud, gated by the
+                    // ArrowCloudQrLoginWhen pref.
+                    let cfg = crate::config::get();
+                    let next = if crate::screens::options::arrowcloud_login::should_auto_show(
+                        cfg.arrowcloud_qr_login_when,
+                    ) {
+                        CurrentScreen::ArrowCloudLogin
+                    } else {
+                        CurrentScreen::SelectColor
+                    };
                     // ProfileLoad asynchronously prepares SelectMusic/SelectCourse state;
                     // avoid redundant eager init here.
-                    self.handle_navigation_action(CurrentScreen::SelectColor);
+                    self.handle_navigation_action(next);
                 }
                 Vec::new()
             }
@@ -5416,6 +5441,10 @@ impl App {
                 &mut self.state.screens.select_color_state,
                 &ev,
             ),
+            CurrentScreen::ArrowCloudLogin => crate::screens::arrowcloud_login::handle_input(
+                &mut self.state.screens.arrowcloud_login_state,
+                &ev,
+            ),
             CurrentScreen::SelectStyle => crate::screens::select_style::handle_input(
                 &mut self.state.screens.select_style_state,
                 &ev,
@@ -5810,6 +5839,10 @@ impl App {
             ),
             CurrentScreen::SelectColor => select_color::get_actors(
                 &self.state.screens.select_color_state,
+                screen_alpha_multiplier,
+            ),
+            CurrentScreen::ArrowCloudLogin => crate::screens::arrowcloud_login::get_actors(
+                &self.state.screens.arrowcloud_login_state,
                 screen_alpha_multiplier,
             ),
             CurrentScreen::SelectStyle => {

--- a/src/app/screen_nav.rs
+++ b/src/app/screen_nav.rs
@@ -166,6 +166,13 @@ impl App {
         if target_screen == CurrentScreen::SelectColor {
             select_color::on_enter(&mut self.state.screens.select_color_state);
         }
+        if target_screen == CurrentScreen::ArrowCloudLogin {
+            self.state.screens.arrowcloud_login_state.active_color_index =
+                self.state.screens.menu_state.active_color_index;
+            crate::screens::arrowcloud_login::on_enter(
+                &mut self.state.screens.arrowcloud_login_state,
+            );
+        }
 
         let menu_music_enabled = config::get().menu_music;
         let target_menu_music = menu_music_enabled
@@ -458,6 +465,13 @@ impl App {
         if target == CurrentScreen::SelectColor {
             select_color::on_enter(&mut self.state.screens.select_color_state);
         }
+        if target == CurrentScreen::ArrowCloudLogin {
+            self.state.screens.arrowcloud_login_state.active_color_index =
+                self.state.screens.menu_state.active_color_index;
+            crate::screens::arrowcloud_login::on_enter(
+                &mut self.state.screens.arrowcloud_login_state,
+            );
+        }
 
         let mut commands: Vec<Command> = Vec::new();
         commands.extend(self.handle_audio_and_profile_on_fade(prev, target));
@@ -501,6 +515,7 @@ impl App {
             CurrentScreen::PlayerOptions => player_options::out_transition(),
             CurrentScreen::SelectProfile => select_profile::out_transition(),
             CurrentScreen::SelectColor => select_color::out_transition(),
+            CurrentScreen::ArrowCloudLogin => crate::screens::arrowcloud_login::out_transition(),
             CurrentScreen::SelectStyle => select_style::out_transition(),
             CurrentScreen::SelectPlayMode => select_mode::out_transition(),
             CurrentScreen::ProfileLoad => profile_load::out_transition(),
@@ -541,6 +556,7 @@ impl App {
             CurrentScreen::PlayerOptions => player_options::in_transition(),
             CurrentScreen::SelectProfile => select_profile::in_transition(),
             CurrentScreen::SelectColor => select_color::in_transition(),
+            CurrentScreen::ArrowCloudLogin => crate::screens::arrowcloud_login::in_transition(),
             CurrentScreen::SelectStyle => select_style::in_transition(),
             CurrentScreen::SelectPlayMode => select_mode::in_transition(),
             CurrentScreen::ProfileLoad => profile_load::in_transition(),

--- a/src/config/load/options.rs
+++ b/src/config/load/options.rs
@@ -76,6 +76,10 @@ fn load_system_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
         .get("Options", "SubmitArrowCloudFails")
         .and_then(|v| v.parse::<u8>().ok())
         .map_or(default.submit_arrowcloud_fails, |v| v != 0);
+    cfg.arrowcloud_qr_login_when = conf
+        .get("Options", "ArrowCloudQrLoginWhen")
+        .and_then(|v| ArrowCloudQrLoginWhen::from_str(&v).ok())
+        .unwrap_or(default.arrowcloud_qr_login_when);
     cfg.separate_unlocks_by_player = conf
         .get("Options", "SeparateUnlocksByPlayer")
         .and_then(|v| v.parse::<u8>().ok())

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,13 +28,14 @@ pub use self::runtime::{
 };
 pub use self::theme::{
     AUTO_SS_CLEARS, AUTO_SS_FAILS, AUTO_SS_FLAG_NAMES, AUTO_SS_NUM_FLAGS, AUTO_SS_PBS,
-    AUTO_SS_QUADS, AUTO_SS_QUINTS, BreakdownStyle, DefaultFailType, DefaultSyncOffset, GameFlag,
-    LanguageFlag, LogLevel, MACHINE_FONT_VARIANTS, MachineBarColor, MachineFont,
-    MachinePreferredPlayMode, MachinePreferredPlayStyle, NewPackMode, RandomBackgroundMode,
-    SelectMusicItlRankMode, SelectMusicItlWheelMode, SelectMusicPatternInfoMode,
-    SelectMusicScoreboxPlacement, SelectMusicSongSelectBgMode, SelectMusicStepArtistBoxMode,
-    SelectMusicWheelStyle, SyncGraphMode, ThemeFlag, VersionOverlaySide, VisualStyle,
-    auto_screenshot_bit, auto_screenshot_mask_from_str, auto_screenshot_mask_to_str,
+    AUTO_SS_QUADS, AUTO_SS_QUINTS, ArrowCloudQrLoginWhen, BreakdownStyle, DefaultFailType,
+    DefaultSyncOffset, GameFlag, LanguageFlag, LogLevel, MACHINE_FONT_VARIANTS, MachineBarColor,
+    MachineFont, MachinePreferredPlayMode, MachinePreferredPlayStyle, NewPackMode,
+    RandomBackgroundMode, SelectMusicItlRankMode, SelectMusicItlWheelMode,
+    SelectMusicPatternInfoMode, SelectMusicScoreboxPlacement, SelectMusicSongSelectBgMode,
+    SelectMusicStepArtistBoxMode, SelectMusicWheelStyle, SyncGraphMode, ThemeFlag,
+    VersionOverlaySide, VisualStyle, auto_screenshot_bit, auto_screenshot_mask_from_str,
+    auto_screenshot_mask_to_str,
 };
 pub use self::update::*;
 
@@ -286,6 +287,9 @@ pub struct Config {
     pub enable_boogiestats: bool,
     pub enable_groovestats: bool,
     pub submit_arrowcloud_fails: bool,
+    /// When to auto-show the ArrowCloud QR-login screen after Select
+    /// Profile.  Mirrors Simply Love's `QRLogin` theme pref.
+    pub arrowcloud_qr_login_when: ArrowCloudQrLoginWhen,
     pub separate_unlocks_by_player: bool,
     pub fastload: bool,
     pub cachesongs: bool,
@@ -436,6 +440,7 @@ impl Default for Config {
             enable_boogiestats: false,
             enable_groovestats: false,
             submit_arrowcloud_fails: false,
+            arrowcloud_qr_login_when: ArrowCloudQrLoginWhen::Sometimes,
             separate_unlocks_by_player: false,
             fastload: true,
             cachesongs: true,

--- a/src/config/store/defaults.rs
+++ b/src/config/store/defaults.rs
@@ -68,6 +68,11 @@ fn push_default_options(content: &mut String, default: &Config) {
         "SubmitArrowCloudFails",
         default.submit_arrowcloud_fails,
     );
+    push_line(
+        content,
+        "ArrowCloudQrLoginWhen",
+        default.arrowcloud_qr_login_when.as_str(),
+    );
     push_bool(content, "FastLoad", default.fastload);
     push_line(content, "FullscreenType", default.fullscreen_type.as_str());
     push_line(content, "Game", default.game_flag.as_str());

--- a/src/config/store/save.rs
+++ b/src/config/store/save.rs
@@ -143,6 +143,11 @@ fn push_saved_options(
         "SubmitArrowCloudFails",
         cfg.submit_arrowcloud_fails,
     );
+    push_line(
+        content,
+        "ArrowCloudQrLoginWhen",
+        cfg.arrowcloud_qr_login_when.as_str(),
+    );
     push_bool(content, "FastLoad", cfg.fastload);
     push_line(content, "FullscreenType", cfg.fullscreen_type.as_str());
     push_line(content, "Game", cfg.game_flag.as_str());

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -678,6 +678,49 @@ impl FromStr for MachinePreferredPlayMode {
     }
 }
 
+/// When to auto-show the ArrowCloud QR-login screen after the user picks
+/// a profile.  Mirrors Simply Love's `QRLogin` theme pref.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ArrowCloudQrLoginWhen {
+    /// Always show the login screen after Select Profile.
+    Always,
+    /// Show only when at least one joined Local player has no saved API
+    /// key.  Default.
+    #[default]
+    Sometimes,
+    /// Never auto-show; only the manual Options entry can launch it.
+    Disabled,
+}
+
+impl ArrowCloudQrLoginWhen {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Always => "Always",
+            Self::Sometimes => "Sometimes",
+            Self::Disabled => "Disabled",
+        }
+    }
+}
+
+impl FromStr for ArrowCloudQrLoginWhen {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut key = String::with_capacity(s.len());
+        for ch in s.trim().chars() {
+            if ch.is_ascii_alphanumeric() {
+                key.push(ch.to_ascii_lowercase());
+            }
+        }
+        match key.as_str() {
+            "always" => Ok(Self::Always),
+            "sometimes" => Ok(Self::Sometimes),
+            "disabled" | "never" | "off" | "no" => Ok(Self::Disabled),
+            _ => Err(()),
+        }
+    }
+}
+
 /// Machine-wide font preference, ported from Simply Love's `ThemeFont` pref.
 ///
 /// Controls which font is used for the Bold / Header / Footer / numbers /

--- a/src/config/update/machine.rs
+++ b/src/config/update/machine.rs
@@ -355,6 +355,17 @@ pub fn update_submit_arrowcloud_fails(enabled: bool) {
     save_without_keymaps();
 }
 
+pub fn update_arrowcloud_qr_login_when(when: ArrowCloudQrLoginWhen) {
+    {
+        let mut cfg = lock_config();
+        if cfg.arrowcloud_qr_login_when == when {
+            return;
+        }
+        cfg.arrowcloud_qr_login_when = when;
+    }
+    save_without_keymaps();
+}
+
 pub fn update_auto_download_unlocks(enabled: bool) {
     {
         let mut cfg = lock_config();

--- a/src/game/profile.rs
+++ b/src/game/profile.rs
@@ -4043,6 +4043,16 @@ fn save_arrowcloud_ini_for_side(side: PlayerSide) {
     }
 }
 
+/// Update the active profile's ArrowCloud API key (in memory + on disk).
+/// No-op when the side has no local profile loaded (Guest).
+pub fn set_arrowcloud_api_key_for_side(side: PlayerSide, api_key: &str) {
+    {
+        let mut profiles = lock_profiles();
+        profiles[side_ix(side)].arrowcloud_api_key = api_key.to_string();
+    }
+    save_arrowcloud_ini_for_side(side);
+}
+
 fn load_for_side(side: PlayerSide) {
     let profile_id = {
         let session = lock_session();

--- a/src/screens/arrowcloud_login.rs
+++ b/src/screens/arrowcloud_login.rs
@@ -1,0 +1,143 @@
+//! Dedicated screen for the ArrowCloud QR device-login step.
+//!
+//! Mirrors Simply Love's `ScreenGrooveStatsLogin`
+//! (`BGAnimations/ScreenGrooveStatsLogin underlay/default.lua`), which
+//! sits between `ScreenSelectProfile` and `ScreenSelectColor` in the
+//! boot-flow branch chain (`Scripts/SL-Branches.lua:78-80`).  Gated by
+//! the `ArrowCloudQrLoginWhen` pref (Always/Sometimes/Disabled).
+//!
+//! The visual state machine + per-side worker is shared with future
+//! entry points; both render the same overlay actors via
+//! [`build_arrowcloud_login_overlay_actors`].
+
+use std::sync::atomic::Ordering;
+
+use crate::engine::input::{InputEvent, VirtualAction};
+use crate::engine::present::actors::Actor;
+use crate::screens::components::shared::{transitions, visual_style_bg};
+use crate::screens::input as screen_input;
+use crate::screens::options::arrowcloud_login::{
+    ArrowCloudLoginUiState, build_arrowcloud_login_overlay_actors, create_arrowcloud_login_ui,
+    poll_arrowcloud_login_ui,
+};
+use crate::screens::{Screen, ScreenAction};
+
+const TRANSITION_IN_DURATION: f32 = 0.3;
+const TRANSITION_OUT_DURATION: f32 = 0.3;
+
+pub struct State {
+    pub active_color_index: i32,
+    pub(crate) ui: Option<ArrowCloudLoginUiState>,
+    /// Animated heart/style background, matching SelectProfile /
+    /// SelectColor.  The overlay panel is rendered on top of this with
+    /// the standard 0.65-alpha black dimmer.
+    bg: visual_style_bg::State,
+    /// Tracks the L+R chord used as the Cancel input on three-key
+    /// cabinets (which have no dedicated Back button).
+    menu_lr_chord: screen_input::MenuLrChordTracker,
+}
+
+pub fn init() -> State {
+    State {
+        active_color_index: crate::config::get().simply_love_color,
+        ui: None,
+        bg: visual_style_bg::State::new(),
+        menu_lr_chord: screen_input::MenuLrChordTracker::default(),
+    }
+}
+
+/// Called every time the app enters this screen.  Spawns a fresh
+/// multi-side login UI (one worker per joined Local side) and discards
+/// any previous instance.
+pub fn on_enter(state: &mut State) {
+    state.ui = Some(create_arrowcloud_login_ui());
+    state.menu_lr_chord = screen_input::MenuLrChordTracker::default();
+}
+
+pub fn in_transition() -> (Vec<Actor>, f32) {
+    transitions::fade_in_black(TRANSITION_IN_DURATION, 1100)
+}
+
+pub fn out_transition() -> (Vec<Actor>, f32) {
+    transitions::fade_out_black(TRANSITION_OUT_DURATION, 1200)
+}
+
+pub fn update(state: &mut State, _dt: f32) {
+    if let Some(ui) = state.ui.as_mut() {
+        poll_arrowcloud_login_ui(ui);
+    }
+}
+
+/// Input mirrors `ScreenGrooveStatsLogin/default.lua:60-65`, with
+/// deadsync-specific Back-to-title behavior:
+///   * Start (or SELECT) → cancel workers, navigate to `SelectColor`
+///                          (advance, even if no QR was scanned).
+///   * Back  (or L+R chord on three-key cabinets) → cancel workers and
+///                          return all the way to the title menu, same
+///                          as Back on `SelectProfile`.
+///
+/// Any other input is consumed.
+pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
+    let three_key = screen_input::three_key_menu_action(&mut state.menu_lr_chord, ev);
+    let is_three_key_confirm = matches!(
+        three_key,
+        Some((_, screen_input::ThreeKeyMenuAction::Confirm))
+    );
+    let is_three_key_cancel = matches!(
+        three_key,
+        Some((_, screen_input::ThreeKeyMenuAction::Cancel))
+    );
+    let is_start = is_three_key_confirm
+        || (ev.pressed
+            && matches!(
+                ev.action,
+                VirtualAction::p1_start
+                    | VirtualAction::p2_start
+                    | VirtualAction::p1_select
+                    | VirtualAction::p2_select
+            ));
+    let is_back = is_three_key_cancel
+        || (ev.pressed
+            && matches!(
+                ev.action,
+                VirtualAction::p1_back | VirtualAction::p2_back
+            ));
+    if is_start {
+        if let Some(ui) = state.ui.as_ref() {
+            ui.cancel.store(true, Ordering::Relaxed);
+        }
+        state.ui = None;
+        crate::engine::audio::play_sfx("assets/sounds/start.ogg");
+        return ScreenAction::Navigate(Screen::SelectColor);
+    }
+    if is_back {
+        if let Some(ui) = state.ui.as_ref() {
+            ui.cancel.store(true, Ordering::Relaxed);
+        }
+        state.ui = None;
+        crate::engine::audio::play_sfx("assets/sounds/change.ogg");
+        log::info!("ArrowCloud QR login cancelled — returning to title menu.");
+        return ScreenAction::Navigate(Screen::Menu);
+    }
+    ScreenAction::None
+}
+
+pub fn get_actors(state: &State, alpha_multiplier: f32) -> Vec<Actor> {
+    let mut actors: Vec<Actor> = Vec::with_capacity(32);
+
+    // Animated heart background — matches SelectProfile / SelectColor.
+    actors.extend(state.bg.build(visual_style_bg::Params {
+        active_color_index: state.active_color_index,
+        backdrop_rgba: [0.0, 0.0, 0.0, 1.0],
+        alpha_mul: 1.0,
+    }));
+
+    if let Some(ui) = state.ui.as_ref() {
+        let mut ui_actors = build_arrowcloud_login_overlay_actors(ui, state.active_color_index);
+        for actor in &mut ui_actors {
+            actor.mul_alpha(alpha_multiplier);
+        }
+        actors.extend(ui_actors);
+    }
+    actors
+}

--- a/src/screens/mod.rs
+++ b/src/screens/mod.rs
@@ -18,6 +18,7 @@ pub mod practice;
 pub mod profile_load;
 pub mod sandbox;
 pub mod select_color;
+pub mod arrowcloud_login;
 pub mod select_course;
 pub mod select_mode;
 pub mod select_music;
@@ -115,6 +116,7 @@ pub enum Screen {
     Mappings,
     Input,
     SelectProfile,
+    ArrowCloudLogin,
     SelectColor,
     SelectStyle,
     SelectPlayMode,
@@ -144,6 +146,7 @@ impl Screen {
             Self::Mappings => "ScreenMapControllers",
             Self::Input => "ScreenTestInput",
             Self::SelectProfile => "ScreenSelectProfile",
+            Self::ArrowCloudLogin => "ScreenArrowCloudLogin",
             Self::SelectColor => "ScreenSelectColor",
             Self::SelectStyle => "ScreenSelectStyle",
             Self::SelectPlayMode => "ScreenSelectPlayMode",

--- a/src/screens/options/arrowcloud_login.rs
+++ b/src/screens/options/arrowcloud_login.rs
@@ -33,6 +33,48 @@ const POLL_INTERVAL_DEFAULT_S: f32 = 3.0;
 
 const ALL_SIDES: [profile::PlayerSide; 2] = [profile::PlayerSide::P1, profile::PlayerSide::P2];
 
+/// Returns `true` when the ArrowCloud QR-login screen should be
+/// auto-shown after Select Profile, given the current pref and live
+/// session state.  Mirrors Simply Love's `Branch.AfterSelectProfile`
+/// rule (`SL-Branches.lua:78-80`):
+///
+/// * `Always`    — always show, regardless of saved keys.
+/// * `Sometimes` — show iff at least one joined Local side has an empty
+///                 `arrowcloud_api_key`.  Guests and unjoined sides
+///                 don't count toward the "needs key" check (matches
+///                 SL's `for player in ivalues(GAMESTATE:GetHumanPlayers())`).
+/// * `Disabled`  — never auto-show.
+pub fn should_auto_show(when: crate::config::ArrowCloudQrLoginWhen) -> bool {
+    should_auto_show_with(when, any_joined_local_side_missing_key)
+}
+
+fn should_auto_show_with<F: FnOnce() -> bool>(
+    when: crate::config::ArrowCloudQrLoginWhen,
+    missing_key_probe: F,
+) -> bool {
+    use crate::config::ArrowCloudQrLoginWhen;
+    match when {
+        ArrowCloudQrLoginWhen::Disabled => false,
+        ArrowCloudQrLoginWhen::Always => true,
+        ArrowCloudQrLoginWhen::Sometimes => missing_key_probe(),
+    }
+}
+
+fn any_joined_local_side_missing_key() -> bool {
+    ALL_SIDES.iter().any(|side| {
+        if !profile::is_session_side_joined(*side) {
+            return false;
+        }
+        if profile::is_session_side_guest(*side) {
+            return false;
+        }
+        profile::get_for_side(*side)
+            .arrowcloud_api_key
+            .trim()
+            .is_empty()
+    })
+}
+
 #[inline]
 fn side_ix(side: profile::PlayerSide) -> usize {
     match side {
@@ -894,5 +936,25 @@ mod tests {
             }
             .is_workless()
         );
+    }
+
+    use crate::config::ArrowCloudQrLoginWhen;
+
+    #[test]
+    fn should_auto_show_disabled_is_always_false() {
+        assert!(!should_auto_show_with(ArrowCloudQrLoginWhen::Disabled, || true));
+        assert!(!should_auto_show_with(ArrowCloudQrLoginWhen::Disabled, || false));
+    }
+
+    #[test]
+    fn should_auto_show_always_is_always_true() {
+        assert!(should_auto_show_with(ArrowCloudQrLoginWhen::Always, || true));
+        assert!(should_auto_show_with(ArrowCloudQrLoginWhen::Always, || false));
+    }
+
+    #[test]
+    fn should_auto_show_sometimes_follows_missing_key_probe() {
+        assert!(should_auto_show_with(ArrowCloudQrLoginWhen::Sometimes, || true));
+        assert!(!should_auto_show_with(ArrowCloudQrLoginWhen::Sometimes, || false));
     }
 }

--- a/src/screens/options/arrowcloud_login.rs
+++ b/src/screens/options/arrowcloud_login.rs
@@ -1,0 +1,898 @@
+//! ArrowCloud QR device-login overlay — shared state machine and renderer.
+//!
+//! Mirrors Simply Love's `ScreenGrooveStatsLogin` design: one QR code
+//! per joined player, shown side by side
+//! (`BGAnimations/ScreenGrooveStatsLogin underlay/default.lua:117-165`).
+//! ArrowCloud's `device-login` API is poll-based rather than websocket,
+//! so each side gets its own independent worker thread that polls
+//! `device-login/poll` and writes the resulting key to its captured
+//! `PlayerSide` on consume.
+//!
+//! This module ships only the infrastructure — the multi-side state
+//! machine, the per-side worker, the slot renderer, and unit tests.
+//! Concrete entry points (post-Select-Profile auto-trigger, per-profile
+//! Link entry) live in follow-up PRs that wrap this module; until they
+//! land, callers are absent on purpose.
+#![allow(dead_code)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::act;
+use crate::assets::i18n::{tr, tr_fmt};
+use crate::engine::present::actors::Actor;
+use crate::engine::present::color;
+use crate::engine::space::{screen_center_x, screen_center_y, screen_height, screen_width};
+use crate::game::online::arrowcloud as ac_online;
+use crate::game::profile;
+use crate::screens::components::shared::qr_code;
+
+const POLL_INTERVAL_MIN_S: f32 = 1.0;
+const POLL_INTERVAL_MAX_S: f32 = 10.0;
+const POLL_INTERVAL_DEFAULT_S: f32 = 3.0;
+
+const ALL_SIDES: [profile::PlayerSide; 2] = [profile::PlayerSide::P1, profile::PlayerSide::P2];
+
+#[inline]
+fn side_ix(side: profile::PlayerSide) -> usize {
+    match side {
+        profile::PlayerSide::P1 => 0,
+        profile::PlayerSide::P2 => 1,
+    }
+}
+
+#[inline]
+fn side_label(side: profile::PlayerSide) -> Arc<str> {
+    match side {
+        profile::PlayerSide::P1 => tr("ArrowCloudLogin", "Player1"),
+        profile::PlayerSide::P2 => tr("ArrowCloudLogin", "Player2"),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum LoginMsg {
+    Started {
+        short_code: String,
+        verification_url: String,
+    },
+    StatusUpdate,
+    Consumed {
+        api_key: String,
+    },
+    Failed {
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum SlotState {
+    /// Side is not joined to the session; the slot is hidden entirely.
+    NotJoined,
+    /// Side is joined but has no Local profile loaded — login is refused.
+    Guest,
+    /// Worker has been spawned, awaiting the `device-login/start` response.
+    Starting,
+    /// Worker has the short code + verification URL and is polling.
+    Pending {
+        short_code: String,
+        verification_url: String,
+    },
+    /// Server returned `consumed` and the API key was persisted.
+    Success,
+    /// Terminal failure for this side (network, expired, cancelled, etc.).
+    Failed { reason: String },
+}
+
+impl SlotState {
+    fn is_workless(&self) -> bool {
+        matches!(
+            self,
+            SlotState::NotJoined | SlotState::Guest | SlotState::Success | SlotState::Failed { .. }
+        )
+    }
+
+    fn is_visible(&self) -> bool {
+        !matches!(self, SlotState::NotJoined)
+    }
+}
+
+pub(crate) struct LoginSlot {
+    pub(crate) side: profile::PlayerSide,
+    pub(crate) state: SlotState,
+    /// Profile display name for this side (e.g. "Player 1", "Alice").
+    /// Shown as the panel header so the user sees exactly which profile
+    /// the key will land in.
+    pub(crate) display_name: String,
+    /// True iff this side already had a non-empty arrowcloud_api_key when
+    /// the overlay was opened.  Used to render a "Currently signed in"
+    /// badge so the user knows scanning will overwrite an existing key.
+    pub(crate) had_existing_key: bool,
+    pub(crate) rx: Option<std::sync::mpsc::Receiver<LoginMsg>>,
+}
+
+pub(crate) struct ArrowCloudLoginUiState {
+    pub(crate) slots: [LoginSlot; 2],
+    pub(crate) cancel: Arc<AtomicBool>,
+}
+
+impl Drop for ArrowCloudLoginUiState {
+    fn drop(&mut self) {
+        // Defensive: if the overlay is torn down without going through
+        // a cancel path, still signal workers to stop.
+        self.cancel.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Spawn ArrowCloud device-login workers — one per joined Local side —
+/// and return a fresh UI state ready to be rendered.
+pub fn create_arrowcloud_login_ui() -> ArrowCloudLoginUiState {
+    let cancel = Arc::new(AtomicBool::new(false));
+    let slots = build_initial_slots(&cancel, |side, tx| {
+        let cancel_for_thread = Arc::clone(&cancel);
+        std::thread::spawn(move || {
+            run_login_session(
+                side,
+                tx,
+                cancel_for_thread,
+                ac_online::device_login_start,
+                ac_online::device_login_poll,
+            );
+        });
+    });
+    ArrowCloudLoginUiState { slots, cancel }
+}
+
+/// Decide which sides need a worker and build the slot array. `spawn`
+/// callback is invoked once per side that should start polling; tests
+/// inject a no-op or mock spawner.
+fn build_initial_slots<F>(_cancel: &Arc<AtomicBool>, mut spawn: F) -> [LoginSlot; 2]
+where
+    F: FnMut(profile::PlayerSide, std::sync::mpsc::Sender<LoginMsg>),
+{
+    let p1 = build_one_slot(profile::PlayerSide::P1, &mut spawn);
+    let p2 = build_one_slot(profile::PlayerSide::P2, &mut spawn);
+    [p1, p2]
+}
+
+fn build_one_slot<F>(side: profile::PlayerSide, spawn: &mut F) -> LoginSlot
+where
+    F: FnMut(profile::PlayerSide, std::sync::mpsc::Sender<LoginMsg>),
+{
+    if !profile::is_session_side_joined(side) {
+        return LoginSlot {
+            side,
+            state: SlotState::NotJoined,
+            display_name: String::new(),
+            had_existing_key: false,
+            rx: None,
+        };
+    }
+    if profile::is_session_side_guest(side) {
+        return LoginSlot {
+            side,
+            state: SlotState::Guest,
+            display_name: String::new(),
+            had_existing_key: false,
+            rx: None,
+        };
+    }
+    let p = profile::get_for_side(side);
+    let had_existing_key = !p.arrowcloud_api_key.trim().is_empty();
+
+    let (tx, rx) = std::sync::mpsc::channel::<LoginMsg>();
+    spawn(side, tx);
+    LoginSlot {
+        side,
+        state: SlotState::Starting,
+        display_name: p.display_name,
+        had_existing_key,
+        rx: Some(rx),
+    }
+}
+
+fn run_login_session<S, P>(
+    _side: profile::PlayerSide,
+    tx: std::sync::mpsc::Sender<LoginMsg>,
+    cancel: Arc<AtomicBool>,
+    start_fn: S,
+    poll_fn: P,
+) where
+    S: Fn(
+        &ac_online::DeviceLoginStartReq,
+    ) -> Result<ac_online::DeviceLoginStartResp, crate::engine::network::NetworkError>,
+    P: Fn(
+        &ac_online::DeviceLoginPollReq,
+    ) -> Result<ac_online::DeviceLoginPollResp, crate::engine::network::NetworkError>,
+{
+    if cancel.load(Ordering::Relaxed) {
+        return;
+    }
+
+    let req = ac_online::DeviceLoginStartReq {
+        machine_label: None,
+        client_version: Some(format!("deadsync {}", env!("CARGO_PKG_VERSION"))),
+        theme_version: None,
+    };
+    let start = match start_fn(&req) {
+        Ok(resp) => resp,
+        Err(err) => {
+            let _ = tx.send(LoginMsg::Failed {
+                reason: format!("{err}"),
+            });
+            return;
+        }
+    };
+
+    let mut interval_s = clamp_poll_interval(start.poll_interval_seconds);
+    let poll_req = ac_online::DeviceLoginPollReq {
+        session_id: start.session_id.clone(),
+        poll_token: start.poll_token.clone(),
+    };
+
+    if tx
+        .send(LoginMsg::Started {
+            short_code: start.short_code.clone(),
+            verification_url: start.verification_url.clone(),
+        })
+        .is_err()
+    {
+        return;
+    }
+
+    loop {
+        if !sleep_with_cancel(interval_s, &cancel) {
+            return;
+        }
+        match poll_fn(&poll_req) {
+            Ok(resp) => {
+                interval_s = clamp_poll_interval(resp.poll_interval_seconds);
+                match resp.status {
+                    ac_online::DeviceLoginStatus::Consumed => {
+                        let api_key = resp.api_key.unwrap_or_default();
+                        if api_key.trim().is_empty() {
+                            let _ = tx.send(LoginMsg::Failed {
+                                reason: "server returned empty api key".to_string(),
+                            });
+                        } else {
+                            let _ = tx.send(LoginMsg::Consumed { api_key });
+                        }
+                        return;
+                    }
+                    ac_online::DeviceLoginStatus::Cancelled
+                    | ac_online::DeviceLoginStatus::Expired => {
+                        let _ = tx.send(LoginMsg::Failed {
+                            reason: format!("{:?}", resp.status).to_lowercase(),
+                        });
+                        return;
+                    }
+                    ac_online::DeviceLoginStatus::Pending
+                    | ac_online::DeviceLoginStatus::Approved => {
+                        if tx.send(LoginMsg::StatusUpdate).is_err() {
+                            return;
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                let _ = tx.send(LoginMsg::Failed {
+                    reason: format!("{err}"),
+                });
+                return;
+            }
+        }
+    }
+}
+
+fn clamp_poll_interval(seconds: Option<u64>) -> f32 {
+    let raw = seconds
+        .map(|s| s as f32)
+        .unwrap_or(POLL_INTERVAL_DEFAULT_S);
+    raw.clamp(POLL_INTERVAL_MIN_S, POLL_INTERVAL_MAX_S)
+}
+
+fn sleep_with_cancel(seconds: f32, cancel: &Arc<AtomicBool>) -> bool {
+    let total = std::time::Duration::from_millis((seconds * 1000.0).max(50.0) as u64);
+    let mut elapsed = std::time::Duration::ZERO;
+    let tick = std::time::Duration::from_millis(100);
+    while elapsed < total {
+        if cancel.load(Ordering::Relaxed) {
+            return false;
+        }
+        let chunk = tick.min(total - elapsed);
+        std::thread::sleep(chunk);
+        elapsed += chunk;
+    }
+    !cancel.load(Ordering::Relaxed)
+}
+
+/// Drain pending channel messages for every slot, updating slot state
+/// and (on success) persisting api keys into per-side profiles.
+pub(crate) fn poll_arrowcloud_login_ui(ui: &mut ArrowCloudLoginUiState) {
+    for slot in &mut ui.slots {
+        let mut msgs: Vec<LoginMsg> = Vec::new();
+        if let Some(rx) = slot.rx.as_ref() {
+            while let Ok(msg) = rx.try_recv() {
+                msgs.push(msg);
+            }
+        }
+        for msg in msgs {
+            apply_login_msg(slot, msg);
+        }
+    }
+}
+
+fn apply_login_msg(slot: &mut LoginSlot, msg: LoginMsg) {
+    match msg {
+        LoginMsg::Started {
+            short_code,
+            verification_url,
+        } => {
+            slot.state = SlotState::Pending {
+                short_code,
+                verification_url,
+            };
+        }
+        LoginMsg::StatusUpdate => {
+            // Approved-but-not-consumed renders identically to Pending —
+            // we only flip to Success once the key has been delivered.
+        }
+        LoginMsg::Consumed { api_key } => {
+            profile::set_arrowcloud_api_key_for_side(slot.side, &api_key);
+            ac_online::refresh_status();
+            // Refresh display_name in case profile state changed.
+            slot.display_name = profile::get_for_side(slot.side).display_name;
+            slot.state = SlotState::Success;
+            slot.rx = None;
+        }
+        LoginMsg::Failed { reason } => {
+            slot.state = SlotState::Failed { reason };
+            slot.rx = None;
+        }
+    }
+}
+
+/// `true` when every slot is in a state that needs no further work —
+/// i.e. it's safe to dismiss without silently dropping an in-flight
+/// session.
+pub(crate) fn login_overlay_is_terminal(ui: &ArrowCloudLoginUiState) -> bool {
+    ui.slots.iter().all(|s| s.state.is_workless())
+}
+
+pub(crate) fn build_arrowcloud_login_overlay_actors(
+    ui: &ArrowCloudLoginUiState,
+    active_color_index: i32,
+) -> Vec<Actor> {
+    let mut out: Vec<Actor> = Vec::with_capacity(24);
+
+    out.push(act!(quad:
+        align(0.0, 0.0):
+        xy(0.0, 0.0):
+        zoomto(screen_width(), screen_height()):
+        diffuse(0.0, 0.0, 0.0, 0.65):
+        z(300)
+    ));
+
+    let cx = screen_center_x();
+    let cy = screen_center_y();
+    let visible_sides: Vec<profile::PlayerSide> = ALL_SIDES
+        .iter()
+        .copied()
+        .filter(|s| ui.slots[side_ix(*s)].state.is_visible())
+        .collect();
+
+    out.push(act!(text:
+        font("miso"):
+        settext(tr("ArrowCloudLogin", "Title").to_string()):
+        align(0.5, 0.5):
+        xy(cx, cy - 200.0):
+        zoom(1.05):
+        horizalign(center):
+        z(301)
+    ));
+
+    if visible_sides.is_empty() {
+        out.push(act!(text:
+            font("miso"):
+            settext(tr("ArrowCloudLogin", "NoPlayerJoined").to_string()):
+            align(0.5, 0.5):
+            xy(cx, cy):
+            zoom(0.95):
+            horizalign(center):
+            z(301)
+        ));
+        return out;
+    }
+
+    let two_up = visible_sides.len() > 1;
+    let panel_offset: f32 = if two_up { 200.0 } else { 0.0 };
+    let qr_size: f32 = if two_up { 150.0 } else { 200.0 };
+    for (i, side) in visible_sides.iter().enumerate() {
+        let slot = &ui.slots[side_ix(*side)];
+        let dx = if two_up && i == 0 {
+            -panel_offset
+        } else if two_up {
+            panel_offset
+        } else {
+            0.0
+        };
+        push_slot_panel(&mut out, slot, cx + dx, cy, qr_size, active_color_index);
+    }
+
+    let footer_key = if login_overlay_is_terminal(ui) {
+        "ContinueHint"
+    } else {
+        "SkipHint"
+    };
+    out.push(act!(text:
+        font("miso"):
+        settext(tr("ArrowCloudLogin", footer_key).to_string()):
+        align(0.5, 0.5):
+        xy(cx, cy + 200.0):
+        zoom(0.9):
+        horizalign(center):
+        z(301)
+    ));
+
+    out
+}
+
+fn push_slot_panel(
+    out: &mut Vec<Actor>,
+    slot: &LoginSlot,
+    panel_cx: f32,
+    panel_cy: f32,
+    qr_size: f32,
+    active_color_index: i32,
+) {
+    let fill = color::decorative_rgba(active_color_index);
+    let side_label_str = side_label(slot.side);
+
+    // Panel header — "Player 1 - <profile name>" so the user sees both
+    // which side the panel is for and exactly which profile's
+    // ArrowCloud.ini will receive the new key, on a single line.
+    let header_text = if slot.display_name.is_empty() {
+        side_label_str.to_string()
+    } else {
+        tr_fmt(
+            "ArrowCloudLogin",
+            "PanelHeader",
+            &[("side", side_label_str.as_ref()), ("name", &slot.display_name)],
+        )
+        .to_string()
+    };
+    out.push(act!(text:
+        font("miso"):
+        settext(header_text):
+        align(0.5, 0.5):
+        xy(panel_cx, panel_cy - 145.0):
+        zoom(0.95):
+        maxwidth(320.0):
+        horizalign(center):
+        z(301):
+        diffuse(fill[0], fill[1], fill[2], 1.0)
+    ));
+
+    match &slot.state {
+        SlotState::NotJoined => {}
+        SlotState::Guest => {
+            out.push(act!(text:
+                font("miso"):
+                settext(tr_fmt(
+                    "ArrowCloudLogin",
+                    "GuestHint",
+                    &[("side", side_label_str.as_ref())],
+                ).to_string()):
+                align(0.5, 0.5):
+                xy(panel_cx, panel_cy):
+                zoom(0.9):
+                maxwidth(260.0):
+                horizalign(center):
+                z(301):
+                diffuse(1.0, 0.85, 0.4, 1.0)
+            ));
+        }
+        SlotState::Starting => {
+            out.push(act!(text:
+                font("miso"):
+                settext(tr("ArrowCloudLogin", "Contacting").to_string()):
+                align(0.5, 0.5):
+                xy(panel_cx, panel_cy):
+                zoom(0.95):
+                horizalign(center):
+                z(301)
+            ));
+            push_status_badge(out, slot, panel_cx, panel_cy);
+        }
+        SlotState::Pending {
+            short_code,
+            verification_url,
+        } => {
+            let qr_actors = qr_code::build(qr_code::QrCodeParams {
+                content: verification_url,
+                center_x: panel_cx,
+                center_y: panel_cy,
+                size: qr_size,
+                border_modules: 2,
+                z: 301,
+            });
+            if qr_actors.is_empty() {
+                out.push(act!(text:
+                    font("miso"):
+                    settext(tr("ArrowCloudLogin", "QrUnavailable").to_string()):
+                    align(0.5, 0.5):
+                    xy(panel_cx, panel_cy):
+                    zoom(0.95):
+                    horizalign(center):
+                    z(301):
+                    diffuse(1.0, 0.3, 0.3, 1.0)
+                ));
+            } else {
+                out.extend(qr_actors);
+            }
+
+            let below_qr = panel_cy + qr_size * 0.5;
+            out.push(act!(text:
+                font("miso"):
+                settext(tr_fmt(
+                    "ArrowCloudLogin",
+                    "Code",
+                    &[("code", short_code.as_str())],
+                ).to_string()):
+                align(0.5, 0.5):
+                xy(panel_cx, below_qr + 20.0):
+                zoom(0.95):
+                horizalign(center):
+                z(301):
+                diffuse(fill[0], fill[1], fill[2], 1.0)
+            ));
+
+            out.push(act!(text:
+                font("miso"):
+                settext(verification_url.clone()):
+                align(0.5, 0.5):
+                xy(panel_cx, below_qr + 45.0):
+                zoom(0.7):
+                maxwidth(if qr_size >= 180.0 { 360.0 } else { 260.0 }):
+                horizalign(center):
+                z(301):
+                diffuse(0.85, 0.85, 0.85, 1.0)
+            ));
+
+            push_status_badge(out, slot, panel_cx, panel_cy - qr_size * 0.5);
+        }
+        SlotState::Success => {
+            out.push(act!(text:
+                font("miso"):
+                settext(tr("ArrowCloudLogin", "SignInComplete").to_string()):
+                align(0.5, 0.5):
+                xy(panel_cx, panel_cy):
+                zoom(1.0):
+                maxwidth(260.0):
+                horizalign(center):
+                z(301):
+                diffuse(0.4, 1.0, 0.5, 1.0)
+            ));
+            out.push(act!(text:
+                font("miso"):
+                settext(tr("ArrowCloudLogin", "KeySaved").to_string()):
+                align(0.5, 0.5):
+                xy(panel_cx, panel_cy + 26.0):
+                zoom(0.8):
+                maxwidth(260.0):
+                horizalign(center):
+                z(301):
+                diffuse(0.85, 0.85, 0.85, 1.0)
+            ));
+        }
+        SlotState::Failed { reason } => {
+            out.push(act!(text:
+                font("miso"):
+                settext(tr_fmt(
+                    "ArrowCloudLogin",
+                    "SignInFailed",
+                    &[("reason", reason.as_str())],
+                ).to_string()):
+                align(0.5, 0.5):
+                xy(panel_cx, panel_cy):
+                zoom(0.85):
+                maxwidth(260.0):
+                horizalign(center):
+                z(301):
+                diffuse(1.0, 0.4, 0.4, 1.0)
+            ));
+        }
+    }
+}
+
+/// Small "Currently signed in" badge shown above an in-flight QR when
+/// the side already has a saved API key.  Warns the user that scanning
+/// will overwrite it.
+fn push_status_badge(out: &mut Vec<Actor>, slot: &LoginSlot, panel_cx: f32, badge_y: f32) {
+    if !slot.had_existing_key {
+        return;
+    }
+    out.push(act!(text:
+        font("miso"):
+        settext(tr("ArrowCloudLogin", "AlreadySignedInBadge").to_string()):
+        align(0.5, 0.5):
+        xy(panel_cx, badge_y - 18.0):
+        zoom(0.65):
+        maxwidth(280.0):
+        horizalign(center):
+        z(301):
+        diffuse(1.0, 0.85, 0.4, 1.0)
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::network::NetworkError;
+    use std::sync::mpsc;
+    use std::sync::{Arc, Mutex};
+
+    fn drain_msgs(rx: &mpsc::Receiver<LoginMsg>) -> Vec<LoginMsg> {
+        let mut out = Vec::new();
+        while let Ok(msg) = rx.try_recv() {
+            out.push(msg);
+        }
+        out
+    }
+
+    fn make_start_ok() -> ac_online::DeviceLoginStartResp {
+        ac_online::DeviceLoginStartResp {
+            session_id: "sess-1".into(),
+            short_code: "ABCD2345".into(),
+            poll_token: "tok-1".into(),
+            poll_interval_seconds: Some(0),
+            verification_url: "https://arrowcloud.dance/device-login/sess-1".into(),
+        }
+    }
+
+    #[test]
+    fn clamp_poll_interval_uses_default_when_missing() {
+        assert!((clamp_poll_interval(None) - POLL_INTERVAL_DEFAULT_S).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn clamp_poll_interval_clamps_to_min() {
+        assert!((clamp_poll_interval(Some(0)) - POLL_INTERVAL_MIN_S).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn clamp_poll_interval_clamps_to_max() {
+        assert!((clamp_poll_interval(Some(9999)) - POLL_INTERVAL_MAX_S).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn worker_emits_started_then_consumed() {
+        let (tx, rx) = mpsc::channel::<LoginMsg>();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let polls = Arc::new(Mutex::new(0u32));
+        let polls_clone = Arc::clone(&polls);
+
+        let start = make_start_ok();
+        let start_fn =
+            move |_req: &ac_online::DeviceLoginStartReq| -> Result<_, NetworkError> {
+                Ok(start.clone())
+            };
+        let poll_fn = move |_req: &ac_online::DeviceLoginPollReq| -> Result<_, NetworkError> {
+            let mut n = polls_clone.lock().unwrap();
+            *n += 1;
+            if *n == 1 {
+                Ok(ac_online::DeviceLoginPollResp {
+                    status: ac_online::DeviceLoginStatus::Pending,
+                    poll_interval_seconds: Some(0),
+                    api_key: None,
+                })
+            } else {
+                Ok(ac_online::DeviceLoginPollResp {
+                    status: ac_online::DeviceLoginStatus::Consumed,
+                    poll_interval_seconds: None,
+                    api_key: Some("AC-KEY-7".into()),
+                })
+            }
+        };
+
+        run_login_session(profile::PlayerSide::P1, tx, cancel, start_fn, poll_fn);
+
+        let msgs = drain_msgs(&rx);
+        assert!(matches!(msgs.first(), Some(LoginMsg::Started { .. })));
+        assert!(
+            msgs.iter()
+                .any(|m| matches!(m, LoginMsg::StatusUpdate { .. }))
+        );
+        assert!(matches!(
+            msgs.last(),
+            Some(LoginMsg::Consumed { api_key }) if api_key == "AC-KEY-7"
+        ));
+        assert_eq!(*polls.lock().unwrap(), 2);
+    }
+
+    #[test]
+    fn worker_reports_failure_on_expired() {
+        let (tx, rx) = mpsc::channel::<LoginMsg>();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let start = make_start_ok();
+        let start_fn =
+            move |_req: &ac_online::DeviceLoginStartReq| -> Result<_, NetworkError> {
+                Ok(start.clone())
+            };
+        let poll_fn = move |_req: &ac_online::DeviceLoginPollReq| -> Result<_, NetworkError> {
+            Ok(ac_online::DeviceLoginPollResp {
+                status: ac_online::DeviceLoginStatus::Expired,
+                poll_interval_seconds: None,
+                api_key: None,
+            })
+        };
+
+        run_login_session(profile::PlayerSide::P1, tx, cancel, start_fn, poll_fn);
+        let msgs = drain_msgs(&rx);
+        assert!(matches!(msgs.last(), Some(LoginMsg::Failed { reason }) if reason == "expired"));
+    }
+
+    #[test]
+    fn worker_reports_failure_when_start_errors() {
+        let (tx, rx) = mpsc::channel::<LoginMsg>();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let start_fn = |_req: &ac_online::DeviceLoginStartReq| -> Result<_, NetworkError> {
+            Err(NetworkError::Request("boom".into()))
+        };
+        let poll_fn = |_req: &ac_online::DeviceLoginPollReq| -> Result<_, NetworkError> {
+            unreachable!("poll should not be called when start fails")
+        };
+
+        run_login_session(profile::PlayerSide::P1, tx, cancel, start_fn, poll_fn);
+        let msgs = drain_msgs(&rx);
+        assert!(matches!(msgs.first(), Some(LoginMsg::Failed { .. })));
+        assert_eq!(msgs.len(), 1);
+    }
+
+    #[test]
+    fn worker_consumed_with_empty_key_is_failure() {
+        let (tx, rx) = mpsc::channel::<LoginMsg>();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let start = make_start_ok();
+        let start_fn =
+            move |_req: &ac_online::DeviceLoginStartReq| -> Result<_, NetworkError> {
+                Ok(start.clone())
+            };
+        let poll_fn = move |_req: &ac_online::DeviceLoginPollReq| -> Result<_, NetworkError> {
+            Ok(ac_online::DeviceLoginPollResp {
+                status: ac_online::DeviceLoginStatus::Consumed,
+                poll_interval_seconds: None,
+                api_key: Some("   ".into()),
+            })
+        };
+
+        run_login_session(profile::PlayerSide::P1, tx, cancel, start_fn, poll_fn);
+        let msgs = drain_msgs(&rx);
+        assert!(matches!(msgs.last(), Some(LoginMsg::Failed { .. })));
+    }
+
+    #[test]
+    fn sleep_with_cancel_returns_false_when_cancelled_mid_wait() {
+        let cancel = Arc::new(AtomicBool::new(false));
+        let cancel_for_thread = Arc::clone(&cancel);
+        let handle = std::thread::spawn(move || sleep_with_cancel(5.0, &cancel_for_thread));
+        std::thread::sleep(std::time::Duration::from_millis(150));
+        cancel.store(true, Ordering::Relaxed);
+        assert!(!handle.join().unwrap());
+    }
+
+    fn slot(side: profile::PlayerSide, state: SlotState) -> LoginSlot {
+        LoginSlot {
+            side,
+            state,
+            display_name: String::new(),
+            had_existing_key: false,
+            rx: None,
+        }
+    }
+
+    #[test]
+    fn login_overlay_is_terminal_true_when_all_slots_workless() {
+        let ui = ArrowCloudLoginUiState {
+            cancel: Arc::new(AtomicBool::new(false)),
+            slots: [
+                slot(profile::PlayerSide::P1, SlotState::Success),
+                slot(profile::PlayerSide::P2, SlotState::NotJoined),
+            ],
+        };
+        assert!(login_overlay_is_terminal(&ui));
+    }
+
+    #[test]
+    fn login_overlay_is_terminal_false_when_any_slot_pending() {
+        let ui = ArrowCloudLoginUiState {
+            cancel: Arc::new(AtomicBool::new(false)),
+            slots: [
+                slot(profile::PlayerSide::P1, SlotState::Success),
+                slot(
+                    profile::PlayerSide::P2,
+                    SlotState::Pending {
+                        short_code: "X".into(),
+                        verification_url: "u".into(),
+                    },
+                ),
+            ],
+        };
+        assert!(!login_overlay_is_terminal(&ui));
+    }
+
+    #[test]
+    fn apply_started_message_moves_slot_to_pending() {
+        let mut s = slot(profile::PlayerSide::P1, SlotState::Starting);
+        apply_login_msg(
+            &mut s,
+            LoginMsg::Started {
+                short_code: "XYZ".into(),
+                verification_url: "https://example".into(),
+            },
+        );
+        assert!(matches!(
+            s.state,
+            SlotState::Pending { ref short_code, .. } if short_code == "XYZ"
+        ));
+    }
+
+    #[test]
+    fn apply_failed_message_clears_rx_and_records_reason() {
+        let (_tx, rx) = mpsc::channel::<LoginMsg>();
+        let mut s = LoginSlot {
+            side: profile::PlayerSide::P2,
+            state: SlotState::Pending {
+                short_code: "X".into(),
+                verification_url: "u".into(),
+            },
+            display_name: String::new(),
+            had_existing_key: false,
+            rx: Some(rx),
+        };
+        apply_login_msg(
+            &mut s,
+            LoginMsg::Failed {
+                reason: "boom".into(),
+            },
+        );
+        assert!(matches!(s.state, SlotState::Failed { ref reason } if reason == "boom"));
+        assert!(s.rx.is_none());
+    }
+
+    #[test]
+    fn drop_signals_cancel() {
+        let cancel = Arc::new(AtomicBool::new(false));
+        {
+            let _ui = ArrowCloudLoginUiState {
+                cancel: Arc::clone(&cancel),
+                slots: [
+                    slot(profile::PlayerSide::P1, SlotState::Starting),
+                    slot(profile::PlayerSide::P2, SlotState::NotJoined),
+                ],
+            };
+            assert!(!cancel.load(Ordering::Relaxed));
+        }
+        assert!(cancel.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn slot_state_is_workless_classification() {
+        assert!(SlotState::NotJoined.is_workless());
+        assert!(SlotState::Guest.is_workless());
+        assert!(SlotState::Success.is_workless());
+        assert!(
+            SlotState::Failed {
+                reason: "x".into()
+            }
+            .is_workless()
+        );
+        assert!(!SlotState::Starting.is_workless());
+        assert!(
+            !SlotState::Pending {
+                short_code: "x".into(),
+                verification_url: "y".into()
+            }
+            .is_workless()
+        );
+    }
+}

--- a/src/screens/options/arrowcloud_login.rs
+++ b/src/screens/options/arrowcloud_login.rs
@@ -7,13 +7,6 @@
 //! so each side gets its own independent worker thread that polls
 //! `device-login/poll` and writes the resulting key to its captured
 //! `PlayerSide` on consume.
-//!
-//! This module ships only the infrastructure — the multi-side state
-//! machine, the per-side worker, the slot renderer, and unit tests.
-//! Concrete entry points (post-Select-Profile auto-trigger, per-profile
-//! Link entry) live in follow-up PRs that wrap this module; until they
-//! land, callers are absent on purpose.
-#![allow(dead_code)]
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/screens/options/input.rs
+++ b/src/screens/options/input.rs
@@ -643,6 +643,8 @@ pub(super) fn apply_submenu_choice_delta(
             crate::game::online::init();
         } else if row.id == SubRowId::ArrowCloudSubmitFails {
             config::update_submit_arrowcloud_fails(yes_no_from_choice(new_index));
+        } else if row.id == SubRowId::ArrowCloudQrLogin {
+            config::update_arrowcloud_qr_login_when(ArrowCloudQrLoginWhen::from_choice(new_index));
         }
     } else if matches!(kind, SubmenuKind::ScoreImport) {
         let row = &rows[row_index];

--- a/src/screens/options/item.rs
+++ b/src/screens/options/item.rs
@@ -173,6 +173,7 @@ pub enum ItemId {
     // ArrowCloud Options submenu
     AcEnable,
     AcSubmitFails,
+    AcQrLogin,
 
     // Online Scoring submenu (launcher)
     OsGsBsOptions,

--- a/src/screens/options/mod.rs
+++ b/src/screens/options/mod.rs
@@ -60,6 +60,7 @@ mod reload;
 use reload::*;
 mod score_import;
 use score_import::*;
+pub(crate) mod arrowcloud_login;
 mod pack_sync;
 use pack_sync::*;
 mod layout;

--- a/src/screens/options/mod.rs
+++ b/src/screens/options/mod.rs
@@ -2,12 +2,12 @@ use crate::act;
 use crate::assets::{self, AssetManager, visual_styles};
 use crate::assets::{FontRole, current_machine_font_key};
 use crate::config::{
-    self, BreakdownStyle, DefaultFailType, DefaultSyncOffset, DisplayMode, FullscreenType,
-    LogLevel, MachineBarColor, MachineFont, MachinePreferredPlayMode, MachinePreferredPlayStyle,
-    NewPackMode, RandomBackgroundMode, SelectMusicItlRankMode, SelectMusicItlWheelMode,
-    SelectMusicPatternInfoMode, SelectMusicScoreboxPlacement, SelectMusicSongSelectBgMode,
-    SelectMusicStepArtistBoxMode, SelectMusicWheelStyle, SimpleIni, SyncGraphMode,
-    VersionOverlaySide, VisualStyle, dirs,
+    self, ArrowCloudQrLoginWhen, BreakdownStyle, DefaultFailType, DefaultSyncOffset, DisplayMode,
+    FullscreenType, LogLevel, MachineBarColor, MachineFont, MachinePreferredPlayMode,
+    MachinePreferredPlayStyle, NewPackMode, RandomBackgroundMode, SelectMusicItlRankMode,
+    SelectMusicItlWheelMode, SelectMusicPatternInfoMode, SelectMusicScoreboxPlacement,
+    SelectMusicSongSelectBgMode, SelectMusicStepArtistBoxMode, SelectMusicWheelStyle, SimpleIni,
+    SyncGraphMode, VersionOverlaySide, VisualStyle, dirs,
 };
 use crate::engine::audio;
 use crate::engine::display::{self, MonitorSpec};

--- a/src/screens/options/row.rs
+++ b/src/screens/options/row.rs
@@ -139,6 +139,7 @@ pub enum SubRowId {
     // ArrowCloud Options
     EnableArrowCloud,
     ArrowCloudSubmitFails,
+    ArrowCloudQrLogin,
     // Online Scoring (launcher)
     GsBsOptions,
     ArrowCloudOptions,

--- a/src/screens/options/state.rs
+++ b/src/screens/options/state.rs
@@ -1074,6 +1074,12 @@ pub fn init() -> State {
         SubRowId::ArrowCloudSubmitFails,
         yes_no_choice_index(cfg.submit_arrowcloud_fails),
     );
+    set_choice_by_id(
+        &mut state.sub[SubmenuKind::ArrowCloud].choice_indices,
+        ARROWCLOUD_OPTIONS_ROWS,
+        SubRowId::ArrowCloudQrLogin,
+        cfg.arrowcloud_qr_login_when.choice_index(),
+    );
     refresh_score_import_options(&mut state);
     refresh_null_or_die_options(&mut state);
     set_choice_by_id(

--- a/src/screens/options/submenus/online.rs
+++ b/src/screens/options/submenus/online.rs
@@ -67,6 +67,16 @@ pub(in crate::screens::options) const ARROWCLOUD_OPTIONS_ROWS: &[SubRow] = &[
         ],
         inline: true,
     },
+    SubRow {
+        id: SubRowId::ArrowCloudQrLogin,
+        label: lookup_key("OptionsGrooveStats", "ArrowCloudQRLogin"),
+        choices: &[
+            localized_choice("OptionsGrooveStats", "ArrowCloudQRLoginAlways"),
+            localized_choice("OptionsGrooveStats", "ArrowCloudQRLoginSometimes"),
+            localized_choice("OptionsGrooveStats", "ArrowCloudQRLoginDisabled"),
+        ],
+        inline: true,
+    },
 ];
 
 pub(in crate::screens::options) const ONLINE_SCORING_OPTIONS_ROWS: &[SubRow] = &[
@@ -159,6 +169,14 @@ pub(in crate::screens::options) const ARROWCLOUD_OPTIONS_ITEMS: &[Item] = &[
         ))],
     },
     Item {
+        id: ItemId::AcQrLogin,
+        name: lookup_key("OptionsGrooveStats", "ArrowCloudQRLogin"),
+        help: &[HelpEntry::Paragraph(lookup_key(
+            "OptionsGrooveStatsHelp",
+            "ArrowCloudQRLoginHelp",
+        ))],
+    },
+    Item {
         id: ItemId::Exit,
         name: lookup_key("Options", "Exit"),
         help: &[HelpEntry::Paragraph(lookup_key(
@@ -202,3 +220,8 @@ pub(in crate::screens::options) const ONLINE_SCORING_OPTIONS_ITEMS: &[Item] = &[
         ))],
     },
 ];
+
+impl ChoiceEnum for ArrowCloudQrLoginWhen {
+    const ALL: &'static [Self] = &[Self::Always, Self::Sometimes, Self::Disabled];
+    const DEFAULT: Self = Self::Sometimes;
+}


### PR DESCRIPTION
Adds `Screen::ArrowCloudLogin` and routes through it after a successful profile selection when `should_auto_show()` returns true. Visually identical to other startup screens (heart background + 0.65-alpha dimmer + per-side panels with QR / short code / verification URL). Matches Simply Love's `Branch.AfterSelectProfile` placement between `ScreenSelectProfile` and `ScreenSelectColor`.

**Stacks on #416** → consumes the `should_auto_show()` helper and the overlay module from the prior PRs.

## What's here

- **`src/screens/arrowcloud_login.rs` (NEW):** standalone screen module wrapping the shared overlay state from `src/screens/options/arrowcloud_login.rs`.
  - `State { active_color_index, ui: Option<ArrowCloudLoginUiState>, bg: visual_style_bg::State }`.
  - `on_enter()` spawns a fresh multi-side login UI on every entry.
  - `update()` polls the worker channels.
  - `handle_input()`:
    - **Start** cancels workers and navigates to `SelectColor` (matches SL's "always advance" semantics, even without a scan).
    - **Back** cancels workers and navigates to `SelectProfile`.
    - Any other input is consumed.
  - `get_actors()` layers the overlay actors on top of the standard heart background.
  - In/out transition pair (0.3 s fade-in/out) matching `SelectColor`.

- **`src/screens/mod.rs`:** `Screen::ArrowCloudLogin` variant + `"ScreenArrowCloudLogin"` `file_name` + `pub mod arrowcloud_login`.

- **`src/app/mod.rs`:**
  - New `arrowcloud_login_state` on `ScreensState`, initialized to the menu's active color.
  - `light_mode_for_screen`, `step_idle` update arm, input dispatch arm, render dispatch arm — all 4 exhaustive-match sites covered.
  - `ScreenAction::SelectProfiles` handler now consults `options::arrowcloud_login::should_auto_show()` and routes to either `ArrowCloudLogin` or `SelectColor`.

- **`src/app/screen_nav.rs`:**
  - in/out transition arms for the new screen.
  - `on_enter` hooks at both commit-screen-change sites so re-entering the screen always spawns fresh workers (and copies the latest color index).

- **`src/screens/options/arrowcloud_login.rs`:** removes the `#![allow(dead_code)]` gate added in #415 — the shared module's public API is now reachable from this screen.

## Behavior

```
GAMEPLAY → SelectProfile → [ArrowCloudLogin if pref enabled] → SelectColor → SelectStyle → ...
```