### PR TITLE
Schedule assist ticks by absolute stream frame to remove latency lag

### DIFF
--- a/crates/deadsync-rules/src/timing.rs
+++ b/crates/deadsync-rules/src/timing.rs
@@ -740,6 +740,13 @@ impl TimingData {
             .saturating_sub(self.global_offset_ns)
     }
 
+    /// Returns the internal (pre-global-offset) time for a beat. This lives in
+    /// the same space as the audio stream's music position, so it is the value
+    /// to use when scheduling assist ticks against the playback stream.
+    pub fn get_time_for_beat_no_offset_ns(&self, target_beat: f32) -> i64 {
+        self.get_time_for_beat_internal_ns(target_beat)
+    }
+
     fn get_time_for_beat_internal_ns(&self, target_beat: f32) -> TimingNs {
         let mut starts = GetBeatStarts::default();
         starts.last_time_ns = self.beat_start_time_ns();
@@ -2201,6 +2208,32 @@ mod tests {
 
         assert!((timing_ns_to_seconds(time_ns) - time_sec).abs() < 0.000_001);
         assert!((timing.get_beat_for_time_ns(time_ns) - beat).abs() < 0.0001);
+    }
+
+    #[test]
+    fn time_for_beat_no_offset_excludes_global_offset() {
+        let global_offset = 0.020;
+        let timing = TimingData::from_segments(
+            0.0,
+            global_offset,
+            &TimingSegments {
+                bpms: vec![(0.0, 120.0)],
+                ..TimingSegments::default()
+            },
+            &[],
+        );
+
+        let beat = 8.0;
+        let no_offset_ns = timing.get_time_for_beat_no_offset_ns(beat);
+        let with_offset_ns = timing.get_time_for_beat_ns(beat);
+
+        // The no-offset time is the internal time; get_time_for_beat_ns subtracts
+        // the global offset, so they must differ by exactly that offset.
+        let offset_ns = timing_ns_from_seconds(global_offset);
+        assert_eq!(no_offset_ns - with_offset_ns, offset_ns);
+
+        // At 120 BPM beat 8 lands at 4.0 s of internal music time.
+        assert!((timing_ns_to_seconds(no_offset_ns) - 4.0).abs() < 0.000_001);
     }
 
     #[test]

--- a/src/engine/audio/mod.rs
+++ b/src/engine/audio/mod.rs
@@ -20,6 +20,48 @@ use std::time::Instant;
 const MAX_ACTIVE_SFX: usize = 32;
 const SFX_QUEUE_CAP: usize = 128;
 const ASSIST_TICK_SFX_PATH: &str = "assets/sounds/assist_tick.ogg";
+/// Upper bound (in device frames) on how far ahead of the audible write head a
+/// scheduled SFX onset may sit before the mixer treats it as stale and drops it.
+/// This is a last-resort sanity bound; seek/stop/track-change staleness is
+/// handled precisely by [`ASSIST_SFX_GEN`]. ~4 s at 48 kHz, ~1 s at 192 kHz.
+const MAX_SCHEDULE_AHEAD_FRAMES: u64 = 192_000;
+
+/// Where a scheduled SFX onset lands relative to the buffer currently being
+/// filled. See [`scheduled_onset_decision`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScheduledOnset {
+    /// Target frame is implausibly far ahead; drop the entry.
+    Drop,
+    /// Onset falls in a later buffer; keep pending without mixing.
+    Pending,
+    /// Mix starting at this sample offset within the current buffer.
+    StartAt(usize),
+}
+
+/// Decides where a scheduled SFX onset lands within the buffer the mixer is
+/// currently filling. `target_stream_frame == 0` means "play immediately".
+/// `total_before` is the absolute write-head frame at the start of this buffer;
+/// `buf_len` is the buffer length in interleaved samples.
+#[inline(always)]
+fn scheduled_onset_decision(
+    target_stream_frame: u64,
+    total_before: u64,
+    device_channels: usize,
+    buf_len: usize,
+) -> ScheduledOnset {
+    if target_stream_frame == 0 {
+        return ScheduledOnset::StartAt(0);
+    }
+    let frames_until = target_stream_frame.saturating_sub(total_before);
+    if frames_until > MAX_SCHEDULE_AHEAD_FRAMES {
+        return ScheduledOnset::Drop;
+    }
+    let offset = (frames_until as usize) * device_channels;
+    if offset >= buf_len {
+        return ScheduledOnset::Pending;
+    }
+    ScheduledOnset::StartAt(offset)
+}
 
 /* ============================== Public API ============================== */
 
