### PR TITLE
feat(gameplay): add configurable background color

### DIFF
--- a/src/config/color.rs
+++ b/src/config/color.rs
@@ -1,0 +1,72 @@
+//! A small ARGB color type used by config options that carry colors (such as
+//! the gameplay background color).
+
+/// An ARGB color. Each channel is a linear value in the range `0.0..=1.0`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Color {
+    pub a: f32,
+    pub r: f32,
+    pub g: f32,
+    pub b: f32,
+}
+
+impl Color {
+    /// Opaque black.
+    pub const BLACK: Self = Self {
+        a: 1.0,
+        r: 0.0,
+        g: 0.0,
+        b: 0.0,
+    };
+
+    /// Build an opaque color (alpha = 1.0) from RGB channels.
+    pub const fn rgb(r: f32, g: f32, b: f32) -> Self {
+        Self { a: 1.0, r, g, b }
+    }
+
+    /// Channels as an `[r, g, b, a]` array for the renderer's tint/diffuse.
+    pub fn to_rgba(self) -> [f32; 4] {
+        [self.r, self.g, self.b, self.a]
+    }
+
+    /// Parse a hex color string (case-insensitive, trimmed, optional leading
+    /// `#`). Accepts both 6-digit `RRGGBB` (opaque) and 8-digit `AARRGGBB`
+    /// forms. Returns `None` for malformed input so the caller can fall back to
+    /// a default.
+    pub fn from_hex(raw: &str) -> Option<Self> {
+        let hex = raw.trim().trim_start_matches('#');
+        if !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return None;
+        }
+        let byte = |idx: usize| u8::from_str_radix(&hex[idx..idx + 2], 16).ok();
+        let chan = |idx: usize| Some(byte(idx)? as f32 / 255.0);
+        match hex.len() {
+            6 => Some(Self {
+                a: 1.0,
+                r: chan(0)?,
+                g: chan(2)?,
+                b: chan(4)?,
+            }),
+            8 => Some(Self {
+                a: chan(0)?,
+                r: chan(2)?,
+                g: chan(4)?,
+                b: chan(6)?,
+            }),
+            _ => None,
+        }
+    }
+
+    /// Format as an uppercase hex string: `#RRGGBB` when fully opaque, otherwise
+    /// `#AARRGGBB`. Round-trips with [`Color::from_hex`].
+    pub fn to_hex(self) -> String {
+        let channel = |v: f32| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
+        let (r, g, b) = (channel(self.r), channel(self.g), channel(self.b));
+        let a = channel(self.a);
+        if a == 255 {
+            format!("#{r:02X}{g:02X}{b:02X}")
+        } else {
+            format!("#{a:02X}{r:02X}{g:02X}{b:02X}")
+        }
+    }
+}

--- a/src/config/load/options.rs
+++ b/src/config/load/options.rs
@@ -113,7 +113,7 @@ fn load_system_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
         .map_or(default.bg_brightness, |v| v.clamp(0.0, 1.0));
     cfg.gameplay_bg_color = conf
         .get("Options", "GameplayBgColor")
-        .and_then(|v| parse_hex_rgb(&v))
+        .and_then(|v| Color::from_hex(&v))
         .unwrap_or(default.gameplay_bg_color);
     cfg.center_1player_notefield = conf
         .get("Options", "Center1Player")
@@ -208,22 +208,6 @@ fn load_system_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
         .get("Options", "LogToFile")
         .and_then(|v| parse_bool_str(&v))
         .unwrap_or(default.log_to_file);
-}
-
-/// Parse a `#RRGGBB` / `RRGGBB` hex color (case-insensitive) into linear 0..1
-/// RGB. Returns `None` for malformed input so the caller can fall back to the
-/// default.
-fn parse_hex_rgb(raw: &str) -> Option<[f32; 3]> {
-    let hex = raw.trim().trim_start_matches('#');
-    if hex.len() != 6 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
-        return None;
-    }
-    let byte = |idx: usize| u8::from_str_radix(&hex[idx..idx + 2], 16).ok();
-    Some([
-        byte(0)? as f32 / 255.0,
-        byte(2)? as f32 / 255.0,
-        byte(4)? as f32 / 255.0,
-    ])
 }
 
 fn load_null_or_die_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
@@ -610,29 +594,50 @@ fn load_runtime_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_hex_rgb;
+    use super::Color;
 
     #[test]
