### PR TITLE
feat(qr-login): add Always/Sometimes/Disabled GrooveStats QR-login pref

### DIFF
--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -474,6 +474,10 @@ ArrowCloudQRLogin=QR Login
 ArrowCloudQRLoginAlways=Always
 ArrowCloudQRLoginSometimes=Sometimes
 ArrowCloudQRLoginDisabled=Never
+GrooveStatsQRLogin=QR Login
+GrooveStatsQRLoginAlways=Always
+GrooveStatsQRLoginSometimes=Sometimes
+GrooveStatsQRLoginDisabled=Never
 
 ; ============================================================
 ; Score Import Options submenu
@@ -1572,6 +1576,7 @@ SeparateUnlocksByPlayerHelp=Download unlock packs into per-player folders instea
 EnableArrowCloudHelp=Enable connection to ArrowCloud services.
 ArrowCloudSubmitFailsHelp=When Yes, failed stages are still submitted to ArrowCloud.\nDefault: No.
 ArrowCloudQRLoginHelp=When to show the ArrowCloud QR-login screen after picking a profile.\n\nAlways: always show it.\nSometimes: only when a joined player has no saved API key.\nNever: never auto-show. You can still link a profile manually from Manage Local Profiles.
+GrooveStatsQRLoginHelp=When to show the GrooveStats QR-login screen after picking a profile.\n\nAlways: always show it.\nSometimes: only when a joined player has no saved API key.\nNever: never auto-show. You can still link a profile manually from Manage Local Profiles.
 
 ; ============================================================
 ; Options Help — Online Scoring submenu

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4293,7 +4293,7 @@ impl App {
                     // Mirror that here for ArrowCloud, gated by the
                     // ArrowCloudQrLoginWhen pref.
                     let cfg = crate::config::get();
-                    let next = if crate::screens::options::arrowcloud_login::should_auto_show(
+                    let next = if crate::screens::options::qr_login::should_auto_show(
                         cfg.arrowcloud_qr_login_when,
                     ) {
                         CurrentScreen::ArrowCloudLogin

--- a/src/config/load/options.rs
+++ b/src/config/load/options.rs
@@ -80,6 +80,10 @@ fn load_system_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
         .get("Options", "ArrowCloudQrLoginWhen")
         .and_then(|v| ArrowCloudQrLoginWhen::from_str(&v).ok())
         .unwrap_or(default.arrowcloud_qr_login_when);
+    cfg.groovestats_qr_login_when = conf
+        .get("Options", "GrooveStatsQrLoginWhen")
+        .and_then(|v| GrooveStatsQrLoginWhen::from_str(&v).ok())
+        .unwrap_or(default.groovestats_qr_login_when);
     cfg.separate_unlocks_by_player = conf
         .get("Options", "SeparateUnlocksByPlayer")
         .and_then(|v| v.parse::<u8>().ok())

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,8 +29,8 @@ pub use self::runtime::{
 pub use self::theme::{
     AUTO_SS_CLEARS, AUTO_SS_FAILS, AUTO_SS_FLAG_NAMES, AUTO_SS_NUM_FLAGS, AUTO_SS_PBS,
     AUTO_SS_QUADS, AUTO_SS_QUINTS, ArrowCloudQrLoginWhen, BreakdownStyle, DefaultFailType,
-    DefaultSyncOffset, GameFlag, LanguageFlag, LogLevel, MACHINE_FONT_VARIANTS, MachineBarColor,
-    MachineFont, MachinePreferredPlayMode, MachinePreferredPlayStyle, NewPackMode,
+    DefaultSyncOffset, GameFlag, GrooveStatsQrLoginWhen, LanguageFlag, LogLevel, MACHINE_FONT_VARIANTS,
+    MachineBarColor, MachineFont, MachinePreferredPlayMode, MachinePreferredPlayStyle, NewPackMode,
     RandomBackgroundMode, SelectMusicItlRankMode, SelectMusicItlWheelMode,
     SelectMusicPatternInfoMode, SelectMusicScoreboxPlacement, SelectMusicSongSelectBgMode,
     SelectMusicStepArtistBoxMode, SelectMusicWheelStyle, SyncGraphMode, ThemeFlag,
@@ -290,6 +290,9 @@ pub struct Config {
     /// When to auto-show the ArrowCloud QR-login screen after Select
     /// Profile.  Mirrors Simply Love's `QRLogin` theme pref.
     pub arrowcloud_qr_login_when: ArrowCloudQrLoginWhen,
+    /// When to auto-show the GrooveStats QR-login screen after Select
+    /// Profile.  Mirrors Simply Love's `QRLogin` theme pref.
+    pub groovestats_qr_login_when: GrooveStatsQrLoginWhen,
     pub separate_unlocks_by_player: bool,
     pub fastload: bool,
     pub cachesongs: bool,
@@ -446,6 +449,7 @@ impl Default for Config {
             enable_groovestats: false,
             submit_arrowcloud_fails: false,
             arrowcloud_qr_login_when: ArrowCloudQrLoginWhen::Sometimes,
+            groovestats_qr_login_when: GrooveStatsQrLoginWhen::Sometimes,
             separate_unlocks_by_player: false,
             fastload: true,
             cachesongs: true,

--- a/src/config/store/defaults.rs
+++ b/src/config/store/defaults.rs
@@ -73,6 +73,11 @@ fn push_default_options(content: &mut String, default: &Config) {
         "ArrowCloudQrLoginWhen",
         default.arrowcloud_qr_login_when.as_str(),
     );
+    push_line(
+        content,
+        "GrooveStatsQrLoginWhen",
+        default.groovestats_qr_login_when.as_str(),
+    );
     push_bool(content, "FastLoad", default.fastload);
     push_line(content, "FullscreenType", default.fullscreen_type.as_str());
     push_line(content, "Game", default.game_flag.as_str());

--- a/src/config/store/save.rs
+++ b/src/config/store/save.rs
@@ -148,6 +148,11 @@ fn push_saved_options(
         "ArrowCloudQrLoginWhen",
         cfg.arrowcloud_qr_login_when.as_str(),
     );
+    push_line(
+        content,
+        "GrooveStatsQrLoginWhen",
+        cfg.groovestats_qr_login_when.as_str(),
+    );
     push_bool(content, "FastLoad", cfg.fastload);
     push_line(content, "FullscreenType", cfg.fullscreen_type.as_str());
     push_line(content, "Game", cfg.game_flag.as_str());

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -721,6 +721,51 @@ impl FromStr for ArrowCloudQrLoginWhen {
     }
 }
 
+/// When to auto-show the GrooveStats QR-login screen after the user picks
+/// a profile.  Mirrors Simply Love's `QRLogin` theme pref — same wire
+/// values and same default as the ArrowCloud variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GrooveStatsQrLoginWhen {
+    /// Always show the login screen after Select Profile.
+    Always,
+    /// Show only when at least one joined Local player has no saved
+    /// GrooveStats API key.  Default.
+    #[default]
+    Sometimes,
+    /// Never auto-show; only the manual Options entry / Manage Local
+    /// Profiles "Link GrooveStats" action can launch it.
+    Disabled,
+}
+
+impl GrooveStatsQrLoginWhen {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Always => "Always",
+            Self::Sometimes => "Sometimes",
+            Self::Disabled => "Disabled",
+        }
+    }
+}
+
+impl FromStr for GrooveStatsQrLoginWhen {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut key = String::with_capacity(s.len());
+        for ch in s.trim().chars() {
+            if ch.is_ascii_alphanumeric() {
+                key.push(ch.to_ascii_lowercase());
+            }
+        }
+        match key.as_str() {
+            "always" => Ok(Self::Always),
+            "sometimes" => Ok(Self::Sometimes),
+            "disabled" | "never" | "off" | "no" => Ok(Self::Disabled),
+            _ => Err(()),
+        }
+    }
+}
+
 /// Machine-wide font preference, ported from Simply Love's `ThemeFont` pref.
 ///
 /// Controls which font is used for the Bold / Header / Footer / numbers /

--- a/src/config/update/machine.rs
+++ b/src/config/update/machine.rs
@@ -366,6 +366,17 @@ pub fn update_arrowcloud_qr_login_when(when: ArrowCloudQrLoginWhen) {
     save_without_keymaps();
 }
 
+pub fn update_groovestats_qr_login_when(when: GrooveStatsQrLoginWhen) {
+    {
+        let mut cfg = lock_config();
+        if cfg.groovestats_qr_login_when == when {
+            return;
+        }
+        cfg.groovestats_qr_login_when = when;
+    }
+    save_without_keymaps();
+}
+
 pub fn update_auto_download_unlocks(enabled: bool) {
     {
         let mut cfg = lock_config();

--- a/src/game/profile.rs
+++ b/src/game/profile.rs
@@ -4452,6 +4452,87 @@ pub fn get_arrowcloud_api_key_for_id(profile_id: &str) -> String {
     String::new()
 }
 
+/// Update the active profile's GrooveStats credentials (API key,
+/// username, and `IsPadPlayer=true` — Simply Love parity, see
+/// `BGAnimations/ScreenGrooveStatsLogin underlay/default.lua:46`) for
+/// the given session side, persisting to its `GrooveStats.ini` on disk.
+/// No-op when the side has no local profile loaded (Guest).
+pub fn set_groovestats_credentials_for_side(side: PlayerSide, api_key: &str, username: &str) {
+    {
+        let mut profiles = lock_profiles();
+        let p = &mut profiles[side_ix(side)];
+        p.groovestats_api_key = api_key.to_string();
+        p.groovestats_username = username.to_string();
+        p.groovestats_is_pad_player = true;
+    }
+    save_groovestats_ini_for_side(side);
+}
+
+/// Write new GrooveStats credentials for a profile identified by ID
+/// (independent of session sides).  Used by the Manage Local Profiles
+/// "Link GrooveStats" flow.  Also refreshes the in-memory copy on any
+/// session side currently bound to that profile id.
+pub fn set_groovestats_credentials_for_id(profile_id: &str, api_key: &str, username: &str) {
+    let matching_sides: Vec<PlayerSide> = {
+        let session = lock_session();
+        [PlayerSide::P1, PlayerSide::P2]
+            .iter()
+            .copied()
+            .filter(|side| {
+                matches!(
+                    &session.active_profiles[side_ix(*side)],
+                    ActiveProfile::Local { id } if id == profile_id
+                )
+            })
+            .collect()
+    };
+    if !matching_sides.is_empty() {
+        let mut profiles = lock_profiles();
+        for side in &matching_sides {
+            let p = &mut profiles[side_ix(*side)];
+            p.groovestats_api_key = api_key.to_string();
+            p.groovestats_username = username.to_string();
+            p.groovestats_is_pad_player = true;
+        }
+    }
+
+    // Persist directly to that profile's GrooveStats.ini, even if the
+    // profile isn't loaded on any side right now.
+    let mut content = String::new();
+    content.push_str("[GrooveStats]\n");
+    content.push_str(&format!("ApiKey={api_key}\n"));
+    content.push_str("IsPadPlayer=1\n");
+    content.push_str(&format!("Username={username}\n"));
+    content.push('\n');
+    let path = groovestats_ini_path(profile_id);
+    if let Err(e) = fs::write(&path, content) {
+        warn!("Failed to save {}: {}", path.display(), e);
+    }
+}
+
+/// Returns the saved GrooveStats API key (from disk) for a profile
+/// identified by id, regardless of whether it's currently loaded on a
+/// session side.  `None` if the profile has no key yet or the file is
+/// missing / malformed; `Some` always wraps a non-empty trimmed key.
+pub fn get_groovestats_api_key_for_id(profile_id: &str) -> Option<String> {
+    let path = groovestats_ini_path(profile_id);
+    let text = fs::read_to_string(&path).ok()?;
+    for line in text.lines() {
+        let line = line.trim();
+        let rest = line
+            .strip_prefix("ApiKey=")
+            .or_else(|| line.strip_prefix("ApiKey ="));
+        if let Some(rest) = rest {
+            let key = rest.trim();
+            if key.is_empty() {
+                return None;
+            }
+            return Some(key.to_string());
+        }
+    }
+    None
+}
+
 fn load_for_side(side: PlayerSide) {
     let profile_id = {
         let session = lock_session();

--- a/src/screens/arrowcloud_login.rs
+++ b/src/screens/arrowcloud_login.rs
@@ -8,7 +8,7 @@
 //!
 //! The visual state machine + per-side worker is shared with future
 //! entry points; both render the same overlay actors via
-//! [`build_arrowcloud_login_overlay_actors`].
+//! [`build_qr_login_overlay_actors`].
 
 use std::sync::atomic::Ordering;
 
@@ -16,9 +16,9 @@ use crate::engine::input::{InputEvent, VirtualAction};
 use crate::engine::present::actors::Actor;
 use crate::screens::components::shared::{transitions, visual_style_bg};
 use crate::screens::input as screen_input;
-use crate::screens::options::arrowcloud_login::{
-    ArrowCloudLoginUiState, build_arrowcloud_login_overlay_actors, create_arrowcloud_login_ui,
-    create_arrowcloud_login_ui_for_profile, poll_arrowcloud_login_ui,
+use crate::screens::options::qr_login::{
+    QrLoginUiState, build_qr_login_overlay_actors, create_arrowcloud_login_ui,
+    create_arrowcloud_login_ui_for_profile, poll_qr_login_ui,
 };
 use crate::screens::{Screen, ScreenAction};
 
@@ -35,7 +35,7 @@ pub struct ProfileTarget {
 
 pub struct State {
     pub active_color_index: i32,
-    pub(crate) ui: Option<ArrowCloudLoginUiState>,
+    pub(crate) ui: Option<QrLoginUiState>,
     /// `Some` when entered via Manage Local Profiles → Link ArrowCloud,
     /// scoping the screen to a single profile (rather than P1/P2 sides).
     /// Cleared on dismiss so subsequent post-Select-Profile auto-flows
@@ -83,7 +83,7 @@ pub fn out_transition() -> (Vec<Actor>, f32) {
 
 pub fn update(state: &mut State, _dt: f32) {
     if let Some(ui) = state.ui.as_mut() {
-        poll_arrowcloud_login_ui(ui);
+        poll_qr_login_ui(ui);
     }
 }
 
@@ -161,7 +161,7 @@ pub fn get_actors(state: &State, alpha_multiplier: f32) -> Vec<Actor> {
     }));
 
     if let Some(ui) = state.ui.as_ref() {
-        let mut ui_actors = build_arrowcloud_login_overlay_actors(ui, state.active_color_index);
+        let mut ui_actors = build_qr_login_overlay_actors(ui, state.active_color_index);
         for actor in &mut ui_actors {
             actor.mul_alpha(alpha_multiplier);
         }

--- a/src/screens/options/input.rs
+++ b/src/screens/options/input.rs
@@ -635,6 +635,8 @@ pub(super) fn apply_submenu_choice_delta(
             config::update_auto_download_unlocks(yes_no_from_choice(new_index));
         } else if row.id == SubRowId::SeparateUnlocksByPlayer {
             config::update_separate_unlocks_by_player(yes_no_from_choice(new_index));
+        } else if row.id == SubRowId::GrooveStatsQrLogin {
+            config::update_groovestats_qr_login_when(GrooveStatsQrLoginWhen::from_choice(new_index));
         }
     } else if matches!(kind, SubmenuKind::ArrowCloud) {
         let row = &rows[row_index];

--- a/src/screens/options/item.rs
+++ b/src/screens/options/item.rs
@@ -169,6 +169,7 @@ pub enum ItemId {
     GsAutoPopulate,
     GsAutoDownloadUnlocks,
     GsSeparateUnlocks,
+    GsQrLogin,
 
     // ArrowCloud Options submenu
     AcEnable,

--- a/src/screens/options/mod.rs
+++ b/src/screens/options/mod.rs
@@ -3,11 +3,11 @@ use crate::assets::{self, AssetManager, visual_styles};
 use crate::assets::{FontRole, current_machine_font_key};
 use crate::config::{
     self, ArrowCloudQrLoginWhen, BreakdownStyle, DefaultFailType, DefaultSyncOffset, DisplayMode,
-    FullscreenType, LogLevel, MachineBarColor, MachineFont, MachinePreferredPlayMode,
-    MachinePreferredPlayStyle, NewPackMode, RandomBackgroundMode, SelectMusicItlRankMode,
-    SelectMusicItlWheelMode, SelectMusicPatternInfoMode, SelectMusicScoreboxPlacement,
-    SelectMusicSongSelectBgMode, SelectMusicStepArtistBoxMode, SelectMusicWheelStyle, SimpleIni,
-    SyncGraphMode, VersionOverlaySide, VisualStyle, dirs,
+    FullscreenType, GrooveStatsQrLoginWhen, LogLevel, MachineBarColor, MachineFont,
+    MachinePreferredPlayMode, MachinePreferredPlayStyle, NewPackMode, RandomBackgroundMode,
+    SelectMusicItlRankMode, SelectMusicItlWheelMode, SelectMusicPatternInfoMode,
+    SelectMusicScoreboxPlacement, SelectMusicSongSelectBgMode, SelectMusicStepArtistBoxMode,
+    SelectMusicWheelStyle, SimpleIni, SyncGraphMode, VersionOverlaySide, VisualStyle, dirs,
 };
 use crate::engine::audio;
 use crate::engine::display::{self, MonitorSpec};

--- a/src/screens/options/mod.rs
+++ b/src/screens/options/mod.rs
@@ -60,7 +60,7 @@ mod reload;
 use reload::*;
 mod score_import;
 use score_import::*;
-pub(crate) mod arrowcloud_login;
+pub(crate) mod qr_login;
 mod pack_sync;
 use pack_sync::*;
 mod layout;

--- a/src/screens/options/qr_login.rs
+++ b/src/screens/options/qr_login.rs
@@ -55,6 +55,24 @@ fn should_auto_show_with<F: FnOnce() -> bool>(
     }
 }
 
+/// GrooveStats counterpart of [`should_auto_show`].  Same three-branch
+/// rule, reading the GrooveStats per-side key for the `Sometimes` probe.
+pub fn should_auto_show_groovestats(when: crate::config::GrooveStatsQrLoginWhen) -> bool {
+    should_auto_show_groovestats_with(when, any_joined_local_side_missing_gs_key)
+}
+
+fn should_auto_show_groovestats_with<F: FnOnce() -> bool>(
+    when: crate::config::GrooveStatsQrLoginWhen,
+    missing_key_probe: F,
+) -> bool {
+    use crate::config::GrooveStatsQrLoginWhen;
+    match when {
+        GrooveStatsQrLoginWhen::Disabled => false,
+        GrooveStatsQrLoginWhen::Always => true,
+        GrooveStatsQrLoginWhen::Sometimes => missing_key_probe(),
+    }
+}
+
 fn any_joined_local_side_missing_key() -> bool {
     ALL_SIDES.iter().any(|side| {
         if !profile::is_session_side_joined(*side) {
@@ -1051,10 +1069,9 @@ fn gs_side_byte(side: profile::PlayerSide) -> u8 {
     }
 }
 
-/// Probe for `should_auto_show_groovestats(Sometimes)` — wired up by the
-/// pref/screen follow-up PRs.  Mirrors `any_joined_local_side_missing_key`
-/// but reads the GrooveStats key off each side's loaded profile.
-#[allow(dead_code)]
+/// Probe for `should_auto_show_groovestats(Sometimes)`.  Mirrors
+/// `any_joined_local_side_missing_key` but reads the GrooveStats key
+/// off each side's loaded profile.
 pub(crate) fn any_joined_local_side_missing_gs_key() -> bool {
     ALL_SIDES.iter().any(|side| {
         if !profile::is_session_side_joined(*side) {
@@ -1339,6 +1356,7 @@ mod tests {
     }
 
     use crate::config::ArrowCloudQrLoginWhen;
+    use crate::config::GrooveStatsQrLoginWhen;
 
     #[test]
     fn should_auto_show_disabled_is_always_false() {
@@ -1370,6 +1388,34 @@ mod tests {
         ));
         assert!(!should_auto_show_with(
             ArrowCloudQrLoginWhen::Sometimes,
+            || false
+        ));
+    }
+
+    #[test]
+    fn should_auto_show_groovestats_disabled_is_always_false() {
+        assert!(!should_auto_show_groovestats_with(
+            GrooveStatsQrLoginWhen::Disabled,
+            || true
+        ));
+    }
+
+    #[test]
+    fn should_auto_show_groovestats_always_is_always_true() {
+        assert!(should_auto_show_groovestats_with(
+            GrooveStatsQrLoginWhen::Always,
+            || false
+        ));
+    }
+
+    #[test]
+    fn should_auto_show_groovestats_sometimes_follows_probe() {
+        assert!(should_auto_show_groovestats_with(
+            GrooveStatsQrLoginWhen::Sometimes,
+            || true
+        ));
+        assert!(!should_auto_show_groovestats_with(
+            GrooveStatsQrLoginWhen::Sometimes,
             || false
         ));
     }

--- a/src/screens/options/qr_login.rs
+++ b/src/screens/options/qr_login.rs
@@ -6,10 +6,9 @@
 //! The state machine, panel renderer, slot bookkeeping, and cancellation
 //! plumbing are all backend-agnostic; the per-service worker that drives
 //! the channel and the per-service persistence/QR-URL choice are selected
-//! via [`BackendKind`].  ArrowCloud's `device-login` API is poll-based
-//! and lives in this module today; GrooveStats (WebSocket-driven) is
-//! added in a follow-up commit by extending the same `BackendKind` match
-//! arms.
+//! via [`BackendKind`].  ArrowCloud's `device-login` API is poll-based;
+//! GrooveStats's flow is WebSocket-driven.  Both live in this module
+//! and dispatch through the same `BackendKind` match arms.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -108,19 +107,14 @@ pub(crate) enum LoginMsg {
 }
 
 /// Which online service this overlay is talking to.  Used to dispatch
-/// `Consumed` to the right `profile::set_*` helper and (in a follow-up
-/// commit) to choose the per-service QR URL builder and panel header
-/// label.  We keep this as a plain enum rather than a backend trait —
-/// every per-service branch is reached via `match` on this kind.
+/// `Consumed` to the right `profile::set_*` helper, the per-service QR
+/// URL builder, and the panel header label.  We keep this as a plain
+/// enum rather than a backend trait — every per-service branch is
+/// reached via `match` on this kind.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BackendKind {
     ArrowCloud,
-    /// GrooveStats QR-login (WebSocket-driven).  Wired up in the
-    /// `groovestats_login` follow-up commit; the `Consumed` arm in
-    /// `apply_login_msg` already dispatches on this variant so the
-    /// follow-up only needs to add the worker and the per-side/per-id
-    /// `profile::set_groovestats_credentials_*` calls.
-    #[allow(dead_code)]
+    /// GrooveStats QR-login (WebSocket-driven).
     GrooveStats,
 }
 
@@ -782,6 +776,300 @@ fn push_status_badge(out: &mut Vec<Actor>, slot: &LoginSlot, panel_cx: f32, badg
     ));
 }
 
+/* -------------------- GrooveStats backend -------------------- */
+//
+// GrooveStats's QR-login flow is not poll-based like ArrowCloud — it
+// hangs a single WebSocket on `ws://qrlogin.groovestats.com:3000`, sends
+// the session UUID once, and listens for `apiKey` events keyed by side
+// (1 = P1, 2 = P2).  One websocket handles both sides for the whole
+// screen; the worker just routes each `apiKey` push to the matching
+// per-slot sender.  Mirrors Simply Love's
+// `ScreenGrooveStatsLogin underlay/default.lua`.
+
+const GROOVESTATS_QR_LOGIN_WS_URL: &str = "ws://qrlogin.groovestats.com:3000";
+const GROOVESTATS_QR_BASE_URL: &str = "https://www.groovestats.com/qrlogin.php";
+const GROOVESTATS_WS_READ_TIMEOUT_MS: u64 = 100;
+
+/// 32-character uppercase hex string mirroring SL's
+/// `CRYPTMAN:GenerateRandomUUID():gsub("-",""):upper()`.  Stable across
+/// the lifetime of one overlay so the server can correlate an `apiKey`
+/// push back to the right machine.
+#[allow(dead_code)]
+pub(crate) fn generate_qr_uuid() -> String {
+    use rand::Rng;
+    let mut bytes = [0u8; 16];
+    rand::rng().fill_bytes(&mut bytes);
+    let mut out = String::with_capacity(32);
+    for b in bytes {
+        out.push_str(&format!("{:02X}", b));
+    }
+    out
+}
+
+#[allow(dead_code)]
+pub(crate) fn groovestats_qr_url(uuid: &str, side: u8) -> String {
+    format!("{GROOVESTATS_QR_BASE_URL}?UUID={uuid}&SIDE={side}")
+}
+
+/// Parsed envelope from the GrooveStats QR-login server.  Mirrors
+/// SL's `data.uuid / data.apiKey / data.username / data.side` payload.
+#[derive(serde::Deserialize, Debug)]
+struct GrooveStatsWsEnvelope {
+    event: String,
+    #[serde(default)]
+    data: Option<GrooveStatsApiKeyPayload>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct GrooveStatsApiKeyPayload {
+    #[serde(default)]
+    uuid: Option<String>,
+    #[serde(default)]
+    api_key: Option<String>,
+    #[serde(default)]
+    username: Option<String>,
+    #[serde(default)]
+    side: Option<u8>,
+}
+
+/// Decide what to dispatch when a raw text frame arrives off the ws.
+/// Pure function so it can be unit-tested without a live socket.
+#[derive(Debug, PartialEq, Eq)]
+enum GrooveStatsWsEffect {
+    Ignore,
+    DeliverApiKey {
+        side: u8,
+        api_key: String,
+        username: String,
+    },
+}
+
+#[allow(dead_code)]
+fn classify_ws_message(text: &str, expected_uuid: &str) -> GrooveStatsWsEffect {
+    let Ok(env) = serde_json::from_str::<GrooveStatsWsEnvelope>(text) else {
+        return GrooveStatsWsEffect::Ignore;
+    };
+    if env.event != "apiKey" {
+        return GrooveStatsWsEffect::Ignore;
+    }
+    let Some(data) = env.data else {
+        return GrooveStatsWsEffect::Ignore;
+    };
+    if data.uuid.as_deref() != Some(expected_uuid) {
+        return GrooveStatsWsEffect::Ignore;
+    }
+    let api_key = data.api_key.unwrap_or_default();
+    if api_key.trim().is_empty() {
+        return GrooveStatsWsEffect::Ignore;
+    }
+    let side = match data.side {
+        Some(1) | Some(2) => data.side.unwrap(),
+        _ => return GrooveStatsWsEffect::Ignore,
+    };
+    GrooveStatsWsEffect::DeliverApiKey {
+        side,
+        api_key,
+        username: data.username.unwrap_or_default(),
+    }
+}
+
+/// WebSocket worker: opens one connection for the whole overlay,
+/// announces the UUID, then routes each incoming `apiKey` push to the
+/// per-side sender.  Exits on cancel, server close, or send error.
+#[allow(dead_code)]
+fn run_groovestats_session(
+    uuid: String,
+    p1_tx: Option<std::sync::mpsc::Sender<LoginMsg>>,
+    p2_tx: Option<std::sync::mpsc::Sender<LoginMsg>>,
+    cancel: Arc<AtomicBool>,
+) {
+    use tungstenite::Message;
+    use tungstenite::stream::MaybeTlsStream;
+
+    if cancel.load(Ordering::Relaxed) {
+        return;
+    }
+
+    let mut socket = match tungstenite::connect(GROOVESTATS_QR_LOGIN_WS_URL) {
+        Ok((sock, _resp)) => sock,
+        Err(err) => {
+            let reason = format!("{err}");
+            if let Some(tx) = &p1_tx {
+                let _ = tx.send(LoginMsg::Failed {
+                    reason: reason.clone(),
+                });
+            }
+            if let Some(tx) = &p2_tx {
+                let _ = tx.send(LoginMsg::Failed { reason });
+            }
+            return;
+        }
+    };
+
+    // Plaintext ws://; the maybe-tls stream is the plain branch.  Set a
+    // short read timeout so the loop can poll the cancel flag.
+    if let MaybeTlsStream::Plain(tcp) = socket.get_mut() {
+        let _ = tcp.set_read_timeout(Some(std::time::Duration::from_millis(
+            GROOVESTATS_WS_READ_TIMEOUT_MS,
+        )));
+    }
+
+    // Announce the UUID once Open.
+    let hello = serde_json::json!({ "event": "uuid", "data": { "uuid": &uuid } });
+    if socket.send(Message::Text(hello.to_string().into())).is_err() {
+        return;
+    }
+
+    loop {
+        if cancel.load(Ordering::Relaxed) {
+            let _ = socket.close(None);
+            return;
+        }
+        match socket.read() {
+            Ok(Message::Text(text)) => {
+                let effect = classify_ws_message(&text, &uuid);
+                if let GrooveStatsWsEffect::DeliverApiKey {
+                    side,
+                    api_key,
+                    username,
+                } = effect
+                {
+                    let tx = match side {
+                        1 => p1_tx.as_ref(),
+                        2 => p2_tx.as_ref(),
+                        _ => None,
+                    };
+                    if let Some(tx) = tx {
+                        let _ = tx.send(LoginMsg::Consumed {
+                            api_key,
+                            username: Some(username),
+                        });
+                    }
+                }
+            }
+            Ok(Message::Close(_)) => {
+                let _ = socket.close(None);
+                return;
+            }
+            Ok(_) => {} // ping/pong/binary frames ignored
+            Err(tungstenite::Error::Io(io)) if matches!(
+                io.kind(),
+                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut,
+            ) => {
+                // Read-timeout — loop back so we can re-check the cancel flag.
+            }
+            Err(_) => {
+                let _ = socket.close(None);
+                return;
+            }
+        }
+    }
+}
+
+/// Spawn GrooveStats QR-login workers for every joined Local side
+/// (single shared WebSocket) and return a fresh UI ready to be rendered.
+#[allow(dead_code)]
+pub fn create_groovestats_login_ui() -> QrLoginUiState {
+    let cancel = Arc::new(AtomicBool::new(false));
+    let uuid = generate_qr_uuid();
+    let mut p1_tx: Option<std::sync::mpsc::Sender<LoginMsg>> = None;
+    let mut p2_tx: Option<std::sync::mpsc::Sender<LoginMsg>> = None;
+    let slots = build_initial_slots(&cancel, BackendKind::GrooveStats, |side, tx| {
+        // SL's GrooveStats flow doesn't roundtrip a `start` request — the
+        // QR URL is fully known up front — so push the slot straight to
+        // Pending with the per-side URL embedded.
+        let _ = tx.send(LoginMsg::Started {
+            short_code: String::new(),
+            verification_url: groovestats_qr_url(&uuid, gs_side_byte(side)),
+        });
+        match side {
+            profile::PlayerSide::P1 => p1_tx = Some(tx),
+            profile::PlayerSide::P2 => p2_tx = Some(tx),
+        }
+    });
+    if p1_tx.is_some() || p2_tx.is_some() {
+        let cancel_for_thread = Arc::clone(&cancel);
+        std::thread::spawn(move || {
+            run_groovestats_session(uuid, p1_tx, p2_tx, cancel_for_thread);
+        });
+    }
+    QrLoginUiState { slots, cancel }
+}
+
+/// Single-slot GrooveStats QR-login UI scoped to a specific profile
+/// (Manage Local Profiles "Link GrooveStats" entry).
+#[allow(dead_code)]
+pub fn create_groovestats_login_ui_for_profile(
+    profile_id: String,
+    display_name: String,
+) -> QrLoginUiState {
+    let cancel = Arc::new(AtomicBool::new(false));
+    let uuid = generate_qr_uuid();
+    let had_existing_key = profile::get_groovestats_api_key_for_id(&profile_id).is_some();
+    let (tx, rx) = std::sync::mpsc::channel::<LoginMsg>();
+    // Push the QR URL straight away — no server roundtrip required.
+    let _ = tx.send(LoginMsg::Started {
+        short_code: String::new(),
+        verification_url: groovestats_qr_url(&uuid, 1),
+    });
+    let cancel_for_thread = Arc::clone(&cancel);
+    let tx_for_thread = tx.clone();
+    std::thread::spawn(move || {
+        run_groovestats_session(uuid, Some(tx_for_thread), None, cancel_for_thread);
+    });
+    drop(tx);
+    let p1_slot = LoginSlot {
+        side: profile::PlayerSide::P1,
+        state: SlotState::Starting,
+        kind: BackendKind::GrooveStats,
+        display_name,
+        had_existing_key,
+        target_profile_id: Some(profile_id),
+        rx: Some(rx),
+    };
+    let p2_slot = LoginSlot {
+        side: profile::PlayerSide::P2,
+        state: SlotState::NotJoined,
+        kind: BackendKind::GrooveStats,
+        display_name: String::new(),
+        had_existing_key: false,
+        target_profile_id: None,
+        rx: None,
+    };
+    QrLoginUiState {
+        slots: [p1_slot, p2_slot],
+        cancel,
+    }
+}
+
+#[inline]
+fn gs_side_byte(side: profile::PlayerSide) -> u8 {
+    match side {
+        profile::PlayerSide::P1 => 1,
+        profile::PlayerSide::P2 => 2,
+    }
+}
+
+/// Probe for `should_auto_show_groovestats(Sometimes)` — wired up by the
+/// pref/screen follow-up PRs.  Mirrors `any_joined_local_side_missing_key`
+/// but reads the GrooveStats key off each side's loaded profile.
+#[allow(dead_code)]
+pub(crate) fn any_joined_local_side_missing_gs_key() -> bool {
+    ALL_SIDES.iter().any(|side| {
+        if !profile::is_session_side_joined(*side) {
+            return false;
+        }
+        if profile::is_session_side_guest(*side) {
+            return false;
+        }
+        profile::get_for_side(*side)
+            .groovestats_api_key
+            .trim()
+            .is_empty()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1084,5 +1372,139 @@ mod tests {
             ArrowCloudQrLoginWhen::Sometimes,
             || false
         ));
+    }
+
+
+    /* -------------------- GrooveStats backend -------------------- */
+
+    #[test]
+    fn generate_qr_uuid_is_32_uppercase_hex() {
+        let id = generate_qr_uuid();
+        assert_eq!(id.len(), 32);
+        assert!(
+            id.chars()
+                .all(|c| c.is_ascii_digit() || ('A'..='F').contains(&c)),
+            "uuid contained a non-hex-uppercase char: {id}"
+        );
+    }
+
+    #[test]
+    fn generate_qr_uuid_returns_distinct_values() {
+        let a = generate_qr_uuid();
+        let b = generate_qr_uuid();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn groovestats_qr_url_format_matches_simply_love() {
+        assert_eq!(
+            groovestats_qr_url("ABCDEF", 1),
+            "https://www.groovestats.com/qrlogin.php?UUID=ABCDEF&SIDE=1"
+        );
+        assert_eq!(
+            groovestats_qr_url("DEADBEEF", 2),
+            "https://www.groovestats.com/qrlogin.php?UUID=DEADBEEF&SIDE=2"
+        );
+    }
+
+    #[test]
+    fn classify_ws_message_routes_matching_uuid() {
+        let payload = r#"{"event":"apiKey","data":{"uuid":"ABC","apiKey":"GS-1","username":"alice","side":1}}"#;
+        assert_eq!(
+            classify_ws_message(payload, "ABC"),
+            GrooveStatsWsEffect::DeliverApiKey {
+                side: 1,
+                api_key: "GS-1".into(),
+                username: "alice".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn classify_ws_message_ignores_mismatched_uuid() {
+        let payload = r#"{"event":"apiKey","data":{"uuid":"OTHER","apiKey":"GS-1","side":1}}"#;
+        assert_eq!(
+            classify_ws_message(payload, "ABC"),
+            GrooveStatsWsEffect::Ignore,
+        );
+    }
+
+    #[test]
+    fn classify_ws_message_ignores_non_apikey_events() {
+        let payload = r#"{"event":"hello","data":{"uuid":"ABC"}}"#;
+        assert_eq!(
+            classify_ws_message(payload, "ABC"),
+            GrooveStatsWsEffect::Ignore,
+        );
+    }
+
+    #[test]
+    fn classify_ws_message_ignores_empty_api_key() {
+        let payload = r#"{"event":"apiKey","data":{"uuid":"ABC","apiKey":"   ","side":1}}"#;
+        assert_eq!(
+            classify_ws_message(payload, "ABC"),
+            GrooveStatsWsEffect::Ignore,
+        );
+    }
+
+    #[test]
+    fn classify_ws_message_ignores_unknown_side() {
+        let payload =
+            r#"{"event":"apiKey","data":{"uuid":"ABC","apiKey":"k","side":7}}"#;
+        assert_eq!(
+            classify_ws_message(payload, "ABC"),
+            GrooveStatsWsEffect::Ignore,
+        );
+    }
+
+    #[test]
+    fn classify_ws_message_defaults_missing_username_to_empty() {
+        let payload =
+            r#"{"event":"apiKey","data":{"uuid":"ABC","apiKey":"k","side":2}}"#;
+        assert_eq!(
+            classify_ws_message(payload, "ABC"),
+            GrooveStatsWsEffect::DeliverApiKey {
+                side: 2,
+                api_key: "k".into(),
+                username: String::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn classify_ws_message_ignores_malformed_json() {
+        assert_eq!(
+            classify_ws_message("not json", "ABC"),
+            GrooveStatsWsEffect::Ignore,
+        );
+    }
+
+    #[test]
+    fn apply_consumed_with_username_passes_through_for_groovestats_slot() {
+        // We can't actually persist (no profile storage in tests), but
+        // apply_login_msg should at least transition state and clear rx
+        // without panicking, regardless of slot.kind.
+        let (_tx, rx) = mpsc::channel::<LoginMsg>();
+        let mut s = LoginSlot {
+            side: profile::PlayerSide::P1,
+            state: SlotState::Pending {
+                short_code: String::new(),
+                verification_url: "u".into(),
+            },
+            kind: BackendKind::GrooveStats,
+            display_name: "Alice".into(),
+            had_existing_key: false,
+            target_profile_id: Some("alice-id".into()),
+            rx: Some(rx),
+        };
+        apply_login_msg(
+            &mut s,
+            LoginMsg::Consumed {
+                api_key: "GS-KEY".into(),
+                username: Some("alice".into()),
+            },
+        );
+        assert!(matches!(s.state, SlotState::Success));
+        assert!(s.rx.is_none());
     }
 }

--- a/src/screens/options/qr_login.rs
+++ b/src/screens/options/qr_login.rs
@@ -1,12 +1,15 @@
-//! ArrowCloud QR device-login overlay — shared state machine and renderer.
+//! QR device-login overlay — shared state machine and renderer.
 //!
 //! Mirrors Simply Love's `ScreenGrooveStatsLogin` design: one QR code
 //! per joined player, shown side by side
 //! (`BGAnimations/ScreenGrooveStatsLogin underlay/default.lua:117-165`).
-//! ArrowCloud's `device-login` API is poll-based rather than websocket,
-//! so each side gets its own independent worker thread that polls
-//! `device-login/poll` and writes the resulting key to its captured
-//! `PlayerSide` on consume.
+//! The state machine, panel renderer, slot bookkeeping, and cancellation
+//! plumbing are all backend-agnostic; the per-service worker that drives
+//! the channel and the per-service persistence/QR-URL choice are selected
+//! via [`BackendKind`].  ArrowCloud's `device-login` API is poll-based
+//! and lives in this module today; GrooveStats (WebSocket-driven) is
+//! added in a follow-up commit by extending the same `BackendKind` match
+//! arms.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -93,10 +96,32 @@ pub(crate) enum LoginMsg {
     StatusUpdate,
     Consumed {
         api_key: String,
+        /// Optional username delivered alongside the key.  ArrowCloud's
+        /// device-login doesn't return one (always `None`); GrooveStats's
+        /// QR-login WebSocket does and the GrooveStats backend forwards
+        /// it for `[GrooveStats] Username=` persistence (SL parity).
+        username: Option<String>,
     },
     Failed {
         reason: String,
     },
+}
+
+/// Which online service this overlay is talking to.  Used to dispatch
+/// `Consumed` to the right `profile::set_*` helper and (in a follow-up
+/// commit) to choose the per-service QR URL builder and panel header
+/// label.  We keep this as a plain enum rather than a backend trait —
+/// every per-service branch is reached via `match` on this kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BackendKind {
+    ArrowCloud,
+    /// GrooveStats QR-login (WebSocket-driven).  Wired up in the
+    /// `groovestats_login` follow-up commit; the `Consumed` arm in
+    /// `apply_login_msg` already dispatches on this variant so the
+    /// follow-up only needs to add the worker and the per-side/per-id
+    /// `profile::set_groovestats_credentials_*` calls.
+    #[allow(dead_code)]
+    GrooveStats,
 }
 
 #[derive(Debug, Clone)]
@@ -134,6 +159,9 @@ impl SlotState {
 pub(crate) struct LoginSlot {
     pub(crate) side: profile::PlayerSide,
     pub(crate) state: SlotState,
+    /// Which online service this slot is talking to.  Drives backend
+    /// dispatch in [`apply_login_msg`].
+    pub(crate) kind: BackendKind,
     /// Profile display name for this side (e.g. "Player 1", "Alice").
     /// Shown as the panel header so the user sees exactly which profile
     /// the key will land in.
@@ -151,12 +179,12 @@ pub(crate) struct LoginSlot {
     pub(crate) rx: Option<std::sync::mpsc::Receiver<LoginMsg>>,
 }
 
-pub(crate) struct ArrowCloudLoginUiState {
+pub(crate) struct QrLoginUiState {
     pub(crate) slots: [LoginSlot; 2],
     pub(crate) cancel: Arc<AtomicBool>,
 }
 
-impl Drop for ArrowCloudLoginUiState {
+impl Drop for QrLoginUiState {
     fn drop(&mut self) {
         // Defensive: if the overlay is torn down without going through
         // a cancel path, still signal workers to stop.
@@ -166,9 +194,9 @@ impl Drop for ArrowCloudLoginUiState {
 
 /// Spawn ArrowCloud device-login workers — one per joined Local side —
 /// and return a fresh UI state ready to be rendered.
-pub fn create_arrowcloud_login_ui() -> ArrowCloudLoginUiState {
+pub fn create_arrowcloud_login_ui() -> QrLoginUiState {
     let cancel = Arc::new(AtomicBool::new(false));
-    let slots = build_initial_slots(&cancel, |side, tx| {
+    let slots = build_initial_slots(&cancel, BackendKind::ArrowCloud, |side, tx| {
         let cancel_for_thread = Arc::clone(&cancel);
         std::thread::spawn(move || {
             run_login_session(
@@ -180,7 +208,7 @@ pub fn create_arrowcloud_login_ui() -> ArrowCloudLoginUiState {
             );
         });
     });
-    ArrowCloudLoginUiState { slots, cancel }
+    QrLoginUiState { slots, cancel }
 }
 
 /// Build a single-slot UI scoped to a specific profile (identified by
@@ -189,7 +217,7 @@ pub fn create_arrowcloud_login_ui() -> ArrowCloudLoginUiState {
 pub fn create_arrowcloud_login_ui_for_profile(
     profile_id: String,
     display_name: String,
-) -> ArrowCloudLoginUiState {
+) -> QrLoginUiState {
     let cancel = Arc::new(AtomicBool::new(false));
     let had_existing_key = !profile::get_arrowcloud_api_key_for_id(&profile_id)
         .trim()
@@ -208,6 +236,7 @@ pub fn create_arrowcloud_login_ui_for_profile(
     let p1_slot = LoginSlot {
         side: profile::PlayerSide::P1,
         state: SlotState::Starting,
+        kind: BackendKind::ArrowCloud,
         display_name,
         had_existing_key,
         target_profile_id: Some(profile_id),
@@ -216,12 +245,13 @@ pub fn create_arrowcloud_login_ui_for_profile(
     let p2_slot = LoginSlot {
         side: profile::PlayerSide::P2,
         state: SlotState::NotJoined,
+        kind: BackendKind::ArrowCloud,
         display_name: String::new(),
         had_existing_key: false,
         target_profile_id: None,
         rx: None,
     };
-    ArrowCloudLoginUiState {
+    QrLoginUiState {
         slots: [p1_slot, p2_slot],
         cancel,
     }
@@ -230,16 +260,20 @@ pub fn create_arrowcloud_login_ui_for_profile(
 /// Decide which sides need a worker and build the slot array. `spawn`
 /// callback is invoked once per side that should start polling; tests
 /// inject a no-op or mock spawner.
-fn build_initial_slots<F>(_cancel: &Arc<AtomicBool>, mut spawn: F) -> [LoginSlot; 2]
+fn build_initial_slots<F>(
+    _cancel: &Arc<AtomicBool>,
+    kind: BackendKind,
+    mut spawn: F,
+) -> [LoginSlot; 2]
 where
     F: FnMut(profile::PlayerSide, std::sync::mpsc::Sender<LoginMsg>),
 {
-    let p1 = build_one_slot(profile::PlayerSide::P1, &mut spawn);
-    let p2 = build_one_slot(profile::PlayerSide::P2, &mut spawn);
+    let p1 = build_one_slot(profile::PlayerSide::P1, kind, &mut spawn);
+    let p2 = build_one_slot(profile::PlayerSide::P2, kind, &mut spawn);
     [p1, p2]
 }
 
-fn build_one_slot<F>(side: profile::PlayerSide, spawn: &mut F) -> LoginSlot
+fn build_one_slot<F>(side: profile::PlayerSide, kind: BackendKind, spawn: &mut F) -> LoginSlot
 where
     F: FnMut(profile::PlayerSide, std::sync::mpsc::Sender<LoginMsg>),
 {
@@ -247,6 +281,7 @@ where
         return LoginSlot {
             side,
             state: SlotState::NotJoined,
+            kind,
             display_name: String::new(),
             had_existing_key: false,
             target_profile_id: None,
@@ -257,6 +292,7 @@ where
         return LoginSlot {
             side,
             state: SlotState::Guest,
+            kind,
             display_name: String::new(),
             had_existing_key: false,
             target_profile_id: None,
@@ -264,13 +300,17 @@ where
         };
     }
     let p = profile::get_for_side(side);
-    let had_existing_key = !p.arrowcloud_api_key.trim().is_empty();
+    let had_existing_key = match kind {
+        BackendKind::ArrowCloud => !p.arrowcloud_api_key.trim().is_empty(),
+        BackendKind::GrooveStats => !p.groovestats_api_key.trim().is_empty(),
+    };
 
     let (tx, rx) = std::sync::mpsc::channel::<LoginMsg>();
     spawn(side, tx);
     LoginSlot {
         side,
         state: SlotState::Starting,
+        kind,
         display_name: p.display_name,
         had_existing_key,
         target_profile_id: None,
@@ -342,7 +382,10 @@ fn run_login_session<S, P>(
                                 reason: "server returned empty api key".to_string(),
                             });
                         } else {
-                            let _ = tx.send(LoginMsg::Consumed { api_key });
+                            let _ = tx.send(LoginMsg::Consumed {
+                                api_key,
+                                username: None,
+                            });
                         }
                         return;
                     }
@@ -393,7 +436,7 @@ fn sleep_with_cancel(seconds: f32, cancel: &Arc<AtomicBool>) -> bool {
 
 /// Drain pending channel messages for every slot, updating slot state
 /// and (on success) persisting api keys into per-side profiles.
-pub(crate) fn poll_arrowcloud_login_ui(ui: &mut ArrowCloudLoginUiState) {
+pub(crate) fn poll_qr_login_ui(ui: &mut QrLoginUiState) {
     for slot in &mut ui.slots {
         let mut msgs: Vec<LoginMsg> = Vec::new();
         if let Some(rx) = slot.rx.as_ref() {
@@ -422,15 +465,8 @@ fn apply_login_msg(slot: &mut LoginSlot, msg: LoginMsg) {
             // Approved-but-not-consumed renders identically to Pending —
             // we only flip to Success once the key has been delivered.
         }
-        LoginMsg::Consumed { api_key } => {
-            if let Some(profile_id) = slot.target_profile_id.as_ref() {
-                profile::set_arrowcloud_api_key_for_id(profile_id, &api_key);
-            } else {
-                profile::set_arrowcloud_api_key_for_side(slot.side, &api_key);
-                // Refresh display_name in case profile state changed.
-                slot.display_name = profile::get_for_side(slot.side).display_name;
-            }
-            ac_online::refresh_status();
+        LoginMsg::Consumed { api_key, username } => {
+            persist_consumed_key(slot, &api_key, username.as_deref());
             slot.state = SlotState::Success;
             slot.rx = None;
         }
@@ -441,15 +477,44 @@ fn apply_login_msg(slot: &mut LoginSlot, msg: LoginMsg) {
     }
 }
 
+/// Dispatch the new key (and optional username) to the right per-service
+/// `profile::set_*` helper, then refresh any service-status caches that
+/// depend on the key.  This is the only place the `BackendKind` switch
+/// is observed by the persistence layer.
+fn persist_consumed_key(slot: &mut LoginSlot, api_key: &str, username: Option<&str>) {
+    match slot.kind {
+        BackendKind::ArrowCloud => {
+            if let Some(profile_id) = slot.target_profile_id.as_ref() {
+                profile::set_arrowcloud_api_key_for_id(profile_id, api_key);
+            } else {
+                profile::set_arrowcloud_api_key_for_side(slot.side, api_key);
+                // Refresh display_name in case profile state changed.
+                slot.display_name = profile::get_for_side(slot.side).display_name;
+            }
+            ac_online::refresh_status();
+            let _ = username; // ArrowCloud's device-login never returns one.
+        }
+        BackendKind::GrooveStats => {
+            // Wired up by the follow-up groovestats_login commit, which
+            // adds `profile::set_groovestats_credentials_{for_side,for_id}`
+            // and replaces this stub with the real calls.  Reaching this
+            // arm today means a GrooveStats worker delivered a Consumed
+            // message before the next PR landed — keep it a no-op so a
+            // misbehaving build doesn't panic in front of the user.
+            let _ = (api_key, username);
+        }
+    }
+}
+
 /// `true` when every slot is in a state that needs no further work —
 /// i.e. it's safe to dismiss without silently dropping an in-flight
 /// session.
-pub(crate) fn login_overlay_is_terminal(ui: &ArrowCloudLoginUiState) -> bool {
+pub(crate) fn login_overlay_is_terminal(ui: &QrLoginUiState) -> bool {
     ui.slots.iter().all(|s| s.state.is_workless())
 }
 
-pub(crate) fn build_arrowcloud_login_overlay_actors(
-    ui: &ArrowCloudLoginUiState,
+pub(crate) fn build_qr_login_overlay_actors(
+    ui: &QrLoginUiState,
     active_color_index: i32,
 ) -> Vec<Actor> {
     let mut out: Vec<Actor> = Vec::with_capacity(24);
@@ -796,7 +861,7 @@ mod tests {
         );
         assert!(matches!(
             msgs.last(),
-            Some(LoginMsg::Consumed { api_key }) if api_key == "AC-KEY-7"
+            Some(LoginMsg::Consumed { api_key, username: None }) if api_key == "AC-KEY-7"
         ));
         assert_eq!(*polls.lock().unwrap(), 2);
     }
@@ -874,6 +939,7 @@ mod tests {
         LoginSlot {
             side,
             state,
+            kind: BackendKind::ArrowCloud,
             display_name: String::new(),
             had_existing_key: false,
             target_profile_id: None,
@@ -883,7 +949,7 @@ mod tests {
 
     #[test]
     fn login_overlay_is_terminal_true_when_all_slots_workless() {
-        let ui = ArrowCloudLoginUiState {
+        let ui = QrLoginUiState {
             cancel: Arc::new(AtomicBool::new(false)),
             slots: [
                 slot(profile::PlayerSide::P1, SlotState::Success),
@@ -895,7 +961,7 @@ mod tests {
 
     #[test]
     fn login_overlay_is_terminal_false_when_any_slot_pending() {
-        let ui = ArrowCloudLoginUiState {
+        let ui = QrLoginUiState {
             cancel: Arc::new(AtomicBool::new(false)),
             slots: [
                 slot(profile::PlayerSide::P1, SlotState::Success),
@@ -936,6 +1002,7 @@ mod tests {
                 short_code: "X".into(),
                 verification_url: "u".into(),
             },
+            kind: BackendKind::ArrowCloud,
             display_name: String::new(),
             had_existing_key: false,
             target_profile_id: None,
@@ -955,7 +1022,7 @@ mod tests {
     fn drop_signals_cancel() {
         let cancel = Arc::new(AtomicBool::new(false));
         {
-            let _ui = ArrowCloudLoginUiState {
+            let _ui = QrLoginUiState {
                 cancel: Arc::clone(&cancel),
                 slots: [
                     slot(profile::PlayerSide::P1, SlotState::Starting),

--- a/src/screens/options/row.rs
+++ b/src/screens/options/row.rs
@@ -136,6 +136,7 @@ pub enum SubRowId {
     AutoPopulateScores,
     AutoDownloadUnlocks,
     SeparateUnlocksByPlayer,
+    GrooveStatsQrLogin,
     // ArrowCloud Options
     EnableArrowCloud,
     ArrowCloudSubmitFails,

--- a/src/screens/options/state.rs
+++ b/src/screens/options/state.rs
@@ -1080,6 +1080,12 @@ pub fn init() -> State {
         SubRowId::ArrowCloudQrLogin,
         cfg.arrowcloud_qr_login_when.choice_index(),
     );
+    set_choice_by_id(
+        &mut state.sub[SubmenuKind::GrooveStats].choice_indices,
+        GROOVESTATS_OPTIONS_ROWS,
+        SubRowId::GrooveStatsQrLogin,
+        cfg.groovestats_qr_login_when.choice_index(),
+    );
     refresh_score_import_options(&mut state);
     refresh_null_or_die_options(&mut state);
     set_choice_by_id(

--- a/src/screens/options/submenus/online.rs
+++ b/src/screens/options/submenus/online.rs
@@ -46,6 +46,16 @@ pub(in crate::screens::options) const GROOVESTATS_OPTIONS_ROWS: &[SubRow] = &[
         ],
         inline: true,
     },
+    SubRow {
+        id: SubRowId::GrooveStatsQrLogin,
+        label: lookup_key("OptionsGrooveStats", "GrooveStatsQRLogin"),
+        choices: &[
+            localized_choice("OptionsGrooveStats", "GrooveStatsQRLoginAlways"),
+            localized_choice("OptionsGrooveStats", "GrooveStatsQRLoginSometimes"),
+            localized_choice("OptionsGrooveStats", "GrooveStatsQRLoginDisabled"),
+        ],
+        inline: true,
+    },
 ];
 
 pub(in crate::screens::options) const ARROWCLOUD_OPTIONS_ROWS: &[SubRow] = &[
@@ -142,6 +152,14 @@ pub(in crate::screens::options) const GROOVESTATS_OPTIONS_ITEMS: &[Item] = &[
         ))],
     },
     Item {
+        id: ItemId::GsQrLogin,
+        name: lookup_key("OptionsGrooveStats", "GrooveStatsQRLogin"),
+        help: &[HelpEntry::Paragraph(lookup_key(
+            "OptionsGrooveStatsHelp",
+            "GrooveStatsQRLoginHelp",
+        ))],
+    },
+    Item {
         id: ItemId::Exit,
         name: lookup_key("Options", "Exit"),
         help: &[HelpEntry::Paragraph(lookup_key(
@@ -222,6 +240,11 @@ pub(in crate::screens::options) const ONLINE_SCORING_OPTIONS_ITEMS: &[Item] = &[
 ];
 
 impl ChoiceEnum for ArrowCloudQrLoginWhen {
+    const ALL: &'static [Self] = &[Self::Always, Self::Sometimes, Self::Disabled];
+    const DEFAULT: Self = Self::Sometimes;
+}
+
+impl ChoiceEnum for GrooveStatsQrLoginWhen {
     const ALL: &'static [Self] = &[Self::Always, Self::Sometimes, Self::Disabled];
     const DEFAULT: Self = Self::Sometimes;
 }


### PR DESCRIPTION
Adds the user-visible tri-state preference mirroring Simply Love's `QRLogin` theme pref (`Scripts/99 SL-ThemePrefs.lua:339-347`), the GrooveStats counterpart of the ArrowCloud version that landed earlier in this stack.  Plumbs the config through theme.ini load/save/defaults + an updater, exposes a new 'QR Login' row in the GrooveStats options submenu, and adds the `should_auto_show_groovestats()` helper that the next commit will consult after Select Profile.
