### PR TITLE
fix(gameplay): cut music at chart end to match ITGmania

### DIFF
--- a/src/game/gameplay.rs
+++ b/src/game/gameplay.rs
@@ -2764,11 +2764,18 @@ fn compute_end_times_ns(
 
 #[inline(always)]
 fn song_audio_end_time_ns(song: &SongData) -> SongTimeNs {
-    if song.music_length_seconds.is_finite() && song.music_length_seconds > 0.0 {
-        song_time_ns_from_seconds(song.music_length_seconds)
-    } else {
-        0
-    }
+    let chart_end = song.precise_last_second();
+    let audio_len = song.music_length_seconds;
+    let end_seconds = match (
+        chart_end.is_finite() && chart_end > 0.0,
+        audio_len.is_finite() && audio_len > 0.0,
+    ) {
+        (true, true) => chart_end.min(audio_len),
+        (true, false) => chart_end,
+        (false, true) => audio_len,
+        (false, false) => return 0,
+    };
+    song_time_ns_from_seconds(end_seconds)
 }
 
 #[inline(always)]
@@ -5586,7 +5593,7 @@ pub fn init(
     );
 
     let song_seed = turn_seed_for_song(&song);
-    let mut attack_song_length_seconds = song.music_length_seconds.max(song.precise_last_second());
+    let mut attack_song_length_seconds = song.precise_last_second();
     if !attack_song_length_seconds.is_finite() || attack_song_length_seconds <= 0.0 {
         attack_song_length_seconds = song.total_length_seconds.max(0) as f32;
     }


### PR DESCRIPTION
Songs like Shady Business in ITL 2026 were playing 15-20s of trailing audio after the chartist's intended end, because gameplay was playing the full audio file rather than stopping at the chart's last second.

This mirrors ITGmania's `ScreenGameplay::GetMusicEndTiming`: the gameplay music end is computed from `min(chart_end, audio_length)`, with the existing transition window applied downstream. When the audio file is shorter than the chart, the audio length wins so we don't pretend to play past the file's natural end.

Display surfaces (evaluation, song wheel, course list, pack durations) and preview clamping are intentionally left on `MusicLengthSeconds` for parity with Simply Love and ITGmania `Song.cpp` -- this PR only changes what the gameplay engine treats as the end of the song.