### PR TITLE
feat(eval): shade scatterplot background by judgment region

### DIFF
--- a/src/config/load/options.rs
+++ b/src/config/load/options.rs
@@ -485,6 +485,10 @@ fn load_runtime_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
         .get("Options", "SmoothHistogram")
         .and_then(|v| v.parse::<u8>().ok())
         .map_or(default.smooth_histogram, |v| v != 0);
+    cfg.shade_scatterplot_judgments = conf
+        .get("Options", "ShadeScatterplotJudgments")
+        .and_then(|v| v.parse::<u8>().ok())
+        .map_or(default.shade_scatterplot_judgments, |v| v != 0);
     cfg.input_debounce_seconds = conf
         .get("Options", "InputDebounceTime")
         .map(|v| v.trim().to_string())

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -295,6 +295,11 @@ pub struct Config {
     pub cachesongs: bool,
     // Whether to apply Gaussian smoothing to the eval histogram (Simply Love style)
     pub smooth_histogram: bool,
+    /// Tint the evaluation scatterplot background in horizontal bands matching
+    /// the active scoring scale's judgment timing windows. Mirrors the
+    /// Simply-Love-SM5-8ms judgment-region shading; off by default to preserve
+    /// the existing solid background.
+    pub shade_scatterplot_judgments: bool,
     /// Conditions for auto-screenshotting the Evaluation screen.
     pub auto_screenshot_eval: u8,
     /// ITGmania InputFilter parity: per-input debounce window in seconds.
@@ -445,6 +450,7 @@ impl Default for Config {
             fastload: true,
             cachesongs: true,
             smooth_histogram: true,
+            shade_scatterplot_judgments: false,
             auto_screenshot_eval: 0,
             input_debounce_seconds: 0.02,
             arcade_options_navigation: false,

--- a/src/config/store/defaults.rs
+++ b/src/config/store/defaults.rs
@@ -275,6 +275,11 @@ fn push_default_options(content: &mut String, default: &Config) {
     push_bool(content, "ShowStats", default.show_stats_mode != 0);
     push_line(content, "ShowStatsMode", default.show_stats_mode.min(3));
     push_bool(content, "SmoothHistogram", default.smooth_histogram);
+    push_bool(
+        content,
+        "ShadeScatterplotJudgments",
+        default.shade_scatterplot_judgments,
+    );
     push_line(
         content,
         "InputDebounceTime",

--- a/src/config/store/save.rs
+++ b/src/config/store/save.rs
@@ -338,6 +338,11 @@ fn push_saved_options(
     push_bool(content, "ShowStats", cfg.show_stats_mode != 0);
     push_line(content, "ShowStatsMode", cfg.show_stats_mode.min(3));
     push_bool(content, "SmoothHistogram", cfg.smooth_histogram);
+    push_bool(
+        content,
+        "ShadeScatterplotJudgments",
+        cfg.shade_scatterplot_judgments,
+    );
     push_line(
         content,
         "InputDebounceTime",

--- a/src/screens/components/evaluation/eval_graphs.rs
+++ b/src/screens/components/evaluation/eval_graphs.rs
@@ -187,6 +187,88 @@ fn push_quad(out: &mut Vec<MeshVertex>, x: f32, y: f32, w: f32, h: f32, color: [
     });
 }
 
+pub fn build_scatter_background_mesh(
+    graph_width: f32,
+    graph_height: f32,
+    worst_window_ms: f32,
+    scale: ScatterPlotScale,
+) -> Vec<MeshVertex> {
+    let w = graph_width.max(0.0);
+    let h = graph_height.max(0.0);
+    if w <= 0.0 || h <= 0.0 {
+        return Vec::new();
+    }
+
+    // Use the same display-window cap the scatter mesh uses so the bands and
+    // the plotted points share the same vertical mapping.
+    let worst = match scale {
+        ScatterPlotScale::HardEx => hard_ex_display_window_ms(worst_window_ms),
+        _ => worst_window_ms,
+    }
+    .max(1.0);
+
+    let timing_windows_ms = crate::game::timing::effective_windows_ms();
+    let w0 = crate::game::timing::FA_PLUS_W0_MS;
+    let w010 = crate::game::timing::FA_PLUS_W010_MS;
+
+    // (outer_ms, color) ordered innermost to outermost. The inner edge of
+    // each band is the outer edge of the previous band (0 for the first).
+    let bands: &[(f32, [f32; 4])] = match scale {
+        ScatterPlotScale::Itg => &[
+            (timing_windows_ms[0], color::JUDGMENT_RGBA[0]),
+            (timing_windows_ms[1], color::JUDGMENT_RGBA[1]),
+            (timing_windows_ms[2], color::JUDGMENT_RGBA[2]),
+            (timing_windows_ms[3], color::JUDGMENT_RGBA[3]),
+            (timing_windows_ms[4], color::JUDGMENT_RGBA[4]),
+        ],
+        ScatterPlotScale::Ex => &[
+            (w0, color::JUDGMENT_RGBA[0]),
+            (timing_windows_ms[0], color::JUDGMENT_FA_PLUS_WHITE_RGBA),
+            (timing_windows_ms[1], color::JUDGMENT_RGBA[1]),
+            (timing_windows_ms[2], color::JUDGMENT_RGBA[2]),
+            (timing_windows_ms[3], color::JUDGMENT_RGBA[3]),
+            (timing_windows_ms[4], color::JUDGMENT_RGBA[4]),
+        ],
+        ScatterPlotScale::HardEx => &[
+            (w010, color::HARD_EX_SCORE_RGBA),
+            (w0, color::JUDGMENT_RGBA[0]),
+            (timing_windows_ms[0], color::JUDGMENT_FA_PLUS_WHITE_RGBA),
+            (timing_windows_ms[1], color::JUDGMENT_RGBA[1]),
+            (timing_windows_ms[2], color::JUDGMENT_RGBA[2]),
+            (timing_windows_ms[3], color::JUDGMENT_RGBA[3]),
+            (timing_windows_ms[4], color::JUDGMENT_RGBA[4]),
+        ],
+        ScatterPlotScale::Arrow | ScatterPlotScale::Foot => return Vec::new(),
+    };
+
+    // Matches Simply Love's `diffusealpha(0.1)` on its judgment-region quads.
+    const BAND_ALPHA: f32 = 0.1;
+
+    let mut out: Vec<MeshVertex> = Vec::with_capacity(bands.len() * 12);
+    let half = h * 0.5;
+    let mut inner_ms: f32 = 0.0;
+    for &(outer_ms, c) in bands {
+        let outer = outer_ms.min(worst);
+        if outer <= inner_ms {
+            continue;
+        }
+        let inner_frac = (inner_ms / worst).clamp(0.0, 1.0);
+        let outer_frac = (outer / worst).clamp(0.0, 1.0);
+        let band_h = (outer_frac - inner_frac) * half;
+        let top_y = (1.0 - outer_frac) * half;
+        let bot_y = half + inner_frac * half;
+        let col = [c[0], c[1], c[2], BAND_ALPHA];
+        push_quad(&mut out, 0.0, top_y, w, band_h, col);
+        push_quad(&mut out, 0.0, bot_y, w, band_h, col);
+        inner_ms = outer;
+        if outer_ms >= worst {
+            break;
+        }
+    }
+
+    out
+}
+
 pub fn build_scatter_mesh(
     scatter: &[ScatterPoint],
     first_second: f32,

--- a/src/screens/evaluation.rs
+++ b/src/screens/evaluation.rs
@@ -10,7 +10,7 @@ use crate::screens::components::shared::screen_bar::{
     AvatarParams, ScreenBarParams, ScreenBarPosition, ScreenBarTitlePlacement,
 };
 use crate::screens::components::{
-    evaluation::{self as eval_panes, eval_grades},
+    evaluation::{self as eval_panes, eval_grades, eval_graphs},
     shared::{
         banner as shared_banner, lobby_hud, mode_pads, screen_bar, test_input, timers, transitions,
         visual_style_bg,
@@ -855,10 +855,10 @@ fn build_eval_density_graph_mesh(
 fn build_eval_scatter_mesh(
     si: &ScoreInfo,
     graph_width: f32,
-    scale: crate::screens::components::evaluation::eval_graphs::ScatterPlotScale,
+    scale: eval_graphs::ScatterPlotScale,
 ) -> Option<Arc<[MeshVertex]>> {
     const GRAPH_H: f32 = 64.0;
-    let verts = crate::screens::components::evaluation::eval_graphs::build_scatter_mesh(
+    let verts = eval_graphs::build_scatter_mesh(
         &si.scatter,
         si.graph_first_second,
         si.graph_last_second,
@@ -870,9 +870,29 @@ fn build_eval_scatter_mesh(
     (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
 }
 
+fn build_eval_scatter_bg_mesh(
+    si: &ScoreInfo,
+    graph_width: f32,
+    pane: EvalGraphPane,
+) -> Option<Arc<[MeshVertex]>> {
+    use eval_graphs::{
+        ScatterPlotScale, build_scatter_background_mesh,
+    };
+    let scale = match pane {
+        EvalGraphPane::Itg => ScatterPlotScale::Itg,
+        EvalGraphPane::Ex => ScatterPlotScale::Ex,
+        EvalGraphPane::HardEx => ScatterPlotScale::HardEx,
+        EvalGraphPane::Arrow | EvalGraphPane::Foot => return None,
+    };
+    const GRAPH_H: f32 = 64.0;
+    let verts =
+        build_scatter_background_mesh(graph_width, GRAPH_H, si.scatter_worst_window_ms, scale);
+    (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
+}
+
 fn build_eval_timing_hist_mesh(
     si: &ScoreInfo,
-    scale: crate::screens::components::evaluation::eval_graphs::TimingHistogramScale,
+    scale: eval_graphs::TimingHistogramScale,
 ) -> Option<Arc<[MeshVertex]>> {
     const PANE_W: f32 = 300.0;
     const PANE_H: f32 = 180.0;
@@ -880,7 +900,7 @@ fn build_eval_timing_hist_mesh(
     const BOT_H: f32 = 13.0;
 
     let graph_h = (PANE_H - TOP_H - BOT_H).max(0.0);
-    let verts = crate::screens::components::evaluation::eval_graphs::build_offset_histogram_mesh(
+    let verts = eval_graphs::build_offset_histogram_mesh(
         &si.histogram,
         PANE_W,
         graph_h,
@@ -1879,6 +1899,9 @@ pub struct State {
     pub scatter_mesh_itg: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS],
     pub scatter_mesh_ex: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS],
     pub scatter_mesh_hard_ex: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS],
+    pub scatter_bg_mesh_itg: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS],
+    pub scatter_bg_mesh_ex: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS],
+    pub scatter_bg_mesh_hard_ex: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS],
     pub scatter_mesh_arrow: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS],
     pub scatter_mesh_foot: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS],
     pub density_graph_texture_key: String,
@@ -1920,6 +1943,9 @@ impl Clone for State {
             scatter_mesh_itg: self.scatter_mesh_itg.clone(),
             scatter_mesh_ex: self.scatter_mesh_ex.clone(),
             scatter_mesh_hard_ex: self.scatter_mesh_hard_ex.clone(),
+            scatter_bg_mesh_itg: self.scatter_bg_mesh_itg.clone(),
+            scatter_bg_mesh_ex: self.scatter_bg_mesh_ex.clone(),
+            scatter_bg_mesh_hard_ex: self.scatter_bg_mesh_hard_ex.clone(),
             scatter_mesh_arrow: self.scatter_mesh_arrow.clone(),
             scatter_mesh_foot: self.scatter_mesh_foot.clone(),
             density_graph_texture_key: self.density_graph_texture_key.clone(),
@@ -1960,6 +1986,12 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
     let mut scatter_mesh_ex: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
         std::array::from_fn(|_| None);
     let mut scatter_mesh_hard_ex: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
+        std::array::from_fn(|_| None);
+    let mut scatter_bg_mesh_itg: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
+        std::array::from_fn(|_| None);
+    let mut scatter_bg_mesh_ex: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
+        std::array::from_fn(|_| None);
+    let mut scatter_bg_mesh_hard_ex: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
         std::array::from_fn(|_| None);
     let mut scatter_mesh_arrow: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
         std::array::from_fn(|_| None);
@@ -2293,75 +2325,81 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
             if scoring_scatter == EvalGraphPane::Itg {
                 scatter_mesh_itg[player_idx] = {
                     const GRAPH_H: f32 = 64.0;
-                    let verts = crate::screens::components::evaluation::eval_graphs::build_scatter_mesh(
+                    let verts = eval_graphs::build_scatter_mesh(
                         &si.scatter,
                         si.graph_first_second,
                         si.graph_last_second,
                         graph_width,
                         GRAPH_H,
                         si.scatter_worst_window_ms,
-                        crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::Itg,
+                        eval_graphs::ScatterPlotScale::Itg,
                     );
                     (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
                 };
+                scatter_bg_mesh_itg[player_idx] =
+                    build_eval_scatter_bg_mesh(si, graph_width, EvalGraphPane::Itg);
             }
 
             if scoring_scatter == EvalGraphPane::Ex {
                 scatter_mesh_ex[player_idx] = {
                     const GRAPH_H: f32 = 64.0;
-                    let verts = crate::screens::components::evaluation::eval_graphs::build_scatter_mesh(
+                    let verts = eval_graphs::build_scatter_mesh(
                         &si.scatter,
                         si.graph_first_second,
                         si.graph_last_second,
                         graph_width,
                         GRAPH_H,
                         si.scatter_worst_window_ms,
-                        crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::Ex,
+                        eval_graphs::ScatterPlotScale::Ex,
                     );
                     (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
                 };
+                scatter_bg_mesh_ex[player_idx] =
+                    build_eval_scatter_bg_mesh(si, graph_width, EvalGraphPane::Ex);
             }
 
             if scoring_scatter == EvalGraphPane::HardEx {
                 scatter_mesh_hard_ex[player_idx] = {
                     const GRAPH_H: f32 = 64.0;
-                    let verts = crate::screens::components::evaluation::eval_graphs::build_scatter_mesh(
+                    let verts = eval_graphs::build_scatter_mesh(
                         &si.scatter,
                         si.graph_first_second,
                         si.graph_last_second,
                         graph_width,
                         GRAPH_H,
                         si.scatter_worst_window_ms,
-                        crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::HardEx,
+                        eval_graphs::ScatterPlotScale::HardEx,
                     );
                     (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
                 };
+                scatter_bg_mesh_hard_ex[player_idx] =
+                    build_eval_scatter_bg_mesh(si, graph_width, EvalGraphPane::HardEx);
             }
 
             scatter_mesh_arrow[player_idx] = {
                 const GRAPH_H: f32 = 64.0;
-                let verts = crate::screens::components::evaluation::eval_graphs::build_scatter_mesh(
+                let verts = eval_graphs::build_scatter_mesh(
                     &si.scatter,
                     si.graph_first_second,
                     si.graph_last_second,
                     graph_width,
                     GRAPH_H,
                     si.scatter_worst_window_ms,
-                    crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::Arrow,
+                    eval_graphs::ScatterPlotScale::Arrow,
                 );
                 (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
             };
 
             scatter_mesh_foot[player_idx] = {
                 const GRAPH_H: f32 = 64.0;
-                let verts = crate::screens::components::evaluation::eval_graphs::build_scatter_mesh(
+                let verts = eval_graphs::build_scatter_mesh(
                     &si.scatter,
                     si.graph_first_second,
                     si.graph_last_second,
                     graph_width,
                     GRAPH_H,
                     si.scatter_worst_window_ms,
-                    crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::Foot,
+                    eval_graphs::ScatterPlotScale::Foot,
                 );
                 (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
             };
@@ -2373,12 +2411,12 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
                 const BOT_H: f32 = 13.0;
 
                 let graph_h = (PANE_H - TOP_H - BOT_H).max(0.0);
-                let verts = crate::screens::components::evaluation::eval_graphs::build_offset_histogram_mesh(
+                let verts = eval_graphs::build_offset_histogram_mesh(
                     &si.histogram,
                     PANE_W,
                     graph_h,
                     PANE_H,
-                    crate::screens::components::evaluation::eval_graphs::TimingHistogramScale::Itg,
+                    eval_graphs::TimingHistogramScale::Itg,
                     crate::config::get().smooth_histogram,
                 );
                 (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
@@ -2391,12 +2429,12 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
                 const BOT_H: f32 = 13.0;
 
                 let graph_h = (PANE_H - TOP_H - BOT_H).max(0.0);
-                let verts = crate::screens::components::evaluation::eval_graphs::build_offset_histogram_mesh(
+                let verts = eval_graphs::build_offset_histogram_mesh(
                     &si.histogram,
                     PANE_W,
                     graph_h,
                     PANE_H,
-                    crate::screens::components::evaluation::eval_graphs::TimingHistogramScale::Ex,
+                    eval_graphs::TimingHistogramScale::Ex,
                     crate::config::get().smooth_histogram,
                 );
                 (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
@@ -2409,12 +2447,12 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
                 const BOT_H: f32 = 13.0;
 
                 let graph_h = (PANE_H - TOP_H - BOT_H).max(0.0);
-                let verts = crate::screens::components::evaluation::eval_graphs::build_offset_histogram_mesh(
+                let verts = eval_graphs::build_offset_histogram_mesh(
                     &si.histogram,
                     PANE_W,
                     graph_h,
                     PANE_H,
-                    crate::screens::components::evaluation::eval_graphs::TimingHistogramScale::HardEx,
+                    eval_graphs::TimingHistogramScale::HardEx,
                     crate::config::get().smooth_histogram,
                 );
                 (!verts.is_empty()).then(|| Arc::from(verts.into_boxed_slice()))
@@ -2479,6 +2517,9 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
         scatter_mesh_itg,
         scatter_mesh_ex,
         scatter_mesh_hard_ex,
+        scatter_bg_mesh_itg,
+        scatter_bg_mesh_ex,
+        scatter_bg_mesh_hard_ex,
         scatter_mesh_arrow,
         scatter_mesh_foot,
         density_graph_texture_key: "__white".to_string(),
@@ -2561,7 +2602,7 @@ pub fn init_from_score_info(
             build_eval_scatter_mesh(
                 si,
                 graph_width,
-                crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::Itg,
+                eval_graphs::ScatterPlotScale::Itg,
             )
         });
     let scatter_mesh_ex: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
@@ -2570,7 +2611,7 @@ pub fn init_from_score_info(
             build_eval_scatter_mesh(
                 si,
                 graph_width,
-                crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::Ex,
+                eval_graphs::ScatterPlotScale::Ex,
             )
         });
     let scatter_mesh_hard_ex: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
@@ -2579,8 +2620,23 @@ pub fn init_from_score_info(
             build_eval_scatter_mesh(
                 si,
                 graph_width,
-                crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::HardEx,
+                eval_graphs::ScatterPlotScale::HardEx,
             )
+        });
+    let scatter_bg_mesh_itg: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
+        std::array::from_fn(|player_idx| {
+            let si = score_info.get(player_idx).and_then(|s| s.as_ref())?;
+            build_eval_scatter_bg_mesh(si, graph_width, EvalGraphPane::Itg)
+        });
+    let scatter_bg_mesh_ex: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
+        std::array::from_fn(|player_idx| {
+            let si = score_info.get(player_idx).and_then(|s| s.as_ref())?;
+            build_eval_scatter_bg_mesh(si, graph_width, EvalGraphPane::Ex)
+        });
+    let scatter_bg_mesh_hard_ex: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
+        std::array::from_fn(|player_idx| {
+            let si = score_info.get(player_idx).and_then(|s| s.as_ref())?;
+            build_eval_scatter_bg_mesh(si, graph_width, EvalGraphPane::HardEx)
         });
     let scatter_mesh_arrow: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
         std::array::from_fn(|player_idx| {
@@ -2588,7 +2644,7 @@ pub fn init_from_score_info(
             build_eval_scatter_mesh(
                 si,
                 graph_width,
-                crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::Arrow,
+                eval_graphs::ScatterPlotScale::Arrow,
             )
         });
     let scatter_mesh_foot: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
@@ -2597,7 +2653,7 @@ pub fn init_from_score_info(
             build_eval_scatter_mesh(
                 si,
                 graph_width,
-                crate::screens::components::evaluation::eval_graphs::ScatterPlotScale::Foot,
+                eval_graphs::ScatterPlotScale::Foot,
             )
         });
     let timing_hist_mesh: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
@@ -2605,7 +2661,7 @@ pub fn init_from_score_info(
             let si = score_info.get(player_idx).and_then(|s| s.as_ref())?;
             build_eval_timing_hist_mesh(
                 si,
-                crate::screens::components::evaluation::eval_graphs::TimingHistogramScale::Itg,
+                eval_graphs::TimingHistogramScale::Itg,
             )
         });
     let timing_hist_mesh_ex: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
@@ -2613,7 +2669,7 @@ pub fn init_from_score_info(
             let si = score_info.get(player_idx).and_then(|s| s.as_ref())?;
             build_eval_timing_hist_mesh(
                 si,
-                crate::screens::components::evaluation::eval_graphs::TimingHistogramScale::Ex,
+                eval_graphs::TimingHistogramScale::Ex,
             )
         });
     let timing_hist_mesh_hard_ex: [Option<Arc<[MeshVertex]>>; MAX_PLAYERS] =
@@ -2621,7 +2677,7 @@ pub fn init_from_score_info(
             let si = score_info.get(player_idx).and_then(|s| s.as_ref())?;
             build_eval_timing_hist_mesh(
                 si,
-                crate::screens::components::evaluation::eval_graphs::TimingHistogramScale::HardEx,
+                eval_graphs::TimingHistogramScale::HardEx,
             )
         });
 
@@ -2641,6 +2697,9 @@ pub fn init_from_score_info(
         scatter_mesh_itg,
         scatter_mesh_ex,
         scatter_mesh_hard_ex,
+        scatter_bg_mesh_itg,
+        scatter_bg_mesh_ex,
+        scatter_bg_mesh_hard_ex,
         scatter_mesh_arrow,
         scatter_mesh_foot,
         density_graph_texture_key: "__white".to_string(),
@@ -4270,19 +4329,19 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                     si,
                     state.timing_hist_mesh[player_idx].as_ref(),
                     controller,
-                    crate::screens::components::evaluation::eval_graphs::TimingHistogramScale::Itg,
+                    eval_graphs::TimingHistogramScale::Itg,
                 )),
                 EvalPane::TimingEx => actors.extend(eval_panes::build_timing_pane(
                     si,
                     state.timing_hist_mesh_ex[player_idx].as_ref(),
                     controller,
-                    crate::screens::components::evaluation::eval_graphs::TimingHistogramScale::Ex,
+                    eval_graphs::TimingHistogramScale::Ex,
                 )),
                 EvalPane::TimingHardEx => actors.extend(eval_panes::build_timing_pane(
                     si,
                     state.timing_hist_mesh_hard_ex[player_idx].as_ref(),
                     controller,
-                    crate::screens::components::evaluation::eval_graphs::TimingHistogramScale::HardEx,
+                    eval_graphs::TimingHistogramScale::HardEx,
                 )),
                 EvalPane::QrCode => actors.extend(eval_panes::build_gs_qr_pane(si, controller)),
                 EvalPane::GrooveStats => actors.extend(eval_panes::build_gs_records_pane(
@@ -4488,6 +4547,16 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                 EvalGraphPane::Arrow => state.scatter_mesh_arrow[player_idx].as_ref(),
                 EvalGraphPane::Foot => state.scatter_mesh_foot[player_idx].as_ref(),
             };
+            let scatter_bg_mesh = if crate::config::get().shade_scatterplot_judgments {
+                match graph_mode {
+                    EvalGraphPane::Itg => state.scatter_bg_mesh_itg[player_idx].as_ref(),
+                    EvalGraphPane::Ex => state.scatter_bg_mesh_ex[player_idx].as_ref(),
+                    EvalGraphPane::HardEx => state.scatter_bg_mesh_hard_ex[player_idx].as_ref(),
+                    EvalGraphPane::Arrow | EvalGraphPane::Foot => None,
+                }
+            } else {
+                None
+            };
             let show_feet_overlay = graph_mode == EvalGraphPane::Foot;
 
             let graph_frame = Actor::Frame {
@@ -4538,6 +4607,23 @@ pub fn get_actors(state: &State, asset_manager: &AssetManager) -> Vec<Actor> {
                             graph_width,
                             graph_height,
                         ),
+                    },
+                    {
+                        if let Some(mesh) = scatter_bg_mesh
+                            && !mesh.is_empty()
+                        {
+                            Actor::Mesh {
+                                align: [0.0, 0.0],
+                                offset: [0.0, 0.0],
+                                size: [SizeSpec::Px(graph_width), SizeSpec::Px(graph_height)],
+                                vertices: mesh.clone(),
+                                visible: true,
+                                blend: BlendMode::Alpha,
+                                z: 2,
+                            }
+                        } else {
+                            act!(sprite("__white"): visible(false))
+                        }
                     },
                     act!(quad:
                         align(0.5, 0.5):


### PR DESCRIPTION
Closes #436

The evaluation scatterplot draws a single dark backdrop, so a viewer has to mentally map each dot back to its judgment tier. This PR mirrors the judgment-region shading from iamchris4life's Simply-Love-SM5-8ms theme (`BGAnimations/ScreenEvaluation common/PerPlayer/Lower/Graphs.lua`): each judgment window becomes a horizontal band, mirrored above and below the zero line, tinted with that tier's judgment color.

## Approach

- New `build_scatter_background_mesh` in `screens/components/evaluation/eval_graphs.rs` emits two quads per tier (top/bottom mirror) at a subtle 0.1 alpha so the plotted points stay the most prominent element. The band ladder follows the active scoring scale:
  - **ITG**: Fantastic, Excellent, Great, Decent, Way Off.
  - **FA+ (Ex)**: adds the inner blue FA+ Fantastic window with a white ring outside it.
  - **HardEx**: prepends the 10 ms magenta inner band on top of the FA+ ladder.
  Arrow and Foot scatter modes carry no judgment semantics, so they return an empty mesh and leave the backdrop solid.
- The bands share the scatter mesh's `hard_ex_display_window_ms` cap so the colored regions line up exactly with the plotted dots.
- `evaluation::State` gets `scatter_bg_mesh_{itg,ex,hard_ex}` populated alongside the scoring scatter in both `init` and `init_from_score_info`. The actor is rendered at z=2 immediately before the existing zero-line quad, so it sits above the density histogram and below the scatter / zero line.

## Config flag

Gated behind a new `Preferences.ini` flag `[Options] ShadeScatterplotJudgments`, default off, following the existing `SmoothHistogram` precedent (config struct field, save / defaults / load wiring, no in-game options entry). The mesh is built unconditionally so toggling at runtime needs no recompute; the renderer drops the bg actor to a hidden placeholder when the flag is off, keeping the actor tree shape identical to today.