### PR TITLE
fix(input): keep pad device order stable across launches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,7 @@ windows = { version = "0.62.2", features = [
     "Win32_System_Threading",
     "Win32_System_LibraryLoader",
     "Win32_System_Variant",
+    "Win32_Storage_FileSystem",
 ] }
 
 [target.'cfg(all(windows, not(target_vendor = "win7")))'.dependencies]
@@ -187,6 +188,7 @@ windows = { version = "0.62.2", features = [
     "Win32_System_LibraryLoader",
     "Win32_System_Variant",
     "Win32_System_WinRT",
+    "Win32_Storage_FileSystem",
 ] }
 
 [target.'cfg(all(not(target_pointer_width = "32"), not(target_vendor = "win7")))'.dependencies]

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -88,6 +88,7 @@ fn load_defaults_after_error() {
     *ADDITIONAL_SONG_FOLDERS.lock().unwrap() = String::new();
     *SMX_P1_SERIAL.lock().unwrap() = None;
     *SMX_P2_SERIAL.lock().unwrap() = None;
+    pad_order::reset();
 }
 
 fn load_runtime_state(conf: &SimpleIni) {
@@ -105,6 +106,7 @@ fn load_runtime_state(conf: &SimpleIni) {
     };
     *SMX_P1_SERIAL.lock().unwrap() = serial("SmxP1Serial");
     *SMX_P2_SERIAL.lock().unwrap() = serial("SmxP2Serial");
+    pad_order::load_order_from_ini(conf);
 }
 
 fn apply_input_runtime_state() {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,6 +6,7 @@ mod keybinds;
 mod load;
 #[path = "null_or_die.rs"]
 mod null_or_die_cfg;
+mod pad_order;
 mod runtime;
 mod store;
 #[cfg(test)]
@@ -26,6 +27,7 @@ pub(crate) use self::keybinds::{
 };
 pub use self::load::{bootstrap_log_to_file, load};
 pub use self::null_or_die_cfg::null_or_die_bias_cfg;
+pub use self::pad_order::{PadOrderBackend, pad_index_for_uuid};
 pub use self::runtime::{
     additional_song_folders, audio_mix_levels, flush_pending_saves, get, machine_default_noteskin,
     smx_pad_assignment,

--- a/src/config/pad_order.rs
+++ b/src/config/pad_order.rs
@@ -28,12 +28,20 @@ pub enum PadOrderBackend {
     Wgi,
     IoHid,
     Hidraw,
+    LinuxEvdev,
+    FreeBsdEvdev,
 }
 
 impl PadOrderBackend {
     /// All persisted backends, used when loading/saving the whole config.
-    pub(super) const ALL: [PadOrderBackend; 4] =
-        [Self::RawInput, Self::Wgi, Self::IoHid, Self::Hidraw];
+    pub(super) const ALL: [PadOrderBackend; 6] = [
+        Self::RawInput,
+        Self::Wgi,
+        Self::IoHid,
+        Self::Hidraw,
+        Self::LinuxEvdev,
+        Self::FreeBsdEvdev,
+    ];
 
     /// The `[Options]` ini key this backend's order is stored under.
     pub(super) const fn ini_key(self) -> &'static str {
@@ -42,6 +50,8 @@ impl PadOrderBackend {
             Self::Wgi => "PadOrderWGI",
             Self::IoHid => "PadOrderIoHid",
             Self::Hidraw => "PadOrderHidraw",
+            Self::LinuxEvdev => "PadOrderLinuxEvdev",
+            Self::FreeBsdEvdev => "PadOrderFreeBsdEvdev",
         }
     }
 }

--- a/src/config/pad_order.rs
+++ b/src/config/pad_order.rs
@@ -1,0 +1,182 @@
+//! Stable per-pad `PadId` assignment.
+//!
+//! Generic HID dance pads (FSR / Teensy class) are assigned a runtime
+//! `PadId(u32)` index in the order the OS enumerates them. That order is not
+//! stable across reboots/replugs, so two pads can swap which one is "Pad 0" vs
+//! "Pad 1" — and since per-pad arrow bindings are pinned to that index, the user
+//! has to re-map every launch.
+//!
+//! To fix this we persist an **append-only, per-backend** list of device UUIDs.
+//! A UUID's position in its backend's list is the `PadId` index that physical
+//! pad always receives. Known UUIDs keep their slot; unknown UUIDs are appended
+//! (never inserted/sorted), so existing pads are never renumbered. This mirrors
+//! how SMX pads pin a serial → player slot, but leaves SMX untouched.
+
+use super::*;
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::sync::{LazyLock, Mutex};
+
+/// Maximum UUIDs persisted per backend (bounds the saved array's growth).
+const PAD_ORDER_CAP: usize = 64;
+
+/// Input backends that persist a stable pad order. SMX is intentionally excluded
+/// — it has its own serial-based assignment.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PadOrderBackend {
+    RawInput,
+    Wgi,
+    IoHid,
+    Hidraw,
+}
+
+impl PadOrderBackend {
+    /// All persisted backends, used when loading/saving the whole config.
+    pub(super) const ALL: [PadOrderBackend; 4] =
+        [Self::RawInput, Self::Wgi, Self::IoHid, Self::Hidraw];
+
+    /// The `[Options]` ini key this backend's order is stored under.
+    pub(super) const fn ini_key(self) -> &'static str {
+        match self {
+            Self::RawInput => "PadOrderRawInput",
+            Self::Wgi => "PadOrderWGI",
+            Self::IoHid => "PadOrderIoHid",
+            Self::Hidraw => "PadOrderHidraw",
+        }
+    }
+}
+
+/// Append-only, per-backend order of pad device UUIDs. The index of a UUID in
+/// its backend's vec is the stable `PadId` that pad receives.
+static PAD_DEVICE_ORDER: LazyLock<Mutex<BTreeMap<PadOrderBackend, Vec<[u8; 16]>>>> =
+    LazyLock::new(|| Mutex::new(BTreeMap::new()));
+
+/// Stable `PadId` index for `uuid` on the given backend.
+///
+/// Returns the UUID's existing slot, or appends it (persisting the updated
+/// order) and returns the new slot. Append-only: known devices are never
+/// renumbered, so per-pad mappings stay bound to the same physical pad.
+pub fn pad_index_for_uuid(backend: PadOrderBackend, uuid: [u8; 16]) -> u32 {
+    let (index, changed) = {
+        let mut order = PAD_DEVICE_ORDER.lock().unwrap();
+        let list = order.entry(backend).or_default();
+        if let Some(i) = list.iter().position(|u| *u == uuid) {
+            (i, false)
+        } else if list.len() >= PAD_ORDER_CAP {
+            // Saved order is full; hand out an ephemeral index without persisting.
+            (list.len(), false)
+        } else {
+            list.push(uuid);
+            (list.len() - 1, true)
+        }
+        // Guard dropped here, before save_without_keymaps() re-locks to serialize.
+    };
+    if changed {
+        save_without_keymaps();
+    }
+    index as u32
+}
+
+/// Replace the in-memory order from the loaded config file.
+pub(super) fn load_order_from_ini(conf: &SimpleIni) {
+    let mut order = PAD_DEVICE_ORDER.lock().unwrap();
+    order.clear();
+    for backend in PadOrderBackend::ALL {
+        let Some(raw) = conf.get("Options", backend.ini_key()) else {
+            continue;
+        };
+        let parsed = sanitize(raw.split(',').filter_map(uuid_from_hex).collect());
+        if !parsed.is_empty() {
+            order.insert(backend, parsed);
+        }
+    }
+}
+
+/// Clear the persisted order (used when the config file can't be read).
+pub(super) fn reset() {
+    PAD_DEVICE_ORDER.lock().unwrap().clear();
+}
+
+/// Comma-separated hex serialization of `backend`'s order (empty when none).
+pub(super) fn serialized(backend: PadOrderBackend) -> String {
+    PAD_DEVICE_ORDER
+        .lock()
+        .unwrap()
+        .get(&backend)
+        .map(|list| list.iter().map(uuid_to_hex).collect::<Vec<_>>().join(","))
+        .unwrap_or_default()
+}
+
+/// Drop duplicates (keeping first occurrence) and cap the list length.
+fn sanitize(list: Vec<[u8; 16]>) -> Vec<[u8; 16]> {
+    let mut out: Vec<[u8; 16]> = Vec::with_capacity(list.len().min(PAD_ORDER_CAP));
+    for u in list {
+        if out.len() >= PAD_ORDER_CAP {
+            break;
+        }
+        if !out.contains(&u) {
+            out.push(u);
+        }
+    }
+    out
+}
+
+fn uuid_to_hex(uuid: &[u8; 16]) -> String {
+    let mut s = String::with_capacity(32);
+    for b in uuid {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+fn uuid_from_hex(s: &str) -> Option<[u8; 16]> {
+    let s = s.trim();
+    if s.len() != 32 || !s.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let mut out = [0u8; 16];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).ok()?;
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_round_trip() {
+        let uuid = [
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+            0xee, 0xff,
+        ];
+        let hex = uuid_to_hex(&uuid);
+        assert_eq!(hex, "00112233445566778899aabbccddeeff");
+        assert_eq!(uuid_from_hex(&hex), Some(uuid));
+    }
+
+    #[test]
+    fn rejects_malformed_hex() {
+        assert_eq!(uuid_from_hex(""), None);
+        assert_eq!(uuid_from_hex("00112233"), None); // too short
+        assert_eq!(uuid_from_hex(&"0".repeat(33)), None); // too long
+        assert_eq!(uuid_from_hex(&"g".repeat(32)), None); // non-hex
+    }
+
+    #[test]
+    fn sanitize_dedups_and_caps() {
+        let a = [1u8; 16];
+        let b = [2u8; 16];
+        assert_eq!(sanitize(vec![a, b, a, b]), vec![a, b]);
+
+        let many: Vec<[u8; 16]> = (0..(PAD_ORDER_CAP as u16 + 10))
+            .map(|i| {
+                let mut u = [0u8; 16];
+                u[0..2].copy_from_slice(&i.to_le_bytes());
+                u
+            })
+            .collect();
+        assert_eq!(sanitize(many).len(), PAD_ORDER_CAP);
+    }
+}

--- a/src/config/store/defaults.rs
+++ b/src/config/store/defaults.rs
@@ -127,6 +127,8 @@ fn push_default_options(content: &mut String, default: &Config) {
     push_line(content, "PadOrderWGI", "");
     push_line(content, "PadOrderIoHid", "");
     push_line(content, "PadOrderHidraw", "");
+    push_line(content, "PadOrderLinuxEvdev", "");
+    push_line(content, "PadOrderFreeBsdEvdev", "");
     push_bool(content, "GfxDebug", default.gfx_debug);
     push_bool(content, "HighDPI", default.high_dpi);
     push_bool(content, "HideMouseCursor", default.hide_mouse_cursor);

--- a/src/config/store/defaults.rs
+++ b/src/config/store/defaults.rs
@@ -122,6 +122,11 @@ fn push_default_options(content: &mut String, default: &Config) {
     // No pad→player assignment by default (slots follow the hardware jumper).
     push_line(content, "SmxP1Serial", "");
     push_line(content, "SmxP2Serial", "");
+    // Persisted pad ordering is empty until pads are seen; seeded at runtime.
+    push_line(content, "PadOrderRawInput", "");
+    push_line(content, "PadOrderWGI", "");
+    push_line(content, "PadOrderIoHid", "");
+    push_line(content, "PadOrderHidraw", "");
     push_bool(content, "GfxDebug", default.gfx_debug);
     push_bool(content, "HighDPI", default.high_dpi);
     push_bool(content, "HideMouseCursor", default.hide_mouse_cursor);

--- a/src/config/store/save.rs
+++ b/src/config/store/save.rs
@@ -186,6 +186,13 @@ fn push_saved_options(
     );
     push_line(content, "SmxP1Serial", smx_p1_serial);
     push_line(content, "SmxP2Serial", smx_p2_serial);
+    for backend in crate::config::pad_order::PadOrderBackend::ALL {
+        push_line(
+            content,
+            backend.ini_key(),
+            crate::config::pad_order::serialized(backend),
+        );
+    }
     push_bool(content, "GfxDebug", cfg.gfx_debug);
     push_bool(content, "HighDPI", cfg.high_dpi);
     push_bool(content, "HideMouseCursor", cfg.hide_mouse_cursor);

--- a/src/engine/input/backends/evdev/freebsd.rs
+++ b/src/engine/input/backends/evdev/freebsd.rs
@@ -125,6 +125,7 @@ struct DevSpec {
     name: String,
     vendor_id: Option<u16>,
     product_id: Option<u16>,
+    uuid: [u8; 16],
 }
 
 #[derive(Default)]
@@ -226,6 +227,16 @@ const fn eviocgname(len: usize) -> libc::c_ulong {
 }
 
 #[inline(always)]
+const fn eviocgphys(len: usize) -> libc::c_ulong {
+    ioc(IOC_READ, b'E' as u32, 0x07, len as u32)
+}
+
+#[inline(always)]
+const fn eviocguniq(len: usize) -> libc::c_ulong {
+    ioc(IOC_READ, b'E' as u32, 0x08, len as u32)
+}
+
+#[inline(always)]
 const fn eviocgbit(ev: u8, len: usize) -> libc::c_ulong {
     ioc(IOC_READ, b'E' as u32, 0x20 + ev as u32, len as u32)
 }
@@ -280,6 +291,49 @@ fn raw_dev_name(file: &std::fs::File) -> Option<String> {
     }
     let len = buf.iter().position(|byte| *byte == 0).unwrap_or(buf.len());
     std::str::from_utf8(&buf[..len]).ok().map(str::to_owned)
+}
+
+/// Reads a NUL-terminated evdev string property (e.g. uniq or phys), returning
+/// `None` on ioctl failure or when the value is empty/whitespace.
+fn raw_dev_string(file: &std::fs::File, request: libc::c_ulong) -> Option<String> {
+    let mut buf = [0u8; 256];
+    // SAFETY: `file` is an open evdev device, `request` is an evdev string-read
+    // ioctl, and `buf` is writable stack storage for the kernel to fill with a
+    // NUL-terminated string.
+    let rc = unsafe { libc::ioctl(file.as_raw_fd(), request, buf.as_mut_ptr()) };
+    if rc < 0 {
+        return None;
+    }
+    let len = buf.iter().position(|byte| *byte == 0).unwrap_or(buf.len());
+    let value = std::str::from_utf8(&buf[..len]).ok()?.trim();
+    (!value.is_empty()).then(|| value.to_owned())
+}
+
+/// Builds the stable identity key for a pad, preferring hardware identifiers
+/// (serial, then USB topology) over model/path so the same physical pad keeps
+/// its `PadId` across reboots and re-plugging into a different port.
+fn uuid_key_from_parts(
+    uniq: Option<&str>,
+    phys: Option<&str>,
+    name: &str,
+    vendor_id: Option<u16>,
+    product_id: Option<u16>,
+    path: &str,
+) -> String {
+    if let Some(uniq) = uniq {
+        return format!("freebsd-evdev:uniq:{uniq}");
+    }
+    if let Some(phys) = phys {
+        return format!("freebsd-evdev:phys:{phys}");
+    }
+    if !name.is_empty() || vendor_id.is_some() || product_id.is_some() {
+        return format!(
+            "freebsd-evdev:name:{name}|vid:{:04x}|pid:{:04x}",
+            vendor_id.unwrap_or(0),
+            product_id.unwrap_or(0),
+        );
+    }
+    format!("freebsd-evdev:path:{path}")
 }
 
 fn raw_dev_info(file: &std::fs::File) -> (Option<u16>, Option<u16>) {
@@ -363,12 +417,26 @@ fn probe_path(path: &str, noisy: bool) -> ProbeResult {
     };
     let name = raw_dev_name(&file).unwrap_or_else(|| format!("evdev:{path}"));
     let (vendor_id, product_id) = raw_dev_info(&file);
+    let uniq = raw_dev_string(&file, eviocguniq(256));
+    let phys = raw_dev_string(&file, eviocgphys(256));
+    let uuid = uuid_from_bytes(
+        uuid_key_from_parts(
+            uniq.as_deref(),
+            phys.as_deref(),
+            &name,
+            vendor_id,
+            product_id,
+            path,
+        )
+        .as_bytes(),
+    );
     ProbeResult::Device(DevSpec {
         class,
         path: path.to_owned(),
         name,
         vendor_id,
         product_id,
+        uuid,
     })
 }
 
@@ -482,7 +550,7 @@ fn open_dev(
     });
     Some(Dev {
         id,
-        uuid: uuid_from_bytes(spec.path.as_bytes()),
+        uuid: spec.uuid,
         name: spec.name,
         path: spec.path,
         file,
@@ -525,7 +593,7 @@ fn add_dev_if_new(
     if spec.class != DevClass::Pad {
         return;
     };
-    let uuid = uuid_from_bytes(spec.path.as_bytes());
+    let uuid = spec.uuid;
     let existing_id = id_by_uuid.get(&uuid).copied();
     // Stable, persisted slot so this pad keeps the same PadId across launches.
     let id = existing_id.unwrap_or_else(|| {
@@ -606,7 +674,7 @@ fn run_inner(
         let path = spec.path.clone();
         match spec.class {
             DevClass::Pad => {
-                let uuid = uuid_from_bytes(spec.path.as_bytes());
+                let uuid = spec.uuid;
                 // Stable, persisted slot so this pad keeps the same PadId across launches.
                 let id = match id_by_uuid.get(&uuid).copied() {
                     Some(id) => id,

--- a/src/engine/input/backends/evdev/freebsd.rs
+++ b/src/engine/input/backends/evdev/freebsd.rs
@@ -512,7 +512,6 @@ fn open_key_dev(spec: DevSpec) -> Option<KeyDev> {
 fn add_dev_if_new(
     path: String,
     devs: &mut Vec<Dev>,
-    next_id: &mut u32,
     id_by_uuid: &mut HashMap<[u8; 16], PadId>,
     initial: bool,
     emit_sys: &mut impl FnMut(GpSystemEvent),
@@ -528,11 +527,16 @@ fn add_dev_if_new(
     };
     let uuid = uuid_from_bytes(spec.path.as_bytes());
     let existing_id = id_by_uuid.get(&uuid).copied();
-    let id = existing_id.unwrap_or(PadId(*next_id));
+    // Stable, persisted slot so this pad keeps the same PadId across launches.
+    let id = existing_id.unwrap_or_else(|| {
+        PadId(crate::config::pad_index_for_uuid(
+            crate::config::PadOrderBackend::FreeBsdEvdev,
+            uuid,
+        ))
+    });
     if let Some(dev) = open_dev(spec, id, initial, emit_sys) {
         if existing_id.is_none() {
             id_by_uuid.insert(dev.uuid, id);
-            *next_id = next_id.saturating_add(1);
         }
         devs.push(dev);
     }
@@ -596,7 +600,6 @@ fn run_inner(
     let watch = DevdWatch::new();
     let mut devs = Vec::new();
     let mut key_devs = Vec::new();
-    let mut next_id = 0u32;
     let mut id_by_uuid: HashMap<[u8; 16], PadId> = HashMap::new();
     let (startup_specs, startup_stats) = scan_event_specs();
     for spec in startup_specs {
@@ -604,10 +607,16 @@ fn run_inner(
         match spec.class {
             DevClass::Pad => {
                 let uuid = uuid_from_bytes(spec.path.as_bytes());
-                let id = PadId(next_id);
+                // Stable, persisted slot so this pad keeps the same PadId across launches.
+                let id = match id_by_uuid.get(&uuid).copied() {
+                    Some(id) => id,
+                    None => PadId(crate::config::pad_index_for_uuid(
+                        crate::config::PadOrderBackend::FreeBsdEvdev,
+                        uuid,
+                    )),
+                };
                 if let Some(dev) = open_dev(spec, id, true, &mut emit_sys) {
                     id_by_uuid.insert(uuid, id);
-                    next_id = next_id.saturating_add(1);
                     devs.push(dev);
                 } else {
                     debug!("freebsd evdev skipped '{path}' during startup");
@@ -855,7 +864,6 @@ fn run_inner(
                     add_dev_if_new(
                         path.clone(),
                         &mut devs,
-                        &mut next_id,
                         &mut id_by_uuid,
                         false,
                         &mut emit_sys,

--- a/src/engine/input/backends/evdev/linux.rs
+++ b/src/engine/input/backends/evdev/linux.rs
@@ -1047,13 +1047,9 @@ fn run_inner(
         Discovery::Udev(state) => {
             for spec in state.enumerate_specs() {
                 match spec.class {
-                    DevClass::Pad => add_dev_if_new(
-                        spec,
-                        &mut devs,
-                        &mut id_by_uuid,
-                        true,
-                        &mut emit_sys,
-                    ),
+                    DevClass::Pad => {
+                        add_dev_if_new(spec, &mut devs, &mut id_by_uuid, true, &mut emit_sys)
+                    }
                     DevClass::Keyboard if scan_keyboards => {
                         add_key_dev_if_new(spec, &mut key_devs, Some(&mut keyboard_startup))
                     }
@@ -1065,13 +1061,9 @@ fn run_inner(
             scan_fallback(&mut fallback, &devs, &key_devs);
             for spec in fallback.specs.drain(..) {
                 match spec.class {
-                    DevClass::Pad => add_dev_if_new(
-                        spec,
-                        &mut devs,
-                        &mut id_by_uuid,
-                        true,
-                        &mut emit_sys,
-                    ),
+                    DevClass::Pad => {
+                        add_dev_if_new(spec, &mut devs, &mut id_by_uuid, true, &mut emit_sys)
+                    }
                     DevClass::Keyboard if scan_keyboards => {
                         add_key_dev_if_new(spec, &mut key_devs, Some(&mut keyboard_startup))
                     }
@@ -1322,13 +1314,9 @@ fn run_inner(
         for event in hotplug.drain(..) {
             match event {
                 HotplugEvent::Add(spec) => match spec.class {
-                    DevClass::Pad => add_dev_if_new(
-                        spec,
-                        &mut devs,
-                        &mut id_by_uuid,
-                        false,
-                        &mut emit_sys,
-                    ),
+                    DevClass::Pad => {
+                        add_dev_if_new(spec, &mut devs, &mut id_by_uuid, false, &mut emit_sys)
+                    }
                     DevClass::Keyboard if scan_keyboards => {
                         add_key_dev_if_new(spec, &mut key_devs, None)
                     }

--- a/src/engine/input/backends/evdev/linux.rs
+++ b/src/engine/input/backends/evdev/linux.rs
@@ -929,7 +929,6 @@ fn open_key_dev(spec: DevSpec, mut stats: Option<&mut KeyboardStartupStats>) -> 
 fn add_dev_if_new(
     spec: DevSpec,
     devs: &mut Vec<Dev>,
-    next_id: &mut u32,
     id_by_uuid: &mut HashMap<[u8; 16], PadId>,
     initial: bool,
     emit_sys: &mut impl FnMut(GpSystemEvent),
@@ -938,11 +937,16 @@ fn add_dev_if_new(
         return;
     }
     let existing_id = id_by_uuid.get(&spec.uuid).copied();
-    let id = existing_id.unwrap_or(PadId(*next_id));
+    // Stable, persisted slot so this pad keeps the same PadId across launches.
+    let id = existing_id.unwrap_or_else(|| {
+        PadId(crate::config::pad_index_for_uuid(
+            crate::config::PadOrderBackend::LinuxEvdev,
+            spec.uuid,
+        ))
+    });
     if let Some(dev) = open_dev(spec, id, initial, emit_sys) {
         if existing_id.is_none() {
             id_by_uuid.insert(dev.uuid, id);
-            *next_id = next_id.saturating_add(1);
         }
         devs.push(dev);
     }
@@ -965,7 +969,6 @@ fn add_key_dev_if_new(
 fn refresh_fallback(
     devs: &mut Vec<Dev>,
     key_devs: &mut Vec<KeyDev>,
-    next_id: &mut u32,
     id_by_uuid: &mut HashMap<[u8; 16], PadId>,
     scratch: &mut FallbackScratch,
     scan_keyboards: bool,
@@ -995,7 +998,7 @@ fn refresh_fallback(
     publish_keyboard_backend_state(key_devs);
     for spec in scratch.specs.drain(..) {
         match spec.class {
-            DevClass::Pad => add_dev_if_new(spec, devs, next_id, id_by_uuid, false, emit_sys),
+            DevClass::Pad => add_dev_if_new(spec, devs, id_by_uuid, false, emit_sys),
             DevClass::Keyboard if scan_keyboards => add_key_dev_if_new(spec, key_devs, None),
             DevClass::Keyboard => {}
         }
@@ -1038,7 +1041,6 @@ fn run_inner(
     let mut key_devs: Vec<KeyDev> = Vec::new();
     let mut fallback = FallbackScratch::default();
     let mut keyboard_startup = KeyboardStartupStats::default();
-    let mut next_id = 0u32;
     let mut id_by_uuid: HashMap<[u8; 16], PadId> = HashMap::new();
 
     match &discovery {
@@ -1048,7 +1050,6 @@ fn run_inner(
                     DevClass::Pad => add_dev_if_new(
                         spec,
                         &mut devs,
-                        &mut next_id,
                         &mut id_by_uuid,
                         true,
                         &mut emit_sys,
@@ -1067,7 +1068,6 @@ fn run_inner(
                     DevClass::Pad => add_dev_if_new(
                         spec,
                         &mut devs,
-                        &mut next_id,
                         &mut id_by_uuid,
                         true,
                         &mut emit_sys,
@@ -1325,7 +1325,6 @@ fn run_inner(
                     DevClass::Pad => add_dev_if_new(
                         spec,
                         &mut devs,
-                        &mut next_id,
                         &mut id_by_uuid,
                         false,
                         &mut emit_sys,
@@ -1345,7 +1344,6 @@ fn run_inner(
             refresh_fallback(
                 &mut devs,
                 &mut key_devs,
-                &mut next_id,
                 &mut id_by_uuid,
                 &mut fallback,
                 scan_keyboards,

--- a/src/engine/input/backends/hidraw.rs
+++ b/src/engine/input/backends/hidraw.rs
@@ -704,13 +704,7 @@ pub fn run(
     let hidraw_paths = scan_hidraw_paths();
     let hidraw_count = hidraw_paths.len();
     for path in hidraw_paths {
-        add_dev_if_new(
-            path,
-            &mut devs,
-            &mut id_by_uuid,
-            true,
-            emit_sys,
-        );
+        add_dev_if_new(path, &mut devs, &mut id_by_uuid, true, emit_sys);
     }
     if devs.is_empty() {
         let _ = watch;
@@ -836,13 +830,9 @@ pub fn run(
         }
         for event in hotplug.drain(..) {
             match event {
-                DevdEvent::Create(path) => add_dev_if_new(
-                    path,
-                    &mut devs,
-                    &mut id_by_uuid,
-                    false,
-                    emit_sys,
-                ),
+                DevdEvent::Create(path) => {
+                    add_dev_if_new(path, &mut devs, &mut id_by_uuid, false, emit_sys)
+                }
                 DevdEvent::Destroy(path) => remove_dev_by_path(&path, &mut devs, emit_sys),
             }
         }

--- a/src/engine/input/backends/hidraw.rs
+++ b/src/engine/input/backends/hidraw.rs
@@ -460,7 +460,6 @@ fn open_dev(
 fn add_dev_if_new(
     path: String,
     devs: &mut Vec<Dev>,
-    next_id: &mut u32,
     id_by_uuid: &mut HashMap<[u8; 16], PadId>,
     initial: bool,
     emit_sys: &mut impl FnMut(GpSystemEvent),
@@ -470,11 +469,16 @@ fn add_dev_if_new(
     }
     let uuid = uuid_from_bytes(path.as_bytes());
     let existing_id = id_by_uuid.get(&uuid).copied();
-    let id = existing_id.unwrap_or(PadId(*next_id));
+    // Stable, persisted slot so this pad keeps the same PadId across launches.
+    let id = existing_id.unwrap_or_else(|| {
+        PadId(crate::config::pad_index_for_uuid(
+            crate::config::PadOrderBackend::Hidraw,
+            uuid,
+        ))
+    });
     if let Some(dev) = open_dev(path, id, initial, emit_sys) {
         if existing_id.is_none() {
             id_by_uuid.insert(dev.uuid, id);
-            *next_id = next_id.saturating_add(1);
         }
         devs.push(dev);
     }
@@ -622,7 +626,6 @@ pub fn run(
 ) -> Result<(), String> {
     let watch = DevdWatch::new();
     let mut devs = Vec::new();
-    let mut next_id = 0u32;
     let mut id_by_uuid: HashMap<[u8; 16], PadId> = HashMap::new();
     let hidraw_paths = scan_hidraw_paths();
     let hidraw_count = hidraw_paths.len();
@@ -630,7 +633,6 @@ pub fn run(
         add_dev_if_new(
             path,
             &mut devs,
-            &mut next_id,
             &mut id_by_uuid,
             true,
             emit_sys,
@@ -763,7 +765,6 @@ pub fn run(
                 DevdEvent::Create(path) => add_dev_if_new(
                     path,
                     &mut devs,
-                    &mut next_id,
                     &mut id_by_uuid,
                     false,
                     emit_sys,

--- a/src/engine/input/backends/hidraw.rs
+++ b/src/engine/input/backends/hidraw.rs
@@ -96,11 +96,29 @@ const fn hidiocgrawname(len: usize) -> libc::c_ulong {
     ior(b'H', 0x04, len)
 }
 
+#[inline(always)]
+const fn hidiocgrawuniq(len: usize) -> libc::c_ulong {
+    ior(b'H', 0x08, len)
+}
+
 struct Dev {
     id: PadId,
     uuid: [u8; 16],
     name: String,
     path: String,
+    file: std::fs::File,
+    max_report_len: usize,
+    reports: Vec<ReportSpec>,
+}
+
+/// A validated controller node that has been opened and identified but not yet
+/// assigned a `PadId`. Building this first lets `add_dev_if_new` allocate a
+/// persisted pad slot only after confirming the node is a usable controller.
+struct PendingDev {
+    uuid: [u8; 16],
+    name: String,
+    vendor_id: Option<u16>,
+    product_id: Option<u16>,
     file: std::fs::File,
     max_report_len: usize,
     reports: Vec<ReportSpec>,
@@ -301,6 +319,55 @@ fn raw_device_name(file: &std::fs::File) -> Option<String> {
     std::str::from_utf8(&buf[..len]).ok().map(str::to_owned)
 }
 
+/// Reads the hidraw serial string (HIDIOCGRAWUNIQ), returning `None` on ioctl
+/// failure or when the value is empty/whitespace.
+fn raw_device_uniq(file: &std::fs::File) -> Option<String> {
+    let mut buf = [0u8; 256];
+    // SAFETY: `file` is an open hidraw device, and `buf` is writable stack
+    // storage for the kernel to fill with the NUL-terminated serial string.
+    let rc = unsafe {
+        libc::ioctl(
+            file.as_raw_fd(),
+            hidiocgrawuniq(buf.len()),
+            buf.as_mut_ptr(),
+        )
+    };
+    if rc < 0 {
+        return None;
+    }
+    let len = buf.iter().position(|b| *b == 0).unwrap_or(buf.len());
+    let value = std::str::from_utf8(&buf[..len]).ok()?.trim();
+    (!value.is_empty()).then(|| value.to_owned())
+}
+
+/// Derives a stable pad identity, preferring the hardware serial so the pad
+/// keeps its `PadId` across reboots and re-plugging into a different USB port.
+/// Falls back to model identity, then the device-node path as a last resort.
+///
+/// NOTE: FreeBSD's HIDIOCGRAWPHYS often reports the device-node name
+/// (e.g. "hidraw0") rather than a USB topology string, so it is deliberately
+/// not used here — it would be no more stable than the path.
+fn stable_uuid(
+    file: &std::fs::File,
+    vendor_id: Option<u16>,
+    product_id: Option<u16>,
+    raw_name: &str,
+    path: &str,
+) -> [u8; 16] {
+    let key = if let Some(uniq) = raw_device_uniq(file) {
+        format!("freebsd-hidraw:uniq:{uniq}")
+    } else if vendor_id.is_some() || product_id.is_some() || !raw_name.is_empty() {
+        format!(
+            "freebsd-hidraw:name:{raw_name}|vid:{:04x}|pid:{:04x}",
+            vendor_id.unwrap_or(0),
+            product_id.unwrap_or(0),
+        )
+    } else {
+        format!("freebsd-hidraw:path:{path}")
+    };
+    uuid_from_bytes(key.as_bytes())
+}
+
 fn raw_device_info(file: &std::fs::File) -> (Option<u16>, Option<u16>) {
     let mut info = HidrawDevInfo::default();
     // SAFETY: `file` is an open hidraw device, and `info` is writable stack
@@ -390,13 +457,8 @@ fn startup_error(hidraw_count: usize) -> String {
     "no /dev/hidraw* nodes found".to_owned()
 }
 
-fn open_dev(
-    path: String,
-    id: PadId,
-    initial: bool,
-    emit_sys: &mut impl FnMut(GpSystemEvent),
-) -> Option<Dev> {
-    let file = match std::fs::File::open(&path) {
+fn probe_dev(path: &str) -> Option<PendingDev> {
+    let file = match std::fs::File::open(path) {
         Ok(file) => file,
         Err(err) => {
             warn!("freebsd hidraw could not open '{path}': {err}");
@@ -436,21 +498,14 @@ fn open_dev(
         return None;
     }
     let (vendor_id, product_id) = raw_device_info(&file);
-    let raw_name = raw_device_name(&file).unwrap_or_else(|| path.clone());
+    let raw_name = raw_device_name(&file).unwrap_or_else(|| path.to_owned());
+    let uuid = stable_uuid(&file, vendor_id, product_id, &raw_name, path);
     let name = format!("hidraw:{raw_name}");
-    emit_sys(GpSystemEvent::Connected {
-        name: name.clone(),
-        id,
+    Some(PendingDev {
+        uuid,
+        name,
         vendor_id,
         product_id,
-        backend: PadBackend::FreeBsdHidraw,
-        initial,
-    });
-    Some(Dev {
-        id,
-        uuid: uuid_from_bytes(path.as_bytes()),
-        name,
-        path,
         file,
         max_report_len,
         reports,
@@ -467,21 +522,40 @@ fn add_dev_if_new(
     if !is_hidraw_path(&path) || devs.iter().any(|dev| dev.path == path) {
         return;
     }
-    let uuid = uuid_from_bytes(path.as_bytes());
-    let existing_id = id_by_uuid.get(&uuid).copied();
+    // Validate the node is a usable controller BEFORE allocating a persisted
+    // pad slot, so non-pad hidraw nodes (keyboards, mice, ...) never consume a
+    // PadId in the saved order.
+    let Some(pending) = probe_dev(&path) else {
+        return;
+    };
+    let existing_id = id_by_uuid.get(&pending.uuid).copied();
     // Stable, persisted slot so this pad keeps the same PadId across launches.
     let id = existing_id.unwrap_or_else(|| {
         PadId(crate::config::pad_index_for_uuid(
             crate::config::PadOrderBackend::Hidraw,
-            uuid,
+            pending.uuid,
         ))
     });
-    if let Some(dev) = open_dev(path, id, initial, emit_sys) {
-        if existing_id.is_none() {
-            id_by_uuid.insert(dev.uuid, id);
-        }
-        devs.push(dev);
+    emit_sys(GpSystemEvent::Connected {
+        name: pending.name.clone(),
+        id,
+        vendor_id: pending.vendor_id,
+        product_id: pending.product_id,
+        backend: PadBackend::FreeBsdHidraw,
+        initial,
+    });
+    if existing_id.is_none() {
+        id_by_uuid.insert(pending.uuid, id);
     }
+    devs.push(Dev {
+        id,
+        uuid: pending.uuid,
+        name: pending.name,
+        path,
+        file: pending.file,
+        max_report_len: pending.max_report_len,
+        reports: pending.reports,
+    });
 }
 
 fn remove_dev_by_path(path: &str, devs: &mut Vec<Dev>, emit_sys: &mut impl FnMut(GpSystemEvent)) {

--- a/src/engine/input/backends/iohid.rs
+++ b/src/engine/input/backends/iohid.rs
@@ -38,6 +38,14 @@ unsafe extern "C" {
     fn CFSetGetCount(the_set: CFTypeRef) -> CFIndex;
     fn CFSetGetValues(the_set: CFTypeRef, values: *mut CFTypeRef);
     fn CFNumberGetValue(number: CFTypeRef, the_type: i32, value_ptr: *mut c_void) -> bool;
+    fn CFStringGetCString(
+        the_string: CFStringRef,
+        buffer: *mut c_char,
+        buffer_size: CFIndex,
+        encoding: u32,
+    ) -> bool;
+    fn CFGetTypeID(cf: CFTypeRef) -> usize;
+    fn CFStringGetTypeID() -> usize;
 
     static kCFRunLoopDefaultMode: CFStringRef;
 }
@@ -99,6 +107,41 @@ fn cfnum_i32(v: CFTypeRef) -> Option<i32> {
     // storage for the requested CoreFoundation number conversion.
     let ok = unsafe { CFNumberGetValue(v, 9, ptr::addr_of_mut!(out).cast::<c_void>()) };
     ok.then_some(out)
+}
+
+/// Reads a CoreFoundation string property value into an owned `String`,
+/// returning `None` when the value is null, not a `CFString`, unreadable, or
+/// empty/whitespace. The value follows the CoreFoundation "Get" rule, so it is
+/// borrowed and must not be released here.
+fn cfstring_value(v: CFTypeRef) -> Option<String> {
+    if v.is_null() {
+        return None;
+    }
+    // SAFETY: `v` is a non-null CoreFoundation object reference; CFGetTypeID
+    // only reads its type tag.
+    if unsafe { CFGetTypeID(v) } != unsafe { CFStringGetTypeID() } {
+        return None;
+    }
+    let mut buf = [0 as c_char; 256];
+    // SAFETY: `v` is confirmed to be a CFString, and `buf` is writable storage
+    // that CFStringGetCString fills with a NUL-terminated UTF-8 string.
+    let ok = unsafe {
+        CFStringGetCString(
+            v,
+            buf.as_mut_ptr(),
+            buf.len() as CFIndex,
+            KCFSTRING_ENCODING_UTF8,
+        )
+    };
+    if !ok {
+        return None;
+    }
+    // SAFETY: on success `buf` holds a NUL-terminated C string within bounds.
+    let s = unsafe { std::ffi::CStr::from_ptr(buf.as_ptr()) }
+        .to_string_lossy()
+        .trim()
+        .to_owned();
+    (!s.is_empty()).then_some(s)
 }
 
 #[derive(Clone, Copy)]
@@ -180,6 +223,7 @@ struct Ctx {
     key_vendor_id: CFStringRef,
     key_product_id: CFStringRef,
     key_location_id: CFStringRef,
+    key_serial_number: CFStringRef,
 }
 
 #[inline(always)]
@@ -470,7 +514,32 @@ extern "C" fn on_match(
             product_id.unwrap_or(0),
             location_id.unwrap_or(-1),
         );
-        let uuid = uuid_from_bytes(name.as_bytes());
+        // Prefer the USB serial so the pad keeps a stable PadId regardless of
+        // which port it is plugged into. Fall back to the (port-bound) LocationID
+        // name when the device exposes no serial.
+        let serial = cfstring_value(IOHIDDeviceGetProperty(device, ctx.key_serial_number));
+        let uuid = match &serial {
+            Some(serial) => {
+                let serial_uuid = uuid_from_bytes(
+                    format!(
+                        "iohid:serial:{:04X}:{:04X}:{serial}",
+                        vendor_id.unwrap_or(0),
+                        product_id.unwrap_or(0),
+                    )
+                    .as_bytes(),
+                );
+                // Some cheap controllers report a constant, non-unique serial. If
+                // another currently-connected pad already resolved to this serial
+                // uuid, fall back to the port-bound identity so the two pads stay
+                // distinct instead of merging onto a single PadId.
+                if ctx.pad_devs.values().any(|dev| dev.uuid == serial_uuid) {
+                    uuid_from_bytes(name.as_bytes())
+                } else {
+                    serial_uuid
+                }
+            }
+            None => uuid_from_bytes(name.as_bytes()),
+        };
         let id = match ctx.id_by_uuid.entry(uuid) {
             Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
@@ -667,6 +736,7 @@ pub fn run(
             key_vendor_id: cfstr("VendorID"),
             key_product_id: cfstr("ProductID"),
             key_location_id: cfstr("LocationID"),
+            key_serial_number: cfstr("SerialNumber"),
         });
 
         let ctx_ptr = ptr::addr_of_mut!(*ctx).cast::<c_void>();

--- a/src/engine/input/backends/iohid.rs
+++ b/src/engine/input/backends/iohid.rs
@@ -168,7 +168,6 @@ struct Ctx {
     emit_pad: Box<dyn FnMut(PadEvent) + Send>,
     emit_sys: Box<dyn FnMut(GpSystemEvent) + Send>,
     emit_key: Box<dyn FnMut(RawKeyboardEvent) + Send>,
-    next_id: u32,
     id_by_uuid: HashMap<[u8; 16], PadId>,
     pad_devs: HashMap<usize, PadDev>,
     key_devs: HashMap<usize, KeyDev>,
@@ -475,8 +474,11 @@ extern "C" fn on_match(
         let id = match ctx.id_by_uuid.entry(uuid) {
             Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
-                let id = PadId(ctx.next_id);
-                ctx.next_id += 1;
+                // Stable, persisted slot so this pad keeps the same PadId across launches.
+                let id = PadId(crate::config::pad_index_for_uuid(
+                    crate::config::PadOrderBackend::IoHid,
+                    uuid,
+                ));
                 *entry.insert(id)
             }
         };
@@ -655,7 +657,6 @@ pub fn run(
             emit_pad: Box::new(emit_pad),
             emit_sys: Box::new(emit_sys),
             emit_key: Box::new(emit_key),
-            next_id: 0,
             id_by_uuid: HashMap::new(),
             pad_devs: HashMap::new(),
             key_devs: HashMap::new(),

--- a/src/engine/input/backends/w32_raw_input.rs
+++ b/src/engine/input/backends/w32_raw_input.rs
@@ -385,6 +385,32 @@ fn read_device_serial(device_path: &str) -> Option<String> {
     (!serial.is_empty()).then(|| serial.to_owned())
 }
 
+/// Derives the persisted identity uuid for a Raw Input pad.
+///
+/// When the device exposes a USB serial the uuid is derived from
+/// vendor/product/serial so the pad keeps the same `PadId` regardless of which
+/// USB port it is plugged into. Serial-less devices fall back to a hash of the
+/// (port-bound) interface path, which only stays stable across relaunches on
+/// the same port. Kept as a free function so the port-independence rule is unit
+/// testable without any HID hardware.
+fn rawinput_uuid(vendor: u16, product: u16, serial: Option<&str>, name: &str) -> [u8; 16] {
+    match serial {
+        Some(serial) => uuid_from_bytes(
+            format!("rawinput:serial:{vendor:04x}:{product:04x}:{serial}").as_bytes(),
+        ),
+        None => uuid_from_bytes(name.as_bytes()),
+    }
+}
+
+/// Lower-case hex of a 16-byte uuid, for diagnostic logging only.
+fn uuid_hex(uuid: &[u8; 16]) -> String {
+    let mut out = String::with_capacity(32);
+    for b in uuid {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
 fn get_device_name(h: HANDLE) -> Option<String> {
     // SAFETY: all pointers passed here reference local buffers that stay alive for
     // each Win32 call, and `h` is a device handle reported by Raw Input.
@@ -529,19 +555,13 @@ fn add_device(ctx: &mut Ctx, h: HANDLE, initial: bool) {
     }
 
     let name = get_device_name(h).unwrap_or_else(|| format!("RawInput:{h:?}"));
+    let vendor = hid.dwVendorId as u16;
+    let product = hid.dwProductId as u16;
     // Prefer the USB serial so the pad keeps a stable PadId regardless of which
     // port it is plugged into. Fall back to the (port-bound) interface path when
     // the device exposes no serial.
-    let uuid = match read_device_serial(&name) {
-        Some(serial) => uuid_from_bytes(
-            format!(
-                "rawinput:serial:{:04x}:{:04x}:{serial}",
-                hid.dwVendorId as u16, hid.dwProductId as u16
-            )
-            .as_bytes(),
-        ),
-        None => uuid_from_bytes(name.as_bytes()),
-    };
+    let serial = read_device_serial(&name);
+    let uuid = rawinput_uuid(vendor, product, serial.as_deref(), &name);
 
     let id = match ctx.id_by_uuid.entry(uuid) {
         Entry::Occupied(entry) => *entry.get(),
@@ -554,6 +574,14 @@ fn add_device(ctx: &mut Ctx, h: HANDLE, initial: bool) {
             *entry.insert(id)
         }
     };
+
+    log::debug!(
+        "RawInput pad connect: name={name:?} vid={vendor:04x} pid={product:04x} serial={} \
+         uuid={} PadId={}",
+        serial.as_deref().unwrap_or("<none:port-bound-fallback>"),
+        uuid_hex(&uuid),
+        id.0,
+    );
 
     let refs = match ctx.refs_by_uuid.entry(uuid) {
         Entry::Occupied(mut entry) => {
@@ -1138,4 +1166,66 @@ pub fn run_keyboard_only(emit_key: impl FnMut(RawKeyboardEvent) + Send + 'static
         held: [false; RAW_KEY_HELD_SLOTS],
         enable_pad: false,
     }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rawinput_uuid;
+
+    // A pad that reports a serial keeps the same uuid no matter which port
+    // (interface path / RIDI_DEVICENAME) it comes back on. This is the whole
+    // point of reading the serial: PadId stays stable across re-plugging.
+    #[test]
+    fn serial_uuid_is_port_independent() {
+        let a = rawinput_uuid(
+            0x1234,
+            0x5678,
+            Some("ABC123"),
+            r"\\?\HID#VID_1234&PID_5678&MI_00#7&port_a#{guid}",
+        );
+        let b = rawinput_uuid(
+            0x1234,
+            0x5678,
+            Some("ABC123"),
+            r"\\?\HID#VID_1234&PID_5678&MI_00#9&port_b#{guid}",
+        );
+        assert_eq!(
+            a, b,
+            "same serial must yield the same uuid regardless of port path"
+        );
+    }
+
+    // Distinct serials on the same model are distinct pads.
+    #[test]
+    fn distinct_serials_are_distinct() {
+        let a = rawinput_uuid(0x1234, 0x5678, Some("ABC123"), "name");
+        let b = rawinput_uuid(0x1234, 0x5678, Some("ZZZ999"), "name");
+        assert_ne!(a, b);
+    }
+
+    // Same serial string but different vendor/product is a different device.
+    #[test]
+    fn vid_pid_participate_in_serial_uuid() {
+        let a = rawinput_uuid(0x1234, 0x5678, Some("ABC123"), "name");
+        let b = rawinput_uuid(0x1111, 0x5678, Some("ABC123"), "name");
+        let c = rawinput_uuid(0x1234, 0x9999, Some("ABC123"), "name");
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+    }
+
+    // Serial-less devices fall back to the interface path, so the uuid follows
+    // the port (stable across relaunch on the same port, not across re-plug).
+    #[test]
+    fn serial_less_falls_back_to_name() {
+        let path = r"\\?\HID#VID_1234&PID_5678&MI_00#7&port_a#{guid}";
+        let fallback = rawinput_uuid(0x1234, 0x5678, None, path);
+        // Deterministic for the same path...
+        assert_eq!(fallback, rawinput_uuid(0x1234, 0x5678, None, path));
+        // ...and differs from the serial-derived identity for the same device.
+        let with_serial = rawinput_uuid(0x1234, 0x5678, Some("ABC123"), path);
+        assert_ne!(fallback, with_serial);
+        // A different port path yields a different fallback uuid (the old bug).
+        let other_port = r"\\?\HID#VID_1234&PID_5678&MI_00#9&port_b#{guid}";
+        assert_ne!(fallback, rawinput_uuid(0x1234, 0x5678, None, other_port));
+    }
 }

--- a/src/engine/input/backends/w32_raw_input.rs
+++ b/src/engine/input/backends/w32_raw_input.rs
@@ -86,7 +86,6 @@ struct Ctx {
     devices: HashMap<isize, Dev>,
     id_by_uuid: HashMap<[u8; 16], PadId>,
     refs_by_uuid: HashMap<[u8; 16], u32>,
-    next_id: u32,
     buf: Vec<u8>,
     held: [bool; RAW_KEY_HELD_SLOTS],
     enable_pad: bool,
@@ -479,8 +478,11 @@ fn add_device(ctx: &mut Ctx, h: HANDLE, initial: bool) {
     let id = match ctx.id_by_uuid.entry(uuid) {
         Entry::Occupied(entry) => *entry.get(),
         Entry::Vacant(entry) => {
-            let id = PadId(ctx.next_id);
-            ctx.next_id = ctx.next_id.saturating_add(1);
+            // Stable, persisted slot so this pad keeps the same PadId across launches.
+            let id = PadId(crate::config::pad_index_for_uuid(
+                crate::config::PadOrderBackend::RawInput,
+                uuid,
+            ));
             *entry.insert(id)
         }
     };
@@ -1049,7 +1051,6 @@ pub fn run(
         devices: HashMap::new(),
         id_by_uuid: HashMap::new(),
         refs_by_uuid: HashMap::new(),
-        next_id: 0,
         buf: Vec::with_capacity(1024),
         held: [false; RAW_KEY_HELD_SLOTS],
         enable_pad: true,
@@ -1065,7 +1066,6 @@ pub fn run_keyboard_only(emit_key: impl FnMut(RawKeyboardEvent) + Send + 'static
         devices: HashMap::new(),
         id_by_uuid: HashMap::new(),
         refs_by_uuid: HashMap::new(),
-        next_id: 0,
         buf: Vec::with_capacity(1024),
         held: [false; RAW_KEY_HELD_SLOTS],
         enable_pad: false,

--- a/src/engine/input/backends/w32_raw_input.rs
+++ b/src/engine/input/backends/w32_raw_input.rs
@@ -329,6 +329,62 @@ fn wide_to_string(mut v: Vec<u16>) -> String {
     String::from_utf16_lossy(&v)
 }
 
+/// Reads the USB serial number string for a HID device interface path.
+///
+/// The path comes from `RIDI_DEVICENAME` and is itself openable. Opening with
+/// zero desired access lets us query even devices held open exclusively
+/// elsewhere. `HidD_GetSerialNumberString` walks to the USB iSerialNumber, so
+/// it recovers a serial even for composite devices whose interface path is
+/// topology-derived. Returns `None` on any failure or an empty/whitespace
+/// serial.
+fn read_device_serial(device_path: &str) -> Option<String> {
+    use windows::Win32::Devices::HumanInterfaceDevice::HidD_GetSerialNumberString;
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_FLAGS_AND_ATTRIBUTES, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+
+    let mut wide: Vec<u16> = device_path.encode_utf16().collect();
+    wide.push(0);
+
+    // SAFETY: `wide` is a NUL-terminated UTF-16 string that outlives the call,
+    // and all other arguments are plain values / None.
+    let handle = unsafe {
+        CreateFileW(
+            PCWSTR(wide.as_ptr()),
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            None,
+            OPEN_EXISTING,
+            FILE_FLAGS_AND_ATTRIBUTES(0),
+            None,
+        )
+    }
+    .ok()?;
+
+    let mut buf = [0u16; 256];
+    // SAFETY: `handle` is an open HID device, and `buf` is writable storage; the
+    // length is passed in bytes as required by HidD_GetSerialNumberString.
+    let ok = unsafe {
+        HidD_GetSerialNumberString(
+            handle,
+            buf.as_mut_ptr().cast::<c_void>(),
+            (buf.len() * size_of::<u16>()) as u32,
+        )
+    };
+
+    // SAFETY: `handle` was opened above and is not used after being closed.
+    let _ = unsafe { CloseHandle(handle) };
+
+    if !ok {
+        return None;
+    }
+    let len = buf.iter().position(|c| *c == 0).unwrap_or(buf.len());
+    let serial = String::from_utf16_lossy(&buf[..len]);
+    let serial = serial.trim();
+    (!serial.is_empty()).then(|| serial.to_owned())
+}
+
 fn get_device_name(h: HANDLE) -> Option<String> {
     // SAFETY: all pointers passed here reference local buffers that stay alive for
     // each Win32 call, and `h` is a device handle reported by Raw Input.
@@ -473,7 +529,19 @@ fn add_device(ctx: &mut Ctx, h: HANDLE, initial: bool) {
     }
 
     let name = get_device_name(h).unwrap_or_else(|| format!("RawInput:{h:?}"));
-    let uuid = uuid_from_bytes(name.as_bytes());
+    // Prefer the USB serial so the pad keeps a stable PadId regardless of which
+    // port it is plugged into. Fall back to the (port-bound) interface path when
+    // the device exposes no serial.
+    let uuid = match read_device_serial(&name) {
+        Some(serial) => uuid_from_bytes(
+            format!(
+                "rawinput:serial:{:04x}:{:04x}:{serial}",
+                hid.dwVendorId as u16, hid.dwProductId as u16
+            )
+            .as_bytes(),
+        ),
+        None => uuid_from_bytes(name.as_bytes()),
+    };
 
     let id = match ctx.id_by_uuid.entry(uuid) {
         Entry::Occupied(entry) => *entry.get(),

--- a/src/engine/input/backends/wgi.rs
+++ b/src/engine/input/backends/wgi.rs
@@ -395,7 +395,6 @@ struct Ctx {
     devs: Vec<Dev>,
     idx_by_uuid: HashMap<[u8; 16], usize>,
     id_by_uuid: HashMap<[u8; 16], PadId>,
-    next_id: u32,
     startup_grace_until: Instant,
 }
 
@@ -423,8 +422,11 @@ fn add_controller(ctx: &mut Ctx, controller: RawGameController) {
     let id = match ctx.id_by_uuid.entry(uuid) {
         Entry::Occupied(entry) => *entry.get(),
         Entry::Vacant(entry) => {
-            let id = PadId(ctx.next_id);
-            ctx.next_id += 1;
+            // Stable, persisted slot so this pad keeps the same PadId across launches.
+            let id = PadId(crate::config::pad_index_for_uuid(
+                crate::config::PadOrderBackend::Wgi,
+                uuid,
+            ));
             *entry.insert(id)
         }
     };
@@ -818,7 +820,6 @@ pub fn run(
         devs: Vec::new(),
         idx_by_uuid: HashMap::new(),
         id_by_uuid: HashMap::new(),
-        next_id: 0,
         startup_grace_until: Instant::now() + STARTUP_GRACE,
     };
 


### PR DESCRIPTION
## Why

Players with two HID dance pads (FSR / Teensy class) reported that the pads sometimes swap which one is "Pad 0" vs "Pad 1" in the Configure Mappings screen, forcing them to re-bind Left/Down/Up/Right every time it happens.

The root cause: each input backend assigned devices a runtime `PadId` in OS enumeration order, with the counter starting from 0 on every launch. That order is not stable across reboots or replugs, and since per-pad arrow bindings are pinned to the index, any reshuffle means the bindings now point at the wrong physical pad.

## Approach

Persist an append-only, per-backend `uuid -> index` order in the config file, so each physical pad keeps a stable `PadId` across launches. This mirrors how SMX pads already pin a serial to a player slot.