### PR TITLE
fix(build): copy assets to the real profile dir for custom cargo profiles

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -196,6 +196,25 @@ fn compile_vulkan_shaders(compiler: &mut Compiler, out_dir: &Path) -> Result<(),
 }
 
 fn compute_target_dir() -> Result<PathBuf, Box<dyn Error>> {
+    // Derive the profile output directory (where the final binary lives, e.g.
+    // `target/local`) from OUT_DIR rather than the PROFILE env var.
+    //
+    // Cargo only ever sets PROFILE to "debug" or "release" — it does NOT reflect
+    // custom profiles. A profile like `[profile.local] inherits = "release"`
+    // builds into `target/local/` but reports PROFILE=release, so the old logic
+    // copied assets to `target/release/` and left the running `target/local`
+    // binary with stale assets (e.g. missing language keys).
+    //
+    // OUT_DIR is always `<target>/<profile>/build/<crate>-<hash>/out`, so its
+    // third ancestor is the real profile output directory for any profile.
+    if let Ok(out_dir) = std::env::var("OUT_DIR") {
+        if let Some(profile_dir) = PathBuf::from(out_dir).ancestors().nth(3) {
+            return Ok(profile_dir.to_path_buf());
+        }
+    }
+
+    // Fallback: best-effort reconstruction from PROFILE (only correct for the
+    // built-in debug/release profiles).
     let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?);
     let profile = std::env::var("PROFILE")?;
     let base = std::env::var("CARGO_TARGET_DIR")


### PR DESCRIPTION
## Problem
Building with a **custom cargo profile** leaves the resulting binary with **stale assets**. For example, with:

```toml
[profile.local]
inherits = "release"
```

cargo build --profile local produces 	arget/local/deadsync.exe, but the assets (e.g. `assets/languages/*.ini`) are copied to `target/release/assets` instead. The running `target/local` binary keeps whatever assets it had from a previous build, so newly added/edited strings never appear — missing i18n keys render on screen as literal `Section.Key` text.

## Root cause
`build.rs`'s `compute_target_dir()` used the `PROFILE` environment variable. Cargo only ever sets `PROFILE` to `debug` or `release` — it does **not** report custom profile names. A custom profile that `inherits = "release"` reports `PROFILE=release`, so `copy_assets` targets `target/release` rather than the actual `target/<profile>` output directory.

## Fix
Derive the profile output directory from `OUT_DIR` instead. `OUT_DIR` is always `<target>/<profile>/build/<crate>-<hash>/out`, so its third ancestor is the real per-profile output directory for **any** profile (built-in or custom). Falls back to the previous `PROFILE`-based behavior if `OUT_DIR` is unavailable.