### PR TITLE
Reuse PadId on controller reconnect across all backends

### DIFF
--- a/src/engine/input/backends/evdev/freebsd.rs
+++ b/src/engine/input/backends/evdev/freebsd.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use crate::engine::input::RawKeyboardEvent;
 use log::{debug, warn};
+use std::collections::HashMap;
 use std::ffi::c_void;
 use std::fs;
 use std::mem::{MaybeUninit, size_of};
@@ -512,6 +513,7 @@ fn add_dev_if_new(
     path: String,
     devs: &mut Vec<Dev>,
     next_id: &mut u32,
+    id_by_uuid: &mut HashMap<[u8; 16], PadId>,
     initial: bool,
     emit_sys: &mut impl FnMut(GpSystemEvent),
 ) {
@@ -524,9 +526,14 @@ fn add_dev_if_new(
     if spec.class != DevClass::Pad {
         return;
     };
-    let id = PadId(*next_id);
+    let uuid = uuid_from_bytes(spec.path.as_bytes());
+    let existing_id = id_by_uuid.get(&uuid).copied();
+    let id = existing_id.unwrap_or(PadId(*next_id));
     if let Some(dev) = open_dev(spec, id, initial, emit_sys) {
-        *next_id = next_id.saturating_add(1);
+        if existing_id.is_none() {
+            id_by_uuid.insert(dev.uuid, id);
+            *next_id = next_id.saturating_add(1);
+        }
         devs.push(dev);
     }
 }
@@ -590,13 +597,16 @@ fn run_inner(
     let mut devs = Vec::new();
     let mut key_devs = Vec::new();
     let mut next_id = 0u32;
+    let mut id_by_uuid: HashMap<[u8; 16], PadId> = HashMap::new();
     let (startup_specs, startup_stats) = scan_event_specs();
     for spec in startup_specs {
         let path = spec.path.clone();
         match spec.class {
             DevClass::Pad => {
+                let uuid = uuid_from_bytes(spec.path.as_bytes());
                 let id = PadId(next_id);
                 if let Some(dev) = open_dev(spec, id, true, &mut emit_sys) {
+                    id_by_uuid.insert(uuid, id);
                     next_id = next_id.saturating_add(1);
                     devs.push(dev);
                 } else {
@@ -842,7 +852,14 @@ fn run_inner(
         for event in hotplug.drain(..) {
             match event {
                 DevdEvent::Create(path) => {
-                    add_dev_if_new(path.clone(), &mut devs, &mut next_id, false, &mut emit_sys);
+                    add_dev_if_new(
+                        path.clone(),
+                        &mut devs,
+                        &mut next_id,
+                        &mut id_by_uuid,
+                        false,
+                        &mut emit_sys,
+                    );
                     if scan_keyboards {
                         add_key_dev_if_new(path, &mut key_devs, false);
                     }

--- a/src/engine/input/backends/evdev/linux.rs
+++ b/src/engine/input/backends/evdev/linux.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use crate::engine::input::RawKeyboardEvent;
 use log::{debug, warn};
+use std::collections::HashMap;
 use std::ffi::{CStr, c_char, c_void};
 use std::fs;
 use std::io::ErrorKind;
@@ -929,15 +930,20 @@ fn add_dev_if_new(
     spec: DevSpec,
     devs: &mut Vec<Dev>,
     next_id: &mut u32,
+    id_by_uuid: &mut HashMap<[u8; 16], PadId>,
     initial: bool,
     emit_sys: &mut impl FnMut(GpSystemEvent),
 ) {
     if devs.iter().any(|dev| dev.path == spec.path) {
         return;
     }
-    let id = PadId(*next_id);
+    let existing_id = id_by_uuid.get(&spec.uuid).copied();
+    let id = existing_id.unwrap_or(PadId(*next_id));
     if let Some(dev) = open_dev(spec, id, initial, emit_sys) {
-        *next_id = next_id.saturating_add(1);
+        if existing_id.is_none() {
+            id_by_uuid.insert(dev.uuid, id);
+            *next_id = next_id.saturating_add(1);
+        }
         devs.push(dev);
     }
 }
@@ -960,6 +966,7 @@ fn refresh_fallback(
     devs: &mut Vec<Dev>,
     key_devs: &mut Vec<KeyDev>,
     next_id: &mut u32,
+    id_by_uuid: &mut HashMap<[u8; 16], PadId>,
     scratch: &mut FallbackScratch,
     scan_keyboards: bool,
     emit_sys: &mut impl FnMut(GpSystemEvent),
@@ -988,7 +995,7 @@ fn refresh_fallback(
     publish_keyboard_backend_state(key_devs);
     for spec in scratch.specs.drain(..) {
         match spec.class {
-            DevClass::Pad => add_dev_if_new(spec, devs, next_id, false, emit_sys),
+            DevClass::Pad => add_dev_if_new(spec, devs, next_id, id_by_uuid, false, emit_sys),
             DevClass::Keyboard if scan_keyboards => add_key_dev_if_new(spec, key_devs, None),
             DevClass::Keyboard => {}
         }
@@ -1032,14 +1039,20 @@ fn run_inner(
     let mut fallback = FallbackScratch::default();
     let mut keyboard_startup = KeyboardStartupStats::default();
     let mut next_id = 0u32;
+    let mut id_by_uuid: HashMap<[u8; 16], PadId> = HashMap::new();
 
     match &discovery {
         Discovery::Udev(state) => {
             for spec in state.enumerate_specs() {
                 match spec.class {
-                    DevClass::Pad => {
-                        add_dev_if_new(spec, &mut devs, &mut next_id, true, &mut emit_sys)
-                    }
+                    DevClass::Pad => add_dev_if_new(
+                        spec,
+                        &mut devs,
+                        &mut next_id,
+                        &mut id_by_uuid,
+                        true,
+                        &mut emit_sys,
+                    ),
                     DevClass::Keyboard if scan_keyboards => {
                         add_key_dev_if_new(spec, &mut key_devs, Some(&mut keyboard_startup))
                     }
@@ -1051,9 +1064,14 @@ fn run_inner(
             scan_fallback(&mut fallback, &devs, &key_devs);
             for spec in fallback.specs.drain(..) {
                 match spec.class {
-                    DevClass::Pad => {
-                        add_dev_if_new(spec, &mut devs, &mut next_id, true, &mut emit_sys)
-                    }
+                    DevClass::Pad => add_dev_if_new(
+                        spec,
+                        &mut devs,
+                        &mut next_id,
+                        &mut id_by_uuid,
+                        true,
+                        &mut emit_sys,
+                    ),
                     DevClass::Keyboard if scan_keyboards => {
                         add_key_dev_if_new(spec, &mut key_devs, Some(&mut keyboard_startup))
                     }
@@ -1304,9 +1322,14 @@ fn run_inner(
         for event in hotplug.drain(..) {
             match event {
                 HotplugEvent::Add(spec) => match spec.class {
-                    DevClass::Pad => {
-                        add_dev_if_new(spec, &mut devs, &mut next_id, false, &mut emit_sys)
-                    }
+                    DevClass::Pad => add_dev_if_new(
+                        spec,
+                        &mut devs,
+                        &mut next_id,
+                        &mut id_by_uuid,
+                        false,
+                        &mut emit_sys,
+                    ),
                     DevClass::Keyboard if scan_keyboards => {
                         add_key_dev_if_new(spec, &mut key_devs, None)
                     }
@@ -1323,6 +1346,7 @@ fn run_inner(
                 &mut devs,
                 &mut key_devs,
                 &mut next_id,
+                &mut id_by_uuid,
                 &mut fallback,
                 scan_keyboards,
                 &mut emit_sys,

--- a/src/engine/input/backends/hidraw.rs
+++ b/src/engine/input/backends/hidraw.rs
@@ -3,6 +3,7 @@ use super::{GpSystemEvent, PadBackend, PadCode, PadDir, PadEvent, PadId, uuid_fr
 use crate::engine::host_time::now_nanos;
 use hidparser::{Report, ReportField, VariableField, parse_report_descriptor};
 use log::{debug, warn};
+use std::collections::HashMap;
 use std::ffi::c_void;
 use std::fs;
 use std::os::fd::AsRawFd;
@@ -460,15 +461,21 @@ fn add_dev_if_new(
     path: String,
     devs: &mut Vec<Dev>,
     next_id: &mut u32,
+    id_by_uuid: &mut HashMap<[u8; 16], PadId>,
     initial: bool,
     emit_sys: &mut impl FnMut(GpSystemEvent),
 ) {
     if !is_hidraw_path(&path) || devs.iter().any(|dev| dev.path == path) {
         return;
     }
-    let id = PadId(*next_id);
+    let uuid = uuid_from_bytes(path.as_bytes());
+    let existing_id = id_by_uuid.get(&uuid).copied();
+    let id = existing_id.unwrap_or(PadId(*next_id));
     if let Some(dev) = open_dev(path, id, initial, emit_sys) {
-        *next_id = next_id.saturating_add(1);
+        if existing_id.is_none() {
+            id_by_uuid.insert(dev.uuid, id);
+            *next_id = next_id.saturating_add(1);
+        }
         devs.push(dev);
     }
 }
@@ -616,10 +623,11 @@ pub fn run(
     let watch = DevdWatch::new();
     let mut devs = Vec::new();
     let mut next_id = 0u32;
+    let mut id_by_uuid: HashMap<[u8; 16], PadId> = HashMap::new();
     let hidraw_paths = scan_hidraw_paths();
     let hidraw_count = hidraw_paths.len();
     for path in hidraw_paths {
-        add_dev_if_new(path, &mut devs, &mut next_id, true, emit_sys);
+        add_dev_if_new(path, &mut devs, &mut next_id, &mut id_by_uuid, true, emit_sys);
     }
     if devs.is_empty() {
         let _ = watch;
@@ -746,7 +754,14 @@ pub fn run(
         for event in hotplug.drain(..) {
             match event {
                 DevdEvent::Create(path) => {
-                    add_dev_if_new(path, &mut devs, &mut next_id, false, emit_sys)
+                    add_dev_if_new(
+                        path,
+                        &mut devs,
+                        &mut next_id,
+                        &mut id_by_uuid,
+                        false,
+                        emit_sys,
+                    )
                 }
                 DevdEvent::Destroy(path) => remove_dev_by_path(&path, &mut devs, emit_sys),
             }


### PR DESCRIPTION
Fixes #405

## Why

Unplugging and replugging the same controller (or cycling between controllers on the same cable, as in the issue) caused the in-game pad index to grow unbounded on Linux. The same `A` button that was originally bound as `Pad 0 Btn 0x10130` ended up reported as `Pad 8 Btn 0x10130` after a few reconnect cycles, breaking existing bindings.

## What

Every controller backend now consults a per-run `id_by_uuid: HashMap<[u8; 16], PadId>` before allocating a new `PadId`. If a device with the same UUID has been seen before in this process, it gets its original id back; otherwise `next_id` is consumed exactly once and the mapping is recorded. The map is never cleared on disconnect, so reconnects are sticky for the lifetime of the process.

This mirrors the behavior the Windows WGI, Windows Raw Input, and macOS IOHID backends already had. The new fix covers the three backends that were still allocating a fresh id every (re)connect:

- `src/engine/input/backends/evdev/linux.rs` (the one called out in #405)
- `src/engine/input/backends/evdev/freebsd.rs`
- `src/engine/input/backends/hidraw.rs`
