### PR TITLE
fix(version): source app version from workspace so UI matches running build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "deadsync-version"
-version = "0.4.667"
+version = "0.4.737"
 dependencies = [
  "log",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deadsync"
-version = "0.4.737"
+version.workspace = true
 authors = ["Patrik Nilsson <perfecttaste@pm.me>"]
 edition = "2024"
 description = "A competitive SM/ITG engine focused on perfect sync and performance."
@@ -43,6 +43,13 @@ members = [
     "crates/deadsync-video",
 ]
 resolver = "3"
+
+# Single source of truth for the application version. The root `deadsync`
+# binary and the `deadsync-version` crate both inherit this via
+# `version.workspace = true`, so `env!("CARGO_PKG_VERSION")` and
+# `deadsync_version::current()` always agree. Bump THIS line on release.
+[workspace.package]
+version = "0.4.737"
 
 [[bin]]
 name = "compose_bench"

--- a/crates/deadsync-updater/src/lib.rs
+++ b/crates/deadsync-updater/src/lib.rs
@@ -54,7 +54,7 @@ pub fn release_url() -> String {
 pub fn user_agent() -> String {
     format!(
         "deadsync/{} (+https://github.com/pnn64/deadsync)",
-        env!("CARGO_PKG_VERSION")
+        deadsync_version::current()
     )
 }
 
@@ -525,7 +525,7 @@ mod tests {
     fn user_agent_includes_version() {
         let ua = user_agent();
         assert!(ua.starts_with("deadsync/"));
-        assert!(ua.contains(env!("CARGO_PKG_VERSION")));
+        assert!(ua.contains(&deadsync_version::current().to_string()));
     }
 
     fn fixture_assets() -> Vec<ReleaseAsset> {

--- a/crates/deadsync-version/Cargo.toml
+++ b/crates/deadsync-version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deadsync-version"
-version = "0.4.667"
+version.workspace = true
 edition = "2024"
 license = "GPL-3.0"
 


### PR DESCRIPTION
## Why

Users who updated (e.g. .667 -> .715) saw the in-app UI still report an old version even though the startup console log was correct, which is confusing when you are trying to confirm an update landed.

## Root cause

The update-process refactor moved version utilities from the root binary crate (`src/engine/version.rs`) into the standalone `crates/deadsync-version` crate. `deadsync_version::current()` reads `env!("CARGO_PKG_VERSION")`, which at compile time resolves to the **`deadsync-version` crate's own** `[package].version`, not the application's.

The release bump only edits the root `Cargo.toml`, so the crate version drifted to `0.4.667` and never moved. As a result:

- Console startup log (root crate `env!(CARGO_PKG_VERSION)`) -> correct.
- UI paths that call `deadsync_version::current()` (menu version line, update overlay, restart log) -> stale `0.4.667`.

## Approach

Make the application version a single workspace-level value:

- Add `[workspace.package].version` as the one source of truth.
- The root `deadsync` package and `deadsync-version` both inherit it via `version.workspace = true`, so `env!(CARGO_PKG_VERSION)` and `deadsync_version::current()` can no longer disagree. Bump that one line on release.
- Switch the updater `user_agent()` off its own crate version to `deadsync_version::current()` (test updated).