@@ -75,6 +117,10 @@ struct QueuedSfx {
     data: Arc<[i16]>,
     lane: SfxLane,
     stop_generation: u64,
+    /// Absolute stream frame (on the `MUSIC_TOTAL_FRAMES` timeline) at which the
+    /// first sample should become audible. `0` means "play immediately" at the
+    /// start of the next buffer (the behaviour for non-scheduled SFX).
+    target_stream_frame: u64,
 }
 
 // Commands to the audio engine
@@ -607,6 +653,11 @@ static MUSIC_TARGET_GAIN_BITS: AtomicU32 = AtomicU32::new(1.0f32.to_bits());
 static MUSIC_GAIN_SNAP_GEN: AtomicU64 = AtomicU64::new(0);
 static MUSIC_MAP_GEN: AtomicU64 = AtomicU64::new(1);
 static SCREEN_SFX_STOP_GEN: AtomicU64 = AtomicU64::new(0);
+// Generation counter for scheduled assist ticks. Bumped on every music stream
+// reset (stop / seek / track change) so any in-flight scheduled tick whose
+// target frame belongs to the previous timeline is dropped by the mixer rather
+// than firing a stale clap.
+static ASSIST_SFX_GEN: AtomicU64 = AtomicU64::new(0);
 
 // Last audio callback timing, used to interpolate the playback position
 // between callback invocations so that the reported stream time is
@@ -992,6 +1043,41 @@ impl PlaybackPosMap {
         }
         closest
     }
+
+    /// Inverse of [`search`]: given a music position in seconds, return the
+    /// track-relative stream frame at which it plays. Prefers the segment that
+    /// contains `music_seconds`; otherwise extrapolates from the nearest segment.
+    fn invert(&self, music_seconds: f64) -> Option<f64> {
+        if self.queue.is_empty() || !music_seconds.is_finite() {
+            return None;
+        }
+        let mut closest = None;
+        let mut closest_dist = f64::INFINITY;
+        for seg in &self.queue {
+            let sec_per_frame = seg.music_sec_per_frame;
+            if !sec_per_frame.is_finite() || sec_per_frame == 0.0 {
+                continue;
+            }
+            let start_sec = seg.music_start_sec;
+            let end_sec = start_sec + sec_per_frame * seg.frames as f64;
+            let (lo, hi) = if start_sec <= end_sec {
+                (start_sec, end_sec)
+            } else {
+                (end_sec, start_sec)
+            };
+            let frame = seg.stream_frame_start as f64 + (music_seconds - start_sec) / sec_per_frame;
+            if music_seconds >= lo && music_seconds < hi {
+                return Some(frame);
+            }
+            let clamped = music_seconds.clamp(lo, hi);
+            let dist = (music_seconds - clamped).abs();
+            if dist < closest_dist {
+                closest_dist = dist;
+                closest = Some(frame);
+            }
+        }
+        closest
+    }
 }
 
 static QUEUED_MUSIC_MAP_SEGS: std::sync::LazyLock<Arc<internal::SpscRingMusicSeg>> =
@@ -1081,7 +1167,8 @@ pub fn play_assist_tick(path: &str) {
         let _ = ENGINE.sfx_sender.try_send(QueuedSfx {
             data: sound_data,
             lane: SfxLane::AssistTick,
-            stop_generation: 0,
+            stop_generation: sfx_stop_generation(SfxLane::AssistTick),
+            target_stream_frame: 0,
         });
         return;
     }
@@ -1096,25 +1183,69 @@ pub fn play_preloaded_assist_tick(path: &str) {
         let _ = ENGINE.sfx_sender.try_send(QueuedSfx {
             data: sound_data,
             lane: SfxLane::AssistTick,
-            stop_generation: 0,
+            stop_generation: sfx_stop_generation(SfxLane::AssistTick),
+            target_stream_frame: 0,
         });
         return;
     }
     play_preloaded_sfx_on_lane(path, SfxLane::AssistTick);
 }
 
