### PR TITLE
Make Tab acceleration keys configurable via keymaps (#206)

### DIFF
--- a/crates/deadsync-input/src/lib.rs
+++ b/crates/deadsync-input/src/lib.rs
@@ -235,10 +235,13 @@ pub enum VirtualAction {
     p2_select,
     p2_operator,
     p2_restart,
+    // System (non-player-scoped) tier.
+    system_fast_forward,
+    system_slow_down,
 }
 
 impl VirtualAction {
-    pub const COUNT: usize = Self::p2_restart as usize + 1;
+    pub const COUNT: usize = Self::system_slow_down as usize + 1;
 
     #[inline(always)]
     pub const fn from_ix(ix: usize) -> Option<Self> {
@@ -269,6 +272,8 @@ impl VirtualAction {
             23 => Some(Self::p2_select),
             24 => Some(Self::p2_operator),
             25 => Some(Self::p2_restart),
+            26 => Some(Self::system_fast_forward),
+            27 => Some(Self::system_slow_down),
             _ => None,
         }
     }
@@ -281,6 +286,15 @@ impl VirtualAction {
     #[inline(always)]
     pub const fn bit(self) -> u32 {
         1u32 << (self.ix() as u32)
+    }
+
+    /// True for the non-player-scoped `System` tier actions. These are excluded
+    /// from the normalized input-event pipeline and the per-player Mappings
+    /// screen; they are consumed directly via keymap lookups (e.g. Tab
+    /// acceleration).
+    #[inline(always)]
+    pub const fn is_system(self) -> bool {
+        matches!(self, Self::system_fast_forward | Self::system_slow_down)
     }
 
     #[inline(always)]
@@ -356,7 +370,15 @@ pub const ALL_VIRTUAL_ACTIONS: [VirtualAction; VirtualAction::COUNT] = [
     VirtualAction::p2_select,
     VirtualAction::p2_start,
     VirtualAction::p2_up,
+    VirtualAction::system_fast_forward,
+    VirtualAction::system_slow_down,
 ];
+
+/// Bitmask of all `System`-tier actions. Used to strip system actions from the
+/// compiled keymap masks so they never enter the normalized input-event
+/// pipeline (they are read directly via keymap lookups instead).
+pub const SYSTEM_ACTION_MASK: u32 =
+    VirtualAction::system_fast_forward.bit() | VirtualAction::system_slow_down.bit();
 
 #[inline(always)]
 pub fn action_from_ini_key_lower(key: &str) -> Option<VirtualAction> {
@@ -393,6 +415,8 @@ pub fn action_from_ini_key_lower(key: &str) -> Option<VirtualAction> {
         "p2_select" => Some(p2_select),
         "p2_operator" => Some(p2_operator),
         "p2_restart" => Some(p2_restart),
+        "system_fastforward" => Some(VirtualAction::system_fast_forward),
+        "system_slowdown" => Some(VirtualAction::system_slow_down),
         _ => None,
     }
 }
@@ -432,6 +456,8 @@ pub const fn action_to_ini_key(action: VirtualAction) -> &'static str {
         p2_select => "P2_Select",
         p2_operator => "P2_Operator",
         p2_restart => "P2_Restart",
+        VirtualAction::system_fast_forward => "System_FastForward",
+        VirtualAction::system_slow_down => "System_SlowDown",
     }
 }
 
@@ -753,7 +779,17 @@ mod tests {
         assert!(!VirtualAction::p1_start.is_gameplay_arrow());
         assert_eq!(VirtualAction::from_ix(0), Some(VirtualAction::p1_up));
         assert_eq!(VirtualAction::from_ix(VirtualAction::COUNT), None);
-        assert_eq!(VirtualAction::p2_restart.ix(), VirtualAction::COUNT - 1);
+        assert_eq!(
+            VirtualAction::system_slow_down.ix(),
+            VirtualAction::COUNT - 1
+        );
+        assert!(VirtualAction::system_fast_forward.is_system());
+        assert!(VirtualAction::system_slow_down.is_system());
+        assert!(!VirtualAction::p2_restart.is_system());
+        assert_eq!(
+            VirtualAction::from_ix(VirtualAction::system_fast_forward.ix()),
+            Some(VirtualAction::system_fast_forward)
+        );
         assert_eq!(
             VirtualAction::p1_left.bit(),
             1 << VirtualAction::p1_left.ix()

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1482,8 +1482,8 @@ pub struct ShellState {
     shift_held: bool,
     ctrl_held: bool,
     alt_held: bool,
-    tab_held: bool,
-    backquote_held: bool,
+    fast_forward_held: bool,
+    slow_down_held: bool,
     tab_acceleration_enabled: bool,
     window_focused: bool,
     window_occluded: bool,
@@ -1661,8 +1661,8 @@ impl ShellState {
             shift_held: false,
             ctrl_held: false,
             alt_held: false,
-            tab_held: false,
-            backquote_held: false,
+            fast_forward_held: false,
+            slow_down_held: false,
             tab_acceleration_enabled: cfg.tab_acceleration,
             // Default to unfocused so background input backends (Win32 RawInput,
             // evdev, IOHID) drop globally-observed key events until the window
@@ -3867,8 +3867,8 @@ impl App {
             self.state.shell.shift_held = false;
             self.state.shell.ctrl_held = false;
             self.state.shell.alt_held = false;
-            self.state.shell.tab_held = false;
-            self.state.shell.backquote_held = false;
+            self.state.shell.fast_forward_held = false;
+            self.state.shell.slow_down_held = false;
             input::clear_debounce_state();
             self.lights.clear_button_pressed();
             self.clear_gameplay_input_events();
@@ -4143,8 +4143,8 @@ impl App {
         let logic_dt = apply_tab_acceleration(
             delta_time,
             self.state.screens.current_screen,
-            self.state.shell.tab_held,
-            self.state.shell.backquote_held,
+            self.state.shell.fast_forward_held,
+            self.state.shell.slow_down_held,
             self.state.shell.tab_acceleration_enabled,
         );
         crate::screens::components::shared::visual_style_bg::tick_global(logic_dt);
@@ -7247,13 +7247,22 @@ impl App {
             KeyCode::AltLeft | KeyCode::AltRight => {
                 self.state.shell.alt_held = raw_key.pressed;
             }
-            KeyCode::Tab => {
-                self.state.shell.tab_held = raw_key.pressed;
-            }
-            KeyCode::Backquote => {
-                self.state.shell.backquote_held = raw_key.pressed;
-            }
             _ => {}
+        }
+
+        if input::with_keymap(|km| {
+            km.raw_key_event_has_action(&raw_key, |action| {
+                action == VirtualAction::system_fast_forward
+            })
+        }) {
+            self.state.shell.fast_forward_held = raw_key.pressed;
+        }
+        if input::with_keymap(|km| {
+            km.raw_key_event_has_action(&raw_key, |action| {
+                action == VirtualAction::system_slow_down
+            })
+        }) {
+            self.state.shell.slow_down_held = raw_key.pressed;
         }
 
         if raw_key.pressed && raw_key.code == KeyCode::F4 && self.state.shell.alt_held {

--- a/src/config/keybinds.rs
+++ b/src/config/keybinds.rs
@@ -51,6 +51,11 @@ fn default_keymap_local() -> Keymap {
     km.bind(A::p2_start, &[InputBinding::Key(KeyCode::NumpadEnter)]);
     km.bind(A::p2_back, &[InputBinding::Key(KeyCode::Numpad0)]);
     km.bind(A::p1_operator, &[InputBinding::Key(KeyCode::ScrollLock)]);
+    km.bind(A::system_fast_forward, &[InputBinding::Key(KeyCode::Tab)]);
+    km.bind(
+        A::system_slow_down,
+        &[InputBinding::Key(KeyCode::Backquote)],
+    );
     // Leave dedicated menu buttons, P2 operator, and restart unbound by default for now.
     km
 }
@@ -74,6 +79,9 @@ const fn default_key_for_action(action: VirtualAction) -> Option<KeyCode> {
         A::p2_select => Some(KeyCode::NumpadDecimal),
         A::p2_start => Some(KeyCode::NumpadEnter),
         A::p2_back => Some(KeyCode::Numpad0),
+        // System (non-player) tier: Tab acceleration fast-forward / slow-down.
+        A::system_fast_forward => Some(KeyCode::Tab),
+        A::system_slow_down => Some(KeyCode::Backquote),
         _ => None,
     }
 }
@@ -817,6 +825,38 @@ mod tests {
         assert_eq!(
             protected_default_key_for_action(&remapped, VirtualAction::p1_menu_up),
             None
+        );
+    }
+
+    #[test]
+    fn default_keymap_binds_system_acceleration_keys() {
+        let defaults = default_keymap_local();
+
+        assert_eq!(
+            defaults.binding_at(VirtualAction::system_fast_forward, 0),
+            Some(InputBinding::Key(KeyCode::Tab))
+        );
+        assert_eq!(
+            defaults.binding_at(VirtualAction::system_slow_down, 0),
+            Some(InputBinding::Key(KeyCode::Backquote))
+        );
+    }
+
+    #[test]
+    fn system_acceleration_keys_round_trip_through_ini() {
+        let mut conf = SimpleIni::new();
+        conf.load_str(
+            "[Keymaps]\nSystem_FastForward=KeyCode::Backquote\nSystem_SlowDown=KeyCode::Tab\n",
+        );
+        let keymap = load_keymap_from_ini_local(&conf);
+
+        assert_eq!(
+            keymap.binding_at(VirtualAction::system_fast_forward, 0),
+            Some(InputBinding::Key(KeyCode::Backquote))
+        );
+        assert_eq!(
+            keymap.binding_at(VirtualAction::system_slow_down, 0),
+            Some(InputBinding::Key(KeyCode::Tab))
         );
     }
 }

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -6,7 +6,7 @@ mod defaults;
 #[path = "store/save.rs"]
 mod save;
 
-const DEFAULT_KEYMAP_LINES: [(&str, &str); 26] = [
+const DEFAULT_KEYMAP_LINES: [(&str, &str); 28] = [
     ("P1_Back", "KeyCode::Escape"),
     ("P1_Down", "KeyCode::ArrowDown,KeyCode::KeyS"),
     ("P1_Left", "KeyCode::ArrowLeft,KeyCode::KeyA"),
@@ -33,6 +33,8 @@ const DEFAULT_KEYMAP_LINES: [(&str, &str); 26] = [
     ("P2_Select", "KeyCode::NumpadDecimal"),
     ("P2_Start", "KeyCode::NumpadEnter"),
     ("P2_Up", "KeyCode::Numpad8"),
+    ("System_FastForward", "KeyCode::Tab"),
+    ("System_SlowDown", "KeyCode::Backquote"),
 ];
 
 pub(super) fn normalize_machine_default_noteskin(raw: &str) -> String {

--- a/src/engine/input/mod.rs
+++ b/src/engine/input/mod.rs
@@ -429,6 +429,10 @@ impl CompiledKeymap {
             for &action in actions {
                 mask |= action.bit();
             }
+            mask &= !deadsync_input::SYSTEM_ACTION_MASK;
+            if mask == 0 {
+                continue;
+            }
             key_rev[ix] = CompiledBindingRev {
                 mask,
                 slot: next_key_slot,
@@ -440,6 +444,10 @@ impl CompiledKeymap {
             let mut mask = 0;
             for &action in actions {
                 mask |= action.bit();
+            }
+            mask &= !deadsync_input::SYSTEM_ACTION_MASK;
+            if mask == 0 {
+                continue;
             }
             key_rev_extra.insert(
                 code,
@@ -456,7 +464,7 @@ impl CompiledKeymap {
             for &action in actions {
                 mask |= action.bit();
             }
-            pad_dir_rev[ix] = mask;
+            pad_dir_rev[ix] = mask & !deadsync_input::SYSTEM_ACTION_MASK;
         }
         let mut pad_dir_on_rev = HashMap::with_capacity(km.pad_dir_on_rev.len());
         let mut max_pad_device: Option<usize> = None;
@@ -464,6 +472,10 @@ impl CompiledKeymap {
             let mut mask = 0;
             for &action in actions {
                 mask |= action.bit();
+            }
+            mask &= !deadsync_input::SYSTEM_ACTION_MASK;
+            if mask == 0 {
+                continue;
             }
             max_pad_device = Some(max_pad_device.map_or(key.0, |max| max.max(key.0)));
             pad_dir_on_rev.insert(key, mask);
@@ -473,6 +485,9 @@ impl CompiledKeymap {
         for (&code, entries) in &km.pad_code_rev {
             let mut compiled_entries = Vec::with_capacity(entries.len());
             for entry in entries {
+                if entry.act.is_system() {
+                    continue;
+                }
                 if let Some(existing) =
                     compiled_entries
                         .iter_mut()

--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -4151,6 +4151,7 @@ const fn input_side(action: VirtualAction) -> Option<profile_data::PlayerSide> {
         | VirtualAction::p2_select
         | VirtualAction::p2_operator
         | VirtualAction::p2_restart => Some(profile_data::PlayerSide::P2),
+        VirtualAction::system_fast_forward | VirtualAction::system_slow_down => None,
     }
 }
 


### PR DESCRIPTION
## Why

The fast-forward (`Tab`) and slow-down (`` ` ``/Backquote) keys used by the Tab-acceleration feature were hard-coded in `App::handle_raw_key_event`, so players could not rebind them. This makes them configurable through `deadsync.ini`'s `[Keymaps]` section like every other binding.

Closes #206

## Approach

The acceleration keys are not player-scoped, so a new non-player `System` tier was added to `VirtualAction` rather than overloading the existing P1/P2 actions:

- **New actions** `system_fast_forward` / `system_slow_down` in `crates/deadsync-input`, wired through `from_ix`, `COUNT`, `ALL_VIRTUAL_ACTIONS`, and the ini key-name maps so they round-trip through the existing load/save/defaults paths automatically.
- **Kept inert in the event pipeline.** System actions are stripped (`SYSTEM_ACTION_MASK`) from the *compiled* keymap so they never emit normalized input events to menus/gameplay. The raw keymap retains them, and `handle_raw_key_event` reads their held-state directly each frame. This cleanly separates "held lookup" from "event emission."
- **Defaults** bind `System_FastForward=Tab` and `System_SlowDown=Backquote`, matching prior behavior out of the box.
- The hard-coded `KeyCode::Tab`/`Backquote` arms were replaced with keymap lookups, and the shell fields renamed `tab_held`/`backquote_held` -> `fast_forward_held`/`slow_down_held`.

## UX note

Per discussion on the issue, these are **ini-only** for now: configurable via `[Keymaps]` but intentionally not surfaced in the per-player Mappings screen.

## Out of scope

`src/screens/practice.rs` keeps its own separate hard-coded `Tab` for chart-editor scroll acceleration; the issue targets `handle_raw_key_event` only.
