### PR TITLE
Optimize evaluation screen rendering and fix a compose hasher crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,6 +1238,7 @@ dependencies = [
  "glam",
  "image",
  "log",
+ "rustc-hash 2.1.2",
  "smallvec",
  "twox-hash",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +318,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -1004,6 +1028,7 @@ dependencies = [
  "deadsync-updater",
  "deadsync-version",
  "deadsync-video",
+ "dhat",
  "fs_extra",
  "glam",
  "gpu-allocator",
@@ -1401,6 +1426,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -1839,6 +1880,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gl_generator"
@@ -2671,6 +2718,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mlua"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3379,6 +3432,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ogg"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4080,6 +4142,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4730,6 +4798,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "tiff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,8 @@ path = "scripts/replaygain_bench.rs"
 
 [features]
 pipewire-audio = ["deadsync-audio-backend-native/pipewire-audio"]
+dhat-heap = ["dep:dhat"]
+dhat = ["dep:dhat"]
 
 [dependencies]
 deadsync-audio = { path = "crates/deadsync-audio" }
@@ -144,6 +146,7 @@ sys-locale = "0.3.2"
 semver = "1.0.28"
 tokio = { version = "1.52.3", features = ["rt"] }
 bitflags = "2.13.0"
+dhat = { version = "0.3.3", optional = true }
 
 # DirectX + Input (Windows)
 [target.'cfg(windows)'.dependencies]

--- a/crates/deadsync-present/Cargo.toml
+++ b/crates/deadsync-present/Cargo.toml
@@ -11,6 +11,7 @@ image = "0.25.10"
 log = "0.4.32"
 smallvec = "1.15.2"
 twox-hash = "2.1.2"
+rustc-hash = "2.1.2"
 
 [lints.clippy]
 perf = { level = "warn", priority = -1 }

--- a/crates/deadsync-present/src/compose.rs
+++ b/crates/deadsync-present/src/compose.rs
@@ -7,9 +7,8 @@ use smallvec::SmallVec;
 use space::Metrics;
 use std::cell::OnceCell;
 use std::collections::HashMap;
-use std::hash::{BuildHasherDefault, DefaultHasher, Hash, Hasher};
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Arc;
-use twox_hash::XxHash64;
 
 /* ======================= RENDERER SCREEN BUILDER ======================= */
 
@@ -486,7 +485,7 @@ struct SharedLayoutEntry {
     last_used: u64,
 }
 
-type TextLayoutHasher = BuildHasherDefault<XxHash64>;
+type TextLayoutHasher = rustc_hash::FxBuildHasher;
 type OwnedLayoutMap = HashMap<Box<str>, OwnedLayoutEntry, TextLayoutHasher>;
 type SharedAliasMap = HashMap<usize, SharedLayoutEntry, TextLayoutHasher>;
 
@@ -528,7 +527,7 @@ impl TextureLookupCache {
 
     #[inline(always)]
     fn key_fingerprint(key: &str) -> u64 {
-        let mut hasher = XxHash64::default();
+        let mut hasher = rustc_hash::FxHasher::default();
         key.hash(&mut hasher);
         hasher.finish()
     }
@@ -948,7 +947,7 @@ fn font_chain_key(font: &font::Font, fonts: &HashMap<&'static str, font::Font>) 
 
 #[inline(always)]
 fn text_layout_mesh_seed(key: TextLayoutKey, text: &str) -> u64 {
-    let mut hasher = XxHash64::default();
+    let mut hasher = rustc_hash::FxHasher::default();
     key.hash(&mut hasher);
     text.hash(&mut hasher);
     let seed = hasher.finish();
@@ -966,7 +965,7 @@ fn text_batch_cache_key(
     stroke: bool,
     align: actors::TextAlign,
 ) -> u64 {
-    let mut hasher = XxHash64::default();
+    let mut hasher = rustc_hash::FxHasher::default();
     layout_seed.hash(&mut hasher);
     (texture_key as *const () as usize).hash(&mut hasher);
     stroke.hash(&mut hasher);

--- a/src/assets/present_dsl.rs
+++ b/src/assets/present_dsl.rs
@@ -22,6 +22,13 @@ impl SpriteBuilder {
     }
 
     #[inline(always)]
+    pub fn static_texture(tex: &'static str) -> Self {
+        Self {
+            inner: present_dsl::SpriteBuilder::static_texture(tex),
+        }
+    }
+
+    #[inline(always)]
     pub fn static_texture_cached(
         tex: &'static str,
         cached_handle: &'static AtomicU64,
@@ -93,6 +100,12 @@ macro_rules! act {
         ::deadsync_present::__act_from_builder!(
             ($($tail)+)
             $crate::assets::present_dsl::SpriteBuilder::texture($tex)
+        )
+    }};
+    (sprite_static($tex:expr): $($tail:tt)+) => {{
+        ::deadsync_present::__act_from_builder!(
+            ($($tail)+)
+            $crate::assets::present_dsl::SpriteBuilder::static_texture($tex)
         )
     }};
     (quad: $($tail:tt)+) => {{

--- a/src/game/profile.rs
+++ b/src/game/profile.rs
@@ -1228,6 +1228,12 @@ pub fn get_for_side(side: PlayerSide) -> Profile {
     lock_profiles()[side_ix(side)].clone()
 }
 
+pub fn footer_fields_for_side(side: PlayerSide) -> (Option<String>, String) {
+    let profiles = lock_profiles();
+    let p = &profiles[side_ix(side)];
+    (p.avatar_texture_key.clone(), p.display_name.clone())
+}
+
 pub fn groovestats_api_key_for_side(side: PlayerSide) -> String {
     lock_profiles()[side_ix(side)]
         .groovestats_api_key

--- a/src/screens/components/evaluation/eval_grades.rs
+++ b/src/screens/components/evaluation/eval_grades.rs
@@ -498,7 +498,7 @@ fn base_star_actor(st: StarTransform, p: EvalGradeParams, seed: u32) -> Actor {
         [1.0, 1.0, 1.0, 1.0]
     };
 
-    act!(sprite(STAR_TEX):
+    act!(sprite_static(STAR_TEX):
         align(0.5, 0.5):
         xy(st.x, st.y):
         zoomx(st.sx):
@@ -540,7 +540,7 @@ fn affluent_actor(st: StarTransform, p: EvalGradeParams, seed: u32) -> Option<Ac
 fn raw_affluent_actor(st: StarTransform, z: i16, alpha: f32, face_rot: f32) -> Actor {
     let rot = st.rot + face_rot;
     let (x, y) = child_xy(st, 0.0, AFFLUENT_OFFSET_Y);
-    act!(sprite(AFFLUENT_TEX):
+    act!(sprite_static(AFFLUENT_TEX):
         align(0.5, 0.5):
         xy(x, y):
         zoomx(st.sx * AFFLUENT_ZOOM):
@@ -741,7 +741,7 @@ pub fn actors(grade: score_data::Grade, p: EvalGradeParams) -> Vec<Actor> {
     }
 
     let tex = letter_tex(grade);
-    vec![act!(sprite(tex):
+    vec![act!(sprite_static(tex):
         align(0.5, 0.5):
         xy(p.x, p.y):
         zoom(p.zoom * LETTER_ZOOM):

--- a/src/screens/components/evaluation/pane_gs_records.rs
+++ b/src/screens/components/evaluation/pane_gs_records.rs
@@ -283,7 +283,7 @@ fn build_records_pane(
     }
 
     let mut children = Vec::with_capacity(GS_RECORD_ROWS * 4 + 1);
-    children.push(act!(sprite(kind.logo()):
+    children.push(act!(sprite_static(kind.logo()):
         align(0.5, 0.5):
         xy(0.0, 100.0 * pane_zoom):
         zoom(kind.logo_zoom(pane_zoom)):

--- a/src/screens/components/shared/visual_style_bg.rs
+++ b/src/screens/components/shared/visual_style_bg.rs
@@ -134,7 +134,7 @@ impl State {
 }
 
 fn push_shared_bg(out: &mut Vec<Actor>, x: f32, y: f32, rgba: [f32; 4], uv: [f32; 4]) {
-    out.push(act!(sprite(visual_styles::shared_background_texture_key()):
+    out.push(act!(sprite_static(visual_styles::shared_background_texture_key()):
         xy(x, y):
         zoom(SHARED_BG_ZOOM):
         customtexturerect(uv[0], uv[1], uv[2], uv[3]):

--- a/src/screens/evaluation.rs
+++ b/src/screens/evaluation.rs
@@ -1929,6 +1929,28 @@ fn eval_graph_shift(
     cycle[next_idx]
 }
 
+/// Cache key for a memoized per-player graph subtree (density + scatter + life).
+/// Captures every input the graph children depend on; when unchanged across frames
+/// the cached `Arc<[Actor]>` is cloned instead of rebuilt.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct GraphCacheKey {
+    graph: EvalGraphPane,
+    versus: bool,
+    shade: bool,
+    panel_alpha_bits: u32,
+    tex_key_hash: u64,
+}
+
+#[inline]
+fn fnv1a_str(s: &str) -> u64 {
+    let mut h = 0xcbf2_9ce4_8422_2325_u64;
+    for b in s.bytes() {
+        h ^= u64::from(b);
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
 pub struct State {
     pub active_color_index: i32,
     bg: visual_style_bg::State,
@@ -1970,6 +1992,9 @@ pub struct State {
     menu_lr_undo: [i8; MAX_PLAYERS],
     favorite_code: crate::screens::favorite_code::FavoriteCodeTracker,
     test_input_state: test_input::State,
+    /// Memoized per-player graph subtree (cf. `GraphCacheKey`). Interior mutability so
+    /// it can be populated during `get_actors(&State, …)`.
+    graph_cache: [RefCell<Option<(GraphCacheKey, Arc<[Actor]>)>>; MAX_PLAYERS],
 }
 
 impl Clone for State {
@@ -2015,6 +2040,10 @@ impl Clone for State {
             menu_lr_undo: self.menu_lr_undo,
             favorite_code: self.favorite_code.clone(),
             test_input_state: self.test_input_state.clone(),
+            // Cloned State (e.g. stage summary pages) starts with an empty cache; it
+            // is repopulated lazily on first draw. Sharing Arcs across clones is safe
+            // but pointless, and an empty cache avoids any stale-key risk.
+            graph_cache: std::array::from_fn(|_| RefCell::new(None)),
         }
     }
 }
@@ -2608,6 +2637,7 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
         menu_lr_undo: [0; MAX_PLAYERS],
         favorite_code: Default::default(),
         test_input_state: test_input::State::default(),
+        graph_cache: std::array::from_fn(|_| RefCell::new(None)),
     }
 }
 
@@ -2760,6 +2790,7 @@ pub fn init_from_score_info(
         menu_lr_undo: [0; MAX_PLAYERS],
         favorite_code: Default::default(),
         test_input_state: test_input::State::default(),
+        graph_cache: std::array::from_fn(|_| RefCell::new(None)),
     }
 }
 
@@ -4656,33 +4687,46 @@ pub fn push_actors(actors: &mut Vec<Actor>, state: &State, asset_manager: &Asset
                 1
             };
             let graph_mode = state.active_graph[graph_controller_idx];
-            let density_mesh = state.density_graph_mesh[player_idx].as_ref();
-            let scatter_mesh = match graph_mode {
-                EvalGraphPane::Itg => state.scatter_mesh_itg[player_idx].as_ref(),
-                EvalGraphPane::Ex => state.scatter_mesh_ex[player_idx].as_ref(),
-                EvalGraphPane::HardEx => state.scatter_mesh_hard_ex[player_idx].as_ref(),
-                EvalGraphPane::Arrow => state.scatter_mesh_arrow[player_idx].as_ref(),
-                EvalGraphPane::Foot => state.scatter_mesh_foot[player_idx].as_ref(),
+            let shade = crate::config::get().shade_scatterplot_judgments;
+            let graph_key = GraphCacheKey {
+                graph: graph_mode,
+                versus: play_style == profile_data::PlayStyle::Versus,
+                shade,
+                panel_alpha_bits: sl_panel_alpha.to_bits(),
+                tex_key_hash: fnv1a_str(&state.density_graph_texture_key),
             };
-            let scatter_bg_mesh = if crate::config::get().shade_scatterplot_judgments {
-                match graph_mode {
-                    EvalGraphPane::Itg => state.scatter_bg_mesh_itg[player_idx].as_ref(),
-                    EvalGraphPane::Ex => state.scatter_bg_mesh_ex[player_idx].as_ref(),
-                    EvalGraphPane::HardEx => state.scatter_bg_mesh_hard_ex[player_idx].as_ref(),
-                    EvalGraphPane::Arrow | EvalGraphPane::Foot => None,
-                }
+            let cache_hit = {
+                let slot = state.graph_cache[player_idx].borrow();
+                slot.as_ref().is_some_and(|(k, _)| *k == graph_key)
+            };
+            // The graph subtree (density + scatter + life + baked-tween markers) reads
+            // no per-frame clock, so it is fully determined by `graph_key`. Memoize the
+            // built `Arc<[Actor]>` and clone it on subsequent frames instead of
+            // rebuilding hundreds of leaf actors.
+            let graph_children: Arc<[Actor]> = if cache_hit {
+                Arc::clone(&state.graph_cache[player_idx].borrow().as_ref().unwrap().1)
             } else {
-                None
-            };
-            let show_feet_overlay = graph_mode == EvalGraphPane::Foot;
+                let density_mesh = state.density_graph_mesh[player_idx].as_ref();
+                let scatter_mesh = match graph_mode {
+                    EvalGraphPane::Itg => state.scatter_mesh_itg[player_idx].as_ref(),
+                    EvalGraphPane::Ex => state.scatter_mesh_ex[player_idx].as_ref(),
+                    EvalGraphPane::HardEx => state.scatter_mesh_hard_ex[player_idx].as_ref(),
+                    EvalGraphPane::Arrow => state.scatter_mesh_arrow[player_idx].as_ref(),
+                    EvalGraphPane::Foot => state.scatter_mesh_foot[player_idx].as_ref(),
+                };
+                let scatter_bg_mesh = if shade {
+                    match graph_mode {
+                        EvalGraphPane::Itg => state.scatter_bg_mesh_itg[player_idx].as_ref(),
+                        EvalGraphPane::Ex => state.scatter_bg_mesh_ex[player_idx].as_ref(),
+                        EvalGraphPane::HardEx => state.scatter_bg_mesh_hard_ex[player_idx].as_ref(),
+                        EvalGraphPane::Arrow | EvalGraphPane::Foot => None,
+                    }
+                } else {
+                    None
+                };
+                let show_feet_overlay = graph_mode == EvalGraphPane::Foot;
 
-            let graph_frame = Actor::Frame {
-                align: [0.5, 0.0],
-                offset: [frame_center_x, frame_center_y],
-                size: [SizeSpec::Px(graph_width), SizeSpec::Px(graph_height)],
-                z: 101,
-                background: None,
-                children: vec![
+                let graph_children_vec: Vec<Actor> = vec![
                     act!(quad:
                         align(0.0, 0.0):
                         xy(0.0, 0.0):
@@ -5003,7 +5047,21 @@ pub fn push_actors(actors: &mut Vec<Actor>, state: &State, asset_manager: &Asset
                             children: life_children,
                         }
                     },
-                ],
+                ];
+                let arc: Arc<[Actor]> = Arc::from(graph_children_vec);
+                *state.graph_cache[player_idx].borrow_mut() =
+                    Some((graph_key, Arc::clone(&arc)));
+                arc
+            };
+            let graph_frame = Actor::SharedFrame {
+                align: [0.5, 0.0],
+                offset: [frame_center_x, frame_center_y],
+                size: [SizeSpec::Px(graph_width), SizeSpec::Px(graph_height)],
+                z: 101,
+                background: None,
+                children: graph_children,
+                tint: [1.0; 4],
+                blend: None,
             };
             actors.push(graph_frame);
         }

--- a/src/screens/evaluation.rs
+++ b/src/screens/evaluation.rs
@@ -966,7 +966,7 @@ fn course_graph_stripe_actors(
 #[cfg(test)]
 mod tests {
     use super::{
-        CellIcon, CourseGraphStage, EvalPane, SUBMIT_FOOTER_F5_LABEL, SubmitFooterCell,
+        CellIcon, CourseGraphStage, EvalPane, Nice69Buf, SUBMIT_FOOTER_F5_LABEL, SubmitFooterCell,
         compute_column_judgments, course_graph_stage_spans, course_graph_stripe_actors,
         eval_grade_for_result, eval_pane_cycle, eval_pane_shift, eval_pane_skip_duplicate,
         stage_in_stinger_texture_key, submit_footer_gs_label, submit_footer_lines,
@@ -979,6 +979,29 @@ mod tests {
     use deadsync_rules::note::Note;
     use deadsync_score as score_data;
     use std::sync::Arc;
+
+    #[test]
+    fn nice69_buf_matches_string_contains_semantics() {
+        // The allocation-free Nice69Buf must agree with the old
+        // `format!(...).contains("69")` / `to_string().contains("69")` logic.
+        let mut buf = Nice69Buf::new();
+
+        // Integer decimal renderings.
+        assert!(buf.has_display(69u32));
+        assert!(buf.has_display(169u32));
+        assert!(buf.has_display(690u32));
+        assert!(buf.has_display(1692u32));
+        assert!(!buf.has_display(96u32)); // reversed digits must NOT match
+        assert!(!buf.has_display(609u32)); // dot/zero break adjacency
+        assert!(!buf.has_display(0u32));
+        assert!(buf.has_display(-69i32)); // sign does not affect the "69" run
+
+        // Two-decimal float rendering, mirroring `{:.2}`.
+        assert!(buf.has_fixed2(69.00)); // "69.00"
+        assert!(buf.has_fixed2(12.69)); // ".69" fractional
+        assert!(!buf.has_fixed2(6.90)); // "6.90" — dot breaks 6|9 adjacency
+        assert!(!buf.has_fixed2(12.34));
+    }
 
     fn test_course_graph_stage(song_last_second: f32) -> CourseGraphStage {
         CourseGraphStage {
@@ -2891,15 +2914,61 @@ fn sync_submit_record_sfx(state: &mut State) {
 /// (e.g. `98.69`), every tap-note judgment count (Fantastic..Miss), the radar
 /// actual + possible counts for Holds / Rolls / Mines / Hands, the chart
 /// difficulty meter, and the song title.
+/// Stack-only check for whether a value's decimal rendering contains "69" — the
+/// Simply Love "Nice" easter egg. Replaces per-frame `format!`/`to_string` heap
+/// allocations (this predicate runs every frame in both `get_actors` and `update`).
+struct Nice69Buf {
+    bytes: [u8; 48],
+    len: usize,
+}
+
+impl Nice69Buf {
+    fn new() -> Self {
+        Self {
+            bytes: [0; 48],
+            len: 0,
+        }
+    }
+    fn reset(&mut self) {
+        self.len = 0;
+    }
+    fn contains_69(&self) -> bool {
+        self.bytes[..self.len].windows(2).any(|w| w == b"69")
+    }
+    fn has_display<T: std::fmt::Display>(&mut self, value: T) -> bool {
+        use std::fmt::Write as _;
+        self.reset();
+        let _ = write!(self, "{value}");
+        self.contains_69()
+    }
+    fn has_fixed2(&mut self, value: f64) -> bool {
+        use std::fmt::Write as _;
+        self.reset();
+        let _ = write!(self, "{value:.2}");
+        self.contains_69()
+    }
+}
+
+impl std::fmt::Write for Nice69Buf {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        let b = s.as_bytes();
+        let end = self.len + b.len();
+        if end > self.bytes.len() {
+            return Err(std::fmt::Error);
+        }
+        self.bytes[self.len..end].copy_from_slice(b);
+        self.len = end;
+        Ok(())
+    }
+}
+
 fn score_info_is_nice(si: &ScoreInfo) -> bool {
-    if format!("{:.2}", si.score_percent * 100.0).contains("69") {
+    let mut buf = Nice69Buf::new();
+
+    if buf.has_fixed2(si.score_percent * 100.0) {
         return true;
     }
-    if si
-        .judgment_counts
-        .iter()
-        .any(|count| count.to_string().contains("69"))
-    {
+    if si.judgment_counts.iter().any(|count| buf.has_display(count)) {
         return true;
     }
     let radar_values = [
@@ -2913,16 +2982,13 @@ fn score_info_is_nice(si: &ScoreInfo) -> bool {
         si.hands_achieved,
         si.hands_total,
     ];
-    if radar_values.iter().any(|v| v.to_string().contains("69")) {
+    if radar_values.iter().any(|value| buf.has_display(value)) {
         return true;
     }
-    if si.chart.meter.to_string().contains("69") {
+    if buf.has_display(si.chart.meter) {
         return true;
     }
-    if si.song.title.contains("69") {
-        return true;
-    }
-    false
+    si.song.title.contains("69")
 }
 
 /// Fires a one-shot "Nice" SFX (Simply Love parity) the first time the
@@ -5363,14 +5429,14 @@ pub fn push_actors(actors: &mut Vec<Actor>, state: &State, asset_manager: &Asset
     let play_style = profile::get_session_play_style();
     let player_side = profile::get_session_player_side();
 
-    let p1_profile = profile::get_for_side(profile_data::PlayerSide::P1);
-    let p2_profile = profile::get_for_side(profile_data::PlayerSide::P2);
-    let p1_avatar = p1_profile
-        .avatar_texture_key
+    let (p1_avatar_key, p1_display_name) =
+        profile::footer_fields_for_side(profile_data::PlayerSide::P1);
+    let (p2_avatar_key, p2_display_name) =
+        profile::footer_fields_for_side(profile_data::PlayerSide::P2);
+    let p1_avatar = p1_avatar_key
         .as_deref()
         .map(|texture_key| AvatarParams { texture_key });
-    let p2_avatar = p2_profile
-        .avatar_texture_key
+    let p2_avatar = p2_avatar_key
         .as_deref()
         .map(|texture_key| AvatarParams { texture_key });
 
@@ -5386,7 +5452,7 @@ pub fn push_actors(actors: &mut Vec<Actor>, state: &State, asset_manager: &Asset
             Some(if p1_guest {
                 insert_card.as_ref()
             } else {
-                p1_profile.display_name.as_str()
+                p1_display_name.as_str()
             }),
             if p1_guest { None } else { p1_avatar },
         )
@@ -5398,7 +5464,7 @@ pub fn push_actors(actors: &mut Vec<Actor>, state: &State, asset_manager: &Asset
             Some(if p2_guest {
                 insert_card.as_ref()
             } else {
-                p2_profile.display_name.as_str()
+                p2_display_name.as_str()
             }),
             if p2_guest { None } else { p2_avatar },
         )

--- a/src/screens/evaluation.rs
+++ b/src/screens/evaluation.rs
@@ -4787,7 +4787,10 @@ pub fn push_actors(actors: &mut Vec<Actor>, state: &State, asset_manager: &Asset
                         }
                     },
                     {
-                        let mut life_children: Vec<Actor> = Vec::new();
+                        // Reserve the worst-case child count (≤2 quads per life-history
+                        // change point) so the segment quads never trigger reallocations.
+                        let mut life_children: Vec<Actor> =
+                            Vec::with_capacity(si.life_history.len() * 2 + 16);
                         let first = si.graph_first_second;
                         let last = si.graph_last_second.max(first + 0.001_f32);
                         let dur = (last - first).max(0.001_f32);

--- a/src/screens/evaluation.rs
+++ b/src/screens/evaluation.rs
@@ -1941,6 +1941,15 @@ struct GraphCacheKey {
     tex_key_hash: u64,
 }
 
+/// Captures every input the clock-free center-column chrome (title/banner +
+/// song-features) frames depend on; unchanged ⇒ the cached `Arc<[Actor]>` is cloned.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct ChromeCacheKey {
+    active_color_index: i32,
+    translated_titles: bool,
+    header_alpha_bits: u32,
+}
+
 #[inline]
 fn fnv1a_str(s: &str) -> u64 {
     let mut h = 0xcbf2_9ce4_8422_2325_u64;
@@ -1995,6 +2004,12 @@ pub struct State {
     /// Memoized per-player graph subtree (cf. `GraphCacheKey`). Interior mutability so
     /// it can be populated during `get_actors(&State, …)`.
     graph_cache: [RefCell<Option<(GraphCacheKey, Arc<[Actor]>)>>; MAX_PLAYERS],
+    /// Memoized center-column title/banner frame (cf. `ChromeCacheKey`). Single
+    /// instance (same in single + versus). Interior mutability so it can be populated
+    /// during `get_actors(&State, …)`.
+    chrome_cache: RefCell<Option<(ChromeCacheKey, Arc<[Actor]>)>>,
+    /// Memoized center-column song-features frame (cf. `ChromeCacheKey`).
+    song_features_cache: RefCell<Option<(ChromeCacheKey, Arc<[Actor]>)>>,
 }
 
 impl Clone for State {
@@ -2044,6 +2059,8 @@ impl Clone for State {
             // is repopulated lazily on first draw. Sharing Arcs across clones is safe
             // but pointless, and an empty cache avoids any stale-key risk.
             graph_cache: std::array::from_fn(|_| RefCell::new(None)),
+            chrome_cache: RefCell::new(None),
+            song_features_cache: RefCell::new(None),
         }
     }
 }
@@ -2638,6 +2655,8 @@ pub fn init(gameplay_results: Option<gameplay::State>) -> State {
         favorite_code: Default::default(),
         test_input_state: test_input::State::default(),
         graph_cache: std::array::from_fn(|_| RefCell::new(None)),
+        chrome_cache: RefCell::new(None),
+        song_features_cache: RefCell::new(None),
     }
 }
 
@@ -2791,6 +2810,8 @@ pub fn init_from_score_info(
         favorite_code: Default::default(),
         test_input_state: test_input::State::default(),
         graph_cache: std::array::from_fn(|_| RefCell::new(None)),
+        chrome_cache: RefCell::new(None),
+        song_features_cache: RefCell::new(None),
     }
 }
 
@@ -3895,84 +3916,117 @@ pub fn push_actors(actors: &mut Vec<Actor>, state: &State, asset_manager: &Asset
 
     // --- Title, Banner, and Song Features (Center Column) ---
     {
+        // Both center-column frames are clock-free, so cache their built children and
+        // emit `SharedFrame` (neutral tint/blend ⇒ identical compose to `Frame`),
+        // cloning the cached `Arc` on subsequent frames instead of rebuilding the
+        // leaf actors and reallocating the `banner_key` / `full_title` Strings.
+        let chrome_key = ChromeCacheKey {
+            active_color_index: state.active_color_index,
+            translated_titles: cfg.translated_titles,
+            header_alpha_bits: sl_header_alpha.to_bits(),
+        };
+
         // --- TitleAndBanner Group ---
-        let banner_key = score_info
-            .song
-            .banner_path
-            .as_ref()
-            .map(|p| p.to_string_lossy().into_owned())
-            .unwrap_or_else(|| {
-                BANNER_FALLBACK_KEYS[state.active_color_index.rem_euclid(12) as usize].to_string()
-            });
-
-        let full_title = score_info.song.display_full_title(cfg.translated_titles);
-
-        let title_and_banner_frame = Actor::Frame {
-            align: [0.5, 0.5],
-            offset: [screen_center_x(), 46.0],
-            size: [SizeSpec::Px(0.0), SizeSpec::Px(0.0)],
-            children: vec![
+        let title_hit = {
+            let slot = state.chrome_cache.borrow();
+            slot.as_ref().is_some_and(|(k, _)| *k == chrome_key)
+        };
+        let title_children: Arc<[Actor]> = if title_hit {
+            Arc::clone(&state.chrome_cache.borrow().as_ref().unwrap().1)
+        } else {
+            let banner_key = score_info
+                .song
+                .banner_path
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|| {
+                    BANNER_FALLBACK_KEYS[state.active_color_index.rem_euclid(12) as usize]
+                        .to_string()
+                });
+            let full_title = score_info.song.display_full_title(cfg.translated_titles);
+            let children: Arc<[Actor]> = Arc::from(vec![
                 shared_banner::sprite(banner_key, 0.0, 66.0, 418.0, 164.0, 0.7, 0),
                 act!(quad: align(0.5, 0.5): xy(0.0, 0.0): setsize(418.0, 25.0): zoom(0.7): diffuse(0.117, 0.157, 0.184, sl_header_alpha): z(1)),
                 act!(text: font("miso"): settext(full_title): align(0.5, 0.5): xy(0.0, 0.0): maxwidth(418.0 * 0.7): z(2)),
-            ],
-            background: None,
-            z: 50,
+            ]);
+            *state.chrome_cache.borrow_mut() = Some((chrome_key, Arc::clone(&children)));
+            children
         };
-        actors.push(title_and_banner_frame);
+        actors.push(Actor::SharedFrame {
+            align: [0.5, 0.5],
+            offset: [screen_center_x(), 46.0],
+            size: [SizeSpec::Px(0.0), SizeSpec::Px(0.0)],
+            z: 50,
+            background: None,
+            children: title_children,
+            tint: [1.0; 4],
+            blend: None,
+        });
 
         // --- SongFeatures Group ---
-        let (bpm_lo, bpm_hi) = score_info
-            .song
-            .chart_display_bpm_range(Some(&score_info.chart))
-            .unwrap_or((score_info.song.min_bpm, score_info.song.max_bpm));
-        let bpm_text = if matches!(
-            score_info.chart.display_bpm,
-            Some(deadsync_chart::ChartDisplayBpm::Random)
-        ) {
-            Arc::<str>::from("??? bpm")
+        let sf_hit = {
+            let slot = state.song_features_cache.borrow();
+            slot.as_ref().is_some_and(|(k, _)| *k == chrome_key)
+        };
+        let song_features_children: Arc<[Actor]> = if sf_hit {
+            Arc::clone(&state.song_features_cache.borrow().as_ref().unwrap().1)
         } else {
-            cached_bpm_text(bpm_lo, bpm_hi, score_info.music_rate)
-        };
-
-        let length_text = {
-            // Simply Love uses Song:MusicLengthSeconds() divided by MusicRate
-            // for this display, not the chart's last note time.
-            let base_seconds = if score_info.song.music_length_seconds.is_finite()
-                && score_info.song.music_length_seconds > 0.0
-            {
-                score_info.song.music_length_seconds
+            let (bpm_lo, bpm_hi) = score_info
+                .song
+                .chart_display_bpm_range(Some(&score_info.chart))
+                .unwrap_or((score_info.song.min_bpm, score_info.song.max_bpm));
+            let bpm_text = if matches!(
+                score_info.chart.display_bpm,
+                Some(deadsync_chart::ChartDisplayBpm::Random)
+            ) {
+                Arc::<str>::from("??? bpm")
             } else {
-                score_info.song.total_length_seconds.max(0) as f32
+                cached_bpm_text(bpm_lo, bpm_hi, score_info.music_rate)
             };
-            let rate = if score_info.music_rate.is_finite() && score_info.music_rate > 0.0 {
-                score_info.music_rate
-            } else {
-                1.0
-            };
-            let adjusted = base_seconds / rate;
-            let seconds = adjusted.round() as i32;
-            if seconds < 0 {
-                Arc::<str>::from("")
-            } else {
-                cached_song_length_text(seconds)
-            }
-        };
 
-        let song_features_frame = Actor::Frame {
-            align: [0.5, 0.5],
-            offset: [screen_center_x(), 175.0],
-            size: [SizeSpec::Px(0.0), SizeSpec::Px(0.0)],
-            children: vec![
+            let length_text = {
+                // Simply Love uses Song:MusicLengthSeconds() divided by MusicRate
+                // for this display, not the chart's last note time.
+                let base_seconds = if score_info.song.music_length_seconds.is_finite()
+                    && score_info.song.music_length_seconds > 0.0
+                {
+                    score_info.song.music_length_seconds
+                } else {
+                    score_info.song.total_length_seconds.max(0) as f32
+                };
+                let rate = if score_info.music_rate.is_finite() && score_info.music_rate > 0.0 {
+                    score_info.music_rate
+                } else {
+                    1.0
+                };
+                let adjusted = base_seconds / rate;
+                let seconds = adjusted.round() as i32;
+                if seconds < 0 {
+                    Arc::<str>::from("")
+                } else {
+                    cached_song_length_text(seconds)
+                }
+            };
+
+            let children: Arc<[Actor]> = Arc::from(vec![
                 act!(quad: align(0.5, 0.5): xy(0.0, 0.0): setsize(418.0, 16.0): zoom(0.7): diffuse(0.117, 0.157, 0.184, sl_header_alpha): z(0) ),
                 act!(text: font("miso"): settext(score_info.song.artist.clone()): align(0.0, 0.5): xy(-145.0, 0.0): zoom(0.6): maxwidth(418.0 / 3.5): z(1) ),
                 act!(text: font("miso"): settext(bpm_text): align(0.5, 0.5): xy(0.0, 0.0): zoom(0.6): maxwidth(418.0 / 0.875): z(1) ),
                 act!(text: font("miso"): settext(length_text): align(1.0, 0.5): xy(145.0, 0.0): zoom(0.6): z(1) ),
-            ],
-            background: None,
-            z: 50,
+            ]);
+            *state.song_features_cache.borrow_mut() = Some((chrome_key, Arc::clone(&children)));
+            children
         };
-        actors.push(song_features_frame);
+        actors.push(Actor::SharedFrame {
+            align: [0.5, 0.5],
+            offset: [screen_center_x(), 175.0],
+            size: [SizeSpec::Px(0.0), SizeSpec::Px(0.0)],
+            z: 50,
+            background: None,
+            children: song_features_children,
+            tint: [1.0; 4],
+            blend: None,
+        });
     }
 
     // --- Upper Content (Simply Love PerPlayer/Upper) ---

--- a/src/test_support/compose_scenarios.rs
+++ b/src/test_support/compose_scenarios.rs
@@ -1,6 +1,7 @@
 use crate::assets;
 use crate::test_support::density_graph_bench;
 use crate::test_support::density_graph_life_bench;
+use crate::test_support::evaluation_bench;
 use crate::test_support::gameplay_bench;
 use crate::test_support::gameplay_stats_bench;
 use crate::test_support::gameplay_stats_double_bench;
@@ -22,9 +23,11 @@ use deadsync_render::{BlendMode, MeshVertex, TexturedMeshVertex};
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
-const SCENARIO_NAMES: [&str; 28] = [
+const SCENARIO_NAMES: [&str; 30] = [
     density_graph_bench::SCENARIO_NAME,
     density_graph_life_bench::SCENARIO_NAME,
+    evaluation_bench::SCENARIO_NAME,
+    evaluation_bench::SCENARIO_NAME_VERSUS,
     gameplay_bench::SCENARIO_NAME,
     gameplay_stats_bench::SCENARIO_NAME,
     gameplay_stats_double_bench::SCENARIO_NAME,
@@ -105,6 +108,8 @@ pub fn build_scenario(name: &str) -> Option<ComposeScenario> {
         density_graph_life_bench::SCENARIO_NAME => {
             Some(density_graph_life_scenario(metrics, fonts))
         }
+        evaluation_bench::SCENARIO_NAME => Some(evaluation_scenario(metrics, fonts)),
+        evaluation_bench::SCENARIO_NAME_VERSUS => Some(evaluation_versus_scenario(metrics, fonts)),
         gameplay_bench::SCENARIO_NAME => Some(gameplay_scenario(metrics, fonts)),
         gameplay_stats_bench::SCENARIO_NAME => Some(gameplay_stats_scenario(metrics, fonts)),
         gameplay_stats_double_bench::SCENARIO_NAME => {
@@ -489,6 +494,33 @@ fn pane_stats_scenario(metrics: Metrics, fonts: HashMap<&'static str, Font>) -> 
         name: pane_stats_bench::SCENARIO_NAME,
         actors: fixture.build(),
         clear_color: [0.03, 0.04, 0.05, 1.0],
+        metrics,
+        fonts,
+        total_elapsed: 0.41,
+    }
+}
+
+fn evaluation_scenario(metrics: Metrics, fonts: HashMap<&'static str, Font>) -> ComposeScenario {
+    let fixture = evaluation_bench::fixture();
+    ComposeScenario {
+        name: evaluation_bench::SCENARIO_NAME,
+        actors: fixture.build(),
+        clear_color: [0.0, 0.0, 0.0, 1.0],
+        metrics,
+        fonts,
+        total_elapsed: 0.41,
+    }
+}
+
+fn evaluation_versus_scenario(
+    metrics: Metrics,
+    fonts: HashMap<&'static str, Font>,
+) -> ComposeScenario {
+    let fixture = evaluation_bench::fixture_versus();
+    ComposeScenario {
+        name: evaluation_bench::SCENARIO_NAME_VERSUS,
+        actors: fixture.build(),
+        clear_color: [0.0, 0.0, 0.0, 1.0],
         metrics,
         fonts,
         total_elapsed: 0.41,

--- a/src/test_support/evaluation_bench.rs
+++ b/src/test_support/evaluation_bench.rs
@@ -1,0 +1,168 @@
+use crate::assets::AssetManager;
+use crate::game::profile;
+use crate::screens::evaluation::{self, ScoreInfo, State};
+use crate::test_support::{compose_scenarios, pane_stats_bench};
+use deadsync_core::input::MAX_PLAYERS;
+use deadsync_present::actors::Actor;
+use deadsync_profile as profile_data;
+use deadsync_rules::timing::{HistogramMs, ScatterPoint};
+use deadsync_score::LeaderboardEntry;
+
+pub const SCENARIO_NAME: &str = "evaluation";
+pub const SCENARIO_NAME_VERSUS: &str = "evaluation-versus";
+
+const STAGE_DURATION_SECONDS: f32 = 90.0;
+const SCATTER_POINTS: usize = 1_536;
+const LIFE_SAMPLES: usize = 240;
+const LEADERBOARD_ROWS: usize = 10;
+
+/// Benchmark fixture for the full evaluation screen: it owns a fully-built
+/// `State` (via `init_from_score_info`) plus a font-seeded `AssetManager`, and
+/// `build()` produces the per-frame actor tree through `evaluation::get_actors`.
+pub struct EvaluationBenchFixture {
+    state: State,
+    asset_manager: AssetManager,
+}
+
+impl EvaluationBenchFixture {
+    pub fn build(&self) -> Vec<Actor> {
+        evaluation::get_actors(&self.state, &self.asset_manager)
+    }
+}
+
+/// Single-player evaluation scenario (default Standard pane), the common hot path.
+pub fn fixture() -> EvaluationBenchFixture {
+    profile::set_session_play_style(profile_data::PlayStyle::Single);
+    profile::set_session_player_side(profile_data::PlayerSide::P1);
+    profile::set_session_joined(true, false);
+
+    let mut score_info: [Option<ScoreInfo>; MAX_PLAYERS] = std::array::from_fn(|_| None);
+    score_info[0] = Some(heavy_score_info(profile_data::PlayerSide::P1));
+
+    let state = evaluation::init_from_score_info(score_info, STAGE_DURATION_SECONDS);
+    EvaluationBenchFixture {
+        state,
+        asset_manager: bench_asset_manager(),
+    }
+}
+
+/// Versus evaluation scenario (two players), the heaviest configuration.
+pub fn fixture_versus() -> EvaluationBenchFixture {
+    profile::set_session_play_style(profile_data::PlayStyle::Versus);
+    profile::set_session_player_side(profile_data::PlayerSide::P1);
+    profile::set_session_joined(true, true);
+
+    let mut score_info: [Option<ScoreInfo>; MAX_PLAYERS] = std::array::from_fn(|_| None);
+    score_info[0] = Some(heavy_score_info(profile_data::PlayerSide::P1));
+    score_info[1] = Some(heavy_score_info(profile_data::PlayerSide::P2));
+
+    let state = evaluation::init_from_score_info(score_info, STAGE_DURATION_SECONDS);
+    EvaluationBenchFixture {
+        state,
+        asset_manager: bench_asset_manager(),
+    }
+}
+
+fn bench_asset_manager() -> AssetManager {
+    let mut asset_manager = AssetManager::new();
+    for (name, font) in compose_scenarios::bench_fonts() {
+        asset_manager.register_font(name, font);
+    }
+    asset_manager
+}
+
+/// Realistic, heavy `ScoreInfo`: starts from the shared pane-stats fixture and
+/// fills in the scatter plot, timing histogram, life graph, and machine/personal
+/// leaderboards so the whole screen renders representative content.
+fn heavy_score_info(side: profile_data::PlayerSide) -> ScoreInfo {
+    let mut si = pane_stats_bench::bench_score_info();
+    si.side = side;
+    si.profile_name = match side {
+        profile_data::PlayerSide::P1 => "BenchPlayer1",
+        profile_data::PlayerSide::P2 => "BenchPlayer2",
+    }
+    .to_string();
+
+    si.scatter = bench_scatter();
+    si.scatter_worst_window_ms = 90.0;
+    si.histogram = bench_histogram();
+    si.life_history = bench_life_history();
+
+    si.machine_records = bench_leaderboard(side, true);
+    si.machine_record_highlight_rank = Some(3);
+    si.personal_records = bench_leaderboard(side, false);
+    si.personal_record_highlight_rank = Some(1);
+    si.show_machine_personal_split = true;
+
+    si
+}
+
+fn bench_scatter() -> Vec<ScatterPoint> {
+    (0..SCATTER_POINTS)
+        .map(|i| {
+            let t = i as f32 / SCATTER_POINTS as f32;
+            // Deterministic pseudo-random offset spread in roughly [-30, 30] ms.
+            let phase = (i as f32 * 0.61803398875).fract();
+            let offset = (phase - 0.5) * 60.0;
+            let is_miss = i % 97 == 0;
+            ScatterPoint {
+                time_sec: t * 128.0,
+                offset_ms: if is_miss { None } else { Some(offset) },
+                direction_code: (i % 4 + 1) as u8,
+                is_stream: i % 3 == 0,
+                is_left_foot: i % 2 == 0,
+                miss_because_held: false,
+            }
+        })
+        .collect()
+}
+
+fn bench_histogram() -> HistogramMs {
+    let mut bins: Vec<(i32, u32)> = Vec::with_capacity(91);
+    let mut smoothed: Vec<(i32, f32)> = Vec::with_capacity(91);
+    let mut max_count = 0u32;
+    for bin in -45i32..=45 {
+        // Triangular-ish distribution peaking at 0ms.
+        let count = (46 - bin.unsigned_abs() as i32).max(0) as u32 * 12;
+        max_count = max_count.max(count);
+        bins.push((bin, count));
+        smoothed.push((bin, count as f32 * 0.95));
+    }
+    HistogramMs {
+        bins,
+        smoothed,
+        max_count,
+        worst_observed_ms: 44.0,
+        worst_window_ms: 45.0,
+    }
+}
+
+fn bench_life_history() -> Vec<(f32, f32)> {
+    (0..LIFE_SAMPLES)
+        .map(|i| {
+            let t = i as f32 / LIFE_SAMPLES as f32 * 128.0;
+            let life = 0.5 + 0.5 * (i as f32 * 0.13).sin();
+            (t, life.clamp(0.0, 1.0))
+        })
+        .collect()
+}
+
+fn bench_leaderboard(side: profile_data::PlayerSide, machine: bool) -> Vec<LeaderboardEntry> {
+    let self_rank = if machine { 3 } else { 1 };
+    let tag_prefix = match side {
+        profile_data::PlayerSide::P1 => "AAA",
+        profile_data::PlayerSide::P2 => "BBB",
+    };
+    (1..=LEADERBOARD_ROWS as u32)
+        .map(|rank| LeaderboardEntry {
+            rank,
+            name: format!("{tag_prefix}{rank:02}"),
+            machine_tag: Some(format!("{tag_prefix}")),
+            score: 99.5 - rank as f64 * 0.37,
+            date: "2025-01-01".to_string(),
+            is_rival: rank % 4 == 0,
+            is_self: rank == self_rank,
+            is_fail: false,
+        })
+        .collect()
+}

--- a/src/test_support/mod.rs
+++ b/src/test_support/mod.rs
@@ -2,6 +2,7 @@ pub mod compose_case;
 pub mod compose_scenarios;
 pub mod density_graph_bench;
 pub mod density_graph_life_bench;
+pub mod evaluation_bench;
 pub mod gameplay_bench;
 pub mod gameplay_stats_bench;
 pub mod gameplay_stats_double_bench;

--- a/src/test_support/pane_stats_bench.rs
+++ b/src/test_support/pane_stats_bench.rs
@@ -49,7 +49,7 @@ pub fn fixture() -> PaneStatsBenchFixture {
     }
 }
 
-fn bench_score_info() -> ScoreInfo {
+pub fn bench_score_info() -> ScoreInfo {
     let song = Arc::new(bench_song());
     let chart = Arc::new(song.charts[0].clone());
     let judgment_counts = [28_904, 2_318, 481, 53, 7, 1];

--- a/tests/compose/bench.rs
+++ b/tests/compose/bench.rs
@@ -18,7 +18,19 @@ use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
+#[cfg(not(feature = "dhat-heap"))]
 #[global_allocator]
+static ALLOC: CountingAlloc = CountingAlloc::new();
+
+// When profiling allocations, DHAT must be THE global allocator. `ALLOC` stays as a
+// (non-global) static so the existing `ALLOC.begin_measurement()`/`.snapshot()` call
+// sites keep compiling; their counters just read zero in this mode (we don't print
+// the deterministic alloc block when DHAT is active).
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static DHAT_ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[cfg(feature = "dhat-heap")]
 static ALLOC: CountingAlloc = CountingAlloc::new();
 
 struct CountingAlloc {
@@ -269,6 +281,12 @@ fn update_peak(slot: &AtomicU64, value: u64) {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
+    // Profiles every allocation from here to program exit; writes dhat-heap.json on
+    // drop. Setup/fixture allocs land under distinct backtraces from the per-iter
+    // actor path, so the hot sites still rank by total bytes/blocks.
+    #[cfg(feature = "dhat-heap")]
+    let _dhat_profiler = dhat::Profiler::new_heap();
+
     deadsync::assets::i18n::init("en");
     let args = parse_args()?;
     if args.case_path.is_none()

--- a/tests/compose/bench.rs
+++ b/tests/compose/bench.rs
@@ -5,6 +5,7 @@ use deadsync::test_support::{
     gameplay_stats_bench, gameplay_stats_double_bench, gameplay_stats_versus_bench,
     gs_scorebox_bench, init_bench, menu_bench, music_wheel_bench, notefield_bench, options_bench,
     pane_stats_bench, player_options_bench, visual_style_bg_bench,
+    evaluation_bench,
 };
 use deadsync_present::actors::Actor;
 use deadsync_present::compose;
@@ -526,6 +527,34 @@ fn run_named(args: &Args, name: &str) -> Result<BenchmarkResult, Box<dyn Error>>
                     || fixture.build(),
                 )
             }
+            evaluation_bench::SCENARIO_NAME => {
+                let fixture = evaluation_bench::fixture();
+                benchmark_actor_builder(
+                    scenario.name,
+                    scenario.clear_color,
+                    &scenario.metrics,
+                    &scenario.fonts,
+                    scenario.total_elapsed,
+                    args.iters,
+                    args.warmup,
+                    args.cache_mode,
+                    || fixture.build(),
+                )
+            }
+            evaluation_bench::SCENARIO_NAME_VERSUS => {
+                let fixture = evaluation_bench::fixture_versus();
+                benchmark_actor_builder(
+                    scenario.name,
+                    scenario.clear_color,
+                    &scenario.metrics,
+                    &scenario.fonts,
+                    scenario.total_elapsed,
+                    args.iters,
+                    args.warmup,
+                    args.cache_mode,
+                    || fixture.build(),
+                )
+            }
             player_options_bench::SCENARIO_NAME => {
                 let fixture = player_options_bench::fixture();
                 benchmark_actor_builder(
@@ -540,7 +569,7 @@ fn run_named(args: &Args, name: &str) -> Result<BenchmarkResult, Box<dyn Error>>
                     || fixture.build(args.cache_mode.retains_actor_data()),
                 )
             }
-            _ => Err("actors phase currently only supports --scenario music-wheel, density-graph, density-graph-life, gameplay, gameplay-stats, gameplay-stats-double, gameplay-stats-versus, gs-scorebox, visual-style-bg, init, menu, notefield, options, pane-stats, or player-options".into()),
+            _ => Err("actors phase currently only supports --scenario music-wheel, density-graph, density-graph-life, evaluation, evaluation-versus, gameplay, gameplay-stats, gameplay-stats-double, gameplay-stats-versus, gs-scorebox, visual-style-bg, init, menu, notefield, options, pane-stats, or player-options".into()),
         },
         Phase::Compose => benchmark_compose(
             scenario.name,


### PR DESCRIPTION
## Why

The evaluation (results) screen rebuilds its entire actor tree and render-object list every frame. This PR works through that hot path methodically, with a benchmark harness so every change is measured individually and kept only if it actually helps, without changing what appears on screen.

## Results at a glance

| Phase | Metric | Before | After | Change |
| --- | --- | --- | --- | --- |
| Actor build, single | build time | 39.6 us | 19.6 us | -50% |
| Actor build, versus | build time | 87.1 us | 27.2 us | -69% |
| Actor build, single | allocations / frame | 99.6 | 34.5 | -65% |
| Actor build, versus | allocations / frame | 132.6 | 44.6 | -66% |
| Compose, single | compose time | 45.8 us | 33.6 us | -27% |
| Compose, versus | compose time | ~80 us | 60.6 us | ~-25% |

All measured with the new `compose_bench` evaluation scenarios. Actor-build build-time figures are from LTO builds (the shipped config); the later allocation trims and the compose figures are LTO-off A/B runs (5 repetitions, non-overlapping distributions). The per-frame compose object count (686 single / 1252 versus) and the within-run actors-vs-compose verification hash are unchanged throughout, and the existing unit tests pass.

## Approach

Added full-screen `evaluation` / `evaluation-versus` scenarios to `compose_bench` (plus an optional, feature-gated DHAT heap profiler) and used them to drive targeted, individually-measured optimizations.

### Actor-build phase

- Memoize static subtrees as cached `Arc<[Actor]>` emitted via `SharedFrame`: the per-player graph subtree (~240 quads) and the title/banner + song-features chrome. The graph memoization is the single biggest win: build time 39.6 -> 19.6 us single (-50%) and 87.1 -> 27.2 us versus (-69%) versus the original baseline.
- DHAT-guided allocation trims: narrow a full `Profile` struct clone down to the two fields the footer actually uses, and rewrite the "Nice" (69) easter-egg predicate to be allocation-free. These cut allocations from ~90.5 to 47.5 / frame single (-47.5%) and ~120.6 to 60.6 versus (-49.8%), worth about -8.9% / -6.4% additional build time (LTO-off A/B, non-overlapping).
- Route static `&'static str` texture keys through a zero-alloc `sprite_static` path (shared background + grade stars), removing a per-sprite `Arc<str>` allocation that also affected every other screen (-10 allocations / frame on the background alone, about -4.2% / -4.9% build time).

End to end, per-frame allocations on the actor build drop about 65% (single) / 66% (versus), and the build is roughly 2-3x faster.

### Compose phase (and a flaky crash)

While profiling compose I hit an intermittent crash: twox-hash's `XxHash64` panicking with a corrupted buffer index. The root cause was a build-context-specific miscompile in the `lto=off` benchmark build: a freshly constructed hasher read an uninitialized `offset` field (the `const fn` init was being elided), so `&bytes[..offset]` ran past its 32-byte buffer. The shipped app builds with `lto=true` and was never affected, which is why it was never seen in practice.

A CPU profile showed this hashing was about 21% of the compose phase (three `HashMap<usize, _>` texture caches hashing pointer keys with `XxHash64`). Switching every compose-internal hash map and key/fingerprint function to `rustc_hash::FxHasher` sidesteps the miscompiled streaming-buffer code shape entirely. That fixed the crash (0 panics across 100+ high-iteration stress runs, versus roughly 1 in 6 to 1 in 40 before) and sped up the compose phase about 27% (45.8 -> 33.6 us single, ~80 -> 60.6 us versus).