### PR TITLE
perf(itl): make is_itl_unlocks_pack allocation-free

### DIFF
--- a/src/game/scores/itl.rs
+++ b/src/game/scores/itl.rs
@@ -492,17 +492,19 @@ pub fn is_itl_song_folder_unlocked_for_side(
 }
 
 /// True when `pack_dir` matches the SL-style pattern `ITL Online <year> Unlocks`
-/// (case-insensitive, any 4-digit year).
+/// (case-insensitive, any 4-digit year). Allocation-free.
 pub fn is_itl_unlocks_pack(pack_dir: &str) -> bool {
-    let trimmed = pack_dir.trim();
-    let lower = trimmed.to_ascii_lowercase();
-    let Some(rest) = lower.strip_prefix("itl online ") else {
+    const PREFIX: &[u8] = b"itl online ";
+    const SUFFIX: &[u8] = b" unlocks";
+    let bytes = pack_dir.trim().as_bytes();
+    if bytes.len() != PREFIX.len() + 4 + SUFFIX.len() {
         return false;
-    };
-    let Some(year_part) = rest.strip_suffix(" unlocks") else {
-        return false;
-    };
-    year_part.len() == 4 && year_part.chars().all(|c| c.is_ascii_digit())
+    }
+    let (prefix, rest) = bytes.split_at(PREFIX.len());
+    let (year, suffix) = rest.split_at(4);
+    prefix.eq_ignore_ascii_case(PREFIX)
+        && suffix.eq_ignore_ascii_case(SUFFIX)
+        && year.iter().all(u8::is_ascii_digit)
 }
 
 pub fn get_cached_itl_tournament_rank_for_side(
@@ -1800,6 +1802,22 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static NEXT_TMP_ID: AtomicU64 = AtomicU64::new(1);
+
+    #[test]
+    fn is_itl_unlocks_pack_matches_expected_patterns() {
+        assert!(is_itl_unlocks_pack("ITL Online 2023 Unlocks"));
+        assert!(is_itl_unlocks_pack("itl online 2024 unlocks"));
+        assert!(is_itl_unlocks_pack("ITL ONLINE 2022 UNLOCKS"));
+        assert!(is_itl_unlocks_pack("  ITL Online 2025 Unlocks  "));
+
+        assert!(!is_itl_unlocks_pack("ITL Online 23 Unlocks"));
+        assert!(!is_itl_unlocks_pack("ITL Online 20XX Unlocks"));
+        assert!(!is_itl_unlocks_pack("ITL Online 2023 Locks"));
+        assert!(!is_itl_unlocks_pack("ITL Offline 2023 Unlocks"));
+        assert!(!is_itl_unlocks_pack("ITL Online 2023  Unlocks"));
+        assert!(!is_itl_unlocks_pack("ITL Online 2023 Unlocks Extra"));
+        assert!(!is_itl_unlocks_pack(""));
+    }
 
     fn sample_chart(chart_type: &str) -> ChartData {
         ChartData {


### PR DESCRIPTION
## What

Rewrites `is_itl_unlocks_pack` to be allocation-free. It previously called `to_ascii_lowercase()` (allocating a `String`) on the pack title to case-insensitively match the `ITL Online <year> Unlocks` pattern. The new implementation matches the pattern directly on byte slices using `eq_ignore_ascii_case`, with an exact-length check and a 4-digit year check — no allocation.

This function is called **once per visible song slot** whenever a player side is joined, so it runs ~15×/frame on a populated wheel.

## Measured lift

Benchmarked with `compose_bench` against the `music-wheel-loaded` fixture (P1 joined; all features on). Vs. the pre-change baseline:

| Metric (music-wheel-loaded) | Baseline | This PR | Δ |
|---|---|---|---|
| allocs / iter | 741.3 | 726.3 | **−15.0** |
| bytes / iter | 13881 | 13806 | **−75** |
| per_iter | ~56.0 µs | ~56.6 µs | flat (within noise) |

The win is purely allocation reduction (one `String` eliminated per joined-side visible slot); the wall-time impact is below the machine's timing noise floor.

Actor/compose hashes **unchanged** (`397550465a25f93a` / `09c2c3efddacb574`) — no behavior change.

## Tests

Adds `is_itl_unlocks_pack_matches_expected_patterns`, covering case-insensitivity, whitespace trimming, the 4-digit-year requirement, and negative cases.

## Reproduce

Requires the `music-wheel-loaded` fixture from #518:

```
cargo run --profile local --bin compose_bench -- --scenario music-wheel-loaded --phase actors --iters 4000 --warmup 800
```
