### PR TITLE
fix(online): report real app version in arrowcloud device login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,7 @@ dependencies = [
  "deadsync-profile",
  "deadsync-rules",
  "deadsync-score",
+ "deadsync-version",
  "rand 0.10.1",
  "serde",
  "serde_json",

--- a/crates/deadsync-online/Cargo.toml
+++ b/crates/deadsync-online/Cargo.toml
@@ -9,6 +9,7 @@ deadsync-net = { path = "../deadsync-net" }
 deadsync-profile = { path = "../deadsync-profile" }
 deadsync-rules = { path = "../deadsync-rules" }
 deadsync-score = { path = "../deadsync-score" }
+deadsync-version = { path = "../deadsync-version" }
 rand = "0.10.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"

--- a/crates/deadsync-online/src/arrowcloud.rs
+++ b/crates/deadsync-online/src/arrowcloud.rs
@@ -1265,7 +1265,7 @@ fn run_device_login_session_with<S, P, F, W>(
 
     let req = DeviceLoginStartReq {
         machine_label: None,
-        client_version: Some(format!("deadsync {}", env!("CARGO_PKG_VERSION"))),
+        client_version: Some(format!("deadsync {}", deadsync_version::current())),
         theme_version: None,
     };
     let start = match start_fn(&req) {


### PR DESCRIPTION
## Problem
The arrowcloud GrooveStats device-login request in `crates/deadsync-online/src/arrowcloud.rs` built `client_version` from `env!("CARGO_PKG_VERSION")`. That macro resolves at compile time to the **`deadsync-online` crate's own** `[package].version` (`0.1.0`, like every internal sub-crate), not the application version. As a result the reported `client_version` was always `"deadsync 0.1.0"`.

This is the same class of bug already addressed for the UI/version display and the updater: sub-crates must not use their own `env!(CARGO_PKG_VERSION)` to mean "the app version." The single source of truth is the `deadsync-version` crate (version `0.4.667`), whose `current()` reports the real workspace version.

## Changes
- Replace `env!("CARGO_PKG_VERSION")` with `deadsync_version::current()` so the device login reports the real version.
- Add the `deadsync-version = { path = "../deadsync-version" }` path dependency to `crates/deadsync-online/Cargo.toml`.