### PR TITLE
perf(song-wheel): reduce per-frame allocations and redundant work in the music wheel

### DIFF
--- a/src/screens/components/select_music/music_wheel.rs
+++ b/src/screens/components/select_music/music_wheel.rs
@@ -463,6 +463,12 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
     };
     let play_style = profile::get_session_play_style();
     let target_chart_type = play_style.chart_type();
+    let p1_joined = profile::is_session_side_joined(profile_data::PlayerSide::P1);
+    let p2_joined = profile::is_session_side_joined(profile_data::PlayerSide::P2);
+    let side_joined = |side: profile_data::PlayerSide| match side {
+        profile_data::PlayerSide::P1 => p1_joined,
+        profile_data::PlayerSide::P2 => p2_joined,
+    };
     let mut song_box_color = p.song_box_color.unwrap_or_else(col_music_wheel_box);
     song_box_color[3] *= song_bg_alpha;
     let default_song_text_color = p.song_text_color.unwrap_or([1.0, 1.0, 1.0, 1.0]);
@@ -515,11 +521,7 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
     let itl_ex_x = screen_width() / widescale(2.15, 2.14) - 40.0;
     let itl_ex_color = color::JUDGMENT_RGBA[0];
     let itl_points_color = [1.0, 1.0, 1.0, 1.0];
