### PR TITLE
fix(gameplay): strip username from ITL unlock pack event footer

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -456,11 +456,13 @@ fn itl_event_intro_name(pack_group: &str) -> Option<String> {
         return None;
     }
 
-    const UNLOCKS_SUFFIX: &str = " unlocks";
-    let name = if lower.ends_with(UNLOCKS_SUFFIX) {
-        &name[..name.len().saturating_sub(UNLOCKS_SUFFIX.len())]
-    } else {
-        name
+    // Personal ITL unlock packs are named "ITL Online <year> Unlocks - <username>".
+    // Cut everything from the " Unlocks" marker onward (including any trailing
+    // "- <username>") so the footer shows just the event name, e.g. "ITL Online 2026".
+    const UNLOCKS_MARKER: &str = " unlocks";
+    let name = match lower.find(UNLOCKS_MARKER) {
+        Some(idx) => &name[..idx],
+        None => name,
     };
     Some(name.trim().to_string())
 }
@@ -10463,6 +10465,17 @@ mod tests {
     fn gameplay_event_intro_strips_itl_unlocks_suffix() {
         let song = test_song(
             "Songs/ITL Online 2026 Unlocks/Example/song.ssc",
+            0.0,
+            ["hard", "medium"],
+        );
+
+        assert_eq!(gameplay_event_intro_text(&song).as_ref(), "ITL Online 2026");
+    }
+
+    #[test]
+    fn gameplay_event_intro_strips_itl_unlocks_username_suffix() {
+        let song = test_song(
+            "Songs/ITL Online 2026 Unlocks - iamchris4life/Example/song.ssc",
             0.0,
             ["hard", "medium"],
         );


### PR DESCRIPTION
## Why

Personal ITL unlock packs are foldered as ITL Online <year> Unlocks - <username>. On the gameplay screen, the persistent Stage/Event footer rendered the full folder name across the bottom of the playfield, so a player's unlock handle (e.g. IAMCHRIS4LIFE) ended up plastered under the notefield. The intended footer for these packs is just the event name, ITL Online 2026.

## What changed

itl_event_intro_name (in src/app/mod.rs) only stripped a *trailing* ` Unlocks`. Personal-unlock folders end with the username instead, so nothing was stripped and the whole name was shown (uppercased by the header font).

The fix cuts everything from the ` Unlocks` marker onward, so both ITL Online 2026 Unlocks and ITL Online 2026 Unlocks - iamchris4life resolve to ITL Online 2026. This feeds the existing gameplay_event_intro_text path that drives both the intro flash and the persistent footer.