### PR TITLE
fix(input): pad config profiles: fix stale sibling list + reassert managed default per session

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8090,6 +8090,23 @@ impl App {
         commands
     }
 
+    /// Begin a new play session: start the session timer, clear per-session state,
+    /// and drop the SMX managed-config resolve signatures so each connected pad's
+    /// default is reasserted for the new session. (A manual Apply from a prior
+    /// session writes the pad + marker but not the resolve signature, so without
+    /// the reset the override would persist into the next session — unlike a full
+    /// app restart, which always resolves fresh.) No-op if a session is active.
+    fn begin_play_session(&mut self) {
+        if self.state.session.session_start_time.is_some() {
+            return;
+        }
+        self.state.session.session_start_time = Some(Instant::now());
+        self.state.session.played_stages.clear();
+        self.state.session.course_individual_stage_indices.clear();
+        self.pad_config_sync.reset_signatures();
+        debug!("Session timer started.");
+    }
+
     fn handle_screen_state_on_fade(&mut self, prev: CurrentScreen, target: CurrentScreen) {
         if prev == CurrentScreen::SelectColor {
             let idx = self.state.screens.select_color_state.active_color_index;
@@ -9180,12 +9197,7 @@ impl App {
 
         if target == CurrentScreen::SelectMusic {
             self.clear_course_runtime();
-            if self.state.session.session_start_time.is_none() {
-                self.state.session.session_start_time = Some(Instant::now());
-                self.state.session.played_stages.clear();
-                self.state.session.course_individual_stage_indices.clear();
-                debug!("Session timer started.");
-            }
+            self.begin_play_session();
 
             match prev {
                 CurrentScreen::PlayerOptions => {
@@ -9447,12 +9459,7 @@ impl App {
                         })
                 });
             self.clear_course_runtime();
-            if self.state.session.session_start_time.is_none() {
-                self.state.session.session_start_time = Some(Instant::now());
-                self.state.session.played_stages.clear();
-                self.state.session.course_individual_stage_indices.clear();
-                debug!("Session timer started.");
-            }
+            self.begin_play_session();
 
             match prev {
                 CurrentScreen::ProfileLoad | CurrentScreen::EvaluationSummary => {

--- a/src/app/pad_config_sync.rs
+++ b/src/app/pad_config_sync.rs
@@ -267,6 +267,34 @@ mod tests {
     }
 
     #[test]
+    fn override_keeps_signature_so_only_a_session_reset_reresolves() {
+        use crate::config::SmxPadPreset;
+        let mut s = PadConfigSync::default();
+        // The managed resolver has already run for pad 0 (signature cached).
+        s.signature[0] = Some(Sig {
+            preset: SmxPadPreset::Low,
+            serial: "S".to_owned(),
+            profile_id: Some("p".to_owned()),
+            pad_type: Some("fsr".to_owned()),
+        });
+        // A manual Apply marks a config active but must NOT touch the signature —
+        // otherwise the resolver keeps short-circuiting and never reverts to the default.
+        s.apply_intent(PadConfigIntent::Override {
+            pad: 0,
+            applied: AppliedPadConfig {
+                preset: false,
+                name: "FS".to_owned(),
+            },
+        });
+        assert!(s.signature[0].is_some());
+        assert_eq!(s.snapshot()[0].as_ref().unwrap().name, "FS");
+        // Starting a new session drops the signature, so the next resolve reapplies
+        // the managed default instead of leaving the override in place.
+        s.reset_signatures();
+        assert!(s.signature[0].is_none());
+    }
+
+    #[test]
     fn signature_matches_compares_every_field_by_borrow() {
         use crate::config::SmxPadPreset;
         let mut s = PadConfigSync::default();

--- a/src/app/pad_config_sync.rs
+++ b/src/app/pad_config_sync.rs
@@ -88,6 +88,17 @@ impl PadConfigSync {
         }
     }
 
+    /// Drop every pad's resolve signature so the managed resolver re-runs and
+    /// re-applies each pad's default on the next frame. Called when a new play
+    /// session begins: a manual Apply from the previous session set `applied` and
+    /// wrote the pad but left the signature intact, so without this the override
+    /// would carry into the next session instead of the managed default being
+    /// reasserted. (A full app restart already resolves fresh; this makes a
+    /// session restart behave the same.)
+    pub fn reset_signatures(&mut self) {
+        self.signature = [None, None];
+    }
+
     /// Whether the cached resolve signature for `pad` already matches these
     /// inputs. Compared by borrow so the steady-state hot path allocates nothing
     /// (no throwaway `Sig`) just to discover that nothing changed; the owned `Sig`
@@ -234,6 +245,25 @@ mod tests {
         assert!(s.profiles_stale(0, Some("p1"), Some("fsr")));
         // ...but the resolve signature is untouched, so the pad isn't rewritten.
         assert!(s.signature[0].is_some());
+    }
+
+    #[test]
+    fn reset_signatures_clears_all_so_managed_resolve_reruns() {
+        use crate::config::SmxPadPreset;
+        let mut s = PadConfigSync::default();
+        for pad in 0..2 {
+            s.signature[pad] = Some(Sig {
+                preset: SmxPadPreset::Medium,
+                serial: "S".to_owned(),
+                profile_id: Some("p1".to_owned()),
+                pad_type: Some("fsr".to_owned()),
+            });
+        }
+        // A new play session drops every signature so the resolver re-runs and
+        // re-applies each pad's default (discarding a prior session's manual Apply).
+        s.reset_signatures();
+        assert!(s.signature[0].is_none());
+        assert!(s.signature[1].is_none());
     }
 
     #[test]

--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -8403,6 +8403,32 @@ fn apply_pad_profile_recall(state: &mut State, p2: bool, preset: bool, name: &st
     applied
 }
 
+/// Pure decision behind [`refresh_sibling_pad_list`]: given the edited `slot`, the
+/// profile it was edited under, and the sibling slot's presence + profile, return
+/// the intent to queue for the sibling — or `None` when the sibling isn't present
+/// or doesn't share the edited profile. Kept free of the global SMX/session reads
+/// so it can be unit-tested.
+fn sibling_refresh_intent(
+    slot: usize,
+    sibling_connected: bool,
+    sibling_profile: Option<&str>,
+    edited_profile: &str,
+    reresolve: bool,
+) -> Option<PadConfigIntent> {
+    if slot >= 2 {
+        return None;
+    }
+    let other = 1 - slot;
+    if !sibling_connected || sibling_profile != Some(edited_profile) {
+        return None;
+    }
+    Some(if reresolve {
+        PadConfigIntent::Invalidate { pad: other }
+    } else {
+        PadConfigIntent::RefreshList { pad: other }
+    })
+}
+
 /// After a management edit to a profile's `padconfig.ini`, queue a refresh for the
 /// *other* pad slot when it views the same profile (always the case in Doubles,
 /// where both pads share the one joined player's profile). The config list is
@@ -8413,24 +8439,21 @@ fn apply_pad_profile_recall(state: &mut State, p2: bool, preset: bool, name: &st
 /// `RefreshList`.
 fn refresh_sibling_pad_list(state: &mut State, slot: usize, profile_id: &str, reresolve: bool) {
     if slot >= 2 {
-        return;
+        return; // avoid the 1 - slot underflow below for an unexpected slot
     }
-    let other = 1 - slot;
-    let other_info = crate::engine::smx::get_info(other);
-    // A disconnected sibling has no list to keep in sync; computing its profile off
-    // stale info would be meaningless anyway.
-    if !other_info.connected {
-        return;
+    // A disconnected sibling has no list to sync, and its profile read off stale
+    // info would be meaningless; the pure helper folds both cases into `None`.
+    let other_info = crate::engine::smx::get_info(1 - slot);
+    let sibling_profile = profile::active_local_profile_id_for_pad(other_info.is_player2);
+    if let Some(intent) = sibling_refresh_intent(
+        slot,
+        other_info.connected,
+        sibling_profile.as_deref(),
+        profile_id,
+        reresolve,
+    ) {
+        state.pad_config_intents.push(intent);
     }
-    if profile::active_local_profile_id_for_pad(other_info.is_player2).as_deref() != Some(profile_id)
-    {
-        return;
-    }
-    state.pad_config_intents.push(if reresolve {
-        PadConfigIntent::Invalidate { pad: other }
-    } else {
-        PadConfigIntent::RefreshList { pad: other }
-    });
 }
 
 /// Handle a confirmed save box: rename an existing config, or capture the cursor
@@ -12613,6 +12636,39 @@ mod tests {
             precise_last_second_seconds: 0.0,
             charts: Vec::new(),
         })
+    }
+
+    #[test]
+    fn sibling_refresh_intent_targets_other_slot_when_profile_matches() {
+        use super::{PadConfigIntent, sibling_refresh_intent};
+        // Same profile + connected sibling: save/rename (reresolve=false) refreshes
+        // the *other* slot's list; delete (reresolve=true) re-resolves it.
+        assert!(matches!(
+            sibling_refresh_intent(0, true, Some("p"), "p", false),
+            Some(PadConfigIntent::RefreshList { pad: 1 })
+        ));
+        assert!(matches!(
+            sibling_refresh_intent(0, true, Some("p"), "p", true),
+            Some(PadConfigIntent::Invalidate { pad: 1 })
+        ));
+        // Symmetric: editing slot 1 targets slot 0.
+        assert!(matches!(
+            sibling_refresh_intent(1, true, Some("p"), "p", false),
+            Some(PadConfigIntent::RefreshList { pad: 0 })
+        ));
+    }
+
+    #[test]
+    fn sibling_refresh_intent_skips_unrelated_or_absent_sibling() {
+        use super::sibling_refresh_intent;
+        // Different profile (two single-player profiles) → leave the sibling alone.
+        assert!(sibling_refresh_intent(0, true, Some("other"), "p", false).is_none());
+        // Sibling not connected → nothing to refresh.
+        assert!(sibling_refresh_intent(0, false, Some("p"), "p", false).is_none());
+        // Sibling has no joined profile (Guest) → nothing to refresh.
+        assert!(sibling_refresh_intent(0, true, None, "p", false).is_none());
+        // Out-of-range editing slot is a no-op (and never underflows).
+        assert!(sibling_refresh_intent(2, true, Some("p"), "p", false).is_none());
     }
 
     #[test]

--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -8403,6 +8403,36 @@ fn apply_pad_profile_recall(state: &mut State, p2: bool, preset: bool, name: &st
     applied
 }
 
+/// After a management edit to a profile's `padconfig.ini`, queue a refresh for the
+/// *other* pad slot when it views the same profile (always the case in Doubles,
+/// where both pads share the one joined player's profile). The config list is
+/// cached per pad slot, so without this a config added/renamed/deleted via one pad
+/// stays invisible in the sibling pad's list until something else invalidates it.
+/// `reresolve` picks the stronger `Invalidate` (re-resolve + rebuild) for edits
+/// that can change what the sibling should apply (delete); otherwise a list-only
+/// `RefreshList`.
+fn refresh_sibling_pad_list(state: &mut State, slot: usize, profile_id: &str, reresolve: bool) {
+    if slot >= 2 {
+        return;
+    }
+    let other = 1 - slot;
+    let other_info = crate::engine::smx::get_info(other);
+    // A disconnected sibling has no list to keep in sync; computing its profile off
+    // stale info would be meaningless anyway.
+    if !other_info.connected {
+        return;
+    }
+    if profile::active_local_profile_id_for_pad(other_info.is_player2).as_deref() != Some(profile_id)
+    {
+        return;
+    }
+    state.pad_config_intents.push(if reresolve {
+        PadConfigIntent::Invalidate { pad: other }
+    } else {
+        PadConfigIntent::RefreshList { pad: other }
+    });
+}
+
 /// Handle a confirmed save box: rename an existing config, or capture the cursor
 /// pad's live tuning as a new named config in the active player's profile. SMX
 /// pads only; no-op for a Guest (no profile to save to).
@@ -8456,6 +8486,9 @@ fn perform_pad_profile_save(state: &mut State) {
                 });
             }
         }
+        // The rename changed a name the sibling pad (same profile, e.g. Doubles)
+        // also lists; refresh its cached copy so it doesn't show the stale name.
+        refresh_sibling_pad_list(state, slot, &profile_id, false);
         audio::play_sfx("assets/sounds/start.ogg");
         return;
     }
@@ -8488,6 +8521,9 @@ fn perform_pad_profile_save(state: &mut State) {
             name,
         },
     });