-    let joined_sides = usize::from(profile::is_session_side_joined(
-        profile_data::PlayerSide::P1,
-    )) + usize::from(profile::is_session_side_joined(
-        profile_data::PlayerSide::P2,
-    ));
+    let joined_sides = usize::from(p1_joined) + usize::from(p2_joined);
     let itl_wheel_mode = itl_wheel_mode_for_sides(p.itl_wheel_mode, joined_sides);
     let is_double_style = matches!(play_style, profile_data::PlayStyle::Double);
     let selected_chart_hash_for_side = |side: profile_data::PlayerSide| {
@@ -531,7 +533,7 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
     };
     if matches!(p.itl_rank_mode, SelectMusicItlRankMode::Overall) && p.allow_online_fetch {
         for side in [profile_data::PlayerSide::P1, profile_data::PlayerSide::P2] {
-            if !profile::is_session_side_joined(side) {
+            if !side_joined(side) {
                 continue;
             }
             if let Some(chart_hash) = selected_chart_hash_for_side(side) {
@@ -540,7 +542,7 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
         }
     }
     let overall_itl_ranks_p1 = if matches!(p.itl_rank_mode, SelectMusicItlRankMode::Overall)
-        && profile::is_session_side_joined(profile_data::PlayerSide::P1)
+        && p1_joined
     {
         Some(scores::get_cached_itl_tournament_overall_ranks_for_side(
             profile_data::PlayerSide::P1,
@@ -549,7 +551,7 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
         None
     };
     let overall_itl_ranks_p2 = if matches!(p.itl_rank_mode, SelectMusicItlRankMode::Overall)
-        && profile::is_session_side_joined(profile_data::PlayerSide::P2)
+        && p2_joined
     {
         Some(scores::get_cached_itl_tournament_overall_ranks_for_side(
             profile_data::PlayerSide::P2,
@@ -722,7 +724,7 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
                                 .iter()
                                 .copied()
                                 .any(|side| {
-                                    profile::is_session_side_joined(side)
+                                    side_joined(side)
                                         && wheel_chart_for_side(side).is_some_and(|chart| {
                                             score_data::lua_chart_submit_allowed(
                                                 chart.short_hash.as_str(),
@@ -826,7 +828,7 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
                             (profile_data::PlayerSide::P1, grade_x_p1),
                             (profile_data::PlayerSide::P2, grade_x_p2),
                         ] {
-                            if !profile::is_session_side_joined(side) {
+                            if !side_joined(side) {
                                 continue;
                             }
                             let Some(chart) = wheel_chart_for_side(side) else {
@@ -924,7 +926,7 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
                             (profile_data::PlayerSide::P1, grade_x_p2),
                             (profile_data::PlayerSide::P2, grade_x_p1),
                         ] {
-                            if !profile::is_session_side_joined(side) {
+                            if !side_joined(side) {
                                 continue;
                             }
                             let Some(side_chart) = wheel_chart_for_side(side) else {
@@ -976,7 +978,7 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
                         if matches!(itl_wheel_mode, SelectMusicItlWheelMode::Off) {
                             continue;
                         }
-                        if !profile::is_session_side_joined(side) {
+                        if !side_joined(side) {
                             continue;
                         }
                         let side_chart = wheel_chart_for_side(side);
@@ -1058,10 +1060,6 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
 
                     // Favorite heart icon
                     {
-                        let p1_joined =
-                            profile::is_session_side_joined(profile_data::PlayerSide::P1);
-                        let p2_joined =
-                            profile::is_session_side_joined(profile_data::PlayerSide::P2);
                         let p1_fav = p1_joined
                             && info.charts.iter().any(|c| {
                                 profile::is_favorite(profile_data::PlayerSide::P1, &c.short_hash)
@@ -1226,8 +1224,6 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
     let selected_is_favorite = if let Some(MusicWheelEntry::Song(info)) =
         p.entries.get(p.selected_index)
     {
-        let p1_joined = profile::is_session_side_joined(profile_data::PlayerSide::P1);
-        let p2_joined = profile::is_session_side_joined(profile_data::PlayerSide::P2);
         info.charts.iter().any(|c| {
             (p1_joined && profile::is_favorite(profile_data::PlayerSide::P1, &c.short_hash))
                 || (p2_joined && profile::is_favorite(profile_data::PlayerSide::P2, &c.short_hash))

--- a/src/screens/components/select_music/music_wheel.rs
+++ b/src/screens/components/select_music/music_wheel.rs
@@ -42,6 +42,13 @@ const NUM_WHEEL_ITEMS_TO_DRAW: usize = 17;
 const NUM_VISIBLE_WHEEL_ITEMS: usize = NUM_WHEEL_ITEMS_TO_DRAW - 2; // 17 -> 15 visible on-screen
 const NUM_WHEEL_SLOTS: usize = NUM_WHEEL_ITEMS_TO_DRAW + 2; // 17 -> 19 internal
 const CENTER_WHEEL_SLOT_INDEX: usize = NUM_WHEEL_SLOTS / 2;
+// Upper bound on actors emitted per wheel slot with every feature enabled and
+// both player sides joined (box + art + title + BG art, plus per-side grades,
+// lamps, ITL rank, ITL wheel score and favorite heart). A single joined side
+// measures ~6 actors/slot, so 16 leaves headroom for two sides and avoids any
+// mid-build Vec reallocation regardless of config.
+const MAX_ACTORS_PER_WHEEL_SLOT: usize = 16;
+const WHEEL_ACTOR_CAPACITY: usize = NUM_WHEEL_SLOTS * MAX_ACTORS_PER_WHEEL_SLOT + 1;
 const WHEEL_DRAW_RADIUS: f32 = (NUM_WHEEL_ITEMS_TO_DRAW as f32) * 0.5; // 8.5
 const SELECTION_HIGHLIGHT_BEAT_PERIOD: f32 = 2.0;
 const LAMP_PULSE_PERIOD: f32 = 0.8;
@@ -445,7 +452,7 @@ pub struct MusicWheelParams<'a> {
 }
 
 pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
-    actors.reserve(NUM_WHEEL_SLOTS * 9 + 1);
+    actors.reserve(WHEEL_ACTOR_CAPACITY);
     let cfg = config::get();
     let translated_titles = cfg.translated_titles;
     let effective_bar_color = cfg.machine_bar_color.resolve(cfg.visual_style);
@@ -1252,7 +1259,7 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
 }
 
 pub fn build(p: MusicWheelParams) -> Vec<Actor> {
-    let mut actors = Vec::with_capacity(NUM_WHEEL_SLOTS * 9 + 1);
+    let mut actors = Vec::with_capacity(WHEEL_ACTOR_CAPACITY);
     push(&mut actors, p);
     actors
 }

--- a/src/screens/components/select_music/music_wheel.rs
+++ b/src/screens/components/select_music/music_wheel.rs
@@ -523,7 +523,7 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
         profile_data::PlayerSide::P2,
     ));
     let itl_wheel_mode = itl_wheel_mode_for_sides(p.itl_wheel_mode, joined_sides);
-    let is_double_style = target_chart_type.to_ascii_lowercase().contains("double");
+    let is_double_style = matches!(play_style, profile_data::PlayStyle::Double);
     let selected_chart_hash_for_side = |side: profile_data::PlayerSide| {
         let Some(MusicWheelEntry::Song(_)) = p.entries.get(p.selected_index) else {
             return None;

--- a/src/screens/components/select_music/music_wheel.rs
+++ b/src/screens/components/select_music/music_wheel.rs
@@ -691,17 +691,25 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
                                 && c.difficulty.eq_ignore_ascii_case("edit")
                         })
                     };
-                    let wheel_chart_for_side = |side: profile_data::PlayerSide| {
-                        let ix = profile_data::runtime_player_index(play_style, side);
+                    let wheel_charts: [Option<&ChartData>; profile_data::PLAYER_SLOTS] =
                         if is_selected_slot {
-                            p.selected_charts[ix]
+                            p.selected_charts
                         } else {
-                            chart_for_preferred_or_nearest_standard(
-                                info,
-                                target_chart_type,
-                                p.preferred_difficulty_index[ix],
-                            )
-                        }
+                            [
+                                chart_for_preferred_or_nearest_standard(
+                                    info,
+                                    target_chart_type,
+                                    p.preferred_difficulty_index[0],
+                                ),
+                                chart_for_preferred_or_nearest_standard(
+                                    info,
+                                    target_chart_type,
+                                    p.preferred_difficulty_index[1],
+                                ),
+                            ]
+                        };
+                    let wheel_chart_for_side = |side: profile_data::PlayerSide| {
+                        wheel_charts[profile_data::runtime_player_index(play_style, side)]
                     };
                     let has_lua = info.has_lua;
                     let lua_submit_allowed = has_lua

--- a/src/screens/components/select_music/music_wheel.rs
+++ b/src/screens/components/select_music/music_wheel.rs
@@ -72,11 +72,6 @@ const ITL_POINTS_SCORE_ZOOM: f32 = 0.13;
 const SONG_NULL_SYNC_RIGHT_EDGE: [f32; 4] = [80.0 / 255.0, 20.0 / 255.0, 27.0 / 255.0, 1.0];
 
 #[inline(always)]
-fn path_texture_key(path: &Path) -> String {
-    path.to_string_lossy().into_owned()
-}
-
-#[inline(always)]
 fn song_select_bg_path(song: &SongData, mode: SelectMusicSongSelectBgMode) -> Option<&PathBuf> {
     match mode {
         SelectMusicSongSelectBgMode::Off => None,
@@ -141,8 +136,11 @@ fn song_select_bg_sprite(
     alpha: f32,
     fade_left: f32,
 ) -> Actor {
-    let key = path_texture_key(path);
-    let mut actor = act!(sprite(key.clone()):
+    let key: Arc<str> = match path.to_string_lossy() {
+        std::borrow::Cow::Borrowed(s) => Arc::from(s),
+        std::borrow::Cow::Owned(s) => Arc::from(s),
+    };
+    let mut actor = act!(sprite(&key):
         align(0.5, 0.5):
         xy(center_x, center_y):
         setsize(width, height):


### PR DESCRIPTION
## What

Five small, behavior-preserving optimizations to `music_wheel::push` (the song-wheel actor builder), each reducing per-frame allocations or redundant work.

## Measured lift

Benchmarked with `compose_bench` against the `music-wheel-loaded` fixture (P1 joined; grades, lamps, ITL rank/wheel and background art all on) and the lean `music-wheel` fixture. Numbers are vs. the pre-change baseline; alloc/byte counts are deterministic, timing is a 3-run median (±~10% machine noise).

| Metric (music-wheel-loaded) | Baseline | This PR | Δ |
|---|---|---|---|
| allocs / iter | 741.3 | 706.3 | **−35.0** |
| bytes / iter | 13881 | 12942 | **−939** |
| per_iter | ~56.0 µs | ~52.1 µs | **~7% faster** |
| allocs / iter (lean music-wheel) | 16.0 | 15.0 | −1.0 |

Actor and compose hashes are **unchanged** (`397550465a25f93a` / `09c2c3efddacb574`), confirming no behavior change.

## Per-commit breakdown

1. **drop per-push `to_ascii_lowercase` for double-style check** — `−1` alloc/iter. Replaces `target_chart_type.to_ascii_lowercase().contains("double")` with a `PlayStyle` match.
2. **memoize per-side wheel chart once per slot** — `0` allocs; eliminates redundant `chart_for_preferred_or_nearest_standard` scans per slot (CPU win, contributes to the time delta).
3. **build BG art texture key once per sprite (3 allocs → 1)** — `−34` allocs/iter, ~`−0.9 KB`/iter.
4. **hoist per-side joined booleans out of the push loop** — `0` allocs; removes ~16 session-mutex locks per frame by computing `p1_joined`/`p2_joined` once and routing checks through a small closure.
5. **size the wheel actor buffer to the worst-case feature set** — `0` allocs on this fixture; prevents a mid-build `Vec` reallocation when both sides are joined with all features enabled.

## Reproduce

Requires the `music-wheel-loaded` fixture from #518:

```
cargo run --profile local --bin compose_bench -- --scenario music-wheel-loaded --phase actors --iters 4000 --warmup 800
```
