### PR TITLE
fix(smx): play a single pad as P2; pad-count-aware StepManiaX options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4178,6 +4178,8 @@ dependencies = [
 [[package]]
 name = "rustmaniax-sdk"
 version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9871902911440b8bc09da20f45ee32d12f741d7dfa9a4df9e0b47392233c6a7"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4177,9 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "rustmaniax-sdk"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ecae32caf951cb8af8750e1b520af75ec6a600413b4444b467470811bdbbbf"
+version = "1.2.0"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
@@ -4392,9 +4390,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smithay-client-toolkit"

--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -312,6 +312,9 @@ DefaultPadConfig=Default Pad Config
 SmxAssignPads=Assign Pads to Players
 SmxSwapPads=Swap P1/P2 Pads
 SmxSwapPadsAction=Swap
+SmxSinglePadPlayer=Pad Player
+SmxSinglePadPlayerP1=Player 1
+SmxSinglePadPlayerP2=Player 2
 SmxAssignStatusLine=Now: P1 = {p1} (blue), P2 = {p2} (red)
 SmxAssignStatusNone=(none)
 SmxAssignStatusConflict=Both pads share a jumper. Assign them so the engine can tell them apart.
@@ -1611,6 +1614,7 @@ SmxManagesPadConfigHelp=Controls who owns your StepManiaX pad thresholds.\nOn: D
 UsbPollingHelp=How often the StepManiaX SDK polls the pads over USB, in microseconds. Lower is more responsive but uses more CPU.\nDefault is 1000us.
 SmxPanelLightsHelp=Light each StepManiaX pad panel with your per-arrow judgement colour during gameplay, plus colours for freezes, rolls, and mine hits. While on, the game drives the panels, which overrides any custom animations loaded on the pad. Turn off to leave the pad's own lighting alone.\nDefault is No.
 DefaultPadConfigHelp=The built-in threshold preset (Low/Medium/High, matching the official StepManiaX tool) DeadSync uses as its default.\nDefault is Low.
+SmxSinglePadPlayerHelp=With a single StepManiaX pad connected, choose whether it plays as Player 1 or Player 2, regardless of its hardware jumper. Pick Player 2 to play a lone stage on the P2 side.
 SmxAssignPadsHelp=Choose which physical pad is Player 1 and which is Player 2 by stepping on each. Use this when both pads share the same P1/P2 jumper, or when the pads are installed on the wrong sides. The pads light blue (P1) and red (P2) so you can see the assignment.
 SmxSwapPadsHelp=Instantly swap which pad is Player 1 and which is Player 2. Handy when the pads are jumpered correctly but installed on the wrong sides. Both pads must be connected.
 DebugFsrDumpHelp=If you have FSRs, use this to create fsrdump.txt in your deadsync folder. Please send it to PerfectTaste so he can debug and implement support for more FSR I/O boards and firmware versions.

--- a/crates/deadsync-smx/Cargo.toml
+++ b/crates/deadsync-smx/Cargo.toml
@@ -9,7 +9,10 @@ deadsync-input = { path = "../deadsync-input" }
 deadsync-input-native = { path = "../deadsync-input-native" }
 deadsync-platform = { path = "../deadsync-platform" }
 log = "0.4.32"
-rustmaniax-sdk = "1.1.3"
+# TEMP path dep on the local SDK fork for the lone-pad single-sided assignment
+# fix (rustmaniax-sdk 1.2.0). Flip back to the plain published `version = "1.2.0"`
+# once that release is published to crates.io.
+rustmaniax-sdk = { version = "1.2.0", path = "../../../rustmaniax-sdk" }
 
 [lints.clippy]
 perf = { level = "warn", priority = -1 }

--- a/crates/deadsync-smx/Cargo.toml
+++ b/crates/deadsync-smx/Cargo.toml
@@ -9,10 +9,7 @@ deadsync-input = { path = "../deadsync-input" }
 deadsync-input-native = { path = "../deadsync-input-native" }
 deadsync-platform = { path = "../deadsync-platform" }
 log = "0.4.32"
-# TEMP path dep on the local SDK fork for the lone-pad single-sided assignment
-# fix (rustmaniax-sdk 1.2.0). Flip back to the plain published `version = "1.2.0"`
-# once that release is published to crates.io.
-rustmaniax-sdk = { version = "1.2.0", path = "../../../rustmaniax-sdk" }
+rustmaniax-sdk = "1.2.0"
 
 [lints.clippy]
 perf = { level = "warn", priority = -1 }

--- a/docs/stepmaniax.md
+++ b/docs/stepmaniax.md
@@ -60,8 +60,9 @@ FSRs** is on):
 | **DeadSync Manages Pad Config** | No / Yes | See [§3](#3-two-ways-to-configure-a-pad). When on, DeadSync writes a resolved config to each pad. |
 | **USB Polling** | 500–1000 µs (50 µs steps) | How often the SDK polls the pads over USB. Lower = more responsive, more CPU. Applied **live**. Default 1000 µs. |
 | **Default Pad Config** | Low / Medium / High | Built-in sensitivity preset (matches the official SMX tool's presets). Used as the fallback when DeadSync manages config and nothing else resolves. |
-| **Assign Pads to Players** | (opens screen) | Press-a-panel flow to choose which physical pad is P1 vs P2. See [§2a](#2a-which-pad-is-p1-vs-p2). Its help text shows the current mapping live. |
-| **Swap P1/P2 Pads** | (action) | One-tap swap of the two pads' player assignment. Both pads must be connected. |
+| **Pad Player** | Player 1 / Player 2 | Shown only when **one** pad is connected. Picks which player that lone pad is, overriding its jumper. See [§2a](#2a-which-pad-is-p1-vs-p2). |
+| **Assign Pads to Players** | (opens screen) | Shown only when **two** pads are connected. Press-a-panel flow to choose which physical pad is P1 vs P2. See [§2a](#2a-which-pad-is-p1-vs-p2). Its help text shows the current mapping live. |
+| **Swap P1/P2 Pads** | (action) | Shown only when **two** pads are connected. One-tap swap of the two pads' player assignment. |
 
 These persist to `deadsync.ini` under `[Options]` (`SmxInput`,
 `SmxManagesPadConfig`, `SmxUsbPollingUs`, `SmxDefaultPadConfig`, and the pad
@@ -93,12 +94,18 @@ are connected. The assignment is stored by serial in `deadsync.ini`
 (`SmxP1Serial` / `SmxP2Serial`) and pushed to the SDK on launch, so it survives
 reconnects and restarts.
 
-### Single-pad auto-promote
+### Single pad: which player?
 
-If you have only **one pad** connected and no serial assignment is saved,
-DeadSync automatically assigns it as **Player 1** regardless of its hardware
-jumper setting. This means a single-stage setup works out of the box even if the
-pad's internal jumper is set to P2.
+With only **one pad** connected and no serial assignment saved, the pad follows
+its hardware **P1/P2 jumper** (P1-jumper → Player 1, P2-jumper → Player 2), and
+DeadSync saves that side automatically. A single stage therefore works out of the
+box on whichever side its jumper selects.
+
+To play a lone pad as the other player, use the **Pad Player** row in the
+StepManiaX options (it appears only when one pad is connected). Pick Player 1 or
+Player 2 and DeadSync pins the pad's serial to that side, overriding the jumper.
+The picker reflects the pad's live player side, so it stays correct as pads
+connect, disconnect, or are swapped while the screen is open.
 
 If you later connect a second pad, clear or update the assignment through the
 Assign Pads to Players flow (or edit `deadsync.ini` directly — see below).
@@ -108,9 +115,9 @@ Assign Pads to Players flow (or edit `deadsync.ini` directly — see below).
 You can bypass the in-game flow and assign pads directly in `deadsync.ini`. This
 is useful if:
 
-- You want to force a single pad to **P2** (rare, e.g. a dedicated doubles
-  second stage).
-- You want to pre-configure assignments before first launch.
+- You want to pre-configure a single pad as **P1** or **P2** before first launch
+  (the in-game **Pad Player** option does the same once the pad is connected).
+- You want to pre-configure two-pad assignments before first launch.
 - The in-game assignment screen isn't cooperating.
 
 #### Finding your pad's serial
@@ -145,7 +152,7 @@ SmxP2Serial=
 Leave a field empty (or remove the line) to not pin that side — it will fall
 back to the hardware jumper for any pad not explicitly assigned.
 
-To assign a single pad as P2 only (overriding auto-promote), set its serial as
+To force a single pad to P2 (overriding its jumper), set its serial as
 `SmxP2Serial` and leave `SmxP1Serial` empty:
 
 ```ini

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4248,9 +4248,11 @@ impl App {
             config::update_smx_pad_assignment(Some(p1), Some(p2));
             return;
         }
-        // Single pad connected with no saved assignment: auto-promote to P1.
-        // With one stage the user virtually always wants P1; the rare P2-only
-        // case can be set manually via SmxP2Serial in deadsync.ini.
+        // Single pad connected with no saved assignment: pin it to its hardware
+        // jumper side (a P1-jumpered stage becomes P1, a P2-jumpered stage becomes
+        // P2). This makes the assignment explicit for profile resolution without
+        // overriding the jumper; the user can still flip it in the StepManiaX
+        // options Pad Player picker.
         let single = match (a.connected, b.connected) {
             (true, false) if a.has_serial_number && !a.serial.is_empty() => Some(&a),
             (false, true) if b.has_serial_number && !b.serial.is_empty() => Some(&b),
@@ -4258,11 +4260,16 @@ impl App {
         };
         if let Some(pad) = single {
             log::info!(
-                "SMX: single pad connected (jumper P{}), auto-promoting to P1 (serial={})",
+                "SMX: single pad connected, auto-assigning to its jumper side P{} (serial={})",
                 if pad.is_player2 { 2 } else { 1 },
                 pad.serial
             );
-            config::update_smx_pad_assignment(Some(pad.serial.clone()), None);
+            let serial = Some(pad.serial.clone());
+            if pad.is_player2 {
+                config::update_smx_pad_assignment(None, serial);
+            } else {
+                config::update_smx_pad_assignment(serial, None);
+            }
         }
     }
 

--- a/src/screens/options/input.rs
+++ b/src/screens/options/input.rs
@@ -377,6 +377,19 @@ pub(super) fn apply_submenu_choice_delta(
                 new_index,
             ));
         }
+        if row.id == SubRowId::SmxSinglePadPlayer {
+            // Pin the lone connected pad's serial to the chosen side (index 0 = P1,
+            // 1 = P2). The SDK then relocates it to that slot. Row is only shown
+            // with exactly one pad connected, so just take whichever slot has one.
+            let serials = deadsync_smx::connected_serials();
+            if let Some(serial) = serials[0].clone().or_else(|| serials[1].clone()) {
+                if new_index == 1 {
+                    config::update_smx_pad_assignment(None, Some(serial));
+                } else {
+                    config::update_smx_pad_assignment(Some(serial), None);
+                }
+            }
+        }
     } else if matches!(kind, SubmenuKind::Lights) {
         let row = &rows[row_index];
         if row.id == SubRowId::LightsDriver {

--- a/src/screens/options/item.rs
+++ b/src/screens/options/item.rs
@@ -69,6 +69,7 @@ pub enum ItemId {
     InpSmxPanelLights,
     InpSmxUsbPolling,
     InpSmxDefaultPadConfig,
+    InpSmxSinglePadPlayer,
     InpSmxAssignPads,
     InpSmxSwapPads,
     InpMenuNavigation,

--- a/src/screens/options/row.rs
+++ b/src/screens/options/row.rs
@@ -59,6 +59,7 @@ pub enum SubRowId {
     SmxPanelLights,
     SmxUsbPolling,
     SmxDefaultPadConfig,
+    SmxSinglePadPlayer,
     SmxAssignPads,
     SmxSwapPads,
     MenuNavigation,

--- a/src/screens/options/state.rs
+++ b/src/screens/options/state.rs
@@ -519,14 +519,11 @@ pub fn init() -> State {
         SubRowId::SmxDefaultPadConfig,
         cfg.smx_default_pad_config.index(),
     );
-    // Single-pad P1/P2 picker: reflect whether the lone connected pad is currently
-    // pinned to P2 (index 1) versus P1/unassigned (index 0).
-    let single_pad_is_p2 = {
-        let (_, p2_serial) = config::smx_pad_assignment();
-        let serials = deadsync_smx::connected_serials();
-        let lone = serials[0].clone().or_else(|| serials[1].clone());
-        lone.is_some() && lone == p2_serial
-    };
+    // Single-pad P1/P2 picker: reflect the slot the SDK currently has the lone pad
+    // in (slot 1 = P2, index 1; slot 0 = P1, index 0). The slot already accounts for
+    // both the saved serial assignment and the hardware jumper, so reading it covers
+    // a pad placed on P2 by its jumper alone, which a serial-only comparison misses.
+    let single_pad_is_p2 = deadsync_smx::get_info(1).connected;
     set_choice_by_id(
         &mut state.sub[SubmenuKind::SmxConfig].choice_indices,
         SMX_CONFIG_OPTIONS_ROWS,

--- a/src/screens/options/state.rs
+++ b/src/screens/options/state.rs
@@ -519,6 +519,20 @@ pub fn init() -> State {
         SubRowId::SmxDefaultPadConfig,
         cfg.smx_default_pad_config.index(),
     );
+    // Single-pad P1/P2 picker: reflect whether the lone connected pad is currently
+    // pinned to P2 (index 1) versus P1/unassigned (index 0).
+    let single_pad_is_p2 = {
+        let (_, p2_serial) = config::smx_pad_assignment();
+        let serials = deadsync_smx::connected_serials();
+        let lone = serials[0].clone().or_else(|| serials[1].clone());
+        lone.is_some() && lone == p2_serial
+    };
+    set_choice_by_id(
+        &mut state.sub[SubmenuKind::SmxConfig].choice_indices,
+        SMX_CONFIG_OPTIONS_ROWS,
+        SubRowId::SmxSinglePadPlayer,
+        usize::from(single_pad_is_p2),
+    );
     set_choice_by_id(
         &mut state.sub[SubmenuKind::InputBackend].choice_indices,
         INPUT_BACKEND_OPTIONS_ROWS,

--- a/src/screens/options/submenus/input_dev.rs
+++ b/src/screens/options/submenus/input_dev.rs
@@ -298,6 +298,17 @@ pub(in crate::screens::options) const SMX_CONFIG_OPTIONS_ROWS: &[SubRow] = &[
         inline: true,
     },
     SubRow {
+        // Shown only when a single pad is connected (the assign/swap rows replace
+        // it when two are connected). Picks which player that lone pad is.
+        id: SubRowId::SmxSinglePadPlayer,
+        label: lookup_key("OptionsInput", "SmxSinglePadPlayer"),
+        choices: &[
+            localized_choice("OptionsInput", "SmxSinglePadPlayerP1"),
+            localized_choice("OptionsInput", "SmxSinglePadPlayerP2"),
+        ],
+        inline: true,
+    },
+    SubRow {
         id: SubRowId::SmxAssignPads,
         label: lookup_key("OptionsInput", "SmxAssignPads"),
         choices: &[localized_choice("Common", "Open")],
@@ -362,6 +373,14 @@ pub(in crate::screens::options) const SMX_CONFIG_OPTIONS_ITEMS: &[Item] = &[
             "OptionsInputHelp",
             "DefaultPadConfigHelp",
         ))],
+    },
+    Item {
+        id: ItemId::InpSmxSinglePadPlayer,
+        name: lookup_key("OptionsInput", "SmxSinglePadPlayer"),
+        help: &[
+            HelpEntry::Paragraph(lookup_key("OptionsInputHelp", "SmxSinglePadPlayerHelp")),
+            HelpEntry::Dynamic(smx_assignment_status),
+        ],
     },
     Item {
         id: ItemId::InpSmxAssignPads,

--- a/src/screens/options/tests.rs
+++ b/src/screens/options/tests.rs
@@ -128,6 +128,10 @@ fn smx_config_items_match_rows() {
             SubRowId::SmxDefaultPadConfig,
             ItemId::InpSmxDefaultPadConfig,
         ),
+        (
+            SubRowId::SmxSinglePadPlayer,
+            ItemId::InpSmxSinglePadPlayer,
+        ),
         (SubRowId::SmxAssignPads, ItemId::InpSmxAssignPads),
         (SubRowId::SmxSwapPads, ItemId::InpSmxSwapPads),
         (SubRowId::SmxUsbPolling, ItemId::InpSmxUsbPolling),

--- a/src/screens/options/update.rs
+++ b/src/screens/options/update.rs
@@ -246,6 +246,16 @@ pub fn update(state: &mut State, dt: f32, asset_manager: &AssetManager) -> Optio
 
     sync_i18n_cache(state);
 
+    // Pads can connect, disconnect, or be swapped while this screen is open, so keep
+    // the single-pad Pad Player picker tracking the live SDK slot (slot 1 = P2)
+    // rather than only the value captured at screen entry.
+    set_choice_by_id(
+        &mut state.sub[SubmenuKind::SmxConfig].choice_indices,
+        SMX_CONFIG_OPTIONS_ROWS,
+        SubRowId::SmxSinglePadPlayer,
+        usize::from(deadsync_smx::get_info(1).connected),
+    );
+
     let mut pending_action: Option<ScreenAction> = None;
     // ------------------------- local submenu fade ------------------------- //
     match state.submenu_transition {

--- a/src/screens/options/visibility.rs
+++ b/src/screens/options/visibility.rs
@@ -256,6 +256,22 @@ pub(super) fn submenu_visible_row_indices(
                 }
             })
             .collect(),
+        SubmenuKind::SmxConfig => {
+            // Pad-assignment rows depend on how many StepManiaX pads are connected:
+            // one pad gets a simple P1/P2 picker; two pads get the assign + swap
+            // rows (which can separate same-jumper pads). With none connected, show
+            // neither.
+            let pad_count = usize::from(deadsync_smx::get_info(0).connected)
+                + usize::from(deadsync_smx::get_info(1).connected);
+            rows.iter()
+                .enumerate()
+                .filter_map(|(idx, row)| match row.id {
+                    SubRowId::SmxSinglePadPlayer if pad_count != 1 => None,
+                    SubRowId::SmxAssignPads | SubRowId::SmxSwapPads if pad_count != 2 => None,
+                    _ => Some(idx),
+                })
+                .collect()
+        }
         _ => (0..rows.len()).collect(),
     }
 }


### PR DESCRIPTION
## Problem

A single StepManiaX stage could not reliably be used on the P2 side:

- A P1-jumpered pad assigned to `SmxP2Serial` showed up as **P1** and its pad config never appeared from Song Select. The player joined P2, but the pad mapped to slot 0 (P1), so no profile resolved.
- A P2-jumpered pad connected on its own was force-assigned to **P1**, overriding its jumper.
- The single-pad player picker could show a stale side after pads were swapped or unplugged with the options screen open.

## Root cause

The SDK only honored a serial-to-player assignment when **both** serials were set **and both** pads were connected. A lone pad always fell back to its hardware jumper, and deadsync further auto-promoted any lone pad to P1. Input routing, config mapping, and lights all key off the SDK slot, so the pad behaved as whatever slot it landed in.

## Fixes

- **SDK (`rustmaniax-sdk` 1.2.0, ported to `stepmaniax-sdk-mp` 1.2.0):** a lone pad whose serial matches a single-sided assignment is relocated to that slot (P2-only to slot 1, P1-only to slot 0). Two-pad ordering is unchanged. deadsync depends on the published 1.2.0 crate.
- A lone pad with no saved assignment is pinned to **its own hardware jumper side** (P1-jumper to P1, P2-jumper to P2) instead of always P1. An assignment the user sets still overrides it.
- **StepManiaX options are now pad-count-aware:** one pad shows a **Pad Player** P1/P2 picker that pins the lone pad's serial; two pads show the existing Assign Pads + Swap rows; the irrelevant rows are hidden in each case.
- The Pad Player picker reads the live SDK slot every frame, so it tracks pads connecting, disconnecting, and swapping while the options screen stays open.

## Testing

- Hardware-verified end to end on a two-pad setup (one P1-jumper, one P2-jumper) across connect, disconnect, and swap, single pad on both P1 and P2.
- SDK `cargo test` and `stepmaniax-sdk-mp` doctest suites green, including new lone-pad cases.
- deadsync builds against published `rustmaniax-sdk 1.2.0`; the StepManiaX options inventory test passes.

## Note

If a `deadsync.ini` carries a stale `SmxP1Serial`/`SmxP2Serial` from before this change, clear those lines (or flip the Pad Player picker) so the jumper-side auto-assignment applies.