### PR TITLE
perf(smx): gate SMX/FSR per-frame work off the non-SMX paths

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3985,9 +3985,20 @@ impl App {
     #[inline(always)]
     fn sync_pad_config_fsr(&mut self) {
         use crate::screens::pad_config;
+        let screen = self.state.screens.current_screen;
+        // Fast path: the FSR monitor is only driven on the Configure Pads screen and the
+        // Song Select pad-config overlay. Everywhere else (gameplay included) there is
+        // nothing to do unless a previously-active monitor still needs releasing, so skip
+        // the config read and all the per-screen work entirely.
+        if !matches!(
+            screen,
+            CurrentScreen::ConfigurePads | CurrentScreen::SelectMusic
+        ) && !self.fsr_pads_active
+        {
+            return;
+        }
         let cfg = config::get();
         let use_fsrs = cfg.use_fsrs;
-        let screen = self.state.screens.current_screen;
         let on_screen = screen == CurrentScreen::ConfigurePads && use_fsrs;
         let on_overlay = screen == CurrentScreen::SelectMusic
             && self
@@ -4417,9 +4428,14 @@ impl App {
             }
         }
 
-        // Mirror the authoritative markers to the screen for display. Done every
-        // frame, so a screen rebuild can't lose them.
-        self.state.screens.select_music_state.smx_applied = self.pad_config_sync.snapshot();
+        // Mirror the authoritative markers to the screen for display. Checked every
+        // frame so a screen rebuild (which resets the mirror to None) can't lose them,
+        // but only cloned when they actually differ — the equality check is a couple of
+        // small string compares, whereas the clone heap-allocates the config name(s)
+        // every frame an SMX pad is connected. Steady state: compare, no allocation.
+        if self.state.screens.select_music_state.smx_applied != self.pad_config_sync.applied {
+            self.state.screens.select_music_state.smx_applied = self.pad_config_sync.snapshot();
+        }
     }
 
     fn sync_lights(&mut self, delta_time: f32, elapsed_seconds: f32) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4348,9 +4348,18 @@ impl App {
         }
 
         let cfg = config::get();
+        // Only query the SMX manager when the managed-config feature is actually on.
+        // With it off (or SMX input disabled) there is nothing to resolve or write, so
+        // skip the per-pad `get_info` lock entirely and just clear the cached signature.
+        // The marker mirror below still runs so a screen rebuild can't lose stale markers.
+        let managing = cfg.smx_input && cfg.smx_manages_pad_config;
         for pad in 0..2 {
+            if !managing {
+                self.pad_config_sync.signature[pad] = None;
+                continue;
+            }
             let info = deadsync_smx::get_info(pad);
-            if !cfg.smx_input || !cfg.smx_manages_pad_config || !info.connected {
+            if !info.connected {
                 self.pad_config_sync.signature[pad] = None;
                 continue;
             }
@@ -4428,7 +4437,13 @@ impl App {
             profile::is_session_side_joined(profile_data::PlayerSide::P2),
         ]);
         self.lights.set_hide_flags(self.current_light_hide_flags());
-        self.sync_gameplay_light_blinks(config.lights_simplify_bass, config.smx_panel_lights);
+        // Panel lights are a sub-feature of SMX input: without smx_input there is no
+        // SDK/manager to drive, so gate on both to keep the per-frame panel diff off the
+        // gameplay path when StepManiaX is disabled.
+        self.sync_gameplay_light_blinks(
+            config.lights_simplify_bass,
+            config.smx_input && config.smx_panel_lights,
+        );
         self.lights.tick(delta_time, elapsed_seconds);
     }
 


### PR DESCRIPTION
## Off-path gating for SMX/FSR per-frame work

Keeps StepManiaX and FSR processing off the per-frame path when the
features aren't in use. All changes are pure performance gating: when
StepManiaX is enabled every guard evaluates to the original path, so
behavior on the SMX-on path is unchanged. The savings only apply when
SMX is disabled or you're not on a pad-config screen.

### Changes (`src/app/mod.rs`)

**Skip SMX work when StepManiaX input is disabled**

- Gameplay panel lights activated on `smx_panel_lights` alone. With
  `smx_input` off there is no SDK/manager to drive, yet the per-column
  panel diff still ran every gameplay frame and pushed no-op events to
  the lights worker. Gate activation on `smx_input && smx_panel_lights`.
- The managed-config sync queried `get_info()` for both pad slots every
  non-gameplay frame before checking the feature flags, locking the SMX
  manager state for nothing when managed config (or `smx_input`) is off.
  Hoist the feature check so the device query is skipped; the marker
  mirror still runs every frame as before.

**Cut per-frame allocation and work on non-SMX paths**

- The applied-config marker mirror to the Song Select screen did an
  unconditional clone every non-gameplay frame, heap-allocating the
  config name string(s) whenever an SMX pad is connected. Compare first
  (cheap small-string equality) and only clone when the markers actually
  changed. A screen rebuild still re-mirrors, because its reset-to-None
  state then differs from the authoritative markers.
- `sync_pad_config_fsr` read the full config by value every frame,
  gameplay included, before discovering it had nothing to do. The FSR
  monitor only runs on Configure Pads and the Song Select overlay, so
  early-return on any other screen (unless a monitor still needs
  releasing) before the config read.

### Net effect

Steady-state SMX/FSR footprint on the common paths drops to a few enum
compares and a no-op return, with no heap traffic when idle.

### Testing

- Builds clean on `fc/smx-fsr-gating`.
- Hardware smoke test on the SMX stage: Configure Pads and the Song
  Select pad-config overlay still show live FSR values; leaving and
  re-entering re-arms the monitor; gameplay panel lights still fire with
  `smx_panel_lights` on.

