### PR TITLE
feat(options): Left/Right navigates on link rows in submenus

### DIFF
--- a/src/screens/options/input.rs
+++ b/src/screens/options/input.rs
@@ -772,6 +772,30 @@ fn selected_submenu_row_has_choices(state: &State, kind: SubmenuKind) -> Option<
     Some(!row_choices(state, kind, rows, row_idx).is_empty())
 }
 
+/// Whether Left/Right on the focused submenu row should fall through to
+/// vertical navigation (like the main menu) instead of cycling a value: true
+/// for rows with nothing to cycle, i.e. pure link/action rows (a single
+/// localized "Open" choice), rows with no choices, and the Exit row. Value
+/// rows keep Left/Right, including ones whose single choice is a placeholder
+/// for a numeric Left/Right adjustment (e.g. the volume sliders).
+fn selected_row_lr_navigates(state: &State) -> bool {
+    let OptionsView::Submenu(kind) = state.view else {
+        return false;
+    };
+    let rows = submenu_rows(kind);
+    let Some(row_idx) = submenu_visible_row_to_actual(state, kind, state.sub_selected) else {
+        return true; // Exit row: nothing to cycle.
+    };
+    let Some(row) = rows.get(row_idx) else {
+        return false;
+    };
+    let open_link = matches!(
+        row.choices,
+        [Choice::Localized(key)] if key.section == "Common" && key.key == "Open"
+    );
+    open_link || row_choices(state, kind, rows, row_idx).is_empty()
+}
+
 fn handle_dedicated_three_key_start_nav(
     state: &mut State,
     asset_manager: &AssetManager,
@@ -1821,14 +1845,16 @@ pub fn handle_input(
         | VirtualAction::p1_menu_left
         | VirtualAction::p2_left
         | VirtualAction::p2_menu_left => {
-            if matches!(state.view, OptionsView::Main) {
-                if ev.pressed {
-                    move_options_selection_vertical(state, asset_manager, NavDirection::Up);
-                    on_nav_press(state, NavDirection::Up);
-                } else {
-                    on_nav_release(state, NavDirection::Up);
-                }
-            } else if ev.pressed {
+            if !ev.pressed {
+                // The press may have armed either hold (nav on a link row,
+                // value-repeat on a choice row) and the cursor may have moved
+                // since; releasing both is a no-op for the one not armed.
+                on_nav_release(state, NavDirection::Up);
+                on_lr_release(state, -1);
+            } else if matches!(state.view, OptionsView::Main) || selected_row_lr_navigates(state) {
+                move_options_selection_vertical(state, asset_manager, NavDirection::Up);
+                on_nav_press(state, NavDirection::Up);
+            } else {
                 if let Some(action) =
                     apply_submenu_choice_delta(state, asset_manager, -1, NavWrap::Wrap)
                 {
@@ -1836,22 +1862,19 @@ pub fn handle_input(
                     return action;
                 }
                 on_lr_press(state, -1);
-            } else {
-                on_lr_release(state, -1);
             }
         }
         VirtualAction::p1_right
         | VirtualAction::p1_menu_right
         | VirtualAction::p2_right
         | VirtualAction::p2_menu_right => {
-            if matches!(state.view, OptionsView::Main) {
-                if ev.pressed {
-                    move_options_selection_vertical(state, asset_manager, NavDirection::Down);
-                    on_nav_press(state, NavDirection::Down);
-                } else {
-                    on_nav_release(state, NavDirection::Down);
-                }
-            } else if ev.pressed {
+            if !ev.pressed {
+                on_nav_release(state, NavDirection::Down);
+                on_lr_release(state, 1);
+            } else if matches!(state.view, OptionsView::Main) || selected_row_lr_navigates(state) {
+                move_options_selection_vertical(state, asset_manager, NavDirection::Down);
+                on_nav_press(state, NavDirection::Down);
+            } else {
                 if let Some(action) =
                     apply_submenu_choice_delta(state, asset_manager, 1, NavWrap::Wrap)
                 {
@@ -1859,8 +1882,6 @@ pub fn handle_input(
                     return action;
                 }
                 on_lr_press(state, 1);
-            } else {
-                on_lr_release(state, 1);
             }
         }
         VirtualAction::p1_start | VirtualAction::p2_start if ev.pressed => {

--- a/src/screens/options/tests.rs
+++ b/src/screens/options/tests.rs
@@ -260,6 +260,55 @@ fn main_options_left_right_move_rows_like_up_down() {
 }
 
 #[test]
+fn link_row_pages_lr_moves_rows_in_standard_mode() {
+    let asset_manager = AssetManager::new();
+    let mut state = init();
+    state.view = OptionsView::Submenu(SubmenuKind::Input);
+
+    // Every row on the Input launcher page is an "Open" link, so Left/Right
+    // navigates up/down exactly like the main options menu.
+    assert_eq!(state.sub_selected, 0);
+    press(&mut state, &asset_manager, VirtualAction::p1_right);
+    assert_eq!(state.sub_selected, 1);
+    press(&mut state, &asset_manager, VirtualAction::p1_left);
+    assert_eq!(state.sub_selected, 0);
+}
+
+#[test]
+fn value_rows_keep_left_right_for_adjustment() {
+    let asset_manager = AssetManager::new();
+    let mut state = init();
+    state.view = OptionsView::Submenu(SubmenuKind::Sound);
+    select_visible_row(&mut state, SubmenuKind::Sound, SubRowId::MasterVolume);
+
+    // Master Volume's single choice is a numeric placeholder, not a link:
+    // Left adjusts the value and must not move the cursor.
+    let row_before = state.sub_selected;
+    let volume_before = state.master_volume_pct;
+    press(&mut state, &asset_manager, VirtualAction::p1_left);
+    assert_eq!(state.sub_selected, row_before);
+    assert!(state.master_volume_pct < volume_before);
+}
+
+#[test]
+fn link_row_lr_release_clears_the_nav_hold() {
+    let asset_manager = AssetManager::new();
+    let mut state = init();
+    state.view = OptionsView::Submenu(SubmenuKind::Input);
+
+    // Press on a link row arms hold-to-scroll; the release must clear it even
+    // though the cursor moved to a different row in between.
+    press(&mut state, &asset_manager, VirtualAction::p1_right);
+    assert_eq!(state.nav_key_held_direction, Some(NavDirection::Down));
+    handle_input(
+        &mut state,
+        &asset_manager,
+        &input_event(VirtualAction::p1_right, false),
+    );
+    assert_eq!(state.nav_key_held_direction, None);
+}
+
+#[test]
 fn input_launcher_three_key_lr_moves_rows_like_service_menu() {
     let asset_manager = AssetManager::new();
     let mut state = init();


### PR DESCRIPTION
## What

Left/Right now falls through to vertical navigation on submenu rows that have nothing to cycle: pure link/action rows (the localized "Open" entries like the Input page's Configure Keyboard / Test Input / Configure Pads / Input Options, the Folders page, and similar rows elsewhere), rows with no choices, and the Exit row.

## Why

Only the main options menu mapped Left/Right to up/down navigation; every submenu reserved them for cycling the focused row's value. On link rows there is no value to cycle, so Left/Right silently did nothing. The dedicated three-key mode already treated the Input page as a nav menu; this brings the standard mode in line, decided per row instead of per page.

## How

- `selected_row_lr_navigates` decides the fall-through: link rows (single localized `Common/Open` choice), rows with no choices, and the Exit row navigate; value rows are untouched, including ones whose single choice is a placeholder for a numeric Left/Right adjustment (volume sliders, max FPS).
- Releases now clear both hold-repeat states (nav hold and value repeat), since a press may have armed either one and the cursor can move between press and release.

## Testing

- Three new tests: link-row pages move rows in standard mode, value rows keep Left/Right for adjustment, and a Left/Right release clears the nav hold even after the cursor moved.
- Verified by hand on hardware across the Input and Folders pages.