### PR TITLE
 fix(smx): auto-promote single pad to P1 regardless of jumper

### DIFF
--- a/docs/stepmaniax.md
+++ b/docs/stepmaniax.md
@@ -93,6 +93,69 @@ are connected. The assignment is stored by serial in `deadsync.ini`
 (`SmxP1Serial` / `SmxP2Serial`) and pushed to the SDK on launch, so it survives
 reconnects and restarts.
 
+### Single-pad auto-promote
+
+If you have only **one pad** connected and no serial assignment is saved,
+DeadSync automatically assigns it as **Player 1** regardless of its hardware
+jumper setting. This means a single-stage setup works out of the box even if the
+pad's internal jumper is set to P2.
+
+If you later connect a second pad, clear or update the assignment through the
+Assign Pads to Players flow (or edit `deadsync.ini` directly — see below).
+
+### Manual serial assignment
+
+You can bypass the in-game flow and assign pads directly in `deadsync.ini`. This
+is useful if:
+
+- You want to force a single pad to **P2** (rare, e.g. a dedicated doubles
+  second stage).
+- You want to pre-configure assignments before first launch.
+- The in-game assignment screen isn't cooperating.
+
+#### Finding your pad's serial
+
+Your pad's full 32-character serial appears in several places:
+
+1. **Trace logs** — set `LogLevel=Trace` in `deadsync.ini`, launch the game, and
+   look for the connect line:
+   ```
+   SMX: pad connected at slot 0: P2 fw=5 serial=fbd71fe2ad721359d4a4a9fcbbb32785
+   ```
+
+2. **FSR debug dump** — from Options → Input Options → Input Options →
+   StepManiaX, the FSR debug dump (when available) prints each pad's serial.
+
+3. **HID capture** — if you run with `SMX_CAPTURE_DIR` set, decode the
+   `.smxhid` file; the `DeviceInfo` response shows the serial.
+
+#### Editing deadsync.ini
+
+Under `[Options]`, set one or both:
+
+```ini
+[Options]
+SmxP1Serial=fbd71fe2ad721359d4a4a9fcbbb32785
+SmxP2Serial=
+```
+
+- **`SmxP1Serial`** — the serial of the pad that should be Player 1.
+- **`SmxP2Serial`** — the serial of the pad that should be Player 2.
+
+Leave a field empty (or remove the line) to not pin that side — it will fall
+back to the hardware jumper for any pad not explicitly assigned.
+
+To assign a single pad as P2 only (overriding auto-promote), set its serial as
+`SmxP2Serial` and leave `SmxP1Serial` empty:
+
+```ini
+[Options]
+SmxP1Serial=
+SmxP2Serial=fbd71fe2ad721359d4a4a9fcbbb32785
+```
+
+Changes take effect on the next launch of DeadSync.
+
 ---
 
 ## 3. Two ways to configure a pad

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4218,11 +4218,12 @@ impl App {
     /// cheap per-pad signature avoids loading config files or rewriting the pad
     /// unless something relevant changed (so manual edits aren't clobbered).
     /// Finally mirror the markers to the screen. Off → DeadSync writes nothing.
-    /// Once both pads are present with real serials and *distinct* jumpers, and
-    /// nothing is saved yet, persist the jumper-derived P1/P2 serial map. This
-    /// pins the (unambiguous) good case so it stays stable even if a pad later
-    /// loses or shares a jumper, and gives the UI a concrete assignment to show.
-    /// The ambiguous same-jumper case is left for the user to assign manually.
+    /// Auto-save the pad→player assignment when none is saved yet:
+    /// - **Two pads, distinct jumpers:** persist the jumper-derived P1/P2 map.
+    /// - **Single pad:** auto-promote to P1 regardless of jumper (the 99%
+    ///   single-stage case; manual `SmxP2Serial` in `deadsync.ini` covers the
+    ///   rare P2-only need).
+    /// The ambiguous same-jumper-two-pad case is left for the user to assign.
     fn reconcile_smx_assignment(&mut self) {
         if matches!(
             self.state.screens.current_screen,
@@ -4245,6 +4246,23 @@ impl App {
         if let Some((p1, p2)) = deadsync_smx::jumper_derived_pair(&a, &b) {
             log::info!("SMX: auto-saving pad assignment from jumpers (P1={p1}, P2={p2})");
             config::update_smx_pad_assignment(Some(p1), Some(p2));
+            return;
+        }
+        // Single pad connected with no saved assignment: auto-promote to P1.
+        // With one stage the user virtually always wants P1; the rare P2-only
+        // case can be set manually via SmxP2Serial in deadsync.ini.
+        let single = match (a.connected, b.connected) {
+            (true, false) if a.has_serial_number && !a.serial.is_empty() => Some(&a),
+            (false, true) if b.has_serial_number && !b.serial.is_empty() => Some(&b),
+            _ => None,
+        };
+        if let Some(pad) = single {
+            log::info!(
+                "SMX: single pad connected (jumper P{}), auto-promoting to P1 (serial={})",
+                if pad.is_player2 { 2 } else { 1 },
+                pad.serial
+            );
+            config::update_smx_pad_assignment(Some(pad.serial.clone()), None);
         }
     }
 


### PR DESCRIPTION
## Summary

  When a user has a single SMX stage with the hardware jumper set to P2, the SDK
  places it in slot 1 (P2). This causes two issues:

  1. The pad's input routes to P2 actions, so the user (who joins as P1) gets no
     pad input.
  2. The in-game Configure Pads overlay filters by joined player side — it only
     shows P1 pads for a P1 player, resulting in "No FSR pads detected."

  The standalone Options → Configure Pads screen uses `PadFilter::All` so it still
  shows the pad there, which makes the bug confusing to diagnose.

  ## Changes

  - **`src/app/mod.rs`**: In `reconcile_smx_assignment()`, after the existing
    two-pad jumper-derived auto-save, add a single-pad auto-promote: if exactly
    one pad is connected with a valid serial and no assignment is saved, pin it as
    `SmxP1Serial`. This makes the SDK reorder it to slot 0 (P1).
  - **`docs/stepmaniax.md`**: Add "Single-pad auto-promote" and "Manual serial
    assignment" subsections documenting the new behavior, how to find your pad's
    serial, and how to manually override with `SmxP1Serial`/`SmxP2Serial` in
    `deadsync.ini`.

  ## Testing

  - Single pad with P2 jumper, no saved assignment → auto-promoted to P1.
  - Single pad with P1 jumper → same behavior as before (already in slot 0, now
    also explicitly pinned).
  - Two pads with distinct jumpers → existing `jumper_derived_pair` path fires
    first (unchanged).
  - Two pads with same jumper → neither path fires, conflict warning as before.
  - Existing `SmxP1Serial`/`SmxP2Serial` in ini → early return, no auto-promote.