### PR TITLE
feat(gameplay): add per-player hide-username option

### DIFF
--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -744,6 +744,7 @@ HideLife=Life
 HideScore=Score
 HideDanger=Danger
 HideComboExplosions=Combo Explosions
+HideUsername=Username
 LifeMeterTypeStandard=Standard
 LifeMeterTypeSurround=Surround
 LifeMeterTypeVertical=Vertical

--- a/crates/deadsync-profile/src/lib.rs
+++ b/crates/deadsync-profile/src/lib.rs
@@ -2508,6 +2508,7 @@ pub struct GameplayHudPlayerSnapshot {
     pub guest: bool,
     pub display_name: String,
     pub avatar_texture_key: Option<String>,
+    pub hide_username: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -2814,6 +2815,7 @@ pub struct PlayerOptionsData {
     pub hide_score: bool,
     pub hide_danger: bool,
     pub hide_combo_explosions: bool,
+    pub hide_username: bool,
     pub column_flash_on_miss: bool,
     pub column_flash_mask: ColumnFlashMask,
     pub subtractive_scoring: bool,
@@ -2931,6 +2933,7 @@ fn default_player_options() -> PlayerOptionsData {
         hide_score: false,
         hide_danger: false,
         hide_combo_explosions: false,
+        hide_username: false,
         column_flash_on_miss: false,
         column_flash_mask: DEFAULT_COLUMN_FLASH_MASK,
         subtractive_scoring: false,
@@ -3323,6 +3326,10 @@ pub fn append_player_options_section(
     content.push_str(&format!(
         "HideComboExplosions={}\n",
         i32::from(options.hide_combo_explosions)
+    ));
+    content.push_str(&format!(
+        "HideUsername={}\n",
+        i32::from(options.hide_username)
     ));
     content.push_str(&format!(
         "ColumnFlashOnMiss={}\n",
@@ -3769,6 +3776,7 @@ pub struct Profile {
     pub hide_score: bool,
     pub hide_danger: bool,
     pub hide_combo_explosions: bool,
+    pub hide_username: bool,
     // Gameplay extras (Simply Love semantics).
     pub column_flash_on_miss: bool,
     pub column_flash_mask: ColumnFlashMask,
@@ -3929,6 +3937,7 @@ impl Default for Profile {
             hide_score: player_options.hide_score,
             hide_danger: player_options.hide_danger,
             hide_combo_explosions: player_options.hide_combo_explosions,
+            hide_username: player_options.hide_username,
             column_flash_on_miss: player_options.column_flash_on_miss,
             column_flash_mask: player_options.column_flash_mask,
             subtractive_scoring: player_options.subtractive_scoring,
@@ -4124,6 +4133,7 @@ impl Profile {
         hide_score: bool,
         hide_danger: bool,
         hide_combo_explosions: bool,
+        hide_username: bool,
     ) -> bool {
         if self.hide_targets == hide_targets
             && self.hide_song_bg == hide_song_bg
@@ -4132,6 +4142,7 @@ impl Profile {
             && self.hide_score == hide_score
             && self.hide_danger == hide_danger
             && self.hide_combo_explosions == hide_combo_explosions
+            && self.hide_username == hide_username
         {
             return false;
         }
@@ -4142,6 +4153,7 @@ impl Profile {
         self.hide_score = hide_score;
         self.hide_danger = hide_danger;
         self.hide_combo_explosions = hide_combo_explosions;
+        self.hide_username = hide_username;
         true
     }
 
@@ -4467,6 +4479,7 @@ impl Profile {
             hide_score: self.hide_score,
             hide_danger: self.hide_danger,
             hide_combo_explosions: self.hide_combo_explosions,
+            hide_username: self.hide_username,
             column_flash_on_miss: self.column_flash_on_miss,
             column_flash_mask: self.column_flash_mask,
             subtractive_scoring: self.subtractive_scoring,
@@ -4586,6 +4599,7 @@ impl Profile {
         self.hide_score = options.hide_score;
         self.hide_danger = options.hide_danger;
         self.hide_combo_explosions = options.hide_combo_explosions;
+        self.hide_username = options.hide_username;
         self.column_flash_on_miss = options.column_flash_on_miss;
         self.column_flash_mask = options.column_flash_mask;
         self.subtractive_scoring = options.subtractive_scoring;
@@ -4938,7 +4952,7 @@ mod tests {
         assert!(profile.hide_early_dw_column_flash);
         assert!(!profile.set_early_dw_options(true, true, true));
 
-        assert!(profile.set_hide_options(true, true, false, true, false, true, true));
+        assert!(profile.set_hide_options(true, true, false, true, false, true, true, true));
         assert!(profile.hide_targets);
         assert!(profile.hide_song_bg);
         assert!(!profile.hide_combo);
@@ -4946,7 +4960,8 @@ mod tests {
         assert!(!profile.hide_score);
         assert!(profile.hide_danger);
         assert!(profile.hide_combo_explosions);
-        assert!(!profile.set_hide_options(true, true, false, true, false, true, true));
+        assert!(profile.hide_username);
+        assert!(!profile.set_hide_options(true, true, false, true, false, true, true, true));
     }
 
     #[test]

--- a/src/game/profile.rs
+++ b/src/game/profile.rs
@@ -253,6 +253,10 @@ fn load_player_options(
         .get(section, "HideComboExplosions")
         .and_then(|s| s.parse::<u8>().ok())
         .map_or(options.hide_combo_explosions, |v| v != 0);
+    options.hide_username = profile_conf
+        .get(section, "HideUsername")
+        .and_then(|s| s.parse::<u8>().ok())
+        .map_or(options.hide_username, |v| v != 0);
     options.column_flash_on_miss = profile_conf
         .get(section, "ColumnFlashOnMiss")
         .and_then(|s| s.parse::<u8>().ok())
@@ -1253,12 +1257,14 @@ pub fn gameplay_hud_snapshot() -> GameplayHudSnapshot {
             guest: p1_guest,
             display_name: p1_profile.display_name.clone(),
             avatar_texture_key: p1_profile.avatar_texture_key.clone(),
+            hide_username: p1_profile.hide_username,
         },
         p2: GameplayHudPlayerSnapshot {
             joined: player_side_is_joined(joined_mask, PlayerSide::P2),
             guest: p2_guest,
             display_name: p2_profile.display_name.clone(),
             avatar_texture_key: p2_profile.avatar_texture_key.clone(),
+            hide_username: p2_profile.hide_username,
         },
     }
 }

--- a/src/game/profile/update.rs
+++ b/src/game/profile/update.rs
@@ -251,6 +251,7 @@ pub fn update_hide_options_for_side(
     hide_score: bool,
     hide_danger: bool,
     hide_combo_explosions: bool,
+    hide_username: bool,
 ) {
     update_profile_ini(side, |profile| {
         profile.set_hide_options(
@@ -261,6 +262,7 @@ pub fn update_hide_options_for_side(
             hide_score,
             hide_danger,
             hide_combo_explosions,
+            hide_username,
         )
     });
 }

--- a/src/screens/gameplay.rs
+++ b/src/screens/gameplay.rs
@@ -8478,7 +8478,7 @@ pub fn push_actors(
 
         let (p1_footer_text, p1_footer_avatar) = if p1_joined {
             (
-                Some(if p1_guest {
+                Some(if p1_guest || hud_snapshot.p1.hide_username {
                     ""
                 } else {
                     hud_snapshot.p1.display_name.as_str()
@@ -8490,7 +8490,7 @@ pub fn push_actors(
         };
         let (p2_footer_text, p2_footer_avatar) = if p2_joined {
             (
-                Some(if p2_guest {
+                Some(if p2_guest || hud_snapshot.p2.hide_username {
                     ""
                 } else {
                     hud_snapshot.p2.display_name.as_str()

--- a/src/screens/player_options/panes/advanced.rs
+++ b/src/screens/player_options/panes/advanced.rs
@@ -500,6 +500,7 @@ const HIDE: BitmaskBinding = fanout_bitmask_binding!(
         (SCORE, hide_score),
         (DANGER, hide_danger),
         (COMBO_EXPLOSIONS, hide_combo_explosions),
+        (USERNAME, hide_username),
     ],
     persist_for_side = |s, p| gp::update_hide_options_for_side(
         s,
@@ -510,6 +511,7 @@ const HIDE: BitmaskBinding = fanout_bitmask_binding!(
         p.hide_score,
         p.hide_danger,
         p.hide_combo_explosions,
+        p.hide_username,
     ),
     sync_visibility = true,
 );
@@ -1273,6 +1275,7 @@ pub(super) fn build_advanced_rows(return_screen: Screen) -> RowMap {
             tr("PlayerOptions", "HideScore").to_string(),
             tr("PlayerOptions", "HideDanger").to_string(),
             tr("PlayerOptions", "HideComboExplosions").to_string(),
+            tr("PlayerOptions", "HideUsername").to_string(),
         ],
     ));
     b.push(Row::cycle(

--- a/src/screens/player_options/row.rs
+++ b/src/screens/player_options/row.rs
@@ -653,11 +653,12 @@ pub(crate) use simple_bitmask_binding;
 ///         (SCORE, hide_score),
 ///         (DANGER, hide_danger),
 ///         (COMBO_EXPLOSIONS, hide_combo_explosions),
+///         (USERNAME, hide_username),
 ///     ],
 ///     persist_for_side = |s, p| gp::update_hide_options_for_side(
 ///         s,
 ///         p.hide_targets, p.hide_song_bg, p.hide_combo, p.hide_lifebar,
-///         p.hide_score, p.hide_danger, p.hide_combo_explosions,
+///         p.hide_score, p.hide_danger, p.hide_combo_explosions, p.hide_username,
 ///     ),
 ///     sync_visibility = true,
 /// );

--- a/src/screens/player_options/state.rs
+++ b/src/screens/player_options/state.rs
@@ -84,6 +84,7 @@ bitflags! {
         const SCORE            = 1 << 4;
         const DANGER           = 1 << 5;
         const COMBO_EXPLOSIONS = 1 << 6;
+        const USERNAME         = 1 << 7;
     }
 }
 


### PR DESCRIPTION
## Why

deadsync renders the player username (and avatar) in the bottom corners during gameplay. Some players want to hide their name on stream or in recordings without hiding the rest of the HUD. There was no way to do that.

Note: this is a deadsync-original element. Neither ITGMania nor Simply-Love-SM5 render a username in the gameplay corners, and their "Hide" optionrow has no equivalent toggle, so there is no upstream parity to match. This follows deadsync's own existing per-player "Hide" pattern instead.

## What

Adds a per-player **Hide username** toggle to the existing player-options "Hide" row:

- New `hide_username` bool on `PlayerOptions` / `Profile`, wired through all conversions and `set_hide_options`.
- Persisted to the profile INI as `HideUsername={0|1}` and surfaced as `USERNAME = 1 << 7`, the 8th bit of the existing `HideMask`.
- Exposed in the UI via the existing `fanout_bitmask_binding!` "Hide" row (new `HideUsername=Username` label in `en.ini`).
- Plumbed into the gameplay HUD snapshot so the footer blanks the **name text** when the flag is set, reusing the same pattern already used for guest profiles. The avatar is intentionally left visible since the request was specifically about the username.
