### PR TITLE
fix(smx): old config for load cell pads, config write fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3917,9 +3917,9 @@ dependencies = [
 
 [[package]]
 name = "rustmaniax-sdk"
-version = "1.1.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280174855285cd9cafb9f4354014d48684520a81df07c39339c10e9e95a4c3f7"
+checksum = "43ecae32caf951cb8af8750e1b520af75ec6a600413b4444b467470811bdbbbf"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ rssp = { git = "https://github.com/pnn64/rssp", branch = "main" }
 null-or-die = { git = "https://github.com/pnn64/null-or-die", branch = "main" }
 
 # StepManiaX pad SDK
-rustmaniax-sdk = "1.1.1"
+rustmaniax-sdk = "1.1.3"
 
 # Software renderer
 softbuffer = "0.4.8"


### PR DESCRIPTION
## Summary

- There was a bug in the RustManiaX SDK writing the wrong length of config to older load cell pads. 
- Bug fixed in the sdk, bumping version to latest