+/// Plays a preloaded gameplay assist tick scheduled to become audible at an
+/// absolute stream frame (see [`assist_tick_stream_frame_for_music_seconds`]).
+/// Because the target frame lies on the same `MUSIC_TOTAL_FRAMES` timeline the
+/// mixer writes against, output latency is compensated implicitly. Falls back to
+/// immediate playback when `target_stream_frame == 0`.
+pub fn play_scheduled_assist_tick(path: &str, target_stream_frame: u64) {
+    if target_stream_frame == 0 {
+        play_preloaded_assist_tick(path);
+        return;
+    }
+    if path == ASSIST_TICK_SFX_PATH
+        && let Some(sound_data) = ASSIST_TICK_SFX.get().cloned()
+    {
+        let _ = ENGINE.sfx_sender.try_send(QueuedSfx {
+            data: sound_data,
+            lane: SfxLane::AssistTick,
+            stop_generation: sfx_stop_generation(SfxLane::AssistTick),
+            target_stream_frame,
+        });
+        return;
+    }
+    // Cache-miss fallback: schedule whatever is cached for this path.
+    #[cfg(test)]
+    if !is_initialized() {
+        return;
+    }
+    let cached = { ENGINE.sfx_cache.lock().unwrap().get(path).cloned() };
+    if let Some(sound_data) = cached {
+        let _ = ENGINE.sfx_sender.try_send(QueuedSfx {
+            data: sound_data,
+            lane: SfxLane::AssistTick,
+            stop_generation: sfx_stop_generation(SfxLane::AssistTick),
+            target_stream_frame,
+        });
+    } else {
+        warn!("Scheduled assist tick cache miss for '{path}'; skipping");
+    }
+}
+
 #[inline(always)]
 fn sfx_stop_generation(lane: SfxLane) -> u64 {
     match lane {
         SfxLane::Screen => SCREEN_SFX_STOP_GEN.load(Ordering::Acquire),
-        SfxLane::Effect | SfxLane::AssistTick => 0,
+        SfxLane::AssistTick => ASSIST_SFX_GEN.load(Ordering::Acquire),
+        SfxLane::Effect => 0,
     }
 }
 
 #[inline(always)]
 fn sfx_is_stale(lane: SfxLane, stop_generation: u64) -> bool {
-    matches!(lane, SfxLane::Screen)
-        && stop_generation != SCREEN_SFX_STOP_GEN.load(Ordering::Acquire)
+    match lane {
+        SfxLane::Screen => stop_generation != SCREEN_SFX_STOP_GEN.load(Ordering::Acquire),
+        SfxLane::AssistTick => stop_generation != ASSIST_SFX_GEN.load(Ordering::Acquire),
+        SfxLane::Effect => false,
+    }
 }
 
 fn play_cached_sfx_on_lane(path: &str, lane: SfxLane) -> bool {
@@ -1129,6 +1260,7 @@ fn play_cached_sfx_on_lane(path: &str, lane: SfxLane) -> bool {
             data: sound_data,
             lane,
             stop_generation: sfx_stop_generation(lane),
+            target_stream_frame: 0,
         });
         return true;
     }
@@ -1171,6 +1303,7 @@ fn play_sfx_on_lane(path: &str, lane: SfxLane) {
         data: sound_data,
         lane,
         stop_generation: sfx_stop_generation(lane),
+        target_stream_frame: 0,
     });
 }
 
@@ -1225,6 +1358,9 @@ fn reset_music_stream_clock() {
     MUSIC_TRACK_START_FRAME.store(total, Ordering::Release);
     MUSIC_TRACK_HAS_STARTED.store(false, Ordering::Release);
     MUSIC_TRACK_ACTIVE.store(false, Ordering::Release);
+    // Invalidate any assist ticks scheduled against the previous timeline; their
+    // absolute target frames no longer correspond to the music position.
+    ASSIST_SFX_GEN.fetch_add(1, Ordering::AcqRel);
     clear_music_stream_clock_seed();
     clear_music_pos_map();
 }
