### PR TITLE
Show subtle log-level warning above version overlay

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6762,6 +6762,7 @@ impl App {
         if cfg.show_version_overlay {
             actors.extend(crate::screens::components::shared::version_overlay::build(
                 cfg.version_overlay_side,
+                cfg.log_level,
             ));
         }
 

--- a/src/screens/components/shared/version_overlay.rs
+++ b/src/screens/components/shared/version_overlay.rs
@@ -9,7 +9,7 @@
 //! `app/mod.rs` checks it each frame.
 
 use crate::act;
-use crate::config::VersionOverlaySide;
+use crate::config::{LogLevel, VersionOverlaySide};
 use crate::engine::present::actors::Actor;
 use crate::engine::space::{screen_height, screen_width};
 use std::sync::{Arc, OnceLock};
@@ -22,6 +22,10 @@ const VERSION_OVERLAY_Z: i16 = 32010;
 
 const MARGIN_X: f32 = 8.0;
 const MARGIN_Y: f32 = -4.0;
+/// Vertical offset of the log-level warning above the version line.
+/// Picked to clear the version glyph height at `zoom(0.55)` with a
+/// small visual gap.
+const WARNING_OFFSET_Y: f32 = -12.0;
 
 static VERSION_TEXT: OnceLock<Arc<str>> = OnceLock::new();
 
@@ -42,18 +46,41 @@ fn version_text() -> Arc<str> {
         .clone()
 }
 
-/// Builds the version watermark actor list. Returns a single text actor
+/// Returns the warning label to display for verbose log levels, or
+/// `None` when the level is quiet enough that no warning is warranted.
+/// Debug/Trace levels generate a lot of disk I/O and can mask real
+/// problems behind a wall of noise, so we surface them on-screen the
+/// same way we surface the build version.
+#[inline]
+fn log_warning_text(level: LogLevel) -> Option<&'static str> {
+    match level {
+        LogLevel::Debug => Some("log: debug"),
+        LogLevel::Trace => Some("log: trace"),
+        LogLevel::Error | LogLevel::Warn | LogLevel::Info => None,
+    }
+}
+
+/// Builds the version watermark actor list. Returns a text actor
 /// anchored to the bottom-left or bottom-right of the window based on
-/// `side`. The vector wrapper matches the convention used by other
-/// shared overlay components (`stats_overlay`, `gamepad_overlay`).
-pub fn build(side: VersionOverlaySide) -> Vec<Actor> {
+/// `side`, plus an optional amber log-level warning stacked just above
+/// it when `log_level` is verbose (Debug/Trace). The vector wrapper
+/// matches the convention used by other shared overlay components
+/// (`stats_overlay`, `gamepad_overlay`).
+pub fn build(side: VersionOverlaySide, log_level: LogLevel) -> Vec<Actor> {
     let text = version_text();
     let w = screen_width();
     let h = screen_height();
-    let actor = match side {
+    let warning = log_warning_text(log_level);
+
+    let mut actors = Vec::with_capacity(1 + usize::from(warning.is_some()));
+    let version_x = match side {
+        VersionOverlaySide::Left => MARGIN_X,
+        VersionOverlaySide::Right => w - MARGIN_X,
+    };
+    let version_actor = match side {
         VersionOverlaySide::Left => act!(text:
             align(0.0, 1.0):
-            xy(MARGIN_X, h + MARGIN_Y):
+            xy(version_x, h + MARGIN_Y):
             font("miso"):
             zoom(0.55):
             settext(text):
@@ -63,7 +90,7 @@ pub fn build(side: VersionOverlaySide) -> Vec<Actor> {
         ),
         VersionOverlaySide::Right => act!(text:
             align(1.0, 1.0):
-            xy(w - MARGIN_X, h + MARGIN_Y):
+            xy(version_x, h + MARGIN_Y):
             font("miso"):
             zoom(0.55):
             settext(text):
@@ -72,5 +99,37 @@ pub fn build(side: VersionOverlaySide) -> Vec<Actor> {
             z(VERSION_OVERLAY_Z)
         ),
     };
-    vec![actor]
+    actors.push(version_actor);
+
+    if let Some(label) = warning {
+        // Amber so the warning reads as "heads up" without screaming;
+        // alpha lifted slightly above the version watermark (0.55 → 0.7)
+        // because the warning is the more actionable of the two.
+        let warning_y = h + MARGIN_Y + WARNING_OFFSET_Y;
+        let warning_actor = match side {
+            VersionOverlaySide::Left => act!(text:
+                align(0.0, 1.0):
+                xy(version_x, warning_y):
+                font("miso"):
+                zoom(0.55):
+                settext(label):
+                diffuse(1.0, 0.78, 0.25, 0.7):
+                horizalign(left):
+                z(VERSION_OVERLAY_Z)
+            ),
+            VersionOverlaySide::Right => act!(text:
+                align(1.0, 1.0):
+                xy(version_x, warning_y):
+                font("miso"):
+                zoom(0.55):
+                settext(label):
+                diffuse(1.0, 0.78, 0.25, 0.7):
+                horizalign(right):
+                z(VERSION_OVERLAY_Z)
+            ),
+        };
+        actors.push(warning_actor);
+    }
+
+    actors
 }


### PR DESCRIPTION
Verbose log levels (Debug/Trace) generate a lot of disk I/O and can mask real problems behind a wall of noise, but once set they're easy to forget about. This surfaces them on-screen the same way we surface the build version: a small watermark that shows up in screenshots and gameplay videos without intruding on the UI.