### PR TITLE
feat(pad-config): Load-cell press/release threshold editing (plus mock pads for UI development)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -143,14 +143,20 @@ fn emit_build_info() {
 }
 
 /// Tell cargo to watch the git files that change when HEAD moves: `.git/HEAD`
-/// (checkouts), the ref file HEAD points at (new commits on the branch), and
-/// `packed-refs` (refs can live there instead after gc). Only existing paths
-/// are emitted; a missing path would make cargo re-run the script every build.
+/// (checkouts), `.git/logs/HEAD` (the reflog, appended on every commit and
+/// checkout — this is what keeps the hash fresh even when the branch ref is
+/// packed or, in a worktree, lives in the common git dir), the ref file HEAD
+/// points at, and `packed-refs`. Only existing paths are emitted; a missing
+/// path would make cargo re-run the script every build.
 fn emit_git_rerun_paths(manifest_dir: &Path) {
     let git_dir = git_output(manifest_dir, &["rev-parse", "--git-dir"])
         .map(|d| manifest_dir.join(d))
         .unwrap_or_else(|| manifest_dir.join(".git"));
-    let mut watch = vec![git_dir.join("HEAD"), git_dir.join("packed-refs")];
+    let mut watch = vec![
+        git_dir.join("HEAD"),
+        git_dir.join("logs/HEAD"),
+        git_dir.join("packed-refs"),
+    ];
     if let Ok(head) = fs::read_to_string(git_dir.join("HEAD"))
         && let Some(reference) = head.trim().strip_prefix("ref: ")
     {

--- a/build.rs
+++ b/build.rs
@@ -122,6 +122,9 @@ fn copy_assets(target_dir: &Path) -> Result<(), Box<dyn Error>> {
 fn emit_build_info() {
     let manifest_dir =
         PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string()));
+    // Re-run when the checked-out commit moves, so an otherwise cached build
+    // can't keep reporting a stale hash/stamp in the startup banner.
+    emit_git_rerun_paths(&manifest_dir);
     let hash = git_output(&manifest_dir, &["rev-parse", "--short=10", "HEAD"])
         .unwrap_or_else(|| "unknown".to_string());
     let stamp = git_output(
@@ -137,6 +140,27 @@ fn emit_build_info() {
     .unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=DEADSYNC_BUILD_HASH={hash}");
     println!("cargo:rustc-env=DEADSYNC_BUILD_STAMP={stamp}");
+}
+
+/// Tell cargo to watch the git files that change when HEAD moves: `.git/HEAD`
+/// (checkouts), the ref file HEAD points at (new commits on the branch), and
+/// `packed-refs` (refs can live there instead after gc). Only existing paths
+/// are emitted; a missing path would make cargo re-run the script every build.
+fn emit_git_rerun_paths(manifest_dir: &Path) {
+    let git_dir = git_output(manifest_dir, &["rev-parse", "--git-dir"])
+        .map(|d| manifest_dir.join(d))
+        .unwrap_or_else(|| manifest_dir.join(".git"));
+    let mut watch = vec![git_dir.join("HEAD"), git_dir.join("packed-refs")];
+    if let Ok(head) = fs::read_to_string(git_dir.join("HEAD"))
+        && let Some(reference) = head.trim().strip_prefix("ref: ")
+    {
+        watch.push(git_dir.join(reference));
+    }
+    for path in watch {
+        if path.exists() {
+            println!("cargo:rerun-if-changed={}", path.display());
+        }
+    }
 }
 
 fn git_output(cwd: &Path, args: &[&str]) -> Option<String> {

--- a/crates/deadsync-input-fsr/src/fsrio.rs
+++ b/crates/deadsync-input-fsr/src/fsrio.rs
@@ -109,6 +109,7 @@ mod imp {
                     aggregate_threshold,
                     active: aggregate_value >= aggregate_threshold && aggregate_threshold > 0,
                     value_scale: MAX_SENSOR_VALUE,
+                    release_threshold: None,
                 }
             });
             vec![PadView {

--- a/crates/deadsync-input-fsr/src/lib.rs
+++ b/crates/deadsync-input-fsr/src/lib.rs
@@ -15,6 +15,13 @@ mod fsrio;
     target_os = "freebsd",
     target_os = "macos"
 ))]
+mod mock;
+#[cfg(any(
+    windows,
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "macos"
+))]
 mod smx;
 
 #[cfg(any(
@@ -26,6 +33,10 @@ mod smx;
 pub struct Monitor {
     fsrio: fsrio::Monitor,
     smx: smx::Monitor,
+    /// Fake SMX pads for UI development (`DEADSYNC_MOCK_PADS`). When set, the
+    /// mock owns the SMX backend slot: native SMX never starts (no pads, no
+    /// USB writes) and SMX-routed edits land here instead.
+    mock: Option<mock::Monitor>,
 }
 
 #[cfg(any(
@@ -39,6 +50,7 @@ impl Monitor {
         Self {
             fsrio: fsrio::Monitor::new(),
             smx: smx::Monitor::new(),
+            mock: mock::Monitor::from_env(),
         }
     }
 
@@ -53,7 +65,10 @@ impl Monitor {
     /// Enumerate every connected FSR pad across all backends.
     pub fn poll_pads(&mut self) -> Vec<PadView> {
         let mut pads = self.fsrio.poll_pads();
-        pads.extend(self.smx.poll_pads());
+        match &mut self.mock {
+            Some(m) => pads.extend(m.poll_pads()),
+            None => pads.extend(self.smx.poll_pads()),
+        }
         pads
     }
 
@@ -74,7 +89,10 @@ impl Monitor {
                 kind == ThresholdKind::Press
                     && self.fsrio.set_threshold(device, button, sensor, value)
             }
-            BackendKind::Smx => self.smx.set_threshold(device, button, sensor, kind, value),
+            BackendKind::Smx => match &mut self.mock {
+                Some(m) => m.set_threshold(device, button, sensor, kind, value),
+                None => self.smx.set_threshold(device, button, sensor, kind, value),
+            },
         }
     }
 
@@ -90,7 +108,10 @@ impl Monitor {
             BackendKind::Fsrio => self
                 .fsrio
                 .set_sensor_enabled(device, button, sensor, enabled),
-            BackendKind::Smx => self.smx.set_sensor_enabled(device, button, sensor, enabled),
+            BackendKind::Smx => match &mut self.mock {
+                Some(m) => m.set_sensor_enabled(device, button, sensor, enabled),
+                None => self.smx.set_sensor_enabled(device, button, sensor, enabled),
+            },
         }
     }
 
