### PR TITLE
fix(ci): sync Cargo.lock deadsync-version to 0.4.745

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "deadsync-version"
-version = "0.4.737"
+version = "0.4.745"
 dependencies = [
  "log",
  "semver",


### PR DESCRIPTION
## Problem
Every job in the `release-all` run failed at the **Build release** step on all platforms (Linux, FreeBSD, macOS, Windows) with:

```
error: cannot update the lock file Cargo.lock because --locked was passed to prevent this
```

Release builds run `cargo build --locked`, which refuses to compile when `Cargo.lock` is out of sync with `Cargo.toml`.

## Root cause
The version bump to `0.4.745` updated `Cargo.lock` for only the top-level `deadsync` package entry. The workspace has a second member that inherits the version via `version.workspace = true` — the `crates/deadsync-version` path crate — and its lock entry was left at `0.4.737`. With the lockfile partially updated, `--locked` blocked the build before compilation.

## Fix
Ran a targeted `cargo update -p deadsync-version` so only that entry is corrected (avoids pulling in unrelated registry crate bumps). Verified `cargo tree --locked` now succeeds.

```diff
 name = "deadsync-version"
-version = "0.4.737"
+version = "0.4.745"
```

One-line change to `Cargo.lock`.