### PR TITLE
perf(menu): cut per-frame compose allocations on title menu

### DIFF
--- a/src/screens/components/menu/logo.rs
+++ b/src/screens/components/menu/logo.rs
@@ -2,6 +2,32 @@ use crate::act;
 use crate::assets;
 use deadsync_present::actors::Actor;
 use deadsync_present::space::screen_center_x;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+// Cached logo aspect ratio (w/h). The logo texture never changes size at
+// runtime, so it is resolved once and reused. A stored value of 0 means "not
+// yet resolved"; the 1x1 fallback is never cached.
+static LOGO_ASPECT_BITS: AtomicU32 = AtomicU32::new(0);
+
+fn logo_aspect() -> f32 {
+    let cached = f32::from_bits(LOGO_ASPECT_BITS.load(Ordering::Relaxed));
+    if cached > 0.0 {
+        return cached;
+    }
+    let Some(dims) = assets::texture_dims("logo.png") else {
+        return 1.0;
+    };
+    if dims.h == 0 {
+        return 1.0;
+    }
+    let aspect = dims.w as f32 / dims.h as f32;
+    // Only memoize a real measurement, not the 1x1 placeholder dimensions that
+    // the asset system may report before the texture is loaded.
+    if dims.w > 1 || dims.h > 1 {
+        LOGO_ASPECT_BITS.store(aspect.to_bits(), Ordering::Relaxed);
+    }
+    aspect
+}
 
 /// Parameters to tweak the layout easily.
 #[derive(Clone, Copy, Debug)]