-    fn parse_hex_rgb_accepts_hash_and_bare_forms() {
-        assert_eq!(parse_hex_rgb("#000000"), Some([0.0, 0.0, 0.0]));
-        assert_eq!(parse_hex_rgb("FFFFFF"), Some([1.0, 1.0, 1.0]));
-        let gray = parse_hex_rgb("#0C0C0C").unwrap();
+    fn from_hex_accepts_hash_and_bare_forms() {
+        assert_eq!(Color::from_hex("#000000"), Some(Color::BLACK));
+        assert_eq!(Color::from_hex("FFFFFF"), Some(Color::rgb(1.0, 1.0, 1.0)));
+        let gray = Color::from_hex("#0C0C0C").unwrap();
         let expected = 12.0 / 255.0;
-        for ch in gray {
+        for ch in [gray.r, gray.g, gray.b] {
             assert!((ch - expected).abs() < f32::EPSILON);
         }
+        assert_eq!(gray.a, 1.0);
     }
 
     #[test]
-    fn parse_hex_rgb_is_case_insensitive_and_trims() {
-        assert_eq!(parse_hex_rgb("  #0c0c0c  "), parse_hex_rgb("#0C0C0C"));
+    fn from_hex_parses_argb() {
+        let c = Color::from_hex("#8001FE7F").unwrap();
+        assert!((c.a - 128.0 / 255.0).abs() < f32::EPSILON);
+        assert!((c.r - 1.0 / 255.0).abs() < f32::EPSILON);
+        assert!((c.g - 254.0 / 255.0).abs() < f32::EPSILON);
+        assert!((c.b - 127.0 / 255.0).abs() < f32::EPSILON);
     }
 
     #[test]
-    fn parse_hex_rgb_rejects_malformed() {
-        assert_eq!(parse_hex_rgb(""), None);
-        assert_eq!(parse_hex_rgb("#FFF"), None);
-        assert_eq!(parse_hex_rgb("#GGGGGG"), None);
-        assert_eq!(parse_hex_rgb("#1234567"), None);
+    fn from_hex_is_case_insensitive_and_trims() {
+        assert_eq!(Color::from_hex("  #0c0c0c  "), Color::from_hex("#0C0C0C"));
+        assert_eq!(
+            Color::from_hex("  80ffffff  "),
+            Color::from_hex("#80FFFFFF")
+        );
+    }
+
+    #[test]
+    fn from_hex_rejects_malformed() {
+        assert_eq!(Color::from_hex(""), None);
+        assert_eq!(Color::from_hex("#FFF"), None);
+        assert_eq!(Color::from_hex("#GGGGGG"), None);
+        assert_eq!(Color::from_hex("#1234567"), None);
+        assert_eq!(Color::from_hex("#123456789"), None);
+    }
+
+    #[test]
+    fn to_hex_round_trips() {
+        assert_eq!(Color::from_hex("#0C0C0C").unwrap().to_hex(), "#0C0C0C");
+        assert_eq!(Color::from_hex("#8001FE7F").unwrap().to_hex(), "#8001FE7F");
     }
 }

--- a/src/config/load/options.rs
+++ b/src/config/load/options.rs
@@ -111,6 +111,10 @@ fn load_system_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
         .get("Options", "BGBrightness")
         .and_then(|v| v.parse::<f32>().ok())
         .map_or(default.bg_brightness, |v| v.clamp(0.0, 1.0));
+    cfg.gameplay_bg_color = conf
+        .get("Options", "GameplayBgColor")
+        .and_then(|v| parse_hex_rgb(&v))
+        .unwrap_or(default.gameplay_bg_color);
     cfg.center_1player_notefield = conf
         .get("Options", "Center1Player")
         .or_else(|| conf.get("Options", "CenteredP1Notefield"))
@@ -204,6 +208,22 @@ fn load_system_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
         .get("Options", "LogToFile")
         .and_then(|v| parse_bool_str(&v))
         .unwrap_or(default.log_to_file);
+}
+
+/// Parse a `#RRGGBB` / `RRGGBB` hex color (case-insensitive) into linear 0..1
+/// RGB. Returns `None` for malformed input so the caller can fall back to the
+/// default.
+fn parse_hex_rgb(raw: &str) -> Option<[f32; 3]> {
+    let hex = raw.trim().trim_start_matches('#');
+    if hex.len() != 6 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let byte = |idx: usize| u8::from_str_radix(&hex[idx..idx + 2], 16).ok();
+    Some([
+        byte(0)? as f32 / 255.0,
+        byte(2)? as f32 / 255.0,
+        byte(4)? as f32 / 255.0,
+    ])
 }
 
 fn load_null_or_die_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
@@ -586,4 +606,33 @@ fn load_runtime_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
             }
         })
         .unwrap_or(default.software_renderer_threads);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_hex_rgb;
