### PR TITLE
docs: fix Linux/FreeBSD data and cache paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,13 +187,13 @@ The whole feature is gated by `CustomSoundsEnabled` in `deadsync.ini`
 
 ## Data Directories
 
-By default, DeadSync stores user data outside the install directory so that upgrading the game doesn't risk overwriting your config, saves, or scores. Linux and FreeBSD use a single `~/.deadsync` root; Windows and macOS use platform-native locations.
+By default, DeadSync stores user data outside the install directory so that upgrading the game doesn't risk overwriting your config, saves, or scores. Each platform uses native, XDG-compliant locations.
 
 ### Default locations
 
 | Platform | Data directory | Cache directory |
 |----------|---------------|-----------------|
-| **Linux / FreeBSD** | `~/.deadsync` | `~/.deadsync/cache` |
+| **Linux / FreeBSD** | `~/.local/share/deadsync` (`$XDG_DATA_HOME/deadsync`) | `~/.cache/deadsync` (`$XDG_CACHE_HOME/deadsync`) |
 | **Windows** | `%APPDATA%\deadsync` | `%APPDATA%\deadsync\cache` |
 | **macOS** | `~/Library/Application Support/deadsync` | `~/Library/Caches/deadsync` |
 


### PR DESCRIPTION
The README's Data Directories table claimed Linux and FreeBSD use `~/.deadsync` (with cache at `~/.deadsync/cache`), but the actual code in `src/config/dirs.rs` uses the `directories` crate's `ProjectDirs`, which is XDG-compliant on Linux/FreeBSD. Users following the README would look in the wrong place for their config, saves, and logs.

Updates the table to the real defaults:

- Data: `~/.local/share/deadsync` (`XDG_DATA_HOME/deadsync`)
- Cache: `~/.cache/deadsync` (`XDG_CACHE_HOME/deadsync`)

Also reworded the intro paragraph since there's no longer a single shared `~/.deadsync` root on Linux. Windows and macOS entries were already correct and are unchanged.