### PR TITLE
Added center line to Average Error Bar

### DIFF
--- a/src/screens/components/gameplay/notefield.rs
+++ b/src/screens/components/gameplay/notefield.rs
@@ -94,6 +94,7 @@ const ERROR_BAR_LINES_FADE_START_S: f32 = 2.5;
 const ERROR_BAR_LINES_FADE_DUR_S: f32 = 0.5;
 const ERROR_BAR_LABEL_FADE_DUR_S: f32 = 0.5;
 const ERROR_BAR_LABEL_HOLD_S: f32 = 2.0;
+const ERROR_BAR_CENTERLINE_WIDTH: f32 = 2.0;
 const OFFSET_INDICATOR_DUR_S: f32 = 0.5;
 const DISPLAY_MODS_ZOOM: f32 = 0.8;
 const DISPLAY_MODS_WRAP_WIDTH_PX: f32 = 125.0;
@@ -110,6 +111,7 @@ const ERROR_BAR_TEXT_EARLY_RGBA: [f32; 4] = color::rgba_hex("#066af4");
 const ERROR_BAR_TEXT_LATE_RGBA: [f32; 4] = color::rgba_hex("#ff5a4e");
 const ERROR_BAR_TEXT_10MS_FAST_RGBA: [f32; 4] = color::rgba_hex("#0051db");
 const ERROR_BAR_TEXT_10MS_SLOW_RGBA: [f32; 4] = color::rgba_hex("#ff1605");
+const ERROR_BAR_CENTERLINE_RGBA: [f32; 4] = color::rgba_hex("#403e3f");
 const ERROR_BAR_TEXT_ZOOM: f32 = 0.25;
 const TEXT_CACHE_LIMIT: usize = 8192;
 const COMBO_PREWARM_CAP: u32 = 2048;
@@ -8703,6 +8705,14 @@ pub fn build_bundles(
                     {
                         let tick_h =
                             ERROR_BAR_HEIGHT_AVERAGE + 4.0 + ERROR_BAR_AVERAGE_TICK_EXTRA_H;
+
+                        hud_actors.push(act!(quad:
+                        align(0.5, 0.5): xy(error_bar_x, average_bar_y):
+                        zoomto(ERROR_BAR_CENTERLINE_WIDTH, tick_h):
+                        diffuse(ERROR_BAR_CENTERLINE_RGBA[0], ERROR_BAR_CENTERLINE_RGBA[1], ERROR_BAR_CENTERLINE_RGBA[2], ERROR_BAR_CENTERLINE_RGBA[3]):
+                        z(Z_ERROR_BAR_AVERAGE)
+                        ));
+
                         let multi_tick = profile.error_bar_multi_tick;
                         let intensity = profile_data::clamp_average_error_bar_intensity(
                             profile.average_error_bar_intensity,


### PR DESCRIPTION
Added a centerline indicator that appears alongside the average error bar when a note is hit.