@@ -98,7 +119,10 @@ impl Monitor {
     pub fn set_auto_recalibration(&mut self, device: PadDeviceId, enabled: bool) -> bool {
         match device.backend {
             BackendKind::Fsrio => self.fsrio.set_auto_recalibration(device, enabled),
-            BackendKind::Smx => self.smx.set_auto_recalibration(device, enabled),
+            BackendKind::Smx => match &mut self.mock {
+                Some(m) => m.set_auto_recalibration(device, enabled),
+                None => self.smx.set_auto_recalibration(device, enabled),
+            },
         }
     }
 
@@ -106,7 +130,10 @@ impl Monitor {
     pub fn set_debounce_micros(&mut self, device: PadDeviceId, micros: u16) -> bool {
         match device.backend {
             BackendKind::Fsrio => self.fsrio.set_debounce_micros(device, micros),
-            BackendKind::Smx => self.smx.set_debounce_micros(device, micros),
+            BackendKind::Smx => match &mut self.mock {
+                Some(m) => m.set_debounce_micros(device, micros),
+                None => self.smx.set_debounce_micros(device, micros),
+            },
         }
     }
 

--- a/crates/deadsync-input-fsr/src/lib.rs
+++ b/crates/deadsync-input-fsr/src/lib.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use deadsync_input::fsr::{BackendKind, PadDeviceId, PadView, ThresholdKind};
+use deadsync_input::fsr::{BackendKind, PadDeviceId, PadView};
 
 #[cfg(any(
     windows,
@@ -35,7 +35,7 @@ pub struct Monitor {
     smx: smx::Monitor,
     /// Fake SMX pads for UI development (`DEADSYNC_MOCK_PADS`). When set, the
     /// mock owns the SMX backend slot: native SMX never starts (no pads, no
-    /// USB writes) and SMX-routed edits land here instead.
+    /// USB writes) and SMX-routed calls land here instead.
     mock: Option<mock::Monitor>,
 }
 
@@ -58,7 +58,10 @@ impl Monitor {
         let mut out = String::new();
         out.push_str(&self.fsrio.debug_dump());
         out.push_str("\n\n");
-        out.push_str(&self.smx.debug_dump());
+        match &mut self.mock {
+            Some(m) => out.push_str(&m.debug_dump()),
+            None => out.push_str(&self.smx.debug_dump()),
+        }
         write_dump_file(path, out)
     }
 
@@ -72,26 +75,41 @@ impl Monitor {
         pads
     }
 
-    /// Set a threshold on a specific pad. `sensor` of `None` applies to every
-    /// sensor in the button (Simple mode); `Some(i)` targets one sensor.
-    /// `kind` picks the press or release threshold; only pads that expose a
-    /// separate release threshold (SMX load cell) accept `Release`.
+    /// Set a single threshold on a specific pad (the backend derives its own
+    /// release side). `sensor` of `None` applies to every sensor in the button
+    /// (Simple mode); `Some(i)` targets one sensor. Load-cell pads edit their
+    /// press/release pair through `set_threshold_pair` instead.
     pub fn set_threshold(
         &mut self,
         device: PadDeviceId,
         button: usize,
         sensor: Option<usize>,
-        kind: ThresholdKind,
         value: u16,
     ) -> bool {
         match device.backend {
-            BackendKind::Fsrio => {
-                kind == ThresholdKind::Press
-                    && self.fsrio.set_threshold(device, button, sensor, value)
-            }
+            BackendKind::Fsrio => self.fsrio.set_threshold(device, button, sensor, value),
             BackendKind::Smx => match &mut self.mock {
-                Some(m) => m.set_threshold(device, button, sensor, kind, value),
-                None => self.smx.set_threshold(device, button, sensor, kind, value),
+                Some(m) => m.set_threshold(device, button, sensor, value),
+                None => self.smx.set_threshold(device, button, sensor, value),
+            },
+        }
+    }
+
+    /// Set a load-cell button's press (high) and release (low) thresholds in
+    /// one config write, so the pad can never observe an inverted intermediate
+    /// pair. Only SMX load-cell pads support this.
+    pub fn set_threshold_pair(
+        &mut self,
+        device: PadDeviceId,
+        button: usize,
+        press: u16,
+        release: u16,
+    ) -> bool {
+        match device.backend {
+            BackendKind::Fsrio => false,
+            BackendKind::Smx => match &mut self.mock {
+                Some(m) => m.set_threshold_pair(device, button, press, release),
+                None => self.smx.set_threshold_pair(device, button, press, release),
             },
         }
     }
@@ -141,7 +159,10 @@ impl Monitor {
     /// while the config screen is open and `false` when leaving it.
     pub fn set_active(&mut self, active: bool) {
         self.fsrio.set_active(active);
-        self.smx.set_active(active);
+        match &mut self.mock {
+            Some(m) => m.set_active(active),
+            None => self.smx.set_active(active),
+        }
     }
 }
 
@@ -152,7 +173,7 @@ impl Monitor {
     target_os = "macos"
 )))]
 mod unsupported {
-    use super::{PadDeviceId, PadView, ThresholdKind};
+    use super::{PadDeviceId, PadView};
     use std::fmt::Write as _;
     use std::path::Path;
     use std::time::SystemTime;
@@ -174,8 +195,17 @@ mod unsupported {
             _device: PadDeviceId,
             _button: usize,
             _sensor: Option<usize>,
-            _kind: ThresholdKind,
             _value: u16,
+        ) -> bool {
+            false
+        }
+
+        pub fn set_threshold_pair(
+            &mut self,
+            _device: PadDeviceId,
+            _button: usize,
+            _press: u16,
+            _release: u16,
         ) -> bool {
             false
         }

--- a/crates/deadsync-input-fsr/src/lib.rs
+++ b/crates/deadsync-input-fsr/src/lib.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use deadsync_input::fsr::{BackendKind, PadDeviceId, PadView};
+use deadsync_input::fsr::{BackendKind, PadDeviceId, PadView, ThresholdKind};
 
 #[cfg(any(
     windows,
@@ -59,16 +59,22 @@ impl Monitor {
 
     /// Set a threshold on a specific pad. `sensor` of `None` applies to every
     /// sensor in the button (Simple mode); `Some(i)` targets one sensor.
+    /// `kind` picks the press or release threshold; only pads that expose a
+    /// separate release threshold (SMX load cell) accept `Release`.
     pub fn set_threshold(
         &mut self,
         device: PadDeviceId,
         button: usize,
         sensor: Option<usize>,
+        kind: ThresholdKind,
         value: u16,
     ) -> bool {
         match device.backend {
-            BackendKind::Fsrio => self.fsrio.set_threshold(device, button, sensor, value),
-            BackendKind::Smx => self.smx.set_threshold(device, button, sensor, value),
+            BackendKind::Fsrio => {
+                kind == ThresholdKind::Press
+                    && self.fsrio.set_threshold(device, button, sensor, value)
+            }
+            BackendKind::Smx => self.smx.set_threshold(device, button, sensor, kind, value),
         }
     }
 
@@ -119,7 +125,7 @@ impl Monitor {
     target_os = "macos"
 )))]
 mod unsupported {
-    use super::{PadDeviceId, PadView};
+    use super::{PadDeviceId, PadView, ThresholdKind};
     use std::fmt::Write as _;
     use std::path::Path;
     use std::time::SystemTime;
@@ -141,6 +147,7 @@ mod unsupported {
             _device: PadDeviceId,
             _button: usize,
             _sensor: Option<usize>,
+            _kind: ThresholdKind,
             _value: u16,
         ) -> bool {
             false

--- a/crates/deadsync-input-fsr/src/mock.rs
+++ b/crates/deadsync-input-fsr/src/mock.rs
@@ -1,0 +1,339 @@
+//! Synthetic SMX pads for UI development, enabled with `DEADSYNC_MOCK_PADS`.
+//!
+//! Set the variable to a comma-separated list of pad kinds, e.g.
+//! `DEADSYNC_MOCK_PADS=loadcell` or `DEADSYNC_MOCK_PADS=loadcell,fsr` (any
+//! other non-empty value means one load-cell pad). Each kind becomes one fake
+//! pad on the Configure Pads screen, with animated sensor readings and
+//! thresholds edited in memory, so the whole editor can be exercised without
+//! hardware. While the variable is set, `engine::smx::init` refuses to start
+//! the SDK, so native SMX is fully off and nothing is written over USB.
+
+use super::smx::{
+    FSR_VALUE_SCALE, LOADCELL_VALUE_SCALE, MAX_DEBOUNCE_US, MAX_FSR_THRESHOLD,
+    MAX_LOADCELL_THRESHOLD, MIN_DEBOUNCE_US, MIN_FSR_THRESHOLD, MIN_LOADCELL_THRESHOLD,
+    PANEL_SENSOR_COUNT, SENSOR_DISPLAY_ORDER, SENSOR_EDGE_LABELS,
+};
+use deadsync_input::fsr::{
+    BackendKind, ButtonView, PAD_BUTTON_COUNT, PAD_BUTTON_LABELS, PadDeviceId, PadView, SensorView,
+    ThresholdKind,
+};
+use std::time::Instant;
+
+/// Starting thresholds: the Low preset's load-cell pair and Medium's FSR value.
+const INIT_LOADCELL_PRESS: u16 = 80;
+const INIT_LOADCELL_RELEASE: u16 = 70;
+const INIT_FSR_THRESHOLD: u16 = 175;
+const INIT_DEBOUNCE_US: u16 = 4000;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MockKind {
+    LoadCell,
+    Fsr,
+}
+
+struct MockPad {
+    kind: MockKind,
+    /// Per-button per-sensor press (high) thresholds. Load-cell buttons keep
+    /// all four in lockstep (one threshold per panel).
+    press: [[u16; PANEL_SENSOR_COUNT]; PAD_BUTTON_COUNT],
+    /// Per-button release (low) thresholds (load cell only).
+    release: [u16; PAD_BUTTON_COUNT],
+    /// Per-sensor enable flags (FSR only).
+    enabled: [[bool; PANEL_SENSOR_COUNT]; PAD_BUTTON_COUNT],
+    auto_recal: bool,
+    debounce_us: u16,
+}
+
+impl MockPad {
+    fn new(kind: MockKind) -> Self {
+        let press = match kind {
+            MockKind::LoadCell => INIT_LOADCELL_PRESS,
+            MockKind::Fsr => INIT_FSR_THRESHOLD,
+        };
+        Self {
+            kind,
+            press: [[press; PANEL_SENSOR_COUNT]; PAD_BUTTON_COUNT],
+            release: [INIT_LOADCELL_RELEASE; PAD_BUTTON_COUNT],
+            enabled: [[true; PANEL_SENSOR_COUNT]; PAD_BUTTON_COUNT],
+            auto_recal: true,
+            debounce_us: INIT_DEBOUNCE_US,
+        }
+    }
+
+    fn threshold_range(&self) -> (u16, u16) {
+        match self.kind {
+            MockKind::LoadCell => (MIN_LOADCELL_THRESHOLD, MAX_LOADCELL_THRESHOLD),
+            MockKind::Fsr => (MIN_FSR_THRESHOLD, MAX_FSR_THRESHOLD),
+        }
+    }
+}
+
+pub struct Monitor {
+    pads: Vec<MockPad>,
+    started: Instant,
+}
+
+impl Monitor {
+    /// Build the mock monitor from `DEADSYNC_MOCK_PADS`, or `None` if unset.
+    pub fn from_env() -> Option<Self> {
+        deadsync_smx::mock_pads_env().map(|spec| Self::from_spec(&spec))
+    }
+
+    fn from_spec(spec: &str) -> Self {
+        let mut kinds: Vec<MockKind> = spec
+            .split(',')
+            .filter_map(|s| match s.trim().to_ascii_lowercase().as_str() {
+                "loadcell" | "load-cell" | "load_cell" => Some(MockKind::LoadCell),
+                "fsr" => Some(MockKind::Fsr),
+                _ => None,
+            })
+            .take(2)
+            .collect();
+        // Any other non-empty value (e.g. "1") still turns the mock on.
+        if kinds.is_empty() {
+            kinds.push(MockKind::LoadCell);
+        }
+        log::info!("SMX mock: providing {} fake pad(s): {kinds:?}", kinds.len());
+        Self {
+            pads: kinds.into_iter().map(MockPad::new).collect(),
+            started: Instant::now(),
+        }
+    }
+
+    pub fn poll_pads(&mut self) -> Vec<PadView> {
+        let t = self.started.elapsed().as_secs_f32();
+        self.pads
+            .iter()
+            .enumerate()
+            .map(|(i, pad)| {
+                let buttons = std::array::from_fn(|b| match pad.kind {
+                    MockKind::LoadCell => load_cell_button(pad, i, b, t),
+                    MockKind::Fsr => fsr_button(pad, i, b, t),
+                });
+                let fsr = pad.kind == MockKind::Fsr;
+                PadView {
+                    device_id: PadDeviceId {
+                        backend: BackendKind::Smx,
+                        index: i,
+                    },
+                    device_name: format!("StepManiaX P{} [MOCK]", i + 1),
+                    is_p2_side: i == 1,
+                    buttons,
+                    supports_advanced: fsr,
+                    simple_per_sensor_bars: !fsr,
+                    supports_sensor_toggle: fsr,
+                    auto_recalibration: fsr.then_some(pad.auto_recal),
+                    debounce_micros: fsr.then_some(pad.debounce_us),
+                }
+            })
+            .collect()
+    }
+
+    pub fn set_threshold(
+        &mut self,
+        device: PadDeviceId,
+        button: usize,
+        sensor: Option<usize>,
+        kind: ThresholdKind,
+        value: u16,
+    ) -> bool {
+        let Some(pad) = self.pad_mut(device, button) else {
+            return false;
+        };
+        let (min, max) = pad.threshold_range();
+        if !(min..=max).contains(&value) {
+            return false;
+        }
+        match (pad.kind, kind) {
+            (MockKind::LoadCell, ThresholdKind::Press) => {
+                pad.press[button] = [value; PANEL_SENSOR_COUNT];
+            }
+            (MockKind::LoadCell, ThresholdKind::Release) => pad.release[button] = value,
+            (MockKind::Fsr, ThresholdKind::Press) => match sensor {
+                Some(s) if s < PANEL_SENSOR_COUNT => pad.press[button][s] = value,
+                Some(_) => return false,
+                None => pad.press[button] = [value; PANEL_SENSOR_COUNT],
+            },
+            (MockKind::Fsr, ThresholdKind::Release) => return false,
+        }
+        true
+    }
+
+    pub fn set_sensor_enabled(
+        &mut self,
+        device: PadDeviceId,
+        button: usize,
+        sensor: usize,
+        enabled: bool,
+    ) -> bool {
+        let Some(pad) = self.pad_mut(device, button) else {
+            return false;
+        };
+        if pad.kind != MockKind::Fsr || sensor >= PANEL_SENSOR_COUNT {
+            return false;
+        }
+        pad.enabled[button][sensor] = enabled;
+        true
+    }
+
+    pub fn set_auto_recalibration(&mut self, device: PadDeviceId, enabled: bool) -> bool {
+        let Some(pad) = self.pad_mut(device, 0) else {
+            return false;
+        };
+        pad.auto_recal = enabled;
+        true
+    }
+
+    pub fn set_debounce_micros(&mut self, device: PadDeviceId, micros: u16) -> bool {
+        if !(MIN_DEBOUNCE_US..=MAX_DEBOUNCE_US).contains(&micros) {
+            return false;
+        }
+        let Some(pad) = self.pad_mut(device, 0) else {
+            return false;
+        };
+        pad.debounce_us = micros;
+        true
+    }
+
+    fn pad_mut(&mut self, device: PadDeviceId, button: usize) -> Option<&mut MockPad> {
+        if device.backend != BackendKind::Smx || button >= PAD_BUTTON_COUNT {
+            return None;
+        }
+        self.pads.get_mut(device.index)
+    }
+}
+
+/// A smooth fake sensor reading: idles at zero with staggered "press" bumps
+/// that cross typical thresholds, so bars move and active states light up.
+fn wave(t: f32, pad: usize, button: usize, sensor: usize, scale: u16) -> u16 {
+    let period = 3.0 + 0.7 * button as f32 + 0.35 * sensor as f32 + 1.3 * pad as f32;
+    let phase = 1.1 * sensor as f32 + 2.3 * button as f32;
+    let s = (t * std::f32::consts::TAU / period + phase).sin();
+    (s.max(0.0).powi(3) * 0.85 * f32::from(scale)) as u16
+}
+
+fn load_cell_button(pad: &MockPad, pad_idx: usize, b: usize, t: f32) -> ButtonView {
+    let threshold = pad.press[b][0];
+    let sensors: Vec<SensorView> = (0..PANEL_SENSOR_COUNT)
+        .map(|s| {
+            let raw_value = wave(t, pad_idx, b, s, LOADCELL_VALUE_SCALE);
+            SensorView {
+                firmware_index: s,
+                label: None, // corners, numbered 1-4 in the UI
+                raw_value,
+                value_norm: normalize(raw_value, LOADCELL_VALUE_SCALE),
+                raw_threshold: threshold,
+                threshold_norm: normalize(threshold, LOADCELL_VALUE_SCALE),
+                active: raw_value >= threshold && threshold > 0,
+                enabled: true,
+            }
+        })
+        .collect();
+    let aggregate_value = sensors.iter().map(|s| s.raw_value).max().unwrap_or(0);
+    ButtonView {
+        label: PAD_BUTTON_LABELS[b],
+        sensors,
+        min_raw_threshold: MIN_LOADCELL_THRESHOLD,
+        max_raw_threshold: MAX_LOADCELL_THRESHOLD,
+        aggregate_value,
+        aggregate_threshold: threshold,
+        active: aggregate_value >= threshold,
+        value_scale: LOADCELL_VALUE_SCALE,
+        release_threshold: Some(pad.release[b]),
+    }
+}
+
+fn fsr_button(pad: &MockPad, pad_idx: usize, b: usize, t: f32) -> ButtonView {
+    let sensors: Vec<SensorView> = SENSOR_DISPLAY_ORDER
+        .iter()
+        .map(|&s| {
+            let raw_value = wave(t, pad_idx, b, s, FSR_VALUE_SCALE);
+            let raw_threshold = pad.press[b][s];
+            SensorView {
+                firmware_index: s,
+                label: Some(SENSOR_EDGE_LABELS[s]),
+                raw_value,
+                value_norm: normalize(raw_value, FSR_VALUE_SCALE),
+                raw_threshold,
+                threshold_norm: normalize(raw_threshold, FSR_VALUE_SCALE),
+                active: raw_value >= raw_threshold && raw_threshold > 0,
+                enabled: pad.enabled[b][s],
+            }
+        })
+        .collect();
+    let aggregate_value = sensors.iter().map(|s| s.raw_value).max().unwrap_or(0);
+    let aggregate_threshold = sensors.iter().map(|s| s.raw_threshold).max().unwrap_or(0);
+    ButtonView {
+        label: PAD_BUTTON_LABELS[b],
+        sensors,
+        min_raw_threshold: MIN_FSR_THRESHOLD,
+        max_raw_threshold: MAX_FSR_THRESHOLD,
+        aggregate_value,
+        aggregate_threshold,
+        active: aggregate_value >= aggregate_threshold && aggregate_threshold > 0,
+        value_scale: FSR_VALUE_SCALE,
+        release_threshold: None,
+    }
+}
+
+fn normalize(value: u16, max: u16) -> f32 {
+    if max == 0 {
+        return 0.0;
+    }
+    (f32::from(value) / f32::from(max)).clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dev(index: usize) -> PadDeviceId {
+        PadDeviceId {
+            backend: BackendKind::Smx,
+            index,
+        }
+    }
+
+    #[test]
+    fn spec_parses_kinds_and_defaults_to_one_load_cell() {
+        let m = Monitor::from_spec("loadcell,fsr");
+        assert_eq!(m.pads.len(), 2);
+        assert_eq!(m.pads[0].kind, MockKind::LoadCell);
+        assert_eq!(m.pads[1].kind, MockKind::Fsr);
+        // Any other non-empty value still enables one load-cell pad.
+        let m = Monitor::from_spec("1");
+        assert_eq!(m.pads.len(), 1);
+        assert_eq!(m.pads[0].kind, MockKind::LoadCell);
+    }
+
+    #[test]
+    fn load_cell_edits_round_trip_into_the_view() {
+        let mut m = Monitor::from_spec("loadcell");
+        assert!(m.set_threshold(dev(0), 1, None, ThresholdKind::Press, 120));
+        assert!(m.set_threshold(dev(0), 1, None, ThresholdKind::Release, 95));
+        let pads = m.poll_pads();
+        assert_eq!(pads[0].buttons[1].aggregate_threshold, 120);
+        assert_eq!(pads[0].buttons[1].release_threshold, Some(95));
+        // Out-of-range values are rejected like the real backend.
+        assert!(!m.set_threshold(dev(0), 1, None, ThresholdKind::Press, 201));
+        assert!(!m.set_threshold(dev(0), 1, None, ThresholdKind::Release, 19));
+    }
+
+    #[test]
+    fn fsr_edits_target_sensors_and_reject_release() {
+        let mut m = Monitor::from_spec("fsr");
+        assert!(m.set_threshold(dev(0), 2, Some(3), ThresholdKind::Press, 60));
+        assert!(!m.set_threshold(dev(0), 2, None, ThresholdKind::Release, 60));
+        assert!(m.set_sensor_enabled(dev(0), 2, 3, false));
+        let pads = m.poll_pads();
+        let button = &pads[0].buttons[2];
+        assert!(button.release_threshold.is_none());
+        let s3 = button
+            .sensors
+            .iter()
+            .find(|s| s.firmware_index == 3)
+            .unwrap();
+        assert_eq!(s3.raw_threshold, 60);
+        assert!(!s3.enabled);
+    }
+}

--- a/crates/deadsync-input-fsr/src/mock.rs
+++ b/crates/deadsync-input-fsr/src/mock.rs
@@ -269,6 +269,9 @@ fn fsr_button(pad: &MockPad, pad_idx: usize, b: usize, t: f32) -> ButtonView {
         .collect();
     let aggregate_value = sensors.iter().map(|s| s.raw_value).max().unwrap_or(0);
     let aggregate_threshold = sensors.iter().map(|s| s.raw_threshold).max().unwrap_or(0);
+    // The panel reads as pressed while any enabled sensor is over its own
+    // threshold (per-sensor, not max-vs-max, which misreads mixed thresholds).
+    let pressed = sensors.iter().any(|s| s.enabled && s.active);
     ButtonView {
         label: PAD_BUTTON_LABELS[b],
         sensors,
@@ -276,7 +279,7 @@ fn fsr_button(pad: &MockPad, pad_idx: usize, b: usize, t: f32) -> ButtonView {
         max_raw_threshold: MAX_FSR_THRESHOLD,
         aggregate_value,
         aggregate_threshold,
-        active: aggregate_value >= aggregate_threshold && aggregate_threshold > 0,
+        active: pressed,
         value_scale: FSR_VALUE_SCALE,
         release_threshold: None,
     }

--- a/crates/deadsync-input-fsr/src/mock.rs
+++ b/crates/deadsync-input-fsr/src/mock.rs
@@ -11,7 +11,7 @@
 use super::smx::{
     FSR_VALUE_SCALE, LOADCELL_VALUE_SCALE, MAX_DEBOUNCE_US, MAX_FSR_THRESHOLD,
     MAX_LOADCELL_THRESHOLD, MIN_DEBOUNCE_US, MIN_FSR_THRESHOLD, MIN_LOADCELL_THRESHOLD,
-    PANEL_SENSOR_COUNT, SENSOR_DISPLAY_ORDER, SENSOR_EDGE_LABELS,
+    PANEL_SENSOR_COUNT, SENSOR_DISPLAY_ORDER, SENSOR_EDGE_LABELS, hysteresis_active,
 };
 use deadsync_input::fsr::{
     BackendKind, ButtonView, PAD_BUTTON_COUNT, PAD_BUTTON_LABELS, PadDeviceId, PadView, SensorView,
@@ -40,6 +40,8 @@ struct MockPad {
     release: [u16; PAD_BUTTON_COUNT],
     /// Per-sensor enable flags (FSR only).
     enabled: [[bool; PANEL_SENSOR_COUNT]; PAD_BUTTON_COUNT],
+    /// Sticky per-sensor pressed state (load cell press/release hysteresis).
+    held: [[bool; PANEL_SENSOR_COUNT]; PAD_BUTTON_COUNT],
     auto_recal: bool,
     debounce_us: u16,
 }
@@ -55,6 +57,7 @@ impl MockPad {
             press: [[press; PANEL_SENSOR_COUNT]; PAD_BUTTON_COUNT],
             release: [INIT_LOADCELL_RELEASE; PAD_BUTTON_COUNT],
             enabled: [[true; PANEL_SENSOR_COUNT]; PAD_BUTTON_COUNT],
+            held: [[false; PANEL_SENSOR_COUNT]; PAD_BUTTON_COUNT],
             auto_recal: true,
             debounce_us: INIT_DEBOUNCE_US,
         }
@@ -103,7 +106,7 @@ impl Monitor {
     pub fn poll_pads(&mut self) -> Vec<PadView> {
         let t = self.started.elapsed().as_secs_f32();
         self.pads
-            .iter()
+            .iter_mut()
             .enumerate()
             .map(|(i, pad)| {
                 let buttons = std::array::from_fn(|b| match pad.kind {
@@ -212,11 +215,13 @@ fn wave(t: f32, pad: usize, button: usize, sensor: usize, scale: u16) -> u16 {
     (s.max(0.0).powi(3) * 0.85 * f32::from(scale)) as u16
 }
 
-fn load_cell_button(pad: &MockPad, pad_idx: usize, b: usize, t: f32) -> ButtonView {
+fn load_cell_button(pad: &mut MockPad, pad_idx: usize, b: usize, t: f32) -> ButtonView {
     let threshold = pad.press[b][0];
+    let release = pad.release[b];
     let sensors: Vec<SensorView> = (0..PANEL_SENSOR_COUNT)
         .map(|s| {
             let raw_value = wave(t, pad_idx, b, s, LOADCELL_VALUE_SCALE);
+            pad.held[b][s] = hysteresis_active(pad.held[b][s], raw_value, release, threshold);
             SensorView {
                 firmware_index: s,
                 label: None, // corners, numbered 1-4 in the UI
@@ -224,7 +229,7 @@ fn load_cell_button(pad: &MockPad, pad_idx: usize, b: usize, t: f32) -> ButtonVi
                 value_norm: normalize(raw_value, LOADCELL_VALUE_SCALE),
                 raw_threshold: threshold,
                 threshold_norm: normalize(threshold, LOADCELL_VALUE_SCALE),
-                active: raw_value >= threshold && threshold > 0,
+                active: pad.held[b][s],
                 enabled: true,
             }
         })
@@ -237,7 +242,8 @@ fn load_cell_button(pad: &MockPad, pad_idx: usize, b: usize, t: f32) -> ButtonVi
         max_raw_threshold: MAX_LOADCELL_THRESHOLD,
         aggregate_value,
         aggregate_threshold: threshold,
-        active: aggregate_value >= threshold,
+        // The panel reads as pressed while any sensor is held (hysteresis).
+        active: pad.held[b].iter().any(|&h| h),
         value_scale: LOADCELL_VALUE_SCALE,
         release_threshold: Some(pad.release[b]),
     }

--- a/crates/deadsync-input-fsr/src/mock.rs
+++ b/crates/deadsync-input-fsr/src/mock.rs
@@ -2,21 +2,20 @@
 //!
 //! Set the variable to a comma-separated list of pad kinds, e.g.
 //! `DEADSYNC_MOCK_PADS=loadcell` or `DEADSYNC_MOCK_PADS=loadcell,fsr` (any
-//! other non-empty value means one load-cell pad). Each kind becomes one fake
-//! pad on the Configure Pads screen, with animated sensor readings and
-//! thresholds edited in memory, so the whole editor can be exercised without
-//! hardware. While the variable is set, `engine::smx::init` refuses to start
-//! the SDK, so native SMX is fully off and nothing is written over USB.
+//! other truthy value means one load-cell pad; empty/`0`/`false`/`off`/`no`
+//! leave the mock off). Each kind becomes one fake pad on the Configure Pads
+//! screen, with animated sensor readings and thresholds edited in memory, so
+//! the whole editor can be exercised without hardware. While the mock is on,
+//! `engine::smx::init` refuses to start the SDK, so native SMX is fully off
+//! and nothing is written over USB.
 
 use super::smx::{
-    FSR_VALUE_SCALE, LOADCELL_VALUE_SCALE, MAX_DEBOUNCE_US, MAX_FSR_THRESHOLD,
-    MAX_LOADCELL_THRESHOLD, MIN_DEBOUNCE_US, MIN_FSR_THRESHOLD, MIN_LOADCELL_THRESHOLD,
-    PANEL_SENSOR_COUNT, SENSOR_DISPLAY_ORDER, SENSOR_EDGE_LABELS, hysteresis_active,
+    LOADCELL_RAW_MAX, MAX_DEBOUNCE_US, MAX_FSR_THRESHOLD, MAX_LOADCELL_THRESHOLD, MIN_DEBOUNCE_US,
+    MIN_FSR_THRESHOLD, MIN_LOADCELL_THRESHOLD, PANEL_SENSOR_COUNT, SENSOR_DISPLAY_ORDER,
+    SENSOR_EDGE_LABELS, SensorReading, fsr_button_view, hysteresis_active, load_cell_button_view,
 };
-use deadsync_input::fsr::{
-    BackendKind, ButtonView, PAD_BUTTON_COUNT, PAD_BUTTON_LABELS, PadDeviceId, PadView, SensorView,
-    ThresholdKind,
-};
+use deadsync_input::fsr::{BackendKind, PAD_BUTTON_COUNT, PAD_BUTTON_LABELS, PadDeviceId, PadView};
+use std::fmt::Write as _;
 use std::time::Instant;
 
 /// Starting thresholds: the Low preset's load-cell pair and Medium's FSR value.
@@ -62,13 +61,6 @@ impl MockPad {
             debounce_us: INIT_DEBOUNCE_US,
         }
     }
-
-    fn threshold_range(&self) -> (u16, u16) {
-        match self.kind {
-            MockKind::LoadCell => (MIN_LOADCELL_THRESHOLD, MAX_LOADCELL_THRESHOLD),
-            MockKind::Fsr => (MIN_FSR_THRESHOLD, MAX_FSR_THRESHOLD),
-        }
-    }
 }
 
 pub struct Monitor {
@@ -92,7 +84,7 @@ impl Monitor {
             })
             .take(2)
             .collect();
-        // Any other non-empty value (e.g. "1") still turns the mock on.
+        // Any other truthy value (e.g. "1") still turns the mock on.
         if kinds.is_empty() {
             kinds.push(MockKind::LoadCell);
         }
@@ -132,33 +124,50 @@ impl Monitor {
             .collect()
     }
 
+    /// Single-threshold (FSR-style) edit; load-cell pads use the pair edit.
     pub fn set_threshold(
         &mut self,
         device: PadDeviceId,
         button: usize,
         sensor: Option<usize>,
-        kind: ThresholdKind,
         value: u16,
     ) -> bool {
         let Some(pad) = self.pad_mut(device, button) else {
             return false;
         };
-        let (min, max) = pad.threshold_range();
-        if !(min..=max).contains(&value) {
+        if pad.kind != MockKind::Fsr || !(MIN_FSR_THRESHOLD..=MAX_FSR_THRESHOLD).contains(&value) {
             return false;
         }
-        match (pad.kind, kind) {
-            (MockKind::LoadCell, ThresholdKind::Press) => {
-                pad.press[button] = [value; PANEL_SENSOR_COUNT];
-            }
-            (MockKind::LoadCell, ThresholdKind::Release) => pad.release[button] = value,
-            (MockKind::Fsr, ThresholdKind::Press) => match sensor {
-                Some(s) if s < PANEL_SENSOR_COUNT => pad.press[button][s] = value,
-                Some(_) => return false,
-                None => pad.press[button] = [value; PANEL_SENSOR_COUNT],
-            },
-            (MockKind::Fsr, ThresholdKind::Release) => return false,
+        match sensor {
+            Some(s) if s < PANEL_SENSOR_COUNT => pad.press[button][s] = value,
+            Some(_) => return false,
+            None => pad.press[button] = [value; PANEL_SENSOR_COUNT],
         }
+        true
+    }
+
+    /// Press/release pair edit for a load-cell button, mirroring the real
+    /// backend's checks (ranges, release strictly below press).
+    pub fn set_threshold_pair(
+        &mut self,
+        device: PadDeviceId,
+        button: usize,
+        press: u16,
+        release: u16,
+    ) -> bool {
+        let Some(pad) = self.pad_mut(device, button) else {
+            return false;
+        };
+        let range = MIN_LOADCELL_THRESHOLD..=MAX_LOADCELL_THRESHOLD;
+        if pad.kind != MockKind::LoadCell
+            || !range.contains(&press)
+            || !range.contains(&release)
+            || release >= press
+        {
+            return false;
+        }
+        pad.press[button] = [press; PANEL_SENSOR_COUNT];
+        pad.release[button] = release;
         true
     }
 
@@ -198,6 +207,38 @@ impl Monitor {
         true
     }
 
+    /// The mock has no hardware test mode to toggle.
+    pub fn set_active(&mut self, _active: bool) {}
+
+    /// Mock section for the FSR debug dump, in place of the (dormant) native
+    /// SMX section, so the dump matches what the UI shows.
+    pub fn debug_dump(&self) -> String {
+        let mut out = String::new();
+        let _ = writeln!(out, "DeadSync StepManiaX mock pads (DEADSYNC_MOCK_PADS)");
+        for (i, pad) in self.pads.iter().enumerate() {
+            let _ = writeln!(out, "Pad {i}: {:?}", pad.kind);
+            for b in 0..PAD_BUTTON_COUNT {
+                match pad.kind {
+                    MockKind::LoadCell => {
+                        let _ = writeln!(
+                            out,
+                            "  {} press: {} release: {}",
+                            PAD_BUTTON_LABELS[b], pad.press[b][0], pad.release[b]
+                        );
+                    }
+                    MockKind::Fsr => {
+                        let _ = writeln!(
+                            out,
+                            "  {} thresholds: {:?} enabled: {:?}",
+                            PAD_BUTTON_LABELS[b], pad.press[b], pad.enabled[b]
+                        );
+                    }
+                }
+            }
+        }
+        out
+    }
+
     fn pad_mut(&mut self, device: PadDeviceId, button: usize) -> Option<&mut MockPad> {
         if device.backend != BackendKind::Smx || button >= PAD_BUTTON_COUNT {
             return None;
@@ -208,88 +249,47 @@ impl Monitor {
 
 /// A smooth fake sensor reading: idles at zero with staggered "press" bumps
 /// that cross typical thresholds, so bars move and active states light up.
-fn wave(t: f32, pad: usize, button: usize, sensor: usize, scale: u16) -> u16 {
+fn wave(t: f32, pad: usize, button: usize, sensor: usize, peak: u16) -> u16 {
     let period = 3.0 + 0.7 * button as f32 + 0.35 * sensor as f32 + 1.3 * pad as f32;
     let phase = 1.1 * sensor as f32 + 2.3 * button as f32;
     let s = (t * std::f32::consts::TAU / period + phase).sin();
-    (s.max(0.0).powi(3) * 0.85 * f32::from(scale)) as u16
+    (s.max(0.0).powi(3) * 0.85 * f32::from(peak)) as u16
 }
 
-fn load_cell_button(pad: &mut MockPad, pad_idx: usize, b: usize, t: f32) -> ButtonView {
-    let threshold = pad.press[b][0];
+fn load_cell_button(
+    pad: &mut MockPad,
+    pad_idx: usize,
+    b: usize,
+    t: f32,
+) -> deadsync_input::fsr::ButtonView {
+    let press = pad.press[b][0];
     let release = pad.release[b];
-    let sensors: Vec<SensorView> = (0..PANEL_SENSOR_COUNT)
-        .map(|s| {
-            let raw_value = wave(t, pad_idx, b, s, LOADCELL_VALUE_SCALE);
-            pad.held[b][s] = hysteresis_active(pad.held[b][s], raw_value, release, threshold);
-            SensorView {
-                firmware_index: s,
-                label: None, // corners, numbered 1-4 in the UI
-                raw_value,
-                value_norm: normalize(raw_value, LOADCELL_VALUE_SCALE),
-                raw_threshold: threshold,
-                threshold_norm: normalize(threshold, LOADCELL_VALUE_SCALE),
-                active: pad.held[b][s],
-                enabled: true,
-            }
-        })
-        .collect();
-    let aggregate_value = sensors.iter().map(|s| s.raw_value).max().unwrap_or(0);
-    ButtonView {
-        label: PAD_BUTTON_LABELS[b],
-        sensors,
-        min_raw_threshold: MIN_LOADCELL_THRESHOLD,
-        max_raw_threshold: MAX_LOADCELL_THRESHOLD,
-        aggregate_value,
-        aggregate_threshold: threshold,
-        // The panel reads as pressed while any sensor is held (hysteresis).
-        active: pad.held[b].iter().any(|&h| h),
-        value_scale: LOADCELL_VALUE_SCALE,
-        release_threshold: Some(pad.release[b]),
+    // Real load-cell readings reach 500, well past the 250 display scale, so
+    // the mock does too (pegged bars + readouts above 250 get exercised).
+    let values: [u16; PANEL_SENSOR_COUNT] =
+        std::array::from_fn(|s| wave(t, pad_idx, b, s, LOADCELL_RAW_MAX));
+    for (s, &v) in values.iter().enumerate() {
+        pad.held[b][s] = hysteresis_active(pad.held[b][s], v, release, press);
     }
+    // The panel reads as pressed while any sensor is held (hysteresis).
+    let panel_active = pad.held[b].iter().any(|&h| h);
+    load_cell_button_view(PAD_BUTTON_LABELS[b], values, press, release, panel_active)
 }
 
-fn fsr_button(pad: &MockPad, pad_idx: usize, b: usize, t: f32) -> ButtonView {
-    let sensors: Vec<SensorView> = SENSOR_DISPLAY_ORDER
-        .iter()
-        .map(|&s| {
-            let raw_value = wave(t, pad_idx, b, s, FSR_VALUE_SCALE);
-            let raw_threshold = pad.press[b][s];
-            SensorView {
-                firmware_index: s,
-                label: Some(SENSOR_EDGE_LABELS[s]),
-                raw_value,
-                value_norm: normalize(raw_value, FSR_VALUE_SCALE),
-                raw_threshold,
-                threshold_norm: normalize(raw_threshold, FSR_VALUE_SCALE),
-                active: raw_value >= raw_threshold && raw_threshold > 0,
-                enabled: pad.enabled[b][s],
-            }
-        })
-        .collect();
-    let aggregate_value = sensors.iter().map(|s| s.raw_value).max().unwrap_or(0);
-    let aggregate_threshold = sensors.iter().map(|s| s.raw_threshold).max().unwrap_or(0);
+fn fsr_button(pad: &MockPad, pad_idx: usize, b: usize, t: f32) -> deadsync_input::fsr::ButtonView {
+    let readings = SENSOR_DISPLAY_ORDER.map(|s| SensorReading {
+        firmware_index: s,
+        label: Some(SENSOR_EDGE_LABELS[s]),
+        value: wave(t, pad_idx, b, s, MAX_FSR_THRESHOLD),
+        threshold: pad.press[b][s],
+        enabled: pad.enabled[b][s],
+    });
     // The panel reads as pressed while any enabled sensor is over its own
     // threshold (per-sensor, not max-vs-max, which misreads mixed thresholds).
-    let pressed = sensors.iter().any(|s| s.enabled && s.active);
-    ButtonView {
-        label: PAD_BUTTON_LABELS[b],
-        sensors,
-        min_raw_threshold: MIN_FSR_THRESHOLD,
-        max_raw_threshold: MAX_FSR_THRESHOLD,
-        aggregate_value,
-        aggregate_threshold,
-        active: pressed,
-        value_scale: FSR_VALUE_SCALE,
-        release_threshold: None,
-    }
-}
-
-fn normalize(value: u16, max: u16) -> f32 {
-    if max == 0 {
-        return 0.0;
-    }
-    (f32::from(value) / f32::from(max)).clamp(0.0, 1.0)
+    let panel_active = readings
+        .iter()
+        .any(|r| r.enabled && r.threshold > 0 && r.value >= r.threshold);
+    fsr_button_view(PAD_BUTTON_LABELS[b], readings, panel_active)
 }
 
 #[cfg(test)]
@@ -309,30 +309,32 @@ mod tests {
         assert_eq!(m.pads.len(), 2);
         assert_eq!(m.pads[0].kind, MockKind::LoadCell);
         assert_eq!(m.pads[1].kind, MockKind::Fsr);
-        // Any other non-empty value still enables one load-cell pad.
+        // Any other truthy value still enables one load-cell pad.
         let m = Monitor::from_spec("1");
         assert_eq!(m.pads.len(), 1);
         assert_eq!(m.pads[0].kind, MockKind::LoadCell);
     }
 
     #[test]
-    fn load_cell_edits_round_trip_into_the_view() {
+    fn load_cell_pair_edits_round_trip_into_the_view() {
         let mut m = Monitor::from_spec("loadcell");
-        assert!(m.set_threshold(dev(0), 1, None, ThresholdKind::Press, 120));
-        assert!(m.set_threshold(dev(0), 1, None, ThresholdKind::Release, 95));
+        assert!(m.set_threshold_pair(dev(0), 1, 120, 95));
         let pads = m.poll_pads();
         assert_eq!(pads[0].buttons[1].aggregate_threshold, 120);
         assert_eq!(pads[0].buttons[1].release_threshold, Some(95));
-        // Out-of-range values are rejected like the real backend.
-        assert!(!m.set_threshold(dev(0), 1, None, ThresholdKind::Press, 201));
-        assert!(!m.set_threshold(dev(0), 1, None, ThresholdKind::Release, 19));
+        // Out-of-range or inverted pairs are rejected like the real backend,
+        // as are single-threshold edits on a load-cell pad.
+        assert!(!m.set_threshold_pair(dev(0), 1, 201, 95));
+        assert!(!m.set_threshold_pair(dev(0), 1, 120, 19));
+        assert!(!m.set_threshold_pair(dev(0), 1, 95, 95));
+        assert!(!m.set_threshold(dev(0), 1, None, 120));
     }
 
     #[test]
-    fn fsr_edits_target_sensors_and_reject_release() {
+    fn fsr_edits_target_sensors_and_reject_pairs() {
         let mut m = Monitor::from_spec("fsr");
-        assert!(m.set_threshold(dev(0), 2, Some(3), ThresholdKind::Press, 60));
-        assert!(!m.set_threshold(dev(0), 2, None, ThresholdKind::Release, 60));
+        assert!(m.set_threshold(dev(0), 2, Some(3), 60));
+        assert!(!m.set_threshold_pair(dev(0), 2, 80, 70));
         assert!(m.set_sensor_enabled(dev(0), 2, 3, false));
         let pads = m.poll_pads();
         let button = &pads[0].buttons[2];

--- a/crates/deadsync-input-fsr/src/smx.rs
+++ b/crates/deadsync-input-fsr/src/smx.rs
@@ -7,30 +7,30 @@ use deadsync_smx::{self as smx, SensorTestData, SensorTestMode, SmxConfig};
 use std::fmt::Write as _;
 use std::time::SystemTime;
 
-const PANEL_SENSOR_COUNT: usize = 4;
+pub(super) const PANEL_SENSOR_COUNT: usize = 4;
 
-const MIN_FSR_THRESHOLD: u16 = 5;
-const MAX_FSR_THRESHOLD: u16 = 250;
+pub(super) const MIN_FSR_THRESHOLD: u16 = 5;
+pub(super) const MAX_FSR_THRESHOLD: u16 = 250;
 
 /// Debounce edit bounds (microseconds). Firmware default is 4000us (4.0ms);
 /// we never let the user drop below 0.5ms.
-const MIN_DEBOUNCE_US: u16 = 500;
-const MAX_DEBOUNCE_US: u16 = 25000;
+pub(super) const MIN_DEBOUNCE_US: u16 = 500;
+pub(super) const MAX_DEBOUNCE_US: u16 = 25000;
 
 // Pre-v5 load-cell pads: 8-bit thresholds (20-200) and live values that scale
 // to 500 (no >>2), matching the official SMX config tool.
-const MIN_LOADCELL_THRESHOLD: u16 = 20;
-const MAX_LOADCELL_THRESHOLD: u16 = 200;
-const FSR_VALUE_SCALE: u16 = 250;
-const LOADCELL_VALUE_SCALE: u16 = 500;
+pub(super) const MIN_LOADCELL_THRESHOLD: u16 = 20;
+pub(super) const MAX_LOADCELL_THRESHOLD: u16 = 200;
+pub(super) const FSR_VALUE_SCALE: u16 = 250;
+pub(super) const LOADCELL_VALUE_SCALE: u16 = 500;
 
 /// Panels exposed for config: (panel_index, label), in L/D/U/R order.
 const VIEW_PANELS: [(usize, &str); PAD_BUTTON_COUNT] = [(3, "L"), (7, "D"), (1, "U"), (5, "R")];
 
 /// Edge label for each of a panel's four FSR sensors, by firmware index.
-const SENSOR_EDGE_LABELS: [&str; PANEL_SENSOR_COUNT] = ["L", "R", "U", "D"];
+pub(super) const SENSOR_EDGE_LABELS: [&str; PANEL_SENSOR_COUNT] = ["L", "R", "U", "D"];
 /// Firmware-index order to display the sensors in so they read L, D, U, R.
-const SENSOR_DISPLAY_ORDER: [usize; PANEL_SENSOR_COUNT] = [0, 3, 2, 1];
+pub(super) const SENSOR_DISPLAY_ORDER: [usize; PANEL_SENSOR_COUNT] = [0, 3, 2, 1];
 
 pub struct Monitor {
     /// Whether the config screen has requested live reads (sensor test mode).

--- a/crates/deadsync-input-fsr/src/smx.rs
+++ b/crates/deadsync-input-fsr/src/smx.rs
@@ -37,18 +37,11 @@ pub(super) const SENSOR_DISPLAY_ORDER: [usize; PANEL_SENSOR_COUNT] = [0, 3, 2, 1
 pub struct Monitor {
     /// Whether the config screen has requested live reads (sensor test mode).
     read_active: bool,
-    /// Sticky per-pad/panel/sensor pressed state for load-cell bars, so the
-    /// view colors with the firmware's press/release hysteresis (green above
-    /// the press threshold, idle again only below the release threshold).
-    lc_held: [[[bool; PANEL_SENSOR_COUNT]; smx::PANEL_COUNT]; 2],
 }
 
 impl Monitor {
     pub fn new() -> Self {
-        Self {
-            read_active: false,
-            lc_held: [[[false; PANEL_SENSOR_COUNT]; smx::PANEL_COUNT]; 2],
-        }
+        Self { read_active: false }
     }
 
     /// Toggle live sensor reads (test mode) on all connected pads. Called by
@@ -96,20 +89,12 @@ impl Monitor {
                 smx::serial_prefix(&info.serial),
             );
 
-            let lc_held = &mut self.lc_held[pad];
             let buttons = std::array::from_fn(|i| {
                 let (panel, label) = VIEW_PANELS[i];
                 if fsr {
                     fsr_button(&config, panel, label, test_data.as_ref(), input_state)
                 } else {
-                    load_cell_button(
-                        &config,
-                        panel,
-                        label,
-                        test_data.as_ref(),
-                        input_state,
-                        &mut lc_held[panel],
-                    )
+                    load_cell_button(&config, panel, label, test_data.as_ref(), input_state)
                 }
             });
 
@@ -393,25 +378,24 @@ fn fsr_button(
 }
 
 /// Build a load-cell panel's button view: four corner readings (numbered 1-4)
-/// that all share the panel's press/release threshold pair. `held` is the
-/// panel's sticky per-sensor pressed state (press/release hysteresis).
+/// that all share the panel's press/release threshold pair. The panel-level
+/// `active` comes from the firmware's input state (its own hysteresis), which
+/// is also what the Simple view colors the bars with; the per-sensor flag is
+/// just the instantaneous press-threshold comparison.
 fn load_cell_button(
     config: &SmxConfig,
     panel: usize,
     label: &'static str,
     test_data: Option<&SensorTestData>,
     input_state: u16,
-    held: &mut [bool; PANEL_SENSOR_COUNT],
 ) -> ButtonView {
     let settings = &config.panel_settings[panel];
     let threshold = u16::from(settings.load_cell_high_threshold);
-    let release = u16::from(settings.load_cell_low_threshold);
     let sensors: Vec<SensorView> = (0..PANEL_SENSOR_COUNT)
         .map(|s| {
             let raw_value = test_data
                 .filter(|d| d.have_data_from_panel[panel])
                 .map_or(0, |d| calibrate_load_cell(d.sensor_level[panel][s]));
-            held[s] = hysteresis_active(held[s], raw_value, release, threshold);
             SensorView {
                 firmware_index: s,
                 label: None, // corners, not edges -> numbered 1-4 in the UI
@@ -419,7 +403,7 @@ fn load_cell_button(
                 value_norm: normalize(raw_value, LOADCELL_VALUE_SCALE),
                 raw_threshold: threshold,
                 threshold_norm: normalize(threshold, LOADCELL_VALUE_SCALE),
-                active: held[s],
+                active: raw_value >= threshold && threshold > 0,
                 enabled: true,
             }
         })

--- a/crates/deadsync-input-fsr/src/smx.rs
+++ b/crates/deadsync-input-fsr/src/smx.rs
@@ -1,7 +1,7 @@
 //! StepManiaX FSR sensor monitor using the shared SmxManager.
 
 use deadsync_input::fsr::{
-    BackendKind, ButtonView, PAD_BUTTON_COUNT, PadDeviceId, PadView, SensorView, ThresholdKind,
+    BackendKind, ButtonView, PAD_BUTTON_COUNT, PadDeviceId, PadView, SensorView,
 };
 use deadsync_smx::{self as smx, SensorTestData, SensorTestMode, SmxConfig};
 use std::fmt::Write as _;
@@ -18,13 +18,15 @@ pub(super) const MIN_DEBOUNCE_US: u16 = 500;
 pub(super) const MAX_DEBOUNCE_US: u16 = 25000;
 
 // Pre-v5 load-cell pads: 8-bit thresholds (20-200) and raw live values that
-// reach 500 (no >>2). We cap the display scale at 250 so the threshold band
+// reach 500 (no >>2). The display scale is capped at 250 so the threshold band
 // uses most of the bar's height (200 sits at 80%) instead of topping out
-// midway; readings past 250 just show a full bar (far beyond "pressed").
+// midway; readings past 250 show a full bar but the numeric readout still
+// reports the true value up to `LOADCELL_RAW_MAX`.
 pub(super) const MIN_LOADCELL_THRESHOLD: u16 = 20;
 pub(super) const MAX_LOADCELL_THRESHOLD: u16 = 200;
 pub(super) const FSR_VALUE_SCALE: u16 = 250;
 pub(super) const LOADCELL_VALUE_SCALE: u16 = 250;
+pub(super) const LOADCELL_RAW_MAX: u16 = 500;
 
 /// Panels exposed for config: (panel_index, label), in L/D/U/R order.
 const VIEW_PANELS: [(usize, &str); PAD_BUTTON_COUNT] = [(3, "L"), (7, "D"), (1, "U"), (5, "R")];
@@ -121,17 +123,15 @@ impl Monitor {
         pads
     }
 
-    /// Set a panel threshold. FSR pads have one user-facing threshold (we write
-    /// `high = value`, `low = value - 1`, so only `Press` is accepted) and allow
-    /// per-sensor edits (`sensor = Some(i)`). Load-cell pads edit their press
-    /// (high) and release (low) thresholds independently by `kind` (`sensor` is
-    /// ignored); keeping release below press is the caller's job.
+    /// Set an FSR panel threshold: we write `high = value`, `low = value - 1`.
+    /// `sensor = Some(i)` targets one sensor, `None` every sensor in the
+    /// panel. Load-cell pads are rejected; their press/release pair is edited
+    /// atomically through `set_threshold_pair`.
     pub fn set_threshold(
         &mut self,
         device: PadDeviceId,
         button: usize,
         sensor: Option<usize>,
-        kind: ThresholdKind,
         value: u16,
     ) -> bool {
         if device.backend != BackendKind::Smx || button >= PAD_BUTTON_COUNT {
@@ -148,56 +148,82 @@ impl Monitor {
             return false;
         };
         let (panel, _) = VIEW_PANELS[button];
-        let fsr = is_fsr(&config);
+        if !is_fsr(&config) {
+            log::trace!("SMX: set_threshold pad {pad} rejected (load-cell pad uses pair edits)");
+            return false;
+        }
         let settings = &mut config.panel_settings[panel];
 
-        if fsr {
-            if info.firmware_version < 5
-                || kind != ThresholdKind::Press
-                || !(MIN_FSR_THRESHOLD..=MAX_FSR_THRESHOLD).contains(&value)
-            {
-                log::trace!(
-                    "SMX: set_threshold pad {pad} panel {panel} rejected (fsr, fw {}, kind {kind:?}, value {value} not in {MIN_FSR_THRESHOLD}..={MAX_FSR_THRESHOLD})",
-                    info.firmware_version
-                );
+        if info.firmware_version < 5 || !(MIN_FSR_THRESHOLD..=MAX_FSR_THRESHOLD).contains(&value) {
+            log::trace!(
+                "SMX: set_threshold pad {pad} panel {panel} rejected (fsr, fw {}, value {value} not in {MIN_FSR_THRESHOLD}..={MAX_FSR_THRESHOLD})",
+                info.firmware_version
+            );
+            return false;
+        }
+        let high = value as u8;
+        let low = high.saturating_sub(1);
+        match sensor {
+            Some(s) if s < PANEL_SENSOR_COUNT => {
+                settings.fsr_high_threshold[s] = high;
+                settings.fsr_low_threshold[s] = low;
+            }
+            Some(s) => {
+                log::trace!("SMX: set_threshold pad {pad} rejected (sensor {s} out of range)");
                 return false;
             }
-            let high = value as u8;
-            let low = high.saturating_sub(1);
-            match sensor {
-                Some(s) if s < PANEL_SENSOR_COUNT => {
+            None => {
+                for s in 0..PANEL_SENSOR_COUNT {
                     settings.fsr_high_threshold[s] = high;
                     settings.fsr_low_threshold[s] = low;
                 }
-                Some(s) => {
-                    log::trace!("SMX: set_threshold pad {pad} rejected (sensor {s} out of range)");
-                    return false;
-                }
-                None => {
-                    for s in 0..PANEL_SENSOR_COUNT {
-                        settings.fsr_high_threshold[s] = high;
-                        settings.fsr_low_threshold[s] = low;
-                    }
-                }
-            }
-        } else {
-            // Load cell: per-panel press (high) / release (low) pair; the
-            // sensor index is ignored.
-            if !(MIN_LOADCELL_THRESHOLD..=MAX_LOADCELL_THRESHOLD).contains(&value) {
-                log::trace!(
-                    "SMX: set_threshold pad {pad} panel {panel} rejected (load-cell, value {value} not in {MIN_LOADCELL_THRESHOLD}..={MAX_LOADCELL_THRESHOLD})"
-                );
-                return false;
-            }
-            match kind {
-                ThresholdKind::Press => settings.load_cell_high_threshold = value as u8,
-                ThresholdKind::Release => settings.load_cell_low_threshold = value as u8,
             }
         }
         smx::set_config(pad, config);
+        log::trace!("SMX: set_threshold pad {pad} panel {panel} sensor {sensor:?} -> {value}");
+        true
+    }
+
+    /// Set a load-cell panel's press (high) and release (low) thresholds in a
+    /// single config write, so the pad never observes an inverted intermediate
+    /// pair. Rejects FSR pads, out-of-range values, and `release >= press`.
+    pub fn set_threshold_pair(
+        &mut self,
+        device: PadDeviceId,
+        button: usize,
+        press: u16,
+        release: u16,
+    ) -> bool {
+        if device.backend != BackendKind::Smx || button >= PAD_BUTTON_COUNT {
+            return false;
+        }
+        let pad = device.index;
+        if !smx::get_info(pad).connected {
+            log::trace!("SMX: set_threshold_pair pad {pad} rejected (not connected)");
+            return false;
+        }
+        let Some(mut config) = smx::get_config(pad) else {
+            log::trace!("SMX: set_threshold_pair pad {pad} rejected (config unavailable)");
+            return false;
+        };
+        let (panel, _) = VIEW_PANELS[button];
+        if is_fsr(&config) {
+            log::trace!("SMX: set_threshold_pair pad {pad} rejected (fsr pad)");
+            return false;
+        }
+        let range = MIN_LOADCELL_THRESHOLD..=MAX_LOADCELL_THRESHOLD;
+        if !range.contains(&press) || !range.contains(&release) || release >= press {
+            log::trace!(
+                "SMX: set_threshold_pair pad {pad} panel {panel} rejected (press {press} / release {release} invalid)"
+            );
+            return false;
+        }
+        let settings = &mut config.panel_settings[panel];
+        settings.load_cell_high_threshold = press as u8;
+        settings.load_cell_low_threshold = release as u8;
+        smx::set_config(pad, config);
         log::trace!(
-            "SMX: set_threshold pad {pad} panel {panel} sensor {sensor:?} {kind:?} -> {value} ({})",
-            if fsr { "fsr" } else { "load-cell" }
+            "SMX: set_threshold_pair pad {pad} panel {panel} -> press {press} release {release}"
         );
         true
     }
@@ -333,8 +359,9 @@ impl Drop for Monitor {
     }
 }
 
-/// Build an FSR panel's button view: four edge sensors (displayed L,D,U,R),
-/// each with its own threshold and enable bit.
+/// Build an FSR panel's button view from the live config: four edge sensors
+/// (displayed L,D,U,R), each with its own threshold and enable bit. The panel
+/// pressed state comes from the firmware's input bitmask.
 fn fsr_button(
     config: &SmxConfig,
     panel: usize,
@@ -343,23 +370,72 @@ fn fsr_button(
     input_state: u16,
 ) -> ButtonView {
     let settings = &config.panel_settings[panel];
-    let sensors: Vec<SensorView> = SENSOR_DISPLAY_ORDER
+    let readings = SENSOR_DISPLAY_ORDER.map(|s| SensorReading {
+        firmware_index: s,
+        label: Some(SENSOR_EDGE_LABELS[s]),
+        value: test_data
+            .filter(|d| d.have_data_from_panel[panel])
+            .map_or(0, |d| calibrate_fsr(d.sensor_level[panel][s])),
+        threshold: u16::from(settings.fsr_high_threshold[s]),
+        enabled: sensor_enabled(config, panel, s),
+    });
+    fsr_button_view(label, readings, input_state & (1u16 << panel) != 0)
+}
+
+/// Build a load-cell panel's button view from the live config: four corner
+/// readings sharing the panel's press/release pair. The panel pressed state
+/// comes from the firmware's input bitmask (its own hysteresis).
+fn load_cell_button(
+    config: &SmxConfig,
+    panel: usize,
+    label: &'static str,
+    test_data: Option<&SensorTestData>,
+    input_state: u16,
+) -> ButtonView {
+    let settings = &config.panel_settings[panel];
+    let values = std::array::from_fn(|s| {
+        test_data
+            .filter(|d| d.have_data_from_panel[panel])
+            .map_or(0, |d| calibrate_load_cell(d.sensor_level[panel][s]))
+    });
+    load_cell_button_view(
+        label,
+        values,
+        u16::from(settings.load_cell_high_threshold),
+        u16::from(settings.load_cell_low_threshold),
+        input_state & (1u16 << panel) != 0,
+    )
+}
+
+/// One sensor's inputs for the shared button-view builders below, which both
+/// the live backend and the mock use so their presentation can't diverge.
+pub(super) struct SensorReading {
+    pub firmware_index: usize,
+    pub label: Option<&'static str>,
+    pub value: u16,
+    pub threshold: u16,
+    pub enabled: bool,
+}
+
+/// Assemble an FSR-style button view (per-sensor thresholds and enable bits).
+/// `panel_active` is the panel's pressed state; per-sensor `active` stays the
+/// instantaneous comparison the Advanced view tunes against.
+pub(super) fn fsr_button_view(
+    label: &'static str,
+    readings: [SensorReading; PANEL_SENSOR_COUNT],
+    panel_active: bool,
+) -> ButtonView {
+    let sensors: Vec<SensorView> = readings
         .iter()
-        .map(|&s| {
-            let raw_value = test_data
-                .filter(|d| d.have_data_from_panel[panel])
-                .map_or(0, |d| calibrate_fsr(d.sensor_level[panel][s]));
-            let raw_threshold = u16::from(settings.fsr_high_threshold[s]);
-            SensorView {
-                firmware_index: s,
-                label: Some(SENSOR_EDGE_LABELS[s]),
-                raw_value,
-                value_norm: normalize(raw_value, FSR_VALUE_SCALE),
-                raw_threshold,
-                threshold_norm: normalize(raw_threshold, FSR_VALUE_SCALE),
-                active: raw_value >= raw_threshold && raw_threshold > 0,
-                enabled: sensor_enabled(config, panel, s),
-            }
+        .map(|r| SensorView {
+            firmware_index: r.firmware_index,
+            label: r.label,
+            raw_value: r.value,
+            value_norm: normalize(r.value, FSR_VALUE_SCALE),
+            raw_threshold: r.threshold,
+            threshold_norm: normalize(r.threshold, FSR_VALUE_SCALE),
+            active: r.value >= r.threshold && r.threshold > 0,
+            enabled: r.enabled,
         })
         .collect();
     let aggregate_value = sensors.iter().map(|s| s.raw_value).max().unwrap_or(0);
@@ -371,41 +447,34 @@ fn fsr_button(
         max_raw_threshold: MAX_FSR_THRESHOLD,
         aggregate_value,
         aggregate_threshold,
-        active: input_state & (1u16 << panel) != 0,
+        active: panel_active,
         value_scale: FSR_VALUE_SCALE,
         release_threshold: None,
     }
 }
 
-/// Build a load-cell panel's button view: four corner readings (numbered 1-4)
-/// that all share the panel's press/release threshold pair. The panel-level
-/// `active` comes from the firmware's input state (its own hysteresis), which
-/// is also what the Simple view colors the bars with; the per-sensor flag is
-/// just the instantaneous press-threshold comparison.
-fn load_cell_button(
-    config: &SmxConfig,
-    panel: usize,
+/// Assemble a load-cell button view: four corner readings (numbered 1-4 in
+/// the UI) sharing one press/release pair. Per-sensor `active` mirrors the
+/// panel state so the view can never disagree with what the bars show.
+pub(super) fn load_cell_button_view(
     label: &'static str,
-    test_data: Option<&SensorTestData>,
-    input_state: u16,
+    values: [u16; PANEL_SENSOR_COUNT],
+    press: u16,
+    release: u16,
+    panel_active: bool,
 ) -> ButtonView {
-    let settings = &config.panel_settings[panel];
-    let threshold = u16::from(settings.load_cell_high_threshold);
-    let sensors: Vec<SensorView> = (0..PANEL_SENSOR_COUNT)
-        .map(|s| {
-            let raw_value = test_data
-                .filter(|d| d.have_data_from_panel[panel])
-                .map_or(0, |d| calibrate_load_cell(d.sensor_level[panel][s]));
-            SensorView {
-                firmware_index: s,
-                label: None, // corners, not edges -> numbered 1-4 in the UI
-                raw_value,
-                value_norm: normalize(raw_value, LOADCELL_VALUE_SCALE),
-                raw_threshold: threshold,
-                threshold_norm: normalize(threshold, LOADCELL_VALUE_SCALE),
-                active: raw_value >= threshold && threshold > 0,
-                enabled: true,
-            }
+    let sensors: Vec<SensorView> = values
+        .iter()
+        .enumerate()
+        .map(|(s, &raw_value)| SensorView {
+            firmware_index: s,
+            label: None, // corners, not edges -> numbered 1-4 in the UI
+            raw_value,
+            value_norm: normalize(raw_value, LOADCELL_VALUE_SCALE),
+            raw_threshold: press,
+            threshold_norm: normalize(press, LOADCELL_VALUE_SCALE),
+            active: panel_active,
+            enabled: true,
         })
         .collect();
     let aggregate_value = sensors.iter().map(|s| s.raw_value).max().unwrap_or(0);
@@ -415,10 +484,10 @@ fn load_cell_button(
         min_raw_threshold: MIN_LOADCELL_THRESHOLD,
         max_raw_threshold: MAX_LOADCELL_THRESHOLD,
         aggregate_value,
-        aggregate_threshold: threshold,
-        active: input_state & (1u16 << panel) != 0,
+        aggregate_threshold: press,
+        active: panel_active,
         value_scale: LOADCELL_VALUE_SCALE,
-        release_threshold: Some(u16::from(settings.load_cell_low_threshold)),
+        release_threshold: Some(release),
     }
 }
 
@@ -467,12 +536,13 @@ fn calibrate_fsr(value: i16) -> u16 {
 }
 
 /// Load-cell readings are used unscaled (no `>>2`), clamping noise at/below
-/// zero to zero and capping at the display scale.
+/// zero to zero and capping at the hardware's 500 ceiling. The display scale
+/// (250) only affects the bars; the numeric readout shows this raw value.
 fn calibrate_load_cell(value: i16) -> u16 {
     if value <= 0 {
         return 0;
     }
-    (value as u16).min(LOADCELL_VALUE_SCALE)
+    (value as u16).min(LOADCELL_RAW_MAX)
 }
 
 /// Sticky pressed state with the firmware's hysteresis: turns on at/above the

--- a/crates/deadsync-input-fsr/src/smx.rs
+++ b/crates/deadsync-input-fsr/src/smx.rs
@@ -1,7 +1,7 @@
 //! StepManiaX FSR sensor monitor using the shared SmxManager.
 
 use deadsync_input::fsr::{
-    BackendKind, ButtonView, PAD_BUTTON_COUNT, PadDeviceId, PadView, SensorView,
+    BackendKind, ButtonView, PAD_BUTTON_COUNT, PadDeviceId, PadView, SensorView, ThresholdKind,
 };
 use deadsync_smx::{self as smx, SensorTestData, SensorTestMode, SmxConfig};
 use std::fmt::Write as _;
@@ -119,14 +119,17 @@ impl Monitor {
         pads
     }
 
-    /// Set a panel threshold. SMX stores a low + high; we write `high = value`,
-    /// `low = value - 1`. FSR pads allow per-sensor edits (`sensor = Some(i)`);
-    /// load-cell pads have a single per-panel threshold (`sensor` is ignored).
+    /// Set a panel threshold. FSR pads have one user-facing threshold (we write
+    /// `high = value`, `low = value - 1`, so only `Press` is accepted) and allow
+    /// per-sensor edits (`sensor = Some(i)`). Load-cell pads edit their press
+    /// (high) and release (low) thresholds independently by `kind` (`sensor` is
+    /// ignored); keeping release below press is the caller's job.
     pub fn set_threshold(
         &mut self,
         device: PadDeviceId,
         button: usize,
         sensor: Option<usize>,
+        kind: ThresholdKind,
         value: u16,
     ) -> bool {
         if device.backend != BackendKind::Smx || button >= PAD_BUTTON_COUNT {
@@ -148,10 +151,11 @@ impl Monitor {
 
         if fsr {
             if info.firmware_version < 5
+                || kind != ThresholdKind::Press
                 || !(MIN_FSR_THRESHOLD..=MAX_FSR_THRESHOLD).contains(&value)
             {
                 log::trace!(
-                    "SMX: set_threshold pad {pad} panel {panel} rejected (fsr, fw {}, value {value} not in {MIN_FSR_THRESHOLD}..={MAX_FSR_THRESHOLD})",
+                    "SMX: set_threshold pad {pad} panel {panel} rejected (fsr, fw {}, kind {kind:?}, value {value} not in {MIN_FSR_THRESHOLD}..={MAX_FSR_THRESHOLD})",
                     info.firmware_version
                 );
                 return false;
@@ -175,19 +179,22 @@ impl Monitor {
                 }
             }
         } else {
-            // Load cell: one threshold per panel; the sensor index is ignored.
+            // Load cell: per-panel press (high) / release (low) pair; the
+            // sensor index is ignored.
             if !(MIN_LOADCELL_THRESHOLD..=MAX_LOADCELL_THRESHOLD).contains(&value) {
                 log::trace!(
                     "SMX: set_threshold pad {pad} panel {panel} rejected (load-cell, value {value} not in {MIN_LOADCELL_THRESHOLD}..={MAX_LOADCELL_THRESHOLD})"
                 );
                 return false;
             }
-            settings.load_cell_high_threshold = value as u8;
-            settings.load_cell_low_threshold = (value as u8).saturating_sub(1);
+            match kind {
+                ThresholdKind::Press => settings.load_cell_high_threshold = value as u8,
+                ThresholdKind::Release => settings.load_cell_low_threshold = value as u8,
+            }
         }
         smx::set_config(pad, config);
         log::trace!(
-            "SMX: set_threshold pad {pad} panel {panel} sensor {sensor:?} -> {value} ({})",
+            "SMX: set_threshold pad {pad} panel {panel} sensor {sensor:?} {kind:?} -> {value} ({})",
             if fsr { "fsr" } else { "load-cell" }
         );
         true
@@ -364,6 +371,7 @@ fn fsr_button(
         aggregate_threshold,
         active: input_state & (1u16 << panel) != 0,
         value_scale: FSR_VALUE_SCALE,
+        release_threshold: None,
     }
 }
 
@@ -405,6 +413,7 @@ fn load_cell_button(
         aggregate_threshold: threshold,
         active: input_state & (1u16 << panel) != 0,
         value_scale: LOADCELL_VALUE_SCALE,
+        release_threshold: Some(u16::from(settings.load_cell_low_threshold)),
     }
 }
 

--- a/crates/deadsync-input-fsr/src/smx.rs
+++ b/crates/deadsync-input-fsr/src/smx.rs
@@ -17,12 +17,14 @@ pub(super) const MAX_FSR_THRESHOLD: u16 = 250;
 pub(super) const MIN_DEBOUNCE_US: u16 = 500;
 pub(super) const MAX_DEBOUNCE_US: u16 = 25000;
 
-// Pre-v5 load-cell pads: 8-bit thresholds (20-200) and live values that scale
-// to 500 (no >>2), matching the official SMX config tool.
+// Pre-v5 load-cell pads: 8-bit thresholds (20-200) and raw live values that
+// reach 500 (no >>2). We cap the display scale at 250 so the threshold band
+// uses most of the bar's height (200 sits at 80%) instead of topping out
+// midway; readings past 250 just show a full bar (far beyond "pressed").
 pub(super) const MIN_LOADCELL_THRESHOLD: u16 = 20;
 pub(super) const MAX_LOADCELL_THRESHOLD: u16 = 200;
 pub(super) const FSR_VALUE_SCALE: u16 = 250;
-pub(super) const LOADCELL_VALUE_SCALE: u16 = 500;
+pub(super) const LOADCELL_VALUE_SCALE: u16 = 250;
 
 /// Panels exposed for config: (panel_index, label), in L/D/U/R order.
 const VIEW_PANELS: [(usize, &str); PAD_BUTTON_COUNT] = [(3, "L"), (7, "D"), (1, "U"), (5, "R")];
@@ -35,11 +37,18 @@ pub(super) const SENSOR_DISPLAY_ORDER: [usize; PANEL_SENSOR_COUNT] = [0, 3, 2, 1
 pub struct Monitor {
     /// Whether the config screen has requested live reads (sensor test mode).
     read_active: bool,
+    /// Sticky per-pad/panel/sensor pressed state for load-cell bars, so the
+    /// view colors with the firmware's press/release hysteresis (green above
+    /// the press threshold, idle again only below the release threshold).
+    lc_held: [[[bool; PANEL_SENSOR_COUNT]; smx::PANEL_COUNT]; 2],
 }
 
 impl Monitor {
     pub fn new() -> Self {
-        Self { read_active: false }
+        Self {
+            read_active: false,
+            lc_held: [[[false; PANEL_SENSOR_COUNT]; smx::PANEL_COUNT]; 2],
+        }
     }
 
     /// Toggle live sensor reads (test mode) on all connected pads. Called by
@@ -87,12 +96,20 @@ impl Monitor {
                 smx::serial_prefix(&info.serial),
             );
 
+            let lc_held = &mut self.lc_held[pad];
             let buttons = std::array::from_fn(|i| {
                 let (panel, label) = VIEW_PANELS[i];
                 if fsr {
                     fsr_button(&config, panel, label, test_data.as_ref(), input_state)
                 } else {
-                    load_cell_button(&config, panel, label, test_data.as_ref(), input_state)
+                    load_cell_button(
+                        &config,
+                        panel,
+                        label,
+                        test_data.as_ref(),
+                        input_state,
+                        &mut lc_held[panel],
+                    )
                 }
             });
 
@@ -376,21 +393,25 @@ fn fsr_button(
 }
 
 /// Build a load-cell panel's button view: four corner readings (numbered 1-4)
-/// that all share the panel's single load-cell threshold.
+/// that all share the panel's press/release threshold pair. `held` is the
+/// panel's sticky per-sensor pressed state (press/release hysteresis).
 fn load_cell_button(
     config: &SmxConfig,
     panel: usize,
     label: &'static str,
     test_data: Option<&SensorTestData>,
     input_state: u16,
+    held: &mut [bool; PANEL_SENSOR_COUNT],
 ) -> ButtonView {
     let settings = &config.panel_settings[panel];
     let threshold = u16::from(settings.load_cell_high_threshold);
+    let release = u16::from(settings.load_cell_low_threshold);
     let sensors: Vec<SensorView> = (0..PANEL_SENSOR_COUNT)
         .map(|s| {
             let raw_value = test_data
                 .filter(|d| d.have_data_from_panel[panel])
                 .map_or(0, |d| calibrate_load_cell(d.sensor_level[panel][s]));
+            held[s] = hysteresis_active(held[s], raw_value, release, threshold);
             SensorView {
                 firmware_index: s,
                 label: None, // corners, not edges -> numbered 1-4 in the UI
@@ -398,7 +419,7 @@ fn load_cell_button(
                 value_norm: normalize(raw_value, LOADCELL_VALUE_SCALE),
                 raw_threshold: threshold,
                 threshold_norm: normalize(threshold, LOADCELL_VALUE_SCALE),
-                active: raw_value >= threshold && threshold > 0,
+                active: held[s],
                 enabled: true,
             }
         })
@@ -461,8 +482,8 @@ fn calibrate_fsr(value: i16) -> u16 {
     (value >> 2) as u16
 }
 
-/// Load-cell readings are used unscaled (0-500 range, no `>>2`), clamping
-/// noise at/below zero to zero.
+/// Load-cell readings are used unscaled (no `>>2`), clamping noise at/below
+/// zero to zero and capping at the display scale.
 fn calibrate_load_cell(value: i16) -> u16 {
     if value <= 0 {
         return 0;
@@ -470,9 +491,43 @@ fn calibrate_load_cell(value: i16) -> u16 {
     (value as u16).min(LOADCELL_VALUE_SCALE)
 }
 
+/// Sticky pressed state with the firmware's hysteresis: turns on at/above the
+/// press (`high`) threshold and off only below the release (`low`) threshold;
+/// in between it keeps its previous state.
+pub(super) fn hysteresis_active(was: bool, value: u16, low: u16, high: u16) -> bool {
+    if high == 0 {
+        false
+    } else if value >= high {
+        true
+    } else if value < low {
+        false
+    } else {
+        was
+    }
+}
+
 fn normalize(value: u16, max: u16) -> f32 {
     if max == 0 {
         return 0.0;
     }
     (value as f32 / max as f32).clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hysteresis_active;
+
+    #[test]
+    fn hysteresis_holds_between_release_and_press() {
+        // Rising: stays off through the band, on at/above press.
+        assert!(!hysteresis_active(false, 69, 70, 80));
+        assert!(!hysteresis_active(false, 75, 70, 80));
+        assert!(hysteresis_active(false, 80, 70, 80));
+        // Falling: stays on through the band, off only below release.
+        assert!(hysteresis_active(true, 79, 70, 80));
+        assert!(hysteresis_active(true, 70, 70, 80));
+        assert!(!hysteresis_active(true, 69, 70, 80));
+        // An unset press threshold never reads as pressed.
+        assert!(!hysteresis_active(true, 100, 0, 0));
+    }
 }

--- a/crates/deadsync-input/src/fsr.rs
+++ b/crates/deadsync-input/src/fsr.rs
@@ -17,6 +17,17 @@ pub struct PadDeviceId {
     pub index: usize,
 }
 
+/// Which of a panel's two thresholds an edit targets. Only pads that expose a
+/// separate release threshold (`ButtonView::release_threshold`) use `Release`;
+/// everything else edits `Press` and lets the backend derive the release side.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ThresholdKind {
+    /// The trigger (high) threshold: the panel activates above it.
+    Press,
+    /// The release (low) threshold: the panel deactivates below it.
+    Release,
+}
+
 /// One physical sensor within a button group.
 ///
 /// Sensors are listed in display order (left-to-right in the UI), which is not
@@ -56,6 +67,10 @@ pub struct ButtonView {
     /// Full-scale value for normalizing the live bars (FSR 250, load cell 500).
     /// May exceed `max_raw_threshold` (load-cell readings outrun their threshold range).
     pub value_scale: u16,
+    /// The release (low) threshold, when the pad exposes it as user-editable
+    /// (SMX load-cell pads). `None` means the backend derives it from the
+    /// press threshold and the Simple view shows a single editable value.
+    pub release_threshold: Option<u16>,
 }
 
 /// A single connected FSR pad, exposed to the config screen.

--- a/crates/deadsync-input/src/fsr.rs
+++ b/crates/deadsync-input/src/fsr.rs
@@ -17,17 +17,6 @@ pub struct PadDeviceId {
     pub index: usize,
 }
 
-/// Which of a panel's two thresholds an edit targets. Only pads that expose a
-/// separate release threshold (`ButtonView::release_threshold`) use `Release`;
-/// everything else edits `Press` and lets the backend derive the release side.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ThresholdKind {
-    /// The trigger (high) threshold: the panel activates above it.
-    Press,
-    /// The release (low) threshold: the panel deactivates below it.
-    Release,
-}
-
 /// One physical sensor within a button group.
 ///
 /// Sensors are listed in display order (left-to-right in the UI), which is not

--- a/crates/deadsync-input/src/fsr.rs
+++ b/crates/deadsync-input/src/fsr.rs
@@ -64,8 +64,9 @@ pub struct ButtonView {
     pub aggregate_value: u16,
     pub aggregate_threshold: u16,
     pub active: bool,
-    /// Full-scale value for normalizing the live bars (FSR 250, load cell 500).
-    /// May exceed `max_raw_threshold` (load-cell readings outrun their threshold range).
+    /// Full-scale value for normalizing the live bars and threshold lines.
+    /// May exceed `max_raw_threshold`; backends pick it so the threshold range
+    /// covers most of the bar (readings past it display as a full bar).
     pub value_scale: u16,
     /// The release (low) threshold, when the pad exposes it as user-editable
     /// (SMX load-cell pads). `None` means the backend derives it from the

--- a/crates/deadsync-smx/src/lib.rs
+++ b/crates/deadsync-smx/src/lib.rs
@@ -54,13 +54,24 @@ pub struct InitConfig {
     pub p2_serial: Option<String>,
 }
 
-/// Value of `DEADSYNC_MOCK_PADS` when set non-empty. Mock pads (see
-/// `deadsync_input_fsr::mock`) replace native SMX entirely: while this is set,
-/// `init` refuses to start the SDK, so UI work can never touch real hardware.
+/// Value of `DEADSYNC_MOCK_PADS` when it enables mock pads (see
+/// `deadsync_input_fsr::mock`). Mock pads replace native SMX entirely: while
+/// enabled, `init` refuses to start the SDK, so UI work can never touch real
+/// hardware. Empty and common falsey values count as unset, so someone
+/// "disabling" with `DEADSYNC_MOCK_PADS=0` doesn't silently get mock pads.
 pub fn mock_pads_env() -> Option<String> {
     std::env::var("DEADSYNC_MOCK_PADS")
         .ok()
-        .filter(|v| !v.trim().is_empty())
+        .filter(|v| mock_spec_enabled(v))
+}
+
+fn mock_spec_enabled(value: &str) -> bool {
+    let v = value.trim();
+    !(v.is_empty()
+        || v == "0"
+        || v.eq_ignore_ascii_case("false")
+        || v.eq_ignore_ascii_case("off")
+        || v.eq_ignore_ascii_case("no"))
 }
 
 /// Initialize the shared SMX manager. Call once at startup.
@@ -857,9 +868,19 @@ mod tests {
     use super::{
         PLAYER_UNCONFIGURED_LIGHT, PLAYER1_LIGHT, PLAYER2_LIGHT, PadConfigData, PanelThresholds,
         SmxPadPreset, conflict_unresolved, indicator_color, jumper_derived_pair, jumpers_conflict,
-        preset_thresholds,
+        mock_spec_enabled, preset_thresholds,
     };
     use rustmaniax_sdk::SmxInfo;
+
+    #[test]
+    fn mock_spec_falsey_values_leave_the_mock_off() {
+        for off in ["", "  ", "0", "false", "FALSE", "off", "Off", "no"] {
+            assert!(!mock_spec_enabled(off), "{off:?} should not enable mocks");
+        }
+        for on in ["1", "true", "loadcell", "fsr", "loadcell,fsr"] {
+            assert!(mock_spec_enabled(on), "{on:?} should enable mocks");
+        }
+    }
 
     #[test]
     fn is_smx_usb_device_requires_both_vid_and_pid() {

--- a/crates/deadsync-smx/src/lib.rs
+++ b/crates/deadsync-smx/src/lib.rs
@@ -54,9 +54,22 @@ pub struct InitConfig {
     pub p2_serial: Option<String>,
 }
 
+/// Value of `DEADSYNC_MOCK_PADS` when set non-empty. Mock pads (see
+/// `deadsync_input_fsr::mock`) replace native SMX entirely: while this is set,
+/// `init` refuses to start the SDK, so UI work can never touch real hardware.
+pub fn mock_pads_env() -> Option<String> {
+    std::env::var("DEADSYNC_MOCK_PADS")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+}
+
 /// Initialize the shared SMX manager. Call once at startup.
 /// Returns false if initialization failed (e.g., hidapi unavailable).
 pub fn init(config: InitConfig) -> bool {
+    if let Some(spec) = mock_pads_env() {
+        log::info!("SMX: DEADSYNC_MOCK_PADS={spec}; native SMX disabled (no USB traffic)");
+        return false;
+    }
     if SHARED.get().is_some() {
         return true;
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4132,11 +4132,12 @@ impl App {
                     device,
                     button,
                     sensor,
+                    kind,
                     value,
                 } => {
                     let _ = self
                         .fsr_monitor
-                        .set_threshold(device, button, sensor, value);
+                        .set_threshold(device, button, sensor, kind, value);
                 }
                 PadCommand::SensorEnabled {
                     device,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4123,6 +4123,7 @@ impl App {
         for cmd in commands {
             let device = match &cmd {
                 PadCommand::Threshold { device, .. }
+                | PadCommand::ThresholdPair { device, .. }
                 | PadCommand::SensorEnabled { device, .. }
                 | PadCommand::AutoRecalibration { device, .. }
                 | PadCommand::Debounce { device, .. } => *device,
@@ -4132,12 +4133,21 @@ impl App {
                     device,
                     button,
                     sensor,
-                    kind,
                     value,
                 } => {
                     let _ = self
                         .fsr_monitor
-                        .set_threshold(device, button, sensor, kind, value);
+                        .set_threshold(device, button, sensor, value);
+                }
+                PadCommand::ThresholdPair {
+                    device,
+                    button,
+                    press,
+                    release,
+                } => {
+                    let _ = self
+                        .fsr_monitor
+                        .set_threshold_pair(device, button, press, release);
                 }
                 PadCommand::SensorEnabled {
                     device,

--- a/src/app/screen_nav.rs
+++ b/src/app/screen_nav.rs
@@ -238,6 +238,7 @@ impl App {
                 pad_state,
                 crate::screens::pad_config::PadFilter::All,
             );
+            crate::screens::pad_config::reset_modes(pad_state);
         } else if target_screen == CurrentScreen::ManageLocalProfiles {
             let color_index = self.state.screens.options_state.active_color_index;
             self.state.screens.manage_local_profiles_state = manage_local_profiles::init();

--- a/src/screens/pad_config.rs
+++ b/src/screens/pad_config.rs
@@ -65,6 +65,9 @@ const ACTIVE_FILL: [f32; 4] = [0.30, 0.95, 0.45, 0.95];
 const THRESHOLD_COLOR: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
 /// Highlight color for the currently selected bar's text (reads on black and green).
 const SELECTED_TEXT: [f32; 4] = [1.0, 0.55, 0.1, 1.0];
+/// Selected-highlight color while the press/release lock is off: red, to read
+/// as an "at your own risk" state (the thresholds can get arbitrarily close).
+const LOCK_OFF_TEXT: [f32; 4] = [1.0, 0.25, 0.2, 1.0];
 /// Caution color for the Extra Advanced section.
 const CAUTION_TEXT: [f32; 4] = [1.0, 0.45, 0.2, 1.0];
 /// "On" color for enable / auto-recal indicators.
@@ -954,7 +957,9 @@ fn build_simple(actors: &mut Vec<Actor>, state: &State, theme: &Theme, as_overla
             let selected = focused_kind.is_some();
             let scale = button.value_scale;
             // A pending whole-button edit shows a single value; otherwise show the
-            // live per-sensor range ("200-230") so Advanced edits are visible here.
+            // live per-sensor range ("200-230") so Advanced edits are visible here,
+            // with faded ghost lines at the divergent per-sensor thresholds.
+            let mut ghost_norms: Vec<f32> = Vec::new();
             let (threshold_label, threshold_norm) = if let Some(v) =
                 pending_simple_threshold(state, pad.device_id, btn_idx, ThresholdKind::Press)
             {
@@ -964,6 +969,10 @@ fn build_simple(actors: &mut Vec<Actor>, state: &State, theme: &Theme, as_overla
                 let label = if mn == mx {
                     mx.to_string()
                 } else {
+                    ghost_norms = divergent_sensor_thresholds(button)
+                        .into_iter()
+                        .map(|v| normalize(v, scale))
+                        .collect();
                     format!("{mn}-{mx}")
                 };
                 (label, normalize(mx, scale))
@@ -994,6 +1003,7 @@ fn build_simple(actors: &mut Vec<Actor>, state: &State, theme: &Theme, as_overla
                     button.active,
                     theme,
                     focused_kind,
+                    state.threshold_lock_off,
                     11.0 + zb,
                 );
             } else {
@@ -1007,6 +1017,7 @@ fn build_simple(actors: &mut Vec<Actor>, state: &State, theme: &Theme, as_overla
                     normalize(button.aggregate_value, scale),
                     threshold_label,
                     threshold_norm,
+                    &ghost_norms,
                     button.active,
                     disabled,
                     x,
@@ -1823,6 +1834,20 @@ fn sensor_threshold_range(button: &ButtonView) -> (u16, u16) {
     (mn, mx)
 }
 
+/// Distinct per-sensor thresholds that diverge from a button's displayed
+/// (max) threshold, for the Simple view's faded ghost lines after per-sensor
+/// Advanced edits. Empty when every sensor agrees.
+fn divergent_sensor_thresholds(button: &ButtonView) -> Vec<u16> {
+    let (_, mx) = sensor_threshold_range(button);
+    let mut out: Vec<u16> = Vec::new();
+    for s in &button.sensors {
+        if s.raw_threshold != mx && !out.contains(&s.raw_threshold) {
+            out.push(s.raw_threshold);
+        }
+    }
+    out
+}
+
 fn group_width(sensors: usize) -> f32 {
     if sensors == 0 {
         return ADV_BAR_W;
@@ -2092,9 +2117,17 @@ fn push_value_cluster(
     button_active: bool,
     theme: &Theme,
     focused_kind: Option<ThresholdKind>,
+    lock_off: bool,
     z: f32,
 ) {
     let selected = focused_kind.is_some();
+    // With the press/release lock off, the selection highlight turns red to
+    // read as an "at your own risk" state (dual-threshold clusters only).
+    let sel = if lock_off && release.is_some() {
+        LOCK_OFF_TEXT
+    } else {
+        SELECTED_TEXT
+    };
     let threshold_norm = threshold_norm.clamp(0.0, 1.0);
     let n = sensors.len().max(1);
     let thin_w = 9.0_f32;
@@ -2124,11 +2157,7 @@ fn push_value_cluster(
             );
         }
         // Sensor number (1-based) below its bar.
-        let nc = if selected {
-            SELECTED_TEXT
-        } else {
-            [1.0, 1.0, 1.0, 0.9]
-        };
+        let nc = if selected { sel } else { [1.0, 1.0, 1.0, 0.9] };
         actors.push(act!(text:
             font("miso"): settext((i + 1).to_string()): align(0.5, 0.0):
             xy(bx, y + BAR_HEIGHT + 6.0): zoom(0.5): horizalign(center):
@@ -2143,11 +2172,7 @@ fn push_value_cluster(
     let release_focused = focused_kind == Some(ThresholdKind::Release);
     let threshold_h = 3.0_f32;
     let threshold_y = y + (1.0 - threshold_norm) * BAR_HEIGHT - threshold_h * 0.5;
-    let press_line = if press_focused {
-        SELECTED_TEXT
-    } else {
-        THRESHOLD_COLOR
-    };
+    let press_line = if press_focused { sel } else { THRESHOLD_COLOR };
     push_quad(
         actors,
         x_center,
@@ -2159,11 +2184,7 @@ fn push_value_cluster(
     );
     if let Some((_, release_norm)) = &release {
         let release_y = y + (1.0 - release_norm.clamp(0.0, 1.0)) * BAR_HEIGHT - threshold_h * 0.5;
-        let release_line = if release_focused {
-            SELECTED_TEXT
-        } else {
-            OFF_TEXT
-        };
+        let release_line = if release_focused { sel } else { OFF_TEXT };
         push_quad(
             actors,
             x_center,
@@ -2192,21 +2213,13 @@ fn push_value_cluster(
         ));
     }
 
-    let text_color = if selected {
-        SELECTED_TEXT
-    } else {
-        [1.0, 1.0, 1.0, 0.95]
-    };
+    let text_color = if selected { sel } else { [1.0, 1.0, 1.0, 0.95] };
     if let Some((release_label, _)) = &release {
         // Release / press values side by side above the press line (low on the
         // left, like the official tool), each lit when it is the one focused.
         let plain = [1.0, 1.0, 1.0, 0.95];
-        let rc = if release_focused {
-            SELECTED_TEXT
-        } else {
-            plain
-        };
-        let pc = if press_focused { SELECTED_TEXT } else { plain };
+        let rc = if release_focused { sel } else { plain };
+        let pc = if press_focused { sel } else { plain };
         actors.push(act!(text:
             font("miso"): settext(release_label.clone()): align(1.0, 1.0):
             xy(x_center - 4.0, threshold_y - 3.0): zoom(0.68): horizalign(right):
@@ -2226,7 +2239,7 @@ fn push_value_cluster(
             actors.push(act!(text:
                 font("miso"): settext(caption.to_owned()): align(0.5, 1.0):
                 xy(x_center, y - 10.0): zoom(0.55): horizalign(center):
-                diffuse(SELECTED_TEXT[0], SELECTED_TEXT[1], SELECTED_TEXT[2], SELECTED_TEXT[3]): z(z + 3.0)
+                diffuse(sel[0], sel[1], sel[2], sel[3]): z(z + 3.0)
             ));
         }
     } else {
@@ -2258,6 +2271,7 @@ fn push_bar(
     value_norm: f32,
     threshold_label: String,
     threshold_norm: f32,
+    ghost_norms: &[f32],
     active: bool,
     disabled: bool,
     x: f32,
@@ -2345,6 +2359,20 @@ fn push_bar(
         THRESHOLD_COLOR,
         z + 2.0,
     );
+    // Faded ghost lines at per-sensor thresholds that diverge from the main
+    // (max) line after Advanced edits, so the spread is visible from Simple.
+    for gn in ghost_norms {
+        let gy = y + (1.0 - gn.clamp(0.0, 1.0)) * BAR_HEIGHT - 1.0;
+        push_quad(
+            actors,
+            x,
+            gy,
+            BAR_WIDTH,
+            2.0,
+            with_alpha(THRESHOLD_COLOR, 0.35),
+            z + 1.9,
+        );
+    }
 
     // Current pressure value, kept high above the bar so a near-max threshold
     // number doesn't clip into it.
@@ -2754,6 +2782,18 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn divergent_sensor_thresholds_lists_distinct_non_max_values() {
+        let mut b = mk_button("L", 50);
+        // Uniform sensors: nothing diverges, no ghost lines.
+        assert!(divergent_sensor_thresholds(&b).is_empty());
+        b.sensors[0].raw_threshold = 30;
+        b.sensors[1].raw_threshold = 40;
+        b.sensors[2].raw_threshold = 40;
+        // sensors[3] stays at 50: the max, drawn as the main line.
+        assert_eq!(divergent_sensor_thresholds(&b), vec![30, 40]);
     }
 
     #[test]

--- a/src/screens/pad_config.rs
+++ b/src/screens/pad_config.rs
@@ -19,11 +19,19 @@ use crate::engine::present::color;
 use crate::screens::components::shared::visual_style_bg;
 use crate::screens::{Screen, ScreenAction};
 use deadsync_core::input::InputSource;
-use deadsync_input::fsr::{
-    ButtonView, PAD_BUTTON_COUNT, PadDeviceId, PadView, SensorView, ThresholdKind,
-};
+use deadsync_input::fsr::{ButtonView, PAD_BUTTON_COUNT, PadDeviceId, PadView, SensorView};
 use deadsync_input::{InputEvent, VirtualAction};
 use deadsync_present::space::{screen_center_x, screen_center_y, screen_height};
+
+/// Which of a load-cell button's two thresholds a Simple-view cursor stop
+/// edits. Pads without a separate release threshold only use `Press`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ThresholdKind {
+    /// The trigger (high) threshold: the panel activates above it.
+    Press,
+    /// The release (low) threshold: the panel deactivates below it.
+    Release,
+}
 
 const TRANSITION_IN_DURATION: f32 = 0.4;
 const TRANSITION_OUT_DURATION: f32 = 0.4;
@@ -83,15 +91,23 @@ struct Theme {
 /// A pending pad-config edit for the app loop to apply to hardware.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PadCommand {
-    /// Threshold edit. `sensor: None` applies to every sensor in the button
-    /// (Simple mode); `Some(i)` targets one sensor (Advanced mode). `kind` is
-    /// `Release` only for the separate release threshold of load-cell pads.
+    /// Single-threshold edit (the backend derives its own release side).
+    /// `sensor: None` applies to every sensor in the button (Simple mode);
+    /// `Some(i)` targets one sensor (Advanced mode).
     Threshold {
         device: PadDeviceId,
         button: usize,
         sensor: Option<usize>,
-        kind: ThresholdKind,
         value: u16,
+    },
+    /// Press+release pair edit for a load-cell button, applied as a single
+    /// config write so the pad can never observe an inverted intermediate
+    /// state (release >= press).
+    ThresholdPair {
+        device: PadDeviceId,
+        button: usize,
+        press: u16,
+        release: u16,
     },
     /// Enable/disable a single sensor (Advanced mode).
     SensorEnabled {
@@ -430,6 +446,9 @@ pub fn reset_modes(state: &mut State) {
     state.saving = None;
     state.delete_armed = false;
     state.profiles_sel = 0;
+    // The press/release lock returns to ON each time the editor is entered,
+    // like the official tool; "at your own risk" mode is opt-in per session.
+    state.threshold_lock_off = false;
 }
 
 pub fn is_profiles_mode(state: &State) -> bool {
@@ -956,40 +975,53 @@ fn build_simple(actors: &mut Vec<Actor>, state: &State, theme: &Theme, as_overla
                 .map(|s| s.kind);
             let selected = focused_kind.is_some();
             let scale = button.value_scale;
-            // A pending whole-button edit shows a single value; otherwise show the
-            // live per-sensor range ("200-230") so Advanced edits are visible here,
-            // with faded ghost lines at the divergent per-sensor thresholds.
-            let mut ghost_norms: Vec<f32> = Vec::new();
-            let (threshold_label, threshold_norm) = if let Some(v) =
-                pending_simple_threshold(state, pad.device_id, btn_idx, ThresholdKind::Press)
-            {
-                (v.to_string(), normalize(v, scale))
-            } else {
-                let (mn, mx) = sensor_threshold_range(button);
-                let label = if mn == mx {
-                    mx.to_string()
-                } else {
-                    ghost_norms = divergent_sensor_thresholds(button)
-                        .into_iter()
-                        .map(|v| normalize(v, scale))
-                        .collect();
-                    format!("{mn}-{mx}")
-                };
-                (label, normalize(mx, scale))
-            };
-            if pad.simple_per_sensor_bars {
+            if let Some(live_release) = button.release_threshold {
                 // Load cells: four corner readings (numbered) sharing the
-                // panel's press/release threshold pair.
-                let release = button.release_threshold.map(|live| {
-                    let v = pending_simple_threshold(
-                        state,
-                        pad.device_id,
-                        btn_idx,
-                        ThresholdKind::Release,
-                    )
-                    .unwrap_or(live);
+                // panel's press/release threshold pair (pending edits are
+                // queued as a pair, so both values come from one lookup).
+                let (press, release) = pending_threshold_pair(state, pad.device_id, btn_idx)
+                    .unwrap_or((button.aggregate_threshold, live_release));
+                push_value_cluster(
+                    actors,
+                    x,
+                    track_y,
+                    button.label,
+                    &button.sensors,
+                    scale,
+                    press.to_string(),
+                    normalize(press, scale),
+                    Some((release.to_string(), normalize(release, scale))),
+                    button.active,
+                    theme,
+                    focused_kind,
+                    state.threshold_lock_off,
+                    11.0 + zb,
+                );
+                continue;
+            }
+            // Single-threshold buttons: a pending whole-button edit shows one
+            // value; otherwise show the live per-sensor range ("200-230") so
+            // Advanced edits are visible here, with faded ghost lines at the
+            // divergent per-sensor thresholds.
+            let mut ghost_norms: Vec<f32> = Vec::new();
+            let (threshold_label, threshold_norm) =
+                if let Some(v) = pending_simple_threshold(state, pad.device_id, btn_idx) {
                     (v.to_string(), normalize(v, scale))
-                });
+                } else {
+                    let (mn, mx) = sensor_threshold_range(button);
+                    let label = if mn == mx {
+                        mx.to_string()
+                    } else {
+                        ghost_norms = divergent_sensor_thresholds(button)
+                            .into_iter()
+                            .map(|v| normalize(v, scale))
+                            .collect();
+                        format!("{mn}-{mx}")
+                    };
+                    (label, normalize(mx, scale))
+                };
+            if pad.simple_per_sensor_bars {
+                // Per-sensor bars without a separate release threshold.
                 push_value_cluster(
                     actors,
                     x,
@@ -999,7 +1031,7 @@ fn build_simple(actors: &mut Vec<Actor>, state: &State, theme: &Theme, as_overla
                     scale,
                     threshold_label,
                     threshold_norm,
-                    release,
+                    None,
                     button.active,
                     theme,
                     focused_kind,
@@ -1526,8 +1558,8 @@ fn adjust_simple_threshold(state: &mut State, delta: i32) {
 
     let Some(live_release) = bar.release_threshold else {
         // Single-threshold button: the backend derives its own release side.
-        let current = pending_simple_threshold(state, device, button, ThresholdKind::Press)
-            .unwrap_or(bar.aggregate_threshold);
+        let current =
+            pending_simple_threshold(state, device, button).unwrap_or(bar.aggregate_threshold);
         let next = (i32::from(current) + delta).clamp(min, max) as u16;
         if next == current {
             return;
@@ -1538,7 +1570,6 @@ fn adjust_simple_threshold(state: &mut State, delta: i32) {
                 device,
                 button,
                 sensor: None,
-                kind: ThresholdKind::Press,
                 value: next,
             },
         );
@@ -1546,16 +1577,13 @@ fn adjust_simple_threshold(state: &mut State, delta: i32) {
     };
 
     // Dual-threshold (load-cell) button: move the edited threshold, dragging
-    // the partner along when they would end up closer than the gap.
+    // the partner along when they would end up closer than the gap. The pair
+    // is queued as one command so it reaches the pad in a single write.
     let gap = i32::from(threshold_gap(state));
-    let press = i32::from(
-        pending_simple_threshold(state, device, button, ThresholdKind::Press)
-            .unwrap_or(bar.aggregate_threshold),
-    );
-    let release = i32::from(
-        pending_simple_threshold(state, device, button, ThresholdKind::Release)
-            .unwrap_or(live_release),
-    );
+    let (pending_press, pending_release) = pending_threshold_pair(state, device, button)
+        .unwrap_or((bar.aggregate_threshold, live_release));
+    let press = i32::from(pending_press);
+    let release = i32::from(pending_release);
     let (new_press, new_release) = match slot.kind {
         ThresholdKind::Press => {
             let p = (press + delta).clamp(min + gap, max);
@@ -1576,31 +1604,15 @@ fn adjust_simple_threshold(state: &mut State, delta: i32) {
     if new == cur || (delta > 0) != (new > cur) {
         return;
     }
-    // Queue the edited threshold first, then the dragged partner (if it moved).
-    let edits = match slot.kind {
-        ThresholdKind::Press => [
-            (ThresholdKind::Press, new_press, press),
-            (ThresholdKind::Release, new_release, release),
-        ],
-        ThresholdKind::Release => [
-            (ThresholdKind::Release, new_release, release),
-            (ThresholdKind::Press, new_press, press),
-        ],
-    };
-    for (kind, value, old) in edits {
-        if value != old {
-            queue_unique(
-                state,
-                PadCommand::Threshold {
-                    device,
-                    button,
-                    sensor: None,
-                    kind,
-                    value: value as u16,
-                },
-            );
-        }
-    }
+    queue_unique(
+        state,
+        PadCommand::ThresholdPair {
+            device,
+            button,
+            press: new_press as u16,
+            release: new_release as u16,
+        },
+    );
 }
 
 fn adjust_sensor_threshold(
@@ -1633,7 +1645,6 @@ fn adjust_sensor_threshold(
             device: dev,
             button,
             sensor: Some(fw),
-            kind: ThresholdKind::Press,
             value: next,
         },
     );
@@ -1654,17 +1665,27 @@ fn same_target(a: &PadCommand, b: &PadCommand) -> bool {
                 device: d1,
                 button: b1,
                 sensor: s1,
-                kind: k1,
                 ..
             },
             Threshold {
                 device: d2,
                 button: b2,
                 sensor: s2,
-                kind: k2,
                 ..
             },
-        ) => d1 == d2 && b1 == b2 && s1 == s2 && k1 == k2,
+        ) => d1 == d2 && b1 == b2 && s1 == s2,
+        (
+            ThresholdPair {
+                device: d1,
+                button: b1,
+                ..
+            },
+            ThresholdPair {
+                device: d2,
+                button: b2,
+                ..
+            },
+        ) => d1 == d2 && b1 == b2,
         (
             SensorEnabled {
                 device: d1,
@@ -1687,22 +1708,28 @@ fn same_target(a: &PadCommand, b: &PadCommand) -> bool {
 
 // ─── Pending / live value lookups ──────────────────────────────────────────────
 
-/// Most recently queued Simple-mode (whole-button) threshold for a
-/// pad+button+kind (`Release` only exists for load-cell buttons).
-fn pending_simple_threshold(
-    state: &State,
-    device: PadDeviceId,
-    button: usize,
-    kind: ThresholdKind,
-) -> Option<u16> {
+/// Most recently queued Simple-mode (whole-button) threshold for a pad+button.
+fn pending_simple_threshold(state: &State, device: PadDeviceId, button: usize) -> Option<u16> {
     state.pending.iter().rev().find_map(|c| match *c {
         PadCommand::Threshold {
             device: d,
             button: b,
             sensor: None,
-            kind: k,
             value,
-        } if d == device && b == button && k == kind => Some(value),
+        } if d == device && b == button => Some(value),
+        _ => None,
+    })
+}
+
+/// Most recently queued press/release pair for a load-cell pad+button.
+fn pending_threshold_pair(state: &State, device: PadDeviceId, button: usize) -> Option<(u16, u16)> {
+    state.pending.iter().rev().find_map(|c| match *c {
+        PadCommand::ThresholdPair {
+            device: d,
+            button: b,
+            press,
+            release,
+        } if d == device && b == button => Some((press, release)),
         _ => None,
     })
 }
@@ -1719,7 +1746,6 @@ fn current_sensor_threshold(
             device: d,
             button: b,
             sensor: Some(s),
-            kind: ThresholdKind::Press,
             value,
         } if d == device && b == button && s == sensor => Some(value),
         _ => None,
@@ -1790,32 +1816,35 @@ struct SimpleSlot {
     kind: ThresholdKind,
 }
 
-/// The Simple-view cursor stops, in display order. Dual-threshold buttons
-/// contribute two: release (low) first, then press (high), so stepping right
-/// reads L-release, L-press, D-release, D-press, …
-fn simple_slots(state: &State) -> Vec<SimpleSlot> {
-    let mut slots = Vec::with_capacity(state.pads.len() * PAD_BUTTON_COUNT * 2);
-    for (p, pad) in state.pads.iter().enumerate() {
-        for (b, button) in pad.buttons.iter().enumerate() {
-            if button.release_threshold.is_some() {
-                slots.push(SimpleSlot {
-                    pad: p,
-                    button: b,
-                    kind: ThresholdKind::Release,
-                });
-            }
-            slots.push(SimpleSlot {
-                pad: p,
-                button: b,
-                kind: ThresholdKind::Press,
-            });
-        }
-    }
-    slots
+/// How many Simple-view cursor stops a button holds: dual-threshold (load
+/// cell) buttons get two, release (low) first then press (high), so stepping
+/// right reads L-release, L-press, D-release, D-press, …
+fn button_stops(button: &ButtonView) -> usize {
+    1 + usize::from(button.release_threshold.is_some())
 }
 
+/// Resolve the flat cursor index to its stop without materializing the list.
 fn selected_slot(state: &State) -> Option<SimpleSlot> {
-    simple_slots(state).get(state.selected).copied()
+    let mut rest = state.selected;
+    for (p, pad) in state.pads.iter().enumerate() {
+        for (b, button) in pad.buttons.iter().enumerate() {
+            let stops = button_stops(button);
+            if rest < stops {
+                let kind = if stops == 2 && rest == 0 {
+                    ThresholdKind::Release
+                } else {
+                    ThresholdKind::Press
+                };
+                return Some(SimpleSlot {
+                    pad: p,
+                    button: b,
+                    kind,
+                });
+            }
+            rest -= stops;
+        }
+    }
+    None
 }
 
 /// Whether a pad has separately editable release thresholds (load cell).
@@ -1833,31 +1862,40 @@ fn threshold_gap(state: &State) -> u16 {
 }
 
 fn total_bars(state: &State) -> usize {
-    simple_slots(state).len()
+    state
+        .pads
+        .iter()
+        .flat_map(|p| p.buttons.iter())
+        .map(button_stops)
+        .sum()
 }
 
-/// Min/max live threshold across a button's sensors (for the Simple-view
-/// range display). Empty buttons report `(0, 0)`.
+/// Min/max live threshold across a button's enabled sensors (for the
+/// Simple-view range display); a disabled sensor's stale threshold never
+/// fires, so it shouldn't widen the range. Buttons with no enabled sensors
+/// report `(0, 0)` (the Simple bar shows OFF instead of a threshold).
 fn sensor_threshold_range(button: &ButtonView) -> (u16, u16) {
     let mut mn = u16::MAX;
     let mut mx = 0u16;
-    for s in &button.sensors {
+    let mut any = false;
+    for s in button.sensors.iter().filter(|s| s.enabled) {
         mn = mn.min(s.raw_threshold);
         mx = mx.max(s.raw_threshold);
+        any = true;
     }
-    if button.sensors.is_empty() {
+    if !any {
         return (0, 0);
     }
     (mn, mx)
 }
 
-/// Distinct per-sensor thresholds that diverge from a button's displayed
+/// Distinct enabled-sensor thresholds that diverge from a button's displayed
 /// (max) threshold, for the Simple view's faded ghost lines after per-sensor
-/// Advanced edits. Empty when every sensor agrees.
+/// Advanced edits. Empty when every enabled sensor agrees.
 fn divergent_sensor_thresholds(button: &ButtonView) -> Vec<u16> {
     let (_, mx) = sensor_threshold_range(button);
     let mut out: Vec<u16> = Vec::new();
-    for s in &button.sensors {
+    for s in button.sensors.iter().filter(|s| s.enabled) {
         if s.raw_threshold != mx && !out.contains(&s.raw_threshold) {
             out.push(s.raw_threshold);
         }
@@ -2763,10 +2801,10 @@ mod tests {
         apply_edit(&mut s, &ev(VirtualAction::p1_start), false);
         assert!(s.advanced.is_none());
         apply_edit(&mut s, &ev(VirtualAction::p1_up), false);
-        // Still Simple → a whole-button edit (sensor: None), not a per-sensor one.
+        // Still Simple → a whole-button pair edit, not a per-sensor one.
         assert!(matches!(
             take_commands(&mut s)[0],
-            PadCommand::Threshold { sensor: None, .. }
+            PadCommand::ThresholdPair { .. }
         ));
     }
 
@@ -2777,24 +2815,27 @@ mod tests {
         let mut s = init();
         set_pads(&mut s, vec![load_cell_pad(0)]);
         assert_eq!(total_bars(&s), 2 * PAD_BUTTON_COUNT);
-        // The landing slot is L's release (low) threshold…
+        // The landing slot is L's release (low) threshold: raising it (with
+        // the lock on, 80/70) drags press along in the same pair command…
         apply_edit(&mut s, &ev(VirtualAction::p1_up), false);
         assert!(matches!(
             take_commands(&mut s)[0],
-            PadCommand::Threshold {
+            PadCommand::ThresholdPair {
                 button: 0,
-                kind: ThresholdKind::Release,
+                press: 85,
+                release: 75,
                 ..
             }
         ));
-        // …one step right is L's press (high)…
+        // …one step right is L's press (high), which raises alone…
         apply_edit(&mut s, &ev(VirtualAction::p1_right), false);
         apply_edit(&mut s, &ev(VirtualAction::p1_up), false);
         assert!(matches!(
             take_commands(&mut s)[0],
-            PadCommand::Threshold {
+            PadCommand::ThresholdPair {
                 button: 0,
-                kind: ThresholdKind::Press,
+                press: 85,
+                release: 70,
                 ..
             }
         ));
@@ -2803,16 +2844,17 @@ mod tests {
         apply_edit(&mut s, &ev(VirtualAction::p1_up), false);
         assert!(matches!(
             take_commands(&mut s)[0],
-            PadCommand::Threshold {
+            PadCommand::ThresholdPair {
                 button: 1,
-                kind: ThresholdKind::Release,
+                press: 85,
+                release: 75,
                 ..
             }
         ));
     }
 
     #[test]
-    fn divergent_sensor_thresholds_lists_distinct_non_max_values() {
+    fn divergent_sensor_thresholds_lists_distinct_enabled_non_max_values() {
         let mut b = mk_button("L", 50);
         // Uniform sensors: nothing diverges, no ghost lines.
         assert!(divergent_sensor_thresholds(&b).is_empty());
@@ -2821,6 +2863,11 @@ mod tests {
         b.sensors[2].raw_threshold = 40;
         // sensors[3] stays at 50: the max, drawn as the main line.
         assert_eq!(divergent_sensor_thresholds(&b), vec![30, 40]);
+        // A disabled sensor's stale threshold never fires, so it draws no
+        // ghost line and stops widening the range label.
+        b.sensors[0].enabled = false;
+        assert_eq!(divergent_sensor_thresholds(&b), vec![40]);
+        assert_eq!(sensor_threshold_range(&b), (40, 50));
     }
 
     #[test]
@@ -2841,20 +2888,12 @@ mod tests {
         set_pads(&mut s, vec![load_cell_pad(0)]); // 80/70: exactly the gap apart
         apply_edit(&mut s, &ev(VirtualAction::p1_up), false); // release 70 -> 75
         let cmds = take_commands(&mut s);
-        assert_eq!(cmds.len(), 2);
+        assert_eq!(cmds.len(), 1);
         assert!(matches!(
             cmds[0],
-            PadCommand::Threshold {
-                kind: ThresholdKind::Release,
-                value: 75,
-                ..
-            }
-        ));
-        assert!(matches!(
-            cmds[1],
-            PadCommand::Threshold {
-                kind: ThresholdKind::Press,
-                value: 85,
+            PadCommand::ThresholdPair {
+                press: 85,
+                release: 75,
                 ..
             }
         ));
@@ -2867,20 +2906,12 @@ mod tests {
         apply_edit(&mut s, &ev(VirtualAction::p1_right), false); // onto L press
         apply_edit(&mut s, &ev(VirtualAction::p1_down), false); // press 80 -> 75
         let cmds = take_commands(&mut s);
-        assert_eq!(cmds.len(), 2);
+        assert_eq!(cmds.len(), 1);
         assert!(matches!(
             cmds[0],
-            PadCommand::Threshold {
-                kind: ThresholdKind::Press,
-                value: 75,
-                ..
-            }
-        ));
-        assert!(matches!(
-            cmds[1],
-            PadCommand::Threshold {
-                kind: ThresholdKind::Release,
-                value: 65,
+            PadCommand::ThresholdPair {
+                press: 75,
+                release: 65,
                 ..
             }
         ));
@@ -2896,9 +2927,9 @@ mod tests {
         assert_eq!(cmds.len(), 1);
         assert!(matches!(
             cmds[0],
-            PadCommand::Threshold {
-                kind: ThresholdKind::Press,
-                value: 85,
+            PadCommand::ThresholdPair {
+                press: 85,
+                release: 70,
                 ..
             }
         ));
@@ -2912,21 +2943,14 @@ mod tests {
         apply_edit(&mut s, &ev(VirtualAction::p1_right), false); // onto L press
         apply_edit(&mut s, &ev(VirtualAction::p1_down), false); // 80 -> 75: release untouched
         apply_edit(&mut s, &ev(VirtualAction::p1_down), false); // 75 -> 70: release nudged to 69
+        // Same-frame edits collapse into the latest pair.
         let cmds = take_commands(&mut s);
-        assert_eq!(cmds.len(), 2);
+        assert_eq!(cmds.len(), 1);
         assert!(matches!(
             cmds[0],
-            PadCommand::Threshold {
-                kind: ThresholdKind::Press,
-                value: 70,
-                ..
-            }
-        ));
-        assert!(matches!(
-            cmds[1],
-            PadCommand::Threshold {
-                kind: ThresholdKind::Release,
-                value: 69,
+            PadCommand::ThresholdPair {
+                press: 70,
+                release: 69,
                 ..
             }
         ));
@@ -2953,20 +2977,12 @@ mod tests {
         set_pads(&mut s, vec![pad]);
         apply_edit(&mut s, &ev(VirtualAction::p1_up), false); // release 185 -> 190 (top of range minus gap)
         let cmds = take_commands(&mut s);
-        assert_eq!(cmds.len(), 2);
+        assert_eq!(cmds.len(), 1);
         assert!(matches!(
             cmds[0],
-            PadCommand::Threshold {
-                kind: ThresholdKind::Release,
-                value: 190,
-                ..
-            }
-        ));
-        assert!(matches!(
-            cmds[1],
-            PadCommand::Threshold {
-                kind: ThresholdKind::Press,
-                value: 200,
+            PadCommand::ThresholdPair {
+                press: 200,
+                release: 190,
                 ..
             }
         ));
@@ -2981,15 +2997,11 @@ mod tests {
             apply_edit(&mut s, &ev(VirtualAction::p1_right), false); // step onto the load-cell pad
         }
         assert_eq!(selected_device(&s).map(|d| d.index), Some(1));
-        // Its first slot is L's release threshold.
+        // Its first slot is L's release threshold (a pair edit).
         apply_edit(&mut s, &ev(VirtualAction::p1_up), false);
         assert!(matches!(
             take_commands(&mut s)[0],
-            PadCommand::Threshold {
-                button: 0,
-                kind: ThresholdKind::Release,
-                ..
-            }
+            PadCommand::ThresholdPair { button: 0, .. }
         ));
     }
 
@@ -3175,9 +3187,12 @@ mod tests {
         let mut s = with_pad();
         set_save_available(&mut s, true);
         begin_profiles(&mut s);
+        s.threshold_lock_off = true;
         reset_modes(&mut s);
         assert!(!is_profiles_mode(&s));
         assert!(!is_saving(&s));
+        // Entering the editor always restores the press/release lock.
+        assert!(!s.threshold_lock_off);
     }
 
     #[test]

--- a/src/screens/pad_config.rs
+++ b/src/screens/pad_config.rs
@@ -2141,7 +2141,9 @@ fn push_value_cluster(
         let vn = normalize(sensor.raw_value, value_scale);
         let fill_h = vn * BAR_HEIGHT;
         if fill_h > 0.0 {
-            let fill = if sensor.active {
+            // All bars color from the PANEL state (the firmware's own
+            // press/release hysteresis on real pads), not per sensor.
+            let fill = if button_active {
                 ACTIVE_FILL
             } else {
                 theme.fill_idle
@@ -2198,9 +2200,9 @@ fn push_value_cluster(
 
     if selected {
         let ox = x_center - (BAR_WIDTH + 12.0) * 0.5;
-        let oy = y - 34.0;
+        let oy = y - 46.0;
         let ow = BAR_WIDTH + 12.0;
-        let oh = BAR_HEIGHT + 70.0;
+        let oh = BAR_HEIGHT + 82.0;
         let t = 2.0_f32;
         let o = [1.0, 1.0, 1.0, 1.0];
         push_quad(actors, x_center, oy, ow, t, o, z + 2.5);
@@ -2214,6 +2216,14 @@ fn push_value_cluster(
     }
 
     let text_color = if selected { sel } else { [1.0, 1.0, 1.0, 0.95] };
+    // Current pressure (peak corner reading) above the bars, like the FSR
+    // view; smaller, leaving room for the Press/Release caption above it.
+    let peak = sensors.iter().map(|s| s.raw_value).max().unwrap_or(0);
+    actors.push(act!(text:
+        font("miso"): settext(peak.to_string()): align(0.5, 1.0):
+        xy(x_center, y - 6.0): zoom(0.68): horizalign(center):
+        diffuse(text_color[0], text_color[1], text_color[2], text_color[3]): z(z + 3.0)
+    ));
     if let Some((release_label, _)) = &release {
         // Release / press values side by side above the press line (low on the
         // left, like the official tool), each lit when it is the one focused.
@@ -2230,7 +2240,7 @@ fn push_value_cluster(
             xy(x_center + 4.0, threshold_y - 3.0): zoom(0.68): horizalign(left):
             diffuse(pc[0], pc[1], pc[2], pc[3]): z(z + 3.0)
         ));
-        // Which of the pair the cursor is editing, above the bars.
+        // Which of the pair the cursor is editing, above the pressure value.
         if let Some(kind) = focused_kind {
             let caption = match kind {
                 ThresholdKind::Press => "Press",
@@ -2238,7 +2248,7 @@ fn push_value_cluster(
             };
             actors.push(act!(text:
                 font("miso"): settext(caption.to_owned()): align(0.5, 1.0):
-                xy(x_center, y - 10.0): zoom(0.55): horizalign(center):
+                xy(x_center, y - 28.0): zoom(0.5): horizalign(center):
                 diffuse(sel[0], sel[1], sel[2], sel[3]): z(z + 3.0)
             ));
         }

--- a/src/screens/pad_config.rs
+++ b/src/screens/pad_config.rs
@@ -19,13 +19,21 @@ use crate::engine::present::color;
 use crate::screens::components::shared::visual_style_bg;
 use crate::screens::{Screen, ScreenAction};
 use deadsync_core::input::InputSource;
-use deadsync_input::fsr::{ButtonView, PAD_BUTTON_COUNT, PadDeviceId, PadView, SensorView};
+use deadsync_input::fsr::{
+    ButtonView, PAD_BUTTON_COUNT, PadDeviceId, PadView, SensorView, ThresholdKind,
+};
 use deadsync_input::{InputEvent, VirtualAction};
 use deadsync_present::space::{screen_center_x, screen_center_y, screen_height};
 
 const TRANSITION_IN_DURATION: f32 = 0.4;
 const TRANSITION_OUT_DURATION: f32 = 0.4;
 const THRESHOLD_STEP: u16 = 5;
+
+/// Gap the press/release lock keeps between a load-cell panel's thresholds,
+/// matching the official SMX config tool's two-thumb slider (MinimumDistance).
+const LOCKED_THRESHOLD_GAP: u16 = 10;
+/// Minimum gap with the lock off: release must always stay below press.
+const UNLOCKED_THRESHOLD_GAP: u16 = 1;
 
 // Debounce editing (microseconds). Displayed as decimal milliseconds.
 const DEBOUNCE_DEFAULT_US: u16 = 4000;
@@ -73,11 +81,13 @@ struct Theme {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PadCommand {
     /// Threshold edit. `sensor: None` applies to every sensor in the button
-    /// (Simple mode); `Some(i)` targets one sensor (Advanced mode).
+    /// (Simple mode); `Some(i)` targets one sensor (Advanced mode). `kind` is
+    /// `Release` only for the separate release threshold of load-cell pads.
     Threshold {
         device: PadDeviceId,
         button: usize,
         sensor: Option<usize>,
+        kind: ThresholdKind,
         value: u16,
     },
     /// Enable/disable a single sensor (Advanced mode).
@@ -145,8 +155,13 @@ pub enum PadFilter {
 pub struct State {
     pub active_color_index: i32,
     pads: Vec<PadView>,
-    /// Flat bar index across every pad: `pad = selected / 4`, `button = selected % 4`.
+    /// Flat cursor index into `simple_slots` (one slot per editable threshold:
+    /// single-threshold buttons get one, load-cell buttons get release + press).
     selected: usize,
+    /// When true, the press/release lock is off: load-cell threshold edits only
+    /// keep release below press instead of `LOCKED_THRESHOLD_GAP` apart.
+    /// (Inverted so the lock defaults to ON, like the official tool.)
+    threshold_lock_off: bool,
     /// When set, the Advanced view is open for this specific pad.
     advanced: Option<PadDeviceId>,
     /// Focus index into the Advanced view's focusable targets.
@@ -343,7 +358,14 @@ pub fn apply_edit(state: &mut State, ev: &InputEvent, fine: bool) -> EditResult 
         return EditResult::ExitToParent;
     }
     if is_start(ev.action) {
-        enter_advanced(state);
+        // Start drills into Advanced; on Simple-only load-cell pads it instead
+        // toggles the press/release lock.
+        let cursor_pad = selected_slot(state).and_then(|s| state.pads.get(s.pad));
+        match cursor_pad {
+            Some(p) if p.supports_advanced => enter_advanced(state),
+            Some(p) if pad_has_release(p) => state.threshold_lock_off = !state.threshold_lock_off,
+            _ => {}
+        }
         return EditResult::Handled;
     }
     let step = if fine { 1 } else { THRESHOLD_STEP as i32 };
@@ -549,8 +571,9 @@ pub fn selected_device(state: &State) -> Option<PadDeviceId> {
     if let Some(dev) = state.advanced {
         return Some(dev);
     }
-    let pad_idx = state.selected / PAD_BUTTON_COUNT;
-    state.pads.get(pad_idx).map(|p| p.device_id)
+    selected_slot(state)
+        .and_then(|s| state.pads.get(s.pad))
+        .map(|p| p.device_id)
 }
 
 pub fn push_actors(actors: &mut Vec<Actor>, state: &State) {
@@ -623,6 +646,7 @@ pub fn push_content(actors: &mut Vec<Actor>, state: &State, as_overlay: bool) {
                 as_overlay,
                 advanced_available: false,
                 save_available: false,
+                threshold_lock: None,
             },
             zb,
         );
@@ -646,6 +670,7 @@ pub fn push_content(actors: &mut Vec<Actor>, state: &State, as_overlay: bool) {
                 as_overlay,
                 advanced_available: false,
                 save_available: false,
+                threshold_lock: None,
             },
             zb,
         );
@@ -887,6 +912,7 @@ fn push_save_box(actors: &mut Vec<Actor>, state: &State, draft: &SaveDraft, zb: 
 // ─── Simple view ─────────────────────────────────────────────────────────────
 
 fn build_simple(actors: &mut Vec<Actor>, state: &State, theme: &Theme, as_overlay: bool, zb: f32) {
+    let selected_cursor = selected_slot(state);
     let group_w = BAR_WIDTH * PAD_BUTTON_COUNT as f32 + BAR_GAP * (PAD_BUTTON_COUNT - 1) as f32;
     let panel_w = group_w + 34.0;
     let total_w = panel_w * state.pads.len() as f32 + PAD_GAP * (state.pads.len() - 1) as f32;
@@ -920,24 +946,41 @@ fn build_simple(actors: &mut Vec<Actor>, state: &State, theme: &Theme, as_overla
         let left = panel_cx - group_w * 0.5 + BAR_WIDTH * 0.5;
         for (btn_idx, button) in pad.buttons.iter().enumerate() {
             let x = left + btn_idx as f32 * (BAR_WIDTH + BAR_GAP);
-            let selected = state.selected == pad_idx * PAD_BUTTON_COUNT + btn_idx;
+            // The focused threshold of this button, if the cursor is on it
+            // (dual-threshold buttons hold two cursor stops).
+            let focused_kind = selected_cursor
+                .filter(|s| s.pad == pad_idx && s.button == btn_idx)
+                .map(|s| s.kind);
+            let selected = focused_kind.is_some();
             let scale = button.value_scale;
             // A pending whole-button edit shows a single value; otherwise show the
             // live per-sensor range ("200-230") so Advanced edits are visible here.
-            let (threshold_label, threshold_norm) =
-                if let Some(v) = pending_simple_threshold(state, pad.device_id, btn_idx) {
-                    (v.to_string(), normalize(v, scale))
+            let (threshold_label, threshold_norm) = if let Some(v) =
+                pending_simple_threshold(state, pad.device_id, btn_idx, ThresholdKind::Press)
+            {
+                (v.to_string(), normalize(v, scale))
+            } else {
+                let (mn, mx) = sensor_threshold_range(button);
+                let label = if mn == mx {
+                    mx.to_string()
                 } else {
-                    let (mn, mx) = sensor_threshold_range(button);
-                    let label = if mn == mx {
-                        mx.to_string()
-                    } else {
-                        format!("{mn}-{mx}")
-                    };
-                    (label, normalize(mx, scale))
+                    format!("{mn}-{mx}")
                 };
+                (label, normalize(mx, scale))
+            };
             if pad.simple_per_sensor_bars {
-                // Load cells: show all four corner readings (numbered) sharing one threshold.
+                // Load cells: four corner readings (numbered) sharing the
+                // panel's press/release threshold pair.
+                let release = button.release_threshold.map(|live| {
+                    let v = pending_simple_threshold(
+                        state,
+                        pad.device_id,
+                        btn_idx,
+                        ThresholdKind::Release,
+                    )
+                    .unwrap_or(live);
+                    (v.to_string(), normalize(v, scale))
+                });
                 push_value_cluster(
                     actors,
                     x,
@@ -947,9 +990,10 @@ fn build_simple(actors: &mut Vec<Actor>, state: &State, theme: &Theme, as_overla
                     scale,
                     threshold_label,
                     threshold_norm,
+                    release,
                     button.active,
                     theme,
-                    selected,
+                    focused_kind,
                     11.0 + zb,
                 );
             } else {
@@ -976,14 +1020,19 @@ fn build_simple(actors: &mut Vec<Actor>, state: &State, theme: &Theme, as_overla
         panel_cx += panel_w + PAD_GAP;
     }
 
-    let selected_pad = state.pads.get(state.selected / PAD_BUTTON_COUNT);
+    let selected_pad = selected_cursor.and_then(|s| state.pads.get(s.pad));
     let advanced_available = selected_pad.is_some_and(|p| p.supports_advanced);
+    // Cursor on a load-cell pad: Start toggles the press/release lock instead.
+    let threshold_lock = selected_pad
+        .filter(|p| !p.supports_advanced && pad_has_release(p))
+        .map(|_| !state.threshold_lock_off);
     push_footer(
         actors,
         Footer::Simple {
             as_overlay,
             advanced_available,
             save_available: state.save_available,
+            threshold_lock,
         },
         zb,
     );
@@ -1277,8 +1326,10 @@ enum AdvTarget {
 }
 
 fn enter_advanced(state: &mut State) {
-    let pad_idx = state.selected / PAD_BUTTON_COUNT;
-    if let Some(pad) = state.pads.get(pad_idx) {
+    let Some(slot) = selected_slot(state) else {
+        return;
+    };
+    if let Some(pad) = state.pads.get(slot.pad) {
         // Load-cell pads are Simple-only.
         if !pad.supports_advanced {
             return;
@@ -1431,31 +1482,97 @@ fn toggle_focused(state: &mut State, dev: PadDeviceId, target: AdvTarget) {
 }
 
 fn adjust_simple_threshold(state: &mut State, delta: i32) {
-    let pad_idx = state.selected / PAD_BUTTON_COUNT;
-    let button = state.selected % PAD_BUTTON_COUNT;
-    let Some(pad) = state.pads.get(pad_idx) else {
+    let Some(slot) = selected_slot(state) else {
         return;
     };
+    let Some(pad) = state.pads.get(slot.pad) else {
+        return;
+    };
+    let button = slot.button;
     let bar = &pad.buttons[button];
     let device = pad.device_id;
-    let current =
-        pending_simple_threshold(state, device, button).unwrap_or(bar.aggregate_threshold);
-    let next = (i32::from(current) + delta).clamp(
+    let (min, max) = (
         i32::from(bar.min_raw_threshold),
         i32::from(bar.max_raw_threshold),
-    ) as u16;
-    if next == current {
+    );
+
+    let Some(live_release) = bar.release_threshold else {
+        // Single-threshold button: the backend derives its own release side.
+        let current = pending_simple_threshold(state, device, button, ThresholdKind::Press)
+            .unwrap_or(bar.aggregate_threshold);
+        let next = (i32::from(current) + delta).clamp(min, max) as u16;
+        if next == current {
+            return;
+        }
+        queue_unique(
+            state,
+            PadCommand::Threshold {
+                device,
+                button,
+                sensor: None,
+                kind: ThresholdKind::Press,
+                value: next,
+            },
+        );
+        return;
+    };
+
+    // Dual-threshold (load-cell) button: move the edited threshold, dragging
+    // the partner along when they would end up closer than the gap.
+    let gap = i32::from(threshold_gap(state));
+    let press = i32::from(
+        pending_simple_threshold(state, device, button, ThresholdKind::Press)
+            .unwrap_or(bar.aggregate_threshold),
+    );
+    let release = i32::from(
+        pending_simple_threshold(state, device, button, ThresholdKind::Release)
+            .unwrap_or(live_release),
+    );
+    let (new_press, new_release) = match slot.kind {
+        ThresholdKind::Press => {
+            let p = (press + delta).clamp(min + gap, max);
+            (p, release.min(p - gap))
+        }
+        ThresholdKind::Release => {
+            let r = (release + delta).clamp(min, max - gap);
+            (press.max(r + gap), r)
+        }
+    };
+    // No-op when the edited threshold can't move, or when the clamps would
+    // move it against the requested direction (possible if the stored pair
+    // starts closer together than the gap).
+    let (cur, new) = match slot.kind {
+        ThresholdKind::Press => (press, new_press),
+        ThresholdKind::Release => (release, new_release),
+    };
+    if new == cur || (delta > 0) != (new > cur) {
         return;
     }
-    queue_unique(
-        state,
-        PadCommand::Threshold {
-            device,
-            button,
-            sensor: None,
-            value: next,
-        },
-    );
+    // Queue the edited threshold first, then the dragged partner (if it moved).
+    let edits = match slot.kind {
+        ThresholdKind::Press => [
+            (ThresholdKind::Press, new_press, press),
+            (ThresholdKind::Release, new_release, release),
+        ],
+        ThresholdKind::Release => [
+            (ThresholdKind::Release, new_release, release),
+            (ThresholdKind::Press, new_press, press),
+        ],
+    };
+    for (kind, value, old) in edits {
+        if value != old {
+            queue_unique(
+                state,
+                PadCommand::Threshold {
+                    device,
+                    button,
+                    sensor: None,
+                    kind,
+                    value: value as u16,
+                },
+            );
+        }
+    }
 }
 
 fn adjust_sensor_threshold(
@@ -1488,6 +1605,7 @@ fn adjust_sensor_threshold(
             device: dev,
             button,
             sensor: Some(fw),
+            kind: ThresholdKind::Press,
             value: next,
         },
     );
@@ -1508,15 +1626,17 @@ fn same_target(a: &PadCommand, b: &PadCommand) -> bool {
                 device: d1,
                 button: b1,
                 sensor: s1,
+                kind: k1,
                 ..
             },
             Threshold {
                 device: d2,
                 button: b2,
                 sensor: s2,
+                kind: k2,
                 ..
             },
-        ) => d1 == d2 && b1 == b2 && s1 == s2,
+        ) => d1 == d2 && b1 == b2 && s1 == s2 && k1 == k2,
         (
             SensorEnabled {
                 device: d1,
@@ -1539,15 +1659,22 @@ fn same_target(a: &PadCommand, b: &PadCommand) -> bool {
 
 // ─── Pending / live value lookups ──────────────────────────────────────────────
 
-/// Most recently queued Simple-mode (whole-button) threshold for a pad+button.
-fn pending_simple_threshold(state: &State, device: PadDeviceId, button: usize) -> Option<u16> {
+/// Most recently queued Simple-mode (whole-button) threshold for a
+/// pad+button+kind (`Release` only exists for load-cell buttons).
+fn pending_simple_threshold(
+    state: &State,
+    device: PadDeviceId,
+    button: usize,
+    kind: ThresholdKind,
+) -> Option<u16> {
     state.pending.iter().rev().find_map(|c| match *c {
         PadCommand::Threshold {
             device: d,
             button: b,
             sensor: None,
+            kind: k,
             value,
-        } if d == device && b == button => Some(value),
+        } if d == device && b == button && k == kind => Some(value),
         _ => None,
     })
 }
@@ -1564,6 +1691,7 @@ fn current_sensor_threshold(
             device: d,
             button: b,
             sensor: Some(s),
+            kind: ThresholdKind::Press,
             value,
         } if d == device && b == button && s == sensor => Some(value),
         _ => None,
@@ -1625,8 +1753,59 @@ fn pad_by_device(state: &State, device: PadDeviceId) -> Option<&PadView> {
     state.pads.iter().find(|p| p.device_id == device)
 }
 
+/// One Simple-view cursor stop: a button's single threshold, or one of the
+/// release/press pair on a dual-threshold (load-cell) button.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SimpleSlot {
+    pad: usize,
+    button: usize,
+    kind: ThresholdKind,
+}
+
+/// The Simple-view cursor stops, in display order. Dual-threshold buttons
+/// contribute two: release (low) first, then press (high), so stepping right
+/// reads L-release, L-press, D-release, D-press, …
+fn simple_slots(state: &State) -> Vec<SimpleSlot> {
+    let mut slots = Vec::with_capacity(state.pads.len() * PAD_BUTTON_COUNT * 2);
+    for (p, pad) in state.pads.iter().enumerate() {
+        for (b, button) in pad.buttons.iter().enumerate() {
+            if button.release_threshold.is_some() {
+                slots.push(SimpleSlot {
+                    pad: p,
+                    button: b,
+                    kind: ThresholdKind::Release,
+                });
+            }
+            slots.push(SimpleSlot {
+                pad: p,
+                button: b,
+                kind: ThresholdKind::Press,
+            });
+        }
+    }
+    slots
+}
+
+fn selected_slot(state: &State) -> Option<SimpleSlot> {
+    simple_slots(state).get(state.selected).copied()
+}
+
+/// Whether a pad has separately editable release thresholds (load cell).
+fn pad_has_release(pad: &PadView) -> bool {
+    pad.buttons.iter().any(|b| b.release_threshold.is_some())
+}
+
+/// The gap load-cell edits keep between release and press.
+fn threshold_gap(state: &State) -> u16 {
+    if state.threshold_lock_off {
+        UNLOCKED_THRESHOLD_GAP
+    } else {
+        LOCKED_THRESHOLD_GAP
+    }
+}
+
 fn total_bars(state: &State) -> usize {
-    state.pads.len() * PAD_BUTTON_COUNT
+    simple_slots(state).len()
 }
 
 /// Min/max live threshold across a button's sensors (for the Simple-view
@@ -1725,6 +1904,9 @@ enum Footer {
         as_overlay: bool,
         advanced_available: bool,
         save_available: bool,
+        /// `Some(on)` when the cursor pad edits press/release pairs (load
+        /// cell): Start toggles the 10-apart lock instead of Advanced.
+        threshold_lock: Option<bool>,
     },
     Advanced {
         supports_toggle: bool,
@@ -1752,6 +1934,7 @@ fn push_footer(actors: &mut Vec<Actor>, footer: Footer, zb: f32) {
             as_overlay,
             advanced_available,
             save_available,
+            threshold_lock,
         } => {
             line(
                 actors,
@@ -1763,13 +1946,22 @@ fn push_footer(actors: &mut Vec<Actor>, footer: Footer, zb: f32) {
                 format!("Up/Down - Threshold +/- {THRESHOLD_STEP} (Shift +/- 1)"),
                 bottom - 70.0,
             );
-            // Combine Advanced + Save on one line; Save only when the cursor pad
+            // Combine the Start action (Advanced, or the press/release lock on
+            // load-cell pads) + Save on one line; Save only when the cursor pad
             // has a profile to save to (in-session, local profile).
-            let action_line = match (advanced_available, save_available) {
-                (true, true) => Some("&START; Advanced    &SELECT; Profiles".to_owned()),
-                (false, true) => Some("Press &SELECT; for pad profiles".to_owned()),
-                (true, false) => Some("Press &START; for Advanced (per-sensor)".to_owned()),
-                (false, false) => None,
+            let start_hint = threshold_lock.map(|on| {
+                format!(
+                    "&START; Press/Release lock: {} (keeps them {LOCKED_THRESHOLD_GAP} apart)",
+                    if on { "ON" } else { "OFF" }
+                )
+            });
+            let action_line = match (start_hint, advanced_available, save_available) {
+                (Some(hint), _, true) => Some(format!("{hint}    &SELECT; Profiles")),
+                (Some(hint), _, false) => Some(hint),
+                (None, true, true) => Some("&START; Advanced    &SELECT; Profiles".to_owned()),
+                (None, false, true) => Some("Press &SELECT; for pad profiles".to_owned()),
+                (None, true, false) => Some("Press &START; for Advanced (per-sensor)".to_owned()),
+                (None, false, false) => None,
             };
             if let Some(action_line) = action_line {
                 line(actors, action_line, bottom - 46.0);
@@ -1896,11 +2088,13 @@ fn push_value_cluster(
     value_scale: u16,
     threshold_label: String,
     threshold_norm: f32,
+    release: Option<(String, f32)>,
     button_active: bool,
     theme: &Theme,
-    selected: bool,
+    focused_kind: Option<ThresholdKind>,
     z: f32,
 ) {
+    let selected = focused_kind.is_some();
     let threshold_norm = threshold_norm.clamp(0.0, 1.0);
     let n = sensors.len().max(1);
     let thin_w = 9.0_f32;
@@ -1942,18 +2136,44 @@ fn push_value_cluster(
         ));
     }
 
-    // One shared threshold line across the whole cluster.
+    // Press (high) threshold line across the whole cluster, plus a dimmer
+    // release (low) line when the pad exposes one. The focused line of the
+    // pair is highlighted and drawn on top.
+    let press_focused = focused_kind == Some(ThresholdKind::Press);
+    let release_focused = focused_kind == Some(ThresholdKind::Release);
     let threshold_h = 3.0_f32;
     let threshold_y = y + (1.0 - threshold_norm) * BAR_HEIGHT - threshold_h * 0.5;
+    let press_line = if press_focused {
+        SELECTED_TEXT
+    } else {
+        THRESHOLD_COLOR
+    };
     push_quad(
         actors,
         x_center,
         threshold_y,
         BAR_WIDTH,
         threshold_h,
-        THRESHOLD_COLOR,
-        z + 2.0,
+        press_line,
+        z + if press_focused { 2.1 } else { 2.0 },
     );
+    if let Some((_, release_norm)) = &release {
+        let release_y = y + (1.0 - release_norm.clamp(0.0, 1.0)) * BAR_HEIGHT - threshold_h * 0.5;
+        let release_line = if release_focused {
+            SELECTED_TEXT
+        } else {
+            OFF_TEXT
+        };
+        push_quad(
+            actors,
+            x_center,
+            release_y,
+            BAR_WIDTH,
+            threshold_h,
+            release_line,
+            z + if release_focused { 2.1 } else { 2.0 },
+        );
+    }
 
     if selected {
         let ox = x_center - (BAR_WIDTH + 12.0) * 0.5;
@@ -1977,12 +2197,46 @@ fn push_value_cluster(
     } else {
         [1.0, 1.0, 1.0, 0.95]
     };
-    // Shared threshold value above the line.
-    actors.push(act!(text:
-        font("miso"): settext(threshold_label): align(0.5, 1.0):
-        xy(x_center, threshold_y - 3.0): zoom(0.68): horizalign(center):
-        diffuse(text_color[0], text_color[1], text_color[2], text_color[3]): z(z + 3.0)
-    ));
+    if let Some((release_label, _)) = &release {
+        // Release / press values side by side above the press line (low on the
+        // left, like the official tool), each lit when it is the one focused.
+        let plain = [1.0, 1.0, 1.0, 0.95];
+        let rc = if release_focused {
+            SELECTED_TEXT
+        } else {
+            plain
+        };
+        let pc = if press_focused { SELECTED_TEXT } else { plain };
+        actors.push(act!(text:
+            font("miso"): settext(release_label.clone()): align(1.0, 1.0):
+            xy(x_center - 4.0, threshold_y - 3.0): zoom(0.68): horizalign(right):
+            diffuse(rc[0], rc[1], rc[2], rc[3]): z(z + 3.0)
+        ));
+        actors.push(act!(text:
+            font("miso"): settext(threshold_label): align(0.0, 1.0):
+            xy(x_center + 4.0, threshold_y - 3.0): zoom(0.68): horizalign(left):
+            diffuse(pc[0], pc[1], pc[2], pc[3]): z(z + 3.0)
+        ));
+        // Which of the pair the cursor is editing, above the bars.
+        if let Some(kind) = focused_kind {
+            let caption = match kind {
+                ThresholdKind::Press => "Press",
+                ThresholdKind::Release => "Release",
+            };
+            actors.push(act!(text:
+                font("miso"): settext(caption.to_owned()): align(0.5, 1.0):
+                xy(x_center, y - 10.0): zoom(0.55): horizalign(center):
+                diffuse(SELECTED_TEXT[0], SELECTED_TEXT[1], SELECTED_TEXT[2], SELECTED_TEXT[3]): z(z + 3.0)
+            ));
+        }
+    } else {
+        // Shared threshold value above the line.
+        actors.push(act!(text:
+            font("miso"): settext(threshold_label): align(0.5, 1.0):
+            xy(x_center, threshold_y - 3.0): zoom(0.68): horizalign(center):
+            diffuse(text_color[0], text_color[1], text_color[2], text_color[3]): z(z + 3.0)
+        ));
+    }
     // Button label below the cluster.
     let label_color = if button_active {
         ACTIVE_FILL
@@ -2176,6 +2430,27 @@ mod tests {
             aggregate_threshold: threshold,
             active: false,
             value_scale: 250,
+            release_threshold: None,
+        }
+    }
+
+    /// A load-cell button: separate press/release thresholds over 20-200.
+    fn mk_loadcell_button(label: &'static str, press: u16, release: u16) -> ButtonView {
+        ButtonView {
+            label,
+            sensors: vec![
+                mk_sensor(0, press),
+                mk_sensor(1, press),
+                mk_sensor(2, press),
+                mk_sensor(3, press),
+            ],
+            min_raw_threshold: 20,
+            max_raw_threshold: 200,
+            aggregate_value: 0,
+            aggregate_threshold: press,
+            active: false,
+            value_scale: 500,
+            release_threshold: Some(release),
         }
     }
 
@@ -2202,9 +2477,16 @@ mod tests {
         }
     }
 
-    /// A Simple-only (load-cell) pad: no Advanced view.
+    /// A Simple-only (load-cell) pad: no Advanced view, and every button has a
+    /// press/release pair (80/70, the lock's gap apart, like the Low preset).
     fn load_cell_pad(index: usize) -> PadView {
         let mut p = smx_pad(index, false);
+        p.buttons = [
+            mk_loadcell_button("L", 80, 70),
+            mk_loadcell_button("D", 80, 70),
+            mk_loadcell_button("U", 80, 70),
+            mk_loadcell_button("R", 80, 70),
+        ];
         p.supports_advanced = false;
         p.simple_per_sensor_bars = true;
         p.supports_sensor_toggle = false;
@@ -2422,12 +2704,225 @@ mod tests {
     fn start_does_not_enter_advanced_on_simple_only_pad() {
         let mut s = init();
         set_pads(&mut s, vec![load_cell_pad(0)]);
-        apply_edit(&mut s, &ev(VirtualAction::p1_start), false); // no-op (Simple only)
+        // On a load-cell pad Start toggles the press/release lock, not Advanced.
+        apply_edit(&mut s, &ev(VirtualAction::p1_start), false);
+        assert!(s.advanced.is_none());
         apply_edit(&mut s, &ev(VirtualAction::p1_up), false);
         // Still Simple → a whole-button edit (sensor: None), not a per-sensor one.
         assert!(matches!(
             take_commands(&mut s)[0],
             PadCommand::Threshold { sensor: None, .. }
+        ));
+    }
+
+    // ── Load-cell press/release pairs ──
+
+    #[test]
+    fn load_cell_buttons_step_release_then_press() {
+        let mut s = init();
+        set_pads(&mut s, vec![load_cell_pad(0)]);
+        assert_eq!(total_bars(&s), 2 * PAD_BUTTON_COUNT);
+        // The landing slot is L's release (low) threshold…
+        apply_edit(&mut s, &ev(VirtualAction::p1_up), false);
+        assert!(matches!(
+            take_commands(&mut s)[0],
+            PadCommand::Threshold {
+                button: 0,
+                kind: ThresholdKind::Release,
+                ..
+            }
+        ));
+        // …one step right is L's press (high)…
+        apply_edit(&mut s, &ev(VirtualAction::p1_right), false);
+        apply_edit(&mut s, &ev(VirtualAction::p1_up), false);
+        assert!(matches!(
+            take_commands(&mut s)[0],
+            PadCommand::Threshold {
+                button: 0,
+                kind: ThresholdKind::Press,
+                ..
+            }
+        ));
+        // …and the next is D's release.
+        apply_edit(&mut s, &ev(VirtualAction::p1_right), false);
+        apply_edit(&mut s, &ev(VirtualAction::p1_up), false);
+        assert!(matches!(
+            take_commands(&mut s)[0],
+            PadCommand::Threshold {
+                button: 1,
+                kind: ThresholdKind::Release,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn start_toggles_the_press_release_lock_on_load_cell_pads() {
+        let mut s = init();
+        set_pads(&mut s, vec![load_cell_pad(0)]);
+        assert!(!s.threshold_lock_off);
+        apply_edit(&mut s, &ev(VirtualAction::p1_start), false);
+        assert!(s.threshold_lock_off);
+        assert!(s.advanced.is_none());
+        apply_edit(&mut s, &ev(VirtualAction::p1_start), false);
+        assert!(!s.threshold_lock_off);
+    }
+
+    #[test]
+    fn locked_release_raise_drags_press_along() {
+        let mut s = init();
+        set_pads(&mut s, vec![load_cell_pad(0)]); // 80/70: exactly the gap apart
+        apply_edit(&mut s, &ev(VirtualAction::p1_up), false); // release 70 -> 75
+        let cmds = take_commands(&mut s);
+        assert_eq!(cmds.len(), 2);
+        assert!(matches!(
+            cmds[0],
+            PadCommand::Threshold {
+                kind: ThresholdKind::Release,
+                value: 75,
+                ..
+            }
+        ));
+        assert!(matches!(
+            cmds[1],
+            PadCommand::Threshold {
+                kind: ThresholdKind::Press,
+                value: 85,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn locked_press_lower_drags_release_along() {
+        let mut s = init();
+        set_pads(&mut s, vec![load_cell_pad(0)]);
+        apply_edit(&mut s, &ev(VirtualAction::p1_right), false); // onto L press
+        apply_edit(&mut s, &ev(VirtualAction::p1_down), false); // press 80 -> 75
+        let cmds = take_commands(&mut s);
+        assert_eq!(cmds.len(), 2);
+        assert!(matches!(
+            cmds[0],
+            PadCommand::Threshold {
+                kind: ThresholdKind::Press,
+                value: 75,
+                ..
+            }
+        ));
+        assert!(matches!(
+            cmds[1],
+            PadCommand::Threshold {
+                kind: ThresholdKind::Release,
+                value: 65,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn locked_press_raise_leaves_release_alone() {
+        let mut s = init();
+        set_pads(&mut s, vec![load_cell_pad(0)]);
+        apply_edit(&mut s, &ev(VirtualAction::p1_right), false); // onto L press
+        apply_edit(&mut s, &ev(VirtualAction::p1_up), false); // press 80 -> 85, gap widens
+        let cmds = take_commands(&mut s);
+        assert_eq!(cmds.len(), 1);
+        assert!(matches!(
+            cmds[0],
+            PadCommand::Threshold {
+                kind: ThresholdKind::Press,
+                value: 85,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn lock_off_still_keeps_release_below_press() {
+        let mut s = init();
+        set_pads(&mut s, vec![load_cell_pad(0)]);
+        apply_edit(&mut s, &ev(VirtualAction::p1_start), false); // lock off
+        apply_edit(&mut s, &ev(VirtualAction::p1_right), false); // onto L press
+        apply_edit(&mut s, &ev(VirtualAction::p1_down), false); // 80 -> 75: release untouched
+        apply_edit(&mut s, &ev(VirtualAction::p1_down), false); // 75 -> 70: release nudged to 69
+        let cmds = take_commands(&mut s);
+        assert_eq!(cmds.len(), 2);
+        assert!(matches!(
+            cmds[0],
+            PadCommand::Threshold {
+                kind: ThresholdKind::Press,
+                value: 70,
+                ..
+            }
+        ));
+        assert!(matches!(
+            cmds[1],
+            PadCommand::Threshold {
+                kind: ThresholdKind::Release,
+                value: 69,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn locked_lower_press_noops_when_pair_sits_under_the_gap() {
+        let mut s = init();
+        let mut pad = load_cell_pad(0);
+        // A pair closer than the gap (possible after unlocked edits): lowering
+        // press can't produce a legal pair, so it must not move anything.
+        pad.buttons[0] = mk_loadcell_button("L", 25, 20);
+        set_pads(&mut s, vec![pad]);
+        apply_edit(&mut s, &ev(VirtualAction::p1_right), false); // onto L press
+        apply_edit(&mut s, &ev(VirtualAction::p1_down), false);
+        assert!(take_commands(&mut s).is_empty());
+    }
+
+    #[test]
+    fn locked_release_raise_clamps_to_keep_press_in_range() {
+        let mut s = init();
+        let mut pad = load_cell_pad(0);
+        pad.buttons[0] = mk_loadcell_button("L", 195, 185);
+        set_pads(&mut s, vec![pad]);
+        apply_edit(&mut s, &ev(VirtualAction::p1_up), false); // release 185 -> 190 (top of range minus gap)
+        let cmds = take_commands(&mut s);
+        assert_eq!(cmds.len(), 2);
+        assert!(matches!(
+            cmds[0],
+            PadCommand::Threshold {
+                kind: ThresholdKind::Release,
+                value: 190,
+                ..
+            }
+        ));
+        assert!(matches!(
+            cmds[1],
+            PadCommand::Threshold {
+                kind: ThresholdKind::Press,
+                value: 200,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn cursor_spans_mixed_single_and_dual_threshold_pads() {
+        let mut s = init();
+        set_pads(&mut s, vec![smx_pad(0, false), load_cell_pad(1)]);
+        assert_eq!(total_bars(&s), 3 * PAD_BUTTON_COUNT); // 4 FSR bars + 8 load-cell slots
+        for _ in 0..PAD_BUTTON_COUNT {
+            apply_edit(&mut s, &ev(VirtualAction::p1_right), false); // step onto the load-cell pad
+        }
+        assert_eq!(selected_device(&s).map(|d| d.index), Some(1));
+        // Its first slot is L's release threshold.
+        apply_edit(&mut s, &ev(VirtualAction::p1_up), false);
+        assert!(matches!(
+            take_commands(&mut s)[0],
+            PadCommand::Threshold {
+                button: 0,
+                kind: ThresholdKind::Release,
+                ..
+            }
         ));
     }
 

--- a/src/screens/pad_config.rs
+++ b/src/screens/pad_config.rs
@@ -2449,7 +2449,7 @@ mod tests {
             aggregate_value: 0,
             aggregate_threshold: press,
             active: false,
-            value_scale: 500,
+            value_scale: 250,
             release_threshold: Some(release),
         }
     }

--- a/src/screens/pad_config.rs
+++ b/src/screens/pad_config.rs
@@ -1113,6 +1113,7 @@ fn build_advanced(actors: &mut Vec<Actor>, state: &State, pad_idx: usize, theme:
                 x,
                 top_y,
                 bar_label,
+                sensor.raw_value,
                 sensor.value_norm,
                 sensor.active && enabled,
                 threshold,
@@ -1191,6 +1192,7 @@ fn push_sensor_bar(
     x: f32,
     y: f32,
     sensor_label: String,
+    raw_value: u16,
     value_norm: f32,
     active: bool,
     raw_threshold: u16,
@@ -1257,12 +1259,27 @@ fn push_sensor_bar(
     } else {
         [1.0, 1.0, 1.0, 0.95]
     };
-    // Threshold value above the bar.
+    // Current pressure value above the bar (the threshold sits by its line).
     actors.push(act!(text:
-        font("miso"): settext(raw_threshold.to_string()): align(0.5, 1.0):
+        font("miso"): settext(raw_value.to_string()): align(0.5, 1.0):
         xy(x, y - 2.0): zoom(0.5): horizalign(center):
         diffuse(text_color[0], text_color[1], text_color[2], text_color[3]): z(z + 3.0)
     ));
+    // Threshold value next to its line, like the Simple view; flip it below
+    // the line near the top of the bar so it can't collide with the pressure.
+    if threshold_norm > 0.85 {
+        actors.push(act!(text:
+            font("miso"): settext(raw_threshold.to_string()): align(0.5, 0.0):
+            xy(x, threshold_y + threshold_h + 1.0): zoom(0.45): horizalign(center):
+            diffuse(text_color[0], text_color[1], text_color[2], text_color[3]): z(z + 3.0)
+        ));
+    } else {
+        actors.push(act!(text:
+            font("miso"): settext(raw_threshold.to_string()): align(0.5, 1.0):
+            xy(x, threshold_y - 1.0): zoom(0.45): horizalign(center):
+            diffuse(text_color[0], text_color[1], text_color[2], text_color[3]): z(z + 3.0)
+        ));
+    }
     // Sensor identifier (edge label, or 1-based number) directly below the bar.
     actors.push(act!(text:
         font("miso"): settext(sensor_label): align(0.5, 0.0):


### PR DESCRIPTION
## Summary

Load-cell SMX pads use a press (high) / release (low) threshold pair per panel,
but the Configure Pads editor only exposed one value and silently wrote
`release = press - 1`. The official SMX tool exposes both on a two-thumb
slider kept at least 10 units apart. This PR brings that to the Simple editor,
along with a set of editor improvements and a hardware-free mock pad mode.

## Configure Pads changes

- **Separate press/release editing for load-cell pads.** Each load-cell panel
  now holds two cursor stops, release then press (L-release, L-press,
  D-release, D-press, ...), so Left/Right walks the pad in twice as many steps.
  FSR pads are unchanged.
- **10-apart lock, default ON** (matches the official tool's
  `MinimumDistance = 10`). Moving one threshold into the gap drags the other
  along; range clamps keep both inside 20-200. Press Start on a load-cell pad
  to toggle the lock off ("at your own risk": the selection highlight turns
  red, and release still always stays at least 1 below press). The lock resets
  to ON each time the editor is entered.
- **Both thresholds rendered**: press and release lines on the bars, values
  side by side (release left, press right, focused one highlighted), plus a
  Press/Release caption for the focused stop.
- **Live pressure readouts**: peak corner reading above each load-cell
  cluster, and per-sensor values above the Advanced bars (the threshold
  number moved next to its line, like the Simple view).
- **Truthful bar colors**: bars turn green from the panel's pressed state
  (the firmware's own press/release hysteresis on real pads), not per-sensor
  instantaneous comparisons.
- **Better bar scaling**: load-cell bars normalize to 250 instead of the raw
  500 ceiling, so the 20-200 threshold band spans ~80% of the bar instead of
  stopping at 40%. Readings past 250 show a full bar; the numeric readout
  still reports the true value up to 500.
- **FSR ghost lines**: when Advanced edits make a panel's sensors diverge,
  the Simple bar draws faded lines at each distinct enabled-sensor threshold
  under the main line (matching the existing "200-230" range label, which now
  also ignores disabled sensors).

## Mock pads (development tool)

`DEADSYNC_MOCK_PADS=loadcell` (or `fsr`, or `loadcell,fsr`) shows fake pads on
the Configure Pads screen with animated sensor readings and in-memory
threshold editing, so the whole editor can be exercised without hardware.
While set, `engine::smx::init` refuses to start the SDK, so native SMX is
fully off and nothing is written over USB. Falsey values (`0`, `false`, `off`,
`no`, empty) leave the mock off. The mock builds its views through the same
builders as the real backend, so their presentation cannot diverge.

## Reliability / internals

- **Atomic pair writes**: load-cell edits travel as one
  `PadCommand::ThresholdPair` applied in a single config write
  (`set_threshold_pair`), so the pad can never observe an inverted
  intermediate pair. The backend rejects `release >= press`;
  `set_threshold` is FSR-only (`high = value`, `low = value - 1`).
- **Fresh build hashes**: the startup banner's hash/stamp could go stale
  because the build script only re-ran when `assets/` changed. It now watches
  `.git/HEAD`, `.git/logs/HEAD`, the branch ref, and `packed-refs`.

## Testing

- 43 `pad_config` tests (slot navigation, lock push/clamp semantics, lock
  toggle and reset, pair dedup, ghost-line selection) plus backend/mock unit
  tests; full suite has no new failures.
- Exercised end to end with mock load-cell and FSR pads.
- Not yet verified on real load-cell hardware (none on hand); FSR behavior is
  unchanged on real pads aside from the ghost lines and Advanced readouts.