@@ -1265,7 +1401,8 @@ fn i16_to_f32(sample: i16) -> f32 {
 mod tests {
     use super::{
         CallbackClockWindow, MUSIC_POS_MAP_BACKLOG_FRAMES, MusicMapSeg, PlaybackPosMap,
-        fallback_music_position, music_clock_seed_enabled, stream_position_frames_from_window,
+        ScheduledOnset, fallback_music_position, music_clock_seed_enabled,
+        scheduled_onset_decision, stream_position_frames_from_window,
     };
 
     #[test]
@@ -1357,6 +1494,98 @@ mod tests {
         );
 
         assert!((frames - 96.0).abs() <= 1e-6, "frames={frames}");
+    }
+
+    #[test]
+    fn playback_pos_map_invert_round_trips_within_segment() {
+        let mut map = PlaybackPosMap::default();
+        map.insert(MusicMapSeg {
+            stream_frame_start: 1_000,
+            frames: 48_000,
+            music_start_sec: 2.0,
+            music_sec_per_frame: 1.0 / 48_000.0,
+        });
+
+        // 0.5 s into the segment's music => 0.5 * 48_000 = 24_000 frames past start.
+        let frame = map.invert(2.5).unwrap();
+        assert!((frame - 25_000.0).abs() <= 1e-6, "frame={frame}");
+
+        // Round-trips with search().
+        let (music_sec, _) = map.search(frame).unwrap();
+        assert!((music_sec - 2.5).abs() <= 1e-9, "music_sec={music_sec}");
+    }
+
+    #[test]
+    fn playback_pos_map_invert_extrapolates_past_last_segment() {
+        let mut map = PlaybackPosMap::default();
+        map.insert(MusicMapSeg {
+            stream_frame_start: 0,
+            frames: 48_000,
+            music_start_sec: 0.0,
+            music_sec_per_frame: 1.0 / 48_000.0,
+        });
+
+        // 1.25 s is past the 1.0 s segment end; linear extrapolation => 60_000.
+        let frame = map.invert(1.25).unwrap();
+        assert!((frame - 60_000.0).abs() <= 1e-6, "frame={frame}");
+    }
+
+    #[test]
+    fn playback_pos_map_invert_rejects_empty_and_non_finite() {
+        let empty = PlaybackPosMap::default();
+        assert!(empty.invert(1.0).is_none());
+
+        let mut map = PlaybackPosMap::default();
+        map.insert(MusicMapSeg {
+            stream_frame_start: 0,
+            frames: 48_000,
+            music_start_sec: 0.0,
+            music_sec_per_frame: 1.0 / 48_000.0,
+        });
+        assert!(map.invert(f64::NAN).is_none());
+    }
+
+    #[test]
+    fn scheduled_onset_immediate_when_target_zero() {
+        assert_eq!(
+            scheduled_onset_decision(0, 10_000, 2, 1_024),
+            ScheduledOnset::StartAt(0)
+        );
+    }
+
+    #[test]
+    fn scheduled_onset_starts_at_offset_within_buffer() {
+        // 100 frames ahead, stereo => sample offset 200, inside a 1_024-sample buffer.
+        assert_eq!(
+            scheduled_onset_decision(10_100, 10_000, 2, 1_024),
+            ScheduledOnset::StartAt(200)
+        );
+    }
+
+    #[test]
+    fn scheduled_onset_pending_when_beyond_buffer() {
+        // 600 frames ahead, stereo => 1_200 samples, beyond a 1_024-sample buffer.
+        assert_eq!(
+            scheduled_onset_decision(10_600, 10_000, 2, 1_024),
+            ScheduledOnset::Pending
+        );
+    }
+
+    #[test]
+    fn scheduled_onset_drops_when_implausibly_far_ahead() {
+        assert_eq!(
+            scheduled_onset_decision(super::MAX_SCHEDULE_AHEAD_FRAMES + 10_001, 10_000, 2, 1_024),
+            ScheduledOnset::Drop
+        );
+    }
+
+    #[test]
+    fn scheduled_onset_fires_when_target_already_passed() {
+        // Target frame already behind the write head => fires at offset 0.
+        assert_eq!(
+            scheduled_onset_decision(9_000, 10_000, 2, 1_024),
+            ScheduledOnset::StartAt(0)
+        );
     }
 }
 
