### PR TITLE
Add configurable music select keyboard shortcuts (P/S/L/T)

### DIFF
--- a/src/config/keybinds.rs
+++ b/src/config/keybinds.rs
@@ -306,6 +306,22 @@ pub(crate) fn parse_keycode(t: &str) -> Option<InputBinding> {
     .map(InputBinding::Key)
 }
 
+/// Serialize a single `KeyCode` to its `KeyCode::Name` INI token.
+#[inline(always)]
+pub(crate) fn keycode_to_token(code: KeyCode) -> String {
+    binding_to_token(InputBinding::Key(code))
+}
+
+/// Parse a `KeyCode::Name` INI token into a bare `KeyCode`, ignoring any
+/// non-keyboard binding tokens (pad/gamepad).
+#[inline(always)]
+pub(crate) fn parse_keycode_to_key(t: &str) -> Option<KeyCode> {
+    match parse_keycode(t)? {
+        InputBinding::Key(code) => Some(code),
+        _ => None,
+    }
+}
+
 #[inline(always)]
 pub(crate) fn parse_pad_code(t: &str) -> Option<InputBinding> {
     parse_gamepad_code_binding(t).map(InputBinding::GamepadCode)

--- a/src/config/load/theme.rs
+++ b/src/config/load/theme.rs
@@ -62,6 +62,22 @@ fn load_machine_flow(conf: &SimpleIni, default: Config, cfg: &mut Config) {
         .get("Theme", "AllowSwitchProfileInMenu")
         .and_then(|v| parse_loose_bool_str(&v))
         .unwrap_or(default.allow_switch_profile_in_menu);
+    cfg.music_select_shortcut_practice = conf
+        .get("Theme", "SelectMusicShortcutPractice")
+        .and_then(|v| parse_keycode_to_key(&v))
+        .unwrap_or(default.music_select_shortcut_practice);
+    cfg.music_select_shortcut_song_search = conf
+        .get("Theme", "SelectMusicShortcutSongSearch")
+        .and_then(|v| parse_keycode_to_key(&v))
+        .unwrap_or(default.music_select_shortcut_song_search);
+    cfg.music_select_shortcut_load_songs = conf
+        .get("Theme", "SelectMusicShortcutLoadSongs")
+        .and_then(|v| parse_keycode_to_key(&v))
+        .unwrap_or(default.music_select_shortcut_load_songs);
+    cfg.music_select_shortcut_test_input = conf
+        .get("Theme", "SelectMusicShortcutTestInput")
+        .and_then(|v| parse_keycode_to_key(&v))
+        .unwrap_or(default.music_select_shortcut_test_input);
     cfg.machine_show_select_color = conf
         .get("Theme", "MachineShowSelectColor")
         .and_then(|v| parse_loose_bool_str(&v))

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -19,7 +19,8 @@ pub use self::keybinds::{
     update_keymap_binding_unique_keyboard,
 };
 pub(crate) use self::keybinds::{
-    editable_key_binding_slot_indices, protected_default_key_for_action,
+    editable_key_binding_slot_indices, keycode_to_token, parse_keycode_to_key,
+    protected_default_key_for_action,
 };
 pub use self::load::{bootstrap_log_to_file, load};
 pub use self::null_or_die_cfg::null_or_die_bias_cfg;
@@ -59,6 +60,7 @@ use crate::engine::logging;
 use log::{info, warn};
 use null_or_die::{BiasCfg, BiasKernel, KernelTarget};
 use std::str::FromStr;
+use winit::keyboard::KeyCode;
 
 const DEFAULT_MACHINE_NOTESKIN: &str = "cel";
 
@@ -195,6 +197,14 @@ pub struct Config {
     pub machine_show_select_profile: bool,
     /// Whether "Switch Profile" appears in the select music sort menu.
     pub allow_switch_profile_in_menu: bool,
+    /// Select Music keyboard shortcut: open Practice Mode for the selected song.
+    pub music_select_shortcut_practice: KeyCode,
+    /// Select Music keyboard shortcut: open the Song Search prompt.
+    pub music_select_shortcut_song_search: KeyCode,
+    /// Select Music keyboard shortcut: reload songs & courses ("Load New Songs").
+    pub music_select_shortcut_load_songs: KeyCode,
+    /// Select Music keyboard shortcut: open the Test Input overlay.
+    pub music_select_shortcut_test_input: KeyCode,
     /// Startup flow: show Select Color before continuing.
     pub machine_show_select_color: bool,
     /// Startup flow: show Select Style before continuing.
@@ -395,6 +405,10 @@ impl Default for Config {
             random_background_mode: RandomBackgroundMode::Off,
             machine_show_select_profile: true,
             allow_switch_profile_in_menu: false,
+            music_select_shortcut_practice: KeyCode::KeyP,
+            music_select_shortcut_song_search: KeyCode::KeyS,
+            music_select_shortcut_load_songs: KeyCode::KeyL,
+            music_select_shortcut_test_input: KeyCode::KeyT,
             machine_show_select_color: true,
             machine_show_select_style: true,
             machine_show_select_play_mode: true,

--- a/src/config/store/defaults.rs
+++ b/src/config/store/defaults.rs
@@ -402,6 +402,26 @@ fn push_default_theme(content: &mut String, default: &Config) {
         "AllowSwitchProfileInMenu",
         default.allow_switch_profile_in_menu,
     );
+    push_line(
+        content,
+        "SelectMusicShortcutPractice",
+        keycode_to_token(default.music_select_shortcut_practice),
+    );
+    push_line(
+        content,
+        "SelectMusicShortcutSongSearch",
+        keycode_to_token(default.music_select_shortcut_song_search),
+    );
+    push_line(
+        content,
+        "SelectMusicShortcutLoadSongs",
+        keycode_to_token(default.music_select_shortcut_load_songs),
+    );
+    push_line(
+        content,
+        "SelectMusicShortcutTestInput",
+        keycode_to_token(default.music_select_shortcut_test_input),
+    );
     push_bool(
         content,
         "MachineShowSelectStyle",

--- a/src/config/store/save.rs
+++ b/src/config/store/save.rs
@@ -457,6 +457,26 @@ fn push_saved_theme(content: &mut String, cfg: &Config) {
         "AllowSwitchProfileInMenu",
         cfg.allow_switch_profile_in_menu,
     );
+    push_line(
+        content,
+        "SelectMusicShortcutPractice",
+        keycode_to_token(cfg.music_select_shortcut_practice),
+    );
+    push_line(
+        content,
+        "SelectMusicShortcutSongSearch",
+        keycode_to_token(cfg.music_select_shortcut_song_search),
+    );
+    push_line(
+        content,
+        "SelectMusicShortcutLoadSongs",
+        keycode_to_token(cfg.music_select_shortcut_load_songs),
+    );
+    push_line(
+        content,
+        "SelectMusicShortcutTestInput",
+        keycode_to_token(cfg.music_select_shortcut_test_input),
+    );
     push_bool(
         content,
         "MachineShowSelectStyle",

--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -8838,6 +8838,62 @@ pub fn handle_confirm(state: &mut State) -> ScreenAction {
     }
 }
 
+/// Maps a raw keyboard press to a Select Music menu action using the
+/// user-configurable shortcut keys. Only fires on the main music wheel
+/// (sort menu and song search hidden) and ignores key repeats. The Practice
+/// Mode shortcut additionally requires a song (not a pack header) to be
+/// selected, mirroring the sort-menu availability rule.
+fn configurable_shortcut_action(
+    state: &State,
+    key: Option<&RawKeyboardEvent>,
+) -> Option<select_music_menu::Action> {
+    let key = key?;
+    if key.repeat {
+        return None;
+    }
+    if !matches!(state.select_music_menu, select_music_menu::State::Hidden)
+        || !matches!(
+            state.song_search,
+            select_music_menu::SongSearchState::Hidden
+        )
+        || !matches!(
+            state.leaderboard,
+            select_music_menu::LeaderboardOverlayState::Hidden
+        )
+        || !matches!(
+            state.downloads_overlay,
+            select_music_menu::DownloadsOverlayState::Hidden
+        )
+        || !preview_mute_allowed(state)
+    {
+        return None;
+    }
+    let cfg = config::get();
+    let code = key.code;
+    if code == cfg.music_select_shortcut_practice {
+        // Practice Mode is only available with a song (not a pack header)
+        // selected. When unavailable, fall through so a duplicate key mapping
+        // can still match another shortcut.
+        let has_song_selected = matches!(
+            state.entries.get(state.selected_index),
+            Some(MusicWheelEntry::Song(_))
+        );
+        if has_song_selected {
+            return Some(select_music_menu::Action::PracticeMode);
+        }
+    }
+    if code == cfg.music_select_shortcut_song_search {
+        return Some(select_music_menu::Action::SongSearch);
+    }
+    if code == cfg.music_select_shortcut_load_songs {
+        return Some(select_music_menu::Action::ReloadSongsCourses);
+    }
+    if code == cfg.music_select_shortcut_test_input {
+        return Some(select_music_menu::Action::TestInput);
+    }
+    None
+}
+
 pub fn handle_raw_key_event(
     state: &mut State,
     key: Option<&RawKeyboardEvent>,
@@ -8959,6 +9015,15 @@ pub fn handle_raw_key_event(
     {
         toggle_preview_mute(state);
         return ScreenAction::ConsumeInput;
+    }
+    if let Some(action) = configurable_shortcut_action(state, key) {
+        // Consume the key even when the dispatched action itself reports
+        // ScreenAction::None, so the shortcut key isn't also translated into a
+        // virtual action (e.g. the default 'S' is also bound to P1 down).
+        return match dispatch_menu_action(state, action) {
+            ScreenAction::None => ScreenAction::ConsumeInput,
+            other => other,
+        };
     }
     if key.is_some_and(|key| key.code == KeyCode::F7) {
         let target_chart_type = profile::get_session_play_style().chart_type();
@@ -12459,6 +12524,93 @@ mod tests {
             handle_raw_key_event(&mut state, Some(&raw_key(KeyCode::KeyM, true, false)), None);
         assert!(matches!(action, ScreenAction::None));
         assert!(!state.preview_music_muted);
+    }
+
+    #[test]
+    fn music_select_shortcut_song_search_opens_prompt() {
+        let mut state = init_placeholder();
+        let action =
+            handle_raw_key_event(&mut state, Some(&raw_key(KeyCode::KeyS, true, false)), None);
+        assert!(matches!(action, ScreenAction::ConsumeInput));
+        assert!(!matches!(
+            state.song_search,
+            super::select_music_menu::SongSearchState::Hidden
+        ));
+    }
+
+    #[test]
+    fn music_select_shortcut_test_input_shows_overlay() {
+        let mut state = init_placeholder();
+        let action =
+            handle_raw_key_event(&mut state, Some(&raw_key(KeyCode::KeyT, true, false)), None);
+        assert!(matches!(action, ScreenAction::ConsumeInput));
+        assert!(state.test_input_overlay_visible);
+    }
+
+    #[test]
+    fn music_select_shortcut_practice_requires_selected_song() {
+        // No song selected: the Practice shortcut does nothing.
+        let mut state = init_placeholder();
+        state.entries = Vec::new();
+        state.selected_index = 0;
+        let action =
+            handle_raw_key_event(&mut state, Some(&raw_key(KeyCode::KeyP, true, false)), None);
+        assert!(!matches!(
+            action,
+            ScreenAction::Navigate(super::Screen::Practice)
+        ));
+
+        // With a song selected: the Practice shortcut navigates to Practice.
+        let mut state = init_placeholder();
+        state.entries = vec![super::MusicWheelEntry::Song(test_song("Shortcut Song"))];
+        state.selected_index = 0;
+        let action =
+            handle_raw_key_event(&mut state, Some(&raw_key(KeyCode::KeyP, true, false)), None);
+        assert!(matches!(
+            action,
+            ScreenAction::Navigate(super::Screen::Practice)
+        ));
+    }
+
+    #[test]
+    fn music_select_shortcut_ignored_with_menu_open_or_repeat() {
+        // Key repeats are ignored.
+        let mut state = init_placeholder();
+        let action =
+            handle_raw_key_event(&mut state, Some(&raw_key(KeyCode::KeyS, true, true)), None);
+        assert!(matches!(action, ScreenAction::None));
+        assert!(matches!(
+            state.song_search,
+            super::select_music_menu::SongSearchState::Hidden
+        ));
+
+        // The shortcut is suppressed while the options menu is open.
+        let mut state = init_placeholder();
+        state.select_music_menu =
+            super::select_music_menu::State::Visible(super::select_music_menu::open());
+        let action =
+            handle_raw_key_event(&mut state, Some(&raw_key(KeyCode::KeyS, true, false)), None);
+        assert!(matches!(
+            state.song_search,
+            super::select_music_menu::SongSearchState::Hidden
+        ));
+        assert!(!matches!(action, ScreenAction::ConsumeInput));
+
+        // The shortcut is suppressed while the exit prompt is showing.
+        let mut state = init_placeholder();
+        state.exit_prompt = super::ExitPromptState::Active {
+            elapsed: 0.0,
+            active_choice: 0,
+            switch_from: None,
+            switch_elapsed: 0.0,
+        };
+        let action =
+            handle_raw_key_event(&mut state, Some(&raw_key(KeyCode::KeyS, true, false)), None);
+        assert!(matches!(
+            state.song_search,
+            super::select_music_menu::SongSearchState::Hidden
+        ));
+        assert!(!matches!(action, ScreenAction::ConsumeInput));
     }
 
     #[test]


### PR DESCRIPTION
## Why

The music select screen exposes Practice Mode, Song Search, Load New Songs, and Test Input only through the options menu. This adds direct keyboard shortcuts so players can jump to those actions without opening the menu, and makes each key remappable for users who want a different layout.

## What

On the song wheel, four shortcuts now trigger the existing menu actions, each remappable via the config INI `[Theme]` section (defaults P/S/L/T):

| Key | Action | INI key |
|-----|--------|---------|
| `P` | Practice Mode (only when a song, not a pack header, is selected) | `SelectMusicShortcutPractice` |
| `S` | Song Search | `SelectMusicShortcutSongSearch` |
| `L` | Load New Songs (reload songs and courses) | `SelectMusicShortcutLoadSongs` |
| `T` | Test Input | `SelectMusicShortcutTestInput` |

The keys are stored as standard `KeyCode::Name` tokens and round-trip through config save/load and defaults, reusing the existing keybind serialization helpers. Invalid or missing INI values fall back to the defaults.