### PR TITLE
fix(select_music): restore wheel position after Set Summary

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8425,8 +8425,12 @@ impl App {
                         &mut self.state.screens.select_music_state,
                     );
                 }
+                CurrentScreen::EvaluationSummary => {
+                    select_music::trigger_immediate_refresh(
+                        &mut self.state.screens.select_music_state,
+                    );
+                }
                 CurrentScreen::ProfileLoad => {
-                    // SelectMusic state is prepared asynchronously while ProfileLoad is displayed.
                     select_music::trigger_immediate_refresh(
                         &mut self.state.screens.select_music_state,
                     );
@@ -8602,7 +8606,7 @@ impl App {
             }
 
             match prev {
-                CurrentScreen::ProfileLoad => {
+                CurrentScreen::ProfileLoad | CurrentScreen::EvaluationSummary => {
                     select_course::trigger_immediate_refresh(
                         &mut self.state.screens.select_course_state,
                     );


### PR DESCRIPTION
Opening the select-music menu, picking **Set Summary**, and then backing out sent the user back to the top of the song wheel instead of the song they were on. The selected song, sort mode, scroll position, and chart picks were all lost.

The `SelectMusic` re-entry handler in `src/app/mod.rs` matched on `prev` with no arm for `EvaluationSummary`, so it fell into the default `_` arm and called `select_music::init()`, wiping the wheel state. `SelectCourse` had the same shape.

Added an explicit `CurrentScreen::EvaluationSummary` arm in both handlers that only calls `trigger_immediate_refresh` to refresh derived data, leaving the wheel state intact. The Set Summary overlay does no gameplay and changes no audio, so a preview reset isn't needed.

Routing is unaffected: `evaluation_summary_return_to(SelectMusic, false)` already correctly returns to `SelectMusic`, and the `pending_post_select_summary_exit` flow still routes to `Initials` as before.