@@ -1555,6 +1784,31 @@ fn lookup_music_position(stream_frames: f64, sample_rate: u32) -> Option<(f32, f
     })
 }
 
+/// Maps a music position (seconds, pre-global-offset stream time) to the
+/// absolute stream frame on the `MUSIC_TOTAL_FRAMES` timeline at which it will
+/// be audible. Returns `None` when there is no usable mapping or the result is
+/// implausible (caller should then fall back to immediate playback).
+///
+/// Runs on the gameplay thread; the lock is fine there since the audio callback
+/// never takes it on its hot path.
+pub fn assist_tick_stream_frame_for_music_seconds(music_seconds: f64) -> Option<u64> {
+    if !music_seconds.is_finite() {
+        return None;
+    }
+    let track_frame = {
+        let mut map = PLAYBACK_POS_MAP.lock().unwrap();
+        while let Some(seg) = internal::music_seg_ring_pop(&PLAYED_MUSIC_MAP_SEGS) {
+            map.insert(seg);
+        }
+        map.invert(music_seconds)?
+    };
+    if !track_frame.is_finite() || track_frame < 0.0 {
+        return None;
+    }
+    let start = MUSIC_TRACK_START_FRAME.load(Ordering::Acquire);
+    Some(start.saturating_add(track_frame.round() as u64))
+}
+
 /// Plays a music track from a file path.
 pub fn play_music(path: PathBuf, cut: Cut, looping: bool, rate: f32) {
     let rate = normalized_music_rate(rate);
@@ -1648,6 +1902,13 @@ pub fn set_music_rate(rate: f32) {
 /// continuously instead of in buffer-sized jumps.
 pub fn get_music_stream_position_seconds() -> f32 {
     get_music_stream_clock_snapshot().stream_seconds
+}
+
+/// Current scheduled-assist-tick generation. Changes on every music stream reset
+/// (stop / seek / track change). Gameplay reads this to detect that previously
+/// scheduled ticks were invalidated and that its scheduling cursor must re-anchor.
+pub fn assist_sfx_generation() -> u64 {
+    ASSIST_SFX_GEN.load(Ordering::Acquire)
 }
 
 #[inline(always)]
@@ -1866,13 +2127,19 @@ fn commit_played_music_map(
     }
 }
 
+/// One actively-mixing SFX voice:
+/// `(samples, cursor, lane, stop_generation, target_stream_frame)`.
+/// `target_stream_frame == 0` means "play immediately"; otherwise the onset is
+/// placed at that absolute stream frame for sample-accurate scheduling.
+type ActiveSfx = (Arc<[i16]>, usize, SfxLane, u64, u64);
+
 struct RenderState {
     music_ring: Arc<internal::SpscRingI16>,
     sfx_receiver: Receiver<QueuedSfx>,
     device_channels: usize,
     mix_i16: Vec<i16>,
     mix_f32: Vec<f32>,
-    active_sfx: Vec<(Arc<[i16]>, usize, SfxLane, u64)>,
+    active_sfx: Vec<ActiveSfx>,
     queued_music_map: Arc<internal::SpscRingMusicSeg>,
     played_music_map: Arc<internal::SpscRingMusicSeg>,
     active_music_map: Option<MusicMapSeg>,
@@ -2005,18 +2272,43 @@ impl RenderState {
             if !sfx_is_stale(new_sfx.lane, new_sfx.stop_generation)
                 && self.active_sfx.len() < MAX_ACTIVE_SFX
             {
-                self.active_sfx
-                    .push((new_sfx.data, 0, new_sfx.lane, new_sfx.stop_generation));
+                self.active_sfx.push((
+                    new_sfx.data,
+                    0,
+                    new_sfx.lane,
+                    new_sfx.stop_generation,
+                    new_sfx.target_stream_frame,
+                ));
             }
         }
 
+        let buf_len = self.mix_f32.len();
         let mut mixed_sfx = false;
         self.active_sfx
-            .retain_mut(|(data, cursor, lane, stop_generation)| {
+            .retain_mut(|(data, cursor, lane, stop_generation, target_stream_frame)| {
                 if sfx_is_stale(*lane, *stop_generation) {
                     return false;
                 }
-                let n = (data.len().saturating_sub(*cursor)).min(self.mix_f32.len());
+                // Scheduled onset: place the first sample at an absolute stream
+                // frame. Because that frame is on the same timeline the mixer
+                // writes against, output latency is compensated implicitly.
+                let start_sample = match scheduled_onset_decision(
+                    *target_stream_frame,
+                    total_before,
+                    device_channels,
+                    buf_len,
+                ) {
+                    // Implausibly far ahead (e.g. a stale timeline that the
+                    // generation guard somehow missed); drop it.
+                    ScheduledOnset::Drop => return false,
+                    // Onset is in a later buffer: keep pending, do not mix or
+                    // advance the cursor so it stays sample-accurate.
+                    ScheduledOnset::Pending => return true,
+                    ScheduledOnset::StartAt(offset) => offset,
+                };
+                // From here on it behaves like a normal cursor sound.
+                *target_stream_frame = 0;
+                let n = (data.len().saturating_sub(*cursor)).min(buf_len - start_sample);
                 mixed_sfx |= n > 0;
                 let lane_vol = match *lane {
                     SfxLane::Effect | SfxLane::Screen => sfx_vol,
@@ -2024,7 +2316,7 @@ impl RenderState {
                 };
                 for i in 0..n {
                     let sfx_sample_f32 = i16_to_f32(data[*cursor + i]) * lane_vol;
-                    self.mix_f32[i] += sfx_sample_f32;
+                    self.mix_f32[start_sample + i] += sfx_sample_f32;
                 }
                 *cursor += n;
                 *cursor < data.len()

--- a/src/engine/audio/mod.rs
+++ b/src/engine/audio/mod.rs
@@ -1213,10 +1213,6 @@ pub fn play_scheduled_assist_tick(path: &str, target_stream_frame: u64) {
         return;
     }
     // Cache-miss fallback: schedule whatever is cached for this path.
-    #[cfg(test)]
-    if !is_initialized() {
-        return;
-    }
     let cached = { ENGINE.sfx_cache.lock().unwrap().get(path).cloned() };
     if let Some(sound_data) = cached {
         let _ = ENGINE.sfx_sender.try_send(QueuedSfx {

--- a/src/game/gameplay.rs
+++ b/src/game/gameplay.rs
@@ -3855,6 +3855,7 @@ pub struct State {
     assist_clap_rows: Vec<usize>,
     assist_clap_cursor: usize,
     assist_last_crossed_row: i32,
+    assist_sfx_gen_seen: u64,
     toggle_flash_text: Option<&'static str>,
     toggle_flash_timer: f32,
     replay_input: Vec<RecordedLaneEdge>,
@@ -6486,6 +6487,7 @@ pub fn init(
         assist_clap_rows,
         assist_clap_cursor: 0,
         assist_last_crossed_row: -1,
+        assist_sfx_gen_seen: audio::assist_sfx_generation(),
         toggle_flash_text: None,
         toggle_flash_timer: 0.0,
         replay_input,
@@ -7901,25 +7903,98 @@ pub fn judge_a_lift(state: &mut State, column: usize, current_time_ns: SongTimeN
 }
 
 #[inline(always)]
-fn run_assist_clap(state: &mut State, current_row: i32) {
+fn run_assist_clap(state: &mut State, current_row: i32, music_time_ns: SongTimeNs, slope: f32) {
     let song_row = current_row.max(0);
-    if song_row < state.assist_last_crossed_row {
-        state.assist_last_crossed_row = song_row;
+
+    // Detect an audio timeline reset (stop / seek / track change). On reset the
+    // mixer drops every scheduled tick from the old timeline, so the scheduling
+    // cursor must re-anchor to the new audible position.
+    let sfx_gen = audio::assist_sfx_generation();
+    let timeline_reset = sfx_gen != state.assist_sfx_gen_seen;
+    if timeline_reset {
+        state.assist_sfx_gen_seen = sfx_gen;
+    }
+
+    if state.tick_mode != TickMode::Assist {
+        // Keep the cursor abreast of the audible position so enabling assist
+        // later doesn't replay already-passed rows.
         state.assist_clap_cursor = assist_clap_cursor_for_row(&state.assist_clap_rows, song_row);
+        state.assist_last_crossed_row = song_row;
         return;
     }
 
-    let crossed_cursor =
-        assist_clap_cursor_for_row(&state.assist_clap_rows, state.assist_last_crossed_row);
-    if state.tick_mode == TickMode::Assist
-        && crossed_cursor < state.assist_clap_rows.len()
-        && state.assist_clap_rows[crossed_cursor] <= song_row as usize
-    {
-        audio::play_preloaded_assist_tick(ASSIST_TICK_SFX_PATH);
+    if timeline_reset {
+        state.assist_clap_cursor = assist_clap_cursor_for_row(&state.assist_clap_rows, song_row);
+        state.assist_last_crossed_row = song_row;
+    } else if song_row > state.assist_last_crossed_row {
+        state.assist_last_crossed_row = song_row;
     }
+    // Minor backward audible jitter (song_row < last_crossed without a timeline
+    // reset) deliberately does NOT rewind the cursor: those rows are already
+    // queued, so re-scheduling them would double-fire.
 
-    state.assist_clap_cursor = assist_clap_cursor_for_row(&state.assist_clap_rows, song_row);
-    state.assist_last_crossed_row = song_row;
+    let future_row = assist_lookahead_future_row(state, music_time_ns, slope, song_row);
+    let rows_len = state.assist_clap_rows.len();
+    while state.assist_clap_cursor < rows_len {
+        let clap_row = state.assist_clap_rows[state.assist_clap_cursor];
+        if clap_row as i64 > i64::from(future_row) {
+            break;
+        }
+        schedule_assist_clap_row(state, clap_row);
+        state.assist_clap_cursor += 1;
+    }
+}
+
+/// Look-ahead horizon (in real seconds) added on top of the estimated output
+/// delay so each clap row is discovered a few frames before the audible write
+/// head reaches it, leaving the mixer room to place the onset sample-accurately.
+const ASSIST_TICK_LOOKAHEAD_MARGIN_SECONDS: f32 = 0.050;
+
+/// Converts the look-ahead horizon from real seconds into music seconds using
+/// the song-clock slope (music seconds per real second, which already folds in
+/// the music rate). A non-positive or non-finite slope falls back to 1.0.
+#[inline(always)]
+fn assist_lookahead_music_horizon_seconds(delay_seconds: f32, slope: f32) -> f32 {
+    let horizon_real = (delay_seconds + ASSIST_TICK_LOOKAHEAD_MARGIN_SECONDS).max(0.0);
+    let slope = if slope.is_finite() && slope > 0.0 {
+        slope
+    } else {
+        1.0
+    };
+    horizon_real * slope
+}
+
+/// Highest assist row whose no-offset music time falls within the look-ahead
+/// horizon ahead of the audible position.
+#[inline(always)]
+fn assist_lookahead_future_row(
+    state: &State,
+    music_time_ns: SongTimeNs,
+    slope: f32,
+    song_row: i32,
+) -> i32 {
+    let delay_seconds =
+        audio::get_output_timing_snapshot().estimated_output_delay_ns as f32 * 1e-9;
+    let music_horizon = assist_lookahead_music_horizon_seconds(delay_seconds, slope);
+    let future_time = song_time_ns_add_seconds(music_time_ns, music_horizon);
+    assist_row_no_offset_ns(state, future_time).max(song_row)
+}
+
+/// Schedules a single assist clap row by its absolute stream frame so the mixer
+/// can place the onset sample-accurately. Falls back to immediate playback when
+/// the row has no usable stream-frame mapping (e.g. during lead-in).
+#[inline(always)]
+fn schedule_assist_clap_row(state: &State, clap_row: usize) {
+    let Some(beat) = state.timing.get_beat_for_row(clap_row) else {
+        audio::play_preloaded_assist_tick(ASSIST_TICK_SFX_PATH);
+        return;
+    };
+    let row_time_ns = state.timing.get_time_for_beat_no_offset_ns(beat);
+    let music_seconds = row_time_ns as f64 * 1e-9;
+    match audio::assist_tick_stream_frame_for_music_seconds(music_seconds) {
+        Some(frame) => audio::play_scheduled_assist_tick(ASSIST_TICK_SFX_PATH, frame),
+        None => audio::play_preloaded_assist_tick(ASSIST_TICK_SFX_PATH),
+    }
 }
 
 #[inline(always)]
@@ -8420,7 +8495,7 @@ pub fn update(state: &mut State, delta_time: f32) -> GameplayAction {
         state.is_in_freeze = beat_info.is_in_freeze;
         state.is_in_delay = beat_info.is_in_delay;
         let song_row = assist_row_no_offset_ns(state, music_time_ns);
-        run_assist_clap(state, song_row);
+        run_assist_clap(state, song_row, music_time_ns, song_clock.seconds_per_second);
 
         for player in 0..state.num_players {
             let delay =
@@ -8740,6 +8815,7 @@ mod tests {
         apply_time_based_mine_avoidance, apply_time_based_tap_misses,
         autoplay_random_offset_music_ns_for_window, begin_outro_attack_clear,
         build_assist_clap_rows, build_attack_mask_windows_for_player, build_column_cues_for_player,
+        assist_lookahead_music_horizon_seconds,
         build_player_judgment_timing, build_row_entry, build_row_grids, closest_lane_note_ns,
         collect_edge_judge_indices, completed_row_final_judgment,
         completed_row_flash_note_indices_and_judgment, compute_end_times_ns,
@@ -11304,6 +11380,30 @@ return Def.ActorFrame{}
             can_be_judged: true,
         }];
         assert_eq!(build_assist_clap_rows(&notes, (0, 1)), vec![48]);
+    }
+
+    #[test]
+    fn assist_lookahead_horizon_adds_margin_and_scales_by_slope() {
+        // At unit slope the horizon is just delay + margin.
+        let h = assist_lookahead_music_horizon_seconds(0.020, 1.0);
+        assert!((h - 0.070).abs() <= 1e-6, "h={h}");
+
+        // A 2x music rate (slope = 2.0) doubles the music-second horizon.
+        let h2 = assist_lookahead_music_horizon_seconds(0.020, 2.0);
+        assert!((h2 - 0.140).abs() <= 1e-6, "h2={h2}");
+    }
+
+    #[test]
+    fn assist_lookahead_horizon_guards_bad_slope_and_negative_delay() {
+        // Non-positive / non-finite slope falls back to 1.0.
+        let margin = super::ASSIST_TICK_LOOKAHEAD_MARGIN_SECONDS;
+        assert!((assist_lookahead_music_horizon_seconds(0.0, 0.0) - margin).abs() <= 1e-6);
+        assert!((assist_lookahead_music_horizon_seconds(0.0, -1.0) - margin).abs() <= 1e-6);
+        assert!((assist_lookahead_music_horizon_seconds(0.0, f32::NAN) - margin).abs() <= 1e-6);
+
+        // Horizon never goes negative even if delay somehow reads negative.
+        let h = assist_lookahead_music_horizon_seconds(-1.0, 1.0);
+        assert!(h >= 0.0, "h={h}");
     }
 
     #[test]


### PR DESCRIPTION
## Why

In Assist (clap) mode the tick lagged the music by the full audio output latency plus up to one mixer-callback period of jitter. The clap was detected against the *audible-now* music time and then queued as a fire-and-forget SFX, which the mixer always started at offset 0 of whatever buffer it was currently filling. That buffer is not audible until roughly one output-delay later, so the clap was always late and the lateness varied with buffer timing.

## Approach

deadsync's mixer already tracks an absolute stream-frame counter and `PLAYBACK_POS_MAP` maps stream frame <-> music seconds, so we now schedule each assist tick by an **absolute target stream frame** rather than playing it immediately. Placing the sample at that frame makes it audible exactly when the audible cursor reaches it, which compensates for output latency implicitly. This mirrors how ITGmania uses look-ahead plus a sample-accurate onset (`m_StartTime` / `iSilentFramesInThisBuffer`).