+
+    #[test]
+    fn parse_hex_rgb_accepts_hash_and_bare_forms() {
+        assert_eq!(parse_hex_rgb("#000000"), Some([0.0, 0.0, 0.0]));
+        assert_eq!(parse_hex_rgb("FFFFFF"), Some([1.0, 1.0, 1.0]));
+        let gray = parse_hex_rgb("#0C0C0C").unwrap();
+        let expected = 12.0 / 255.0;
+        for ch in gray {
+            assert!((ch - expected).abs() < f32::EPSILON);
+        }
+    }
+
+    #[test]
+    fn parse_hex_rgb_is_case_insensitive_and_trims() {
+        assert_eq!(parse_hex_rgb("  #0c0c0c  "), parse_hex_rgb("#0C0C0C"));
+    }
+
+    #[test]
+    fn parse_hex_rgb_rejects_malformed() {
+        assert_eq!(parse_hex_rgb(""), None);
+        assert_eq!(parse_hex_rgb("#FFF"), None);
+        assert_eq!(parse_hex_rgb("#GGGGGG"), None);
+        assert_eq!(parse_hex_rgb("#1234567"), None);
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,5 @@
 mod audio;
+mod color;
 pub mod dirs;
 mod ini;
 mod keybinds;
@@ -13,6 +14,7 @@ mod theme;
 mod update;
 
 pub use self::audio::{AudioMixLevels, AudioOutputMode, LinuxAudioBackend};
+pub use self::color::Color;
 pub use self::ini::SimpleIni;
 pub use self::keybinds::{
     clear_keymap_binding, update_keymap_binding_unique_gamepad,
@@ -121,11 +123,11 @@ pub struct Config {
     // Global background brightness during gameplay (ITGmania: Pref "BGBrightness").
     // 1.0 = full brightness, 0.0 = black.
     pub bg_brightness: f32,
-    // Gameplay background color used when a song has no background image (the
-    // fallback that would otherwise be solid black). RGB in 0..1, parsed from a
+    // Gameplay background color drawn behind the playfield. The song background
+    // image (if any) is alpha-blended over it by `bg_brightness`. Parsed from a
     // `#RRGGBB` hex string in `deadsync.ini` (key `GameplayBgColor`). Default is
     // black so behavior is unchanged unless explicitly overridden.
-    pub gameplay_bg_color: [f32; 3],
+    pub gameplay_bg_color: Color,
     // ITGmania/Simply Love parity: center the active single-player notefield in gameplay.
     pub center_1player_notefield: bool,
     /// ITGmania-style wheel banner cache toggle.
@@ -358,7 +360,7 @@ impl Default for Config {
             translated_titles: false,
             mine_hit_sound: true,
             bg_brightness: 0.7,
-            gameplay_bg_color: [0.0, 0.0, 0.0],
+            gameplay_bg_color: Color::BLACK,
             center_1player_notefield: false,
             banner_cache: true,
             cdtitle_cache: true,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -121,6 +121,11 @@ pub struct Config {
     // Global background brightness during gameplay (ITGmania: Pref "BGBrightness").
     // 1.0 = full brightness, 0.0 = black.
     pub bg_brightness: f32,
+    // Gameplay background color used when a song has no background image (the
+    // fallback that would otherwise be solid black). RGB in 0..1, parsed from a
+    // `#RRGGBB` hex string in `deadsync.ini` (key `GameplayBgColor`). Default is
+    // black so behavior is unchanged unless explicitly overridden.
+    pub gameplay_bg_color: [f32; 3],
     // ITGmania/Simply Love parity: center the active single-player notefield in gameplay.
     pub center_1player_notefield: bool,
     /// ITGmania-style wheel banner cache toggle.
@@ -353,6 +358,7 @@ impl Default for Config {
             translated_titles: false,
             mine_hit_sound: true,
             bg_brightness: 0.7,
+            gameplay_bg_color: [0.0, 0.0, 0.0],
             center_1player_notefield: false,
             banner_cache: true,
             cdtitle_cache: true,

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -81,3 +81,14 @@ fn push_line(content: &mut String, key: &str, value: impl std::fmt::Display) {
 fn push_bool(content: &mut String, key: &str, enabled: bool) {
     push_line(content, key, if enabled { 1 } else { 0 });
 }
+
+/// Format linear 0..1 RGB as an uppercase `#RRGGBB` hex string for the ini.
+fn rgb_to_hex(color: [f32; 3]) -> String {
+    let channel = |v: f32| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
+    format!(
+        "#{:02X}{:02X}{:02X}",
+        channel(color[0]),
+        channel(color[1]),
+        channel(color[2])
+    )
+}

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -81,14 +81,3 @@ fn push_line(content: &mut String, key: &str, value: impl std::fmt::Display) {
 fn push_bool(content: &mut String, key: &str, enabled: bool) {
     push_line(content, key, if enabled { 1 } else { 0 });
 }
-
-/// Format linear 0..1 RGB as an uppercase `#RRGGBB` hex string for the ini.
-fn rgb_to_hex(color: [f32; 3]) -> String {
-    let channel = |v: f32| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
-    format!(
-        "#{:02X}{:02X}{:02X}",
-        channel(color[0]),
-        channel(color[1]),
-        channel(color[2])
-    )
-}

--- a/src/config/store/defaults.rs
+++ b/src/config/store/defaults.rs
@@ -34,7 +34,7 @@ fn push_default_options(content: &mut String, default: &Config) {
     push_line(
         content,
         "GameplayBgColor",
-        rgb_to_hex(default.gameplay_bg_color),
+        default.gameplay_bg_color.to_hex(),
     );
     push_bool(content, "BannerCache", default.banner_cache);
     push_bool(content, "CacheSongs", default.cachesongs);

--- a/src/config/store/defaults.rs
+++ b/src/config/store/defaults.rs
@@ -31,6 +31,11 @@ fn push_default_options(content: &mut String, default: &Config) {
         default.updater_install_enabled,
     );
     push_line(content, "BGBrightness", default.bg_brightness);
+    push_line(
+        content,
+        "GameplayBgColor",
+        rgb_to_hex(default.gameplay_bg_color),
+    );
     push_bool(content, "BannerCache", default.banner_cache);
     push_bool(content, "CacheSongs", default.cachesongs);
     push_bool(content, "CDTitleCache", default.cdtitle_cache);

--- a/src/config/store/save.rs
+++ b/src/config/store/save.rs
@@ -49,6 +49,11 @@ fn push_saved_options(
         cfg.updater_install_enabled,
     );
     push_line(content, "BGBrightness", cfg.bg_brightness.clamp(0.0, 1.0));
+    push_line(
+        content,
+        "GameplayBgColor",
+        rgb_to_hex(cfg.gameplay_bg_color),
+    );
     push_bool(content, "BannerCache", cfg.banner_cache);
     push_bool(content, "CacheSongs", cfg.cachesongs);
     push_bool(content, "CDTitleCache", cfg.cdtitle_cache);

--- a/src/config/store/save.rs
+++ b/src/config/store/save.rs
@@ -49,11 +49,7 @@ fn push_saved_options(
         cfg.updater_install_enabled,
     );
     push_line(content, "BGBrightness", cfg.bg_brightness.clamp(0.0, 1.0));
-    push_line(
-        content,
-        "GameplayBgColor",
-        rgb_to_hex(cfg.gameplay_bg_color),
-    );
+    push_line(content, "GameplayBgColor", cfg.gameplay_bg_color.to_hex());
     push_bool(content, "BannerCache", cfg.banner_cache);
     push_bool(content, "CacheSongs", cfg.cachesongs);
     push_bool(content, "CDTitleCache", cfg.cdtitle_cache);

--- a/src/screens/gameplay.rs
+++ b/src/screens/gameplay.rs
@@ -1121,23 +1121,46 @@ pub fn out_transition() -> (Vec<Actor>, f32) {
 
 // --- DRAWING ---
 
-fn build_background(state: &State, bg_brightness: f32) -> Actor {
+fn push_background(
+    actors: &mut Vec<Actor>,
+    state: &State,
+    bg_brightness: f32,
+    base_color: [f32; 3],
+) {
     let sw = screen_width();
     let sh = screen_height();
+    let cx = screen_center_x();
+    let cy = screen_center_y();
     let bg_brightness = bg_brightness.clamp(0.0, 1.0);
-    let mut actor = shared_banner::cover_sprite(
-        state.background_texture_key.clone(),
-        screen_center_x(),
-        screen_center_y(),
-        sw,
-        sh,
-        1.0,
-        -100,
-    );
-    if let Actor::Sprite { tint, .. } = &mut actor {
-        *tint = [bg_brightness, bg_brightness, bg_brightness, 1.0];
+
+    // Solid base fill behind everything. This is what shows when the song has no
+    // background image, and what the song background is dimmed toward as
+    // BGBrightness drops. Defaults to black, preserving the original look.
+    let mut base =
+        shared_banner::cover_sprite(Arc::<str>::from("__white"), cx, cy, sw, sh, 1.0, -101);
+    if let Actor::Sprite { tint, .. } = &mut base {
+        *tint = [base_color[0], base_color[1], base_color[2], 1.0];
     }
-    actor
+    actors.push(base);
+
+    // Song background image (when one exists), alpha-blended over the base so
+    // BGBrightness fades it toward the base color. With a black base this matches
+    // the previous RGB-dimming behavior exactly.
+    if &*state.background_texture_key != "__black" {
+        let mut img = shared_banner::cover_sprite(
+            state.background_texture_key.clone(),
+            cx,
+            cy,
+            sw,
+            sh,
+            1.0,
+            -100,
+        );
+        if let Actor::Sprite { tint, .. } = &mut img {
+            *tint = [1.0, 1.0, 1.0, bg_brightness];
+        }
+        actors.push(img);
+    }
 }
 
 fn song_lua_has_visible_tex(
@@ -7081,7 +7104,7 @@ pub fn push_actors(
     let mut overlay_proxy_source = proxy_requests.overlay.then_some(Vec::new());
     // --- Background and Filter ---
     let underlay_start = actors.len();
-    actors.push(build_background(state, cfg.bg_brightness));
+    push_background(&mut actors, state, cfg.bg_brightness, cfg.gameplay_bg_color);
     for (layer_idx, layer) in state.song_lua_background_visual_layers.iter().enumerate() {
         if state.current_music_time_display < layer.start_second {
             continue;

--- a/src/screens/gameplay.rs
+++ b/src/screens/gameplay.rs
@@ -1125,7 +1125,7 @@ fn push_background(
     actors: &mut Vec<Actor>,
     state: &State,
     bg_brightness: f32,
-    base_color: [f32; 3],
+    base_color: crate::config::Color,
 ) {
     let sw = screen_width();
     let sh = screen_height();
@@ -1139,7 +1139,7 @@ fn push_background(
     let mut base =
         shared_banner::cover_sprite(Arc::<str>::from("__white"), cx, cy, sw, sh, 1.0, -101);
     if let Actor::Sprite { tint, .. } = &mut base {
-        *tint = [base_color[0], base_color[1], base_color[2], 1.0];
+        *tint = base_color.to_rgba();
     }
     actors.push(base);
 


### PR DESCRIPTION
## Why

The gameplay background is hard-coded to solid black, which some players find harsh to stare at during long sessions. This adds an option to use any solid color instead (for example `#0C0C0C` dark gray), configured entirely from `deadsync.ini` with no Options UI.

## What

- Adds a `GameplayBgColor` key to the `[Options]` section of `deadsync.ini`. It accepts an `#RRGGBB` (or bare `RRGGBB`) hex value, is case-insensitive and trimmed, and defaults to black so existing setups are unaffected.
- Plumbs the value through config load/save/defaults, with a `parse_hex_rgb` helper (plus unit tests) and an `rgb_to_hex` serializer mirroring the existing `BGBrightness` handling.
- Reworks the gameplay background render: a solid base fill in `GameplayBgColor` is drawn behind the playfield, and the song background image is alpha-blended over it by `BGBrightness`.

## Behavior

Over the default black base, alpha-blending the song image by `BGBrightness` is mathematically identical to the previous RGB-dimming behavior, so nothing changes for existing configs. With a colored base:

- `BGBrightness=0` -> the gameplay background is the pure configured color, even on songs that have a background image.
- `BGBrightness=1` -> the song image is shown fully (unchanged).
- in between -> the song image blends toward the configured color.