@@ -25,13 +51,16 @@ impl Default for LogoParams {
 /// Build the “banner inside logo” stack with the actor DSL.
 /// Returns a `Vec<Actor>` to be included in a screen's actor list.
 pub fn build_logo(params: LogoParams) -> Vec<Actor> {
-    // Get logo's native dimensions from the asset system, with a safe fallback.
-    let logo_dims = assets::texture_dims("logo.png").unwrap_or(assets::TexMeta { w: 1, h: 1 });
-    let logo_aspect = if logo_dims.h > 0 {
-        logo_dims.w as f32 / logo_dims.h as f32
-    } else {
-        1.0
-    };
+    let mut out = Vec::with_capacity(2);
+    push_logo(&mut out, params, 1.0);
+    out
+}
+
+/// Append the “banner inside logo” stack directly into `out`, scaling each
+/// sprite's alpha by `alpha_multiplier`.
+pub fn push_logo(out: &mut Vec<Actor>, params: LogoParams, alpha_multiplier: f32) {
+    // Resolve the logo's display size from its (cached) native aspect ratio.
+    let logo_aspect = logo_aspect();
 
     // Calculate the final display width of the logo based on the target height and true aspect ratio.
     let logo_h = params.target_h;
@@ -43,25 +72,31 @@ pub fn build_logo(params: LogoParams) -> Vec<Actor> {
     // The dance banner will be centered vertically within the logo's final height.
     let dance_center_y = 0.5f32.mul_add(logo_h, logo_top_y) - params.banner_y_offset_inside;
 
-    vec![
-        // The dance banner's width is constrained to the logo's width.
-        // `zoomtowidth` will automatically calculate its height while preserving its aspect ratio.
-        act!(sprite("dance.png"):
-            align(0.5, 0.5):
-            xy(center_x, dance_center_y):
-            zoomtowidth(logo_w)
-        ),
-        // The logo's height is set directly.
-        // `zoomtoheight` will automatically calculate its width while preserving its aspect ratio.
-        act!(sprite("logo.png"):
-            align(0.5, 0.0):
-            xy(center_x, logo_top_y):
-            zoomtoheight(logo_h)
-        ),
-    ]
+    out.reserve(2);
+    // The dance banner's width is constrained to the logo's width.
+    // `zoomtowidth` will automatically calculate its height while preserving its aspect ratio.
+    out.push(act!(sprite("dance.png"):
+        align(0.5, 0.5):
+        xy(center_x, dance_center_y):
+        zoomtowidth(logo_w):
+        diffuse(1.0, 1.0, 1.0, alpha_multiplier)
+    ));
+    // The logo's height is set directly.
+    // `zoomtoheight` will automatically calculate its width while preserving its aspect ratio.
+    out.push(act!(sprite("logo.png"):
+        align(0.5, 0.0):
+        xy(center_x, logo_top_y):
+        zoomtoheight(logo_h):
+        diffuse(1.0, 1.0, 1.0, alpha_multiplier)
+    ));
 }
 
 /// Convenience: build with default params.
 pub fn build_logo_default() -> Vec<Actor> {
     build_logo(LogoParams::default())
+}
+
+/// Convenience: append with default params and an alpha multiplier.
+pub fn push_logo_default(out: &mut Vec<Actor>, alpha_multiplier: f32) {
+    push_logo(out, LogoParams::default(), alpha_multiplier);
 }

--- a/src/screens/components/menu/menu_list.rs
+++ b/src/screens/components/menu/menu_list.rs
@@ -26,6 +26,13 @@ pub struct MenuParams<'a> {
 /// Build a vertical, center-aligned menu with focus-based sizing and color.
 pub fn build_vertical_menu(p: MenuParams) -> Vec<Actor> {
     let mut out = Vec::with_capacity(p.options.len());
+    push_vertical_menu(&mut out, p);
+    out
+}
+
+/// Append a vertical, center-aligned menu directly into `out`.
+pub fn push_vertical_menu(out: &mut Vec<Actor>, p: MenuParams) {
+    out.reserve(p.options.len());
     let center_x = screen_center_x();
 
     for (i, label) in p.options.iter().enumerate() {
@@ -57,5 +64,4 @@ pub fn build_vertical_menu(p: MenuParams) -> Vec<Actor> {
             horizalign(center)
         ));
     }
-    out
 }

--- a/src/screens/menu.rs
+++ b/src/screens/menu.rs
@@ -108,8 +108,40 @@ pub struct State {
     info_text_cache: RefCell<Option<(Option<String>, Arc<str>)>>,
     groovestats_text_cache: RefCell<Option<StatusTextCache<GrooveStatusKey, 3>>>,
     arrowcloud_text_cache: RefCell<Option<StatusTextCache<ArrowCloudStatusKey, 1>>>,
+    label_cache: RefCell<Option<MenuLabelCache>>,
     menu_lr_chord: screen_input::MenuLrChordTracker,
     menu_lr_undo: [i8; 2],
+}
+
+// Translated, frame-invariant menu/footer strings. These only change when the
+// active language changes, so they are cached and invalidated alongside the
+// other render caches via the i18n revision check.
+#[derive(Clone)]
+struct MenuLabelCache {
+    menu_labels: [Arc<str>; OPTION_COUNT],
+    event_mode: Arc<str>,
+    press_start: Arc<str>,
+}
+
+fn build_menu_label_cache() -> MenuLabelCache {
+    MenuLabelCache {
+        menu_labels: [
+            tr("Menu", "Gameplay"),
+            tr("Menu", "Options"),
+            tr("Menu", "Exit"),
+        ],
+        event_mode: tr("Common", "EventMode"),
+        press_start: tr("Common", "PressStart"),
+    }
+}
+
+fn menu_labels(state: &State) -> MenuLabelCache {
+    if let Some(cache) = state.label_cache.borrow().as_ref() {
+        return cache.clone();
+    }
+    let cache = build_menu_label_cache();
+    *state.label_cache.borrow_mut() = Some(cache.clone());
+    cache
 }
 
 pub fn init() -> State {
@@ -123,6 +155,7 @@ pub fn init() -> State {
         info_text_cache: RefCell::new(None),
         groovestats_text_cache: RefCell::new(None),
         arrowcloud_text_cache: RefCell::new(None),
+        label_cache: RefCell::new(None),
         menu_lr_chord: screen_input::MenuLrChordTracker::default(),
         menu_lr_undo: [0; 2],
     }
@@ -163,6 +196,7 @@ pub fn clear_render_cache(state: &State) {
     *state.info_text_cache.borrow_mut() = None;
     *state.groovestats_text_cache.borrow_mut() = None;
     *state.arrowcloud_text_cache.borrow_mut() = None;
+    *state.label_cache.borrow_mut() = None;
 }
 
 fn sync_i18n_cache(state: &State) {
@@ -414,13 +448,7 @@ pub fn push_actors(actors: &mut Vec<Actor>, state: &State, alpha_multiplier: f32
     let info2_y_tl = lp.top_margin - INFO_MARGIN_ABOVE - INFO_PX;
     let info1_y_tl = info2_y_tl - INFO_PX - INFO_GAP;
 
-    let logo_actors = logo::build_logo_default();
-    for mut actor in logo_actors {
-        if let Actor::Sprite { tint, .. } = &mut actor {
-            tint[3] *= alpha_multiplier;
-        }
-        actors.push(actor);
-    }
+    logo::push_logo_default(actors, alpha_multiplier);
 
     let mut info_color = [1.0, 1.0, 1.0, 1.0];
     info_color[3] *= alpha_multiplier;
@@ -438,15 +466,11 @@ pub fn push_actors(actors: &mut Vec<Actor>, state: &State, alpha_multiplier: f32
     selected[3] *= alpha_multiplier;
     normal[3] *= alpha_multiplier;
 
-    let menu_labels = [
-        tr("Menu", "Gameplay"),
-        tr("Menu", "Options"),
-        tr("Menu", "Exit"),
-    ];
+    let labels = menu_labels(state);
 
     // --- UPDATED PARAMS FOR THE NEW MENU LIST BUILDER ---
     let params = menu_list::MenuParams {
-        options: &menu_labels,
+        options: &labels.menu_labels,
         selected_index: state.selected_index,
         start_center_y: base_y,
         row_spacing: MENU_ROW_SPACING,
@@ -454,22 +478,20 @@ pub fn push_actors(actors: &mut Vec<Actor>, state: &State, alpha_multiplier: f32
         normal_color: normal,
         font: current_machine_font_key(FontRole::Bold),
     };
-    actors.extend(menu_list::build_vertical_menu(params));
+    menu_list::push_vertical_menu(actors, params);
 
     // --- footer bar ---
     let mut footer_fg = [1.0, 1.0, 1.0, 1.0];
     footer_fg[3] *= alpha_multiplier;
-    let event_mode = tr("Common", "EventMode");
-    let press_start = tr("Common", "PressStart");
 
     actors.push(screen_bar::build_title_menu(screen_bar::ScreenBarParams {
-        title: event_mode.as_ref(),
+        title: labels.event_mode.as_ref(),
         title_placement: screen_bar::ScreenBarTitlePlacement::Center,
         position: screen_bar::ScreenBarPosition::Bottom,
         transparent: true,
-        left_text: Some(press_start.as_ref()),
+        left_text: Some(labels.press_start.as_ref()),
         center_text: None,
-        right_text: Some(press_start.as_ref()),
+        right_text: Some(labels.press_start.as_ref()),
         left_avatar: None,
         right_avatar: None,
         fg_color: footer_fg,


### PR DESCRIPTION
## Why

The title menu rebuilds its full actor list every frame in `menu::push_actors`. A few helpers on that hot path allocated throwaway data each frame: the logo and vertical-menu builders each returned a fresh `Vec<Actor>` that was immediately copied into the caller's vec, the logo aspect ratio was recomputed via a string-keyed `texture_dims` lookup every frame, and the menu/footer labels called `tr()` (lock + hashmap lookups) on every frame even though they only change with the active language.

## What changed

- **Logo** (`logo.rs`): added `push_logo_default(out, alpha)` that appends sprites directly into the caller's vec, and memoized the logo aspect ratio in an atomic (resolved once; the 1x1 placeholder is never cached).
- **Menu list** (`menu_list.rs`): added `push_vertical_menu(out, params)` that appends directly instead of returning a `Vec` that gets `extend`ed in.
- **Menu screen** (`menu.rs`): cache the translated menu labels (Gameplay/Options/Exit) and footer strings (EventMode/PressStart) as `Arc<str>` in `State`, invalidated alongside the existing render caches via the i18n revision check.

The existing `build_logo*` / `build_vertical_menu` functions are kept as thin wrappers.

## Results

Measured with the existing `menu` compose benchmark (`tests/compose/bench.rs`), steady-state `retained` mode:

| metric | before | after |
|---|---|---|
| allocs/iter | 3.001 | 1.001 |
| bytes/iter | 3602.9 | 1602.9 (-55%) |
| time/iter | 1.949us | 1.718us (-12%) |

`fresh` mode also drops 2 allocs and 2000 bytes/iter. The benchmark's verify step reports identical actor and compose hashes before and after, so the output is byte-for-byte unchanged: no visual or behavioral difference.