+    // The sibling pad (same profile, e.g. Doubles) caches its own copy of the list;
+    // refresh it so the new config shows there too without another edit.
+    refresh_sibling_pad_list(state, slot, &profile_id, false);
     audio::play_sfx("assets/sounds/start.ogg");
 }
 
@@ -8573,6 +8609,9 @@ fn perform_pad_profile_delete(state: &mut State) {
         state
             .pad_config_intents
             .push(PadConfigIntent::Invalidate { pad: slot });
+        // The delete removes the config for every pad sharing this profile; the
+        // sibling (e.g. Doubles) re-resolves too in case it was that pad's default.
+        refresh_sibling_pad_list(state, slot, &profile_id, true);
         audio::play_sfx("assets/sounds/start.ogg");
     }
 }


### PR DESCRIPTION
## Summary
  Fixes two StepManiaX pad-config bugs found while testing on hardware (P1+P2 FSR
  pads), plus regression tests.

  ## Bug 1 — sibling pad's config list went stale after an edit
  **Problem:** In Doubles both pads belong to one player and share that profile's
  `padconfig.ini`, but the saved-config list is cached per pad slot. Creating,
  renaming, or deleting a config on one pad only refreshed that pad's cached list,
  so the other pad kept showing a stale list — a newly saved config stayed invisible
  until some unrelated action invalidated the cache (e.g. hitting "Set default").
  **Fix:** When a management edit changes the shared file, also refresh the sibling
  slot's cached list when it resolves to the same profile — `RefreshList` for
  save/rename, `Invalidate` for delete (the deleted config may have been the
  sibling's default).

  ## Bug 2 — managed default not reasserted when starting a new session
  **Problem:** With "deadsync manages pad config" on, the resolver only re-runs when
  `{preset, serial, profile_id, pad_type}` changes. Manually applying a saved config
  writes the pad and updates the active marker but doesn't move that signature, so
  exiting to the menu and starting a new session (same profile still joined) never
  re-resolved — the manual choice persisted instead of reverting to the default. A
  full app restart appeared to work only because it wipes in-memory state.

  **Fix:** Reset the resolve signatures at session start (`begin_play_session`), so
  the managed default is reapplied for each new session. A manual Apply still lasts
  the current session (survives song → eval → select-music round-trips).

  ## Testing
  - Verified on hardware (two FSR pads, P1+P2): both repros fixed; cold-boot
    behavior unchanged.
  - Unit tests: `sibling_refresh_intent_*` (sibling-refresh decision);
    `reset_signatures_*` and `override_keeps_signature_*` (session-reset / override
    interaction).
  - `cargo check` clean; pad/sibling test suites green.