### PR TITLE
options: const-fold literal render colors

### DIFF
--- a/src/screens/options/render.rs
+++ b/src/screens/options/render.rs
@@ -473,11 +473,14 @@ pub fn push_actors(
     /* --------------------------- MAIN CONTENT UI -------------------------- */
 
     // --- global colors ---
-    let col_active_bg = color::rgba_hex("#333333"); // active bg for normal rows
+    const COL_ACTIVE_BG: [f32; 4] = color::rgba_hex("#333333"); // active bg for normal rows
 
     // inactive bg = #071016 @ 0.8 alpha
-    let base_inactive = color::rgba_hex("#071016");
-    let col_inactive_bg: [f32; 4] = [base_inactive[0], base_inactive[1], base_inactive[2], 0.8];
+    const BASE_INACTIVE: [f32; 4] = color::rgba_hex("#071016");
+    const COL_INACTIVE_BG: [f32; 4] =
+        [BASE_INACTIVE[0], BASE_INACTIVE[1], BASE_INACTIVE[2], 0.8];
+    let col_active_bg = COL_ACTIVE_BG;
+    let col_inactive_bg = COL_INACTIVE_BG;
 
     let col_white = [1.0, 1.0, 1.0, 1.0];
     let col_black = [0.0, 0.0, 0.0, 1.0];
@@ -739,7 +742,8 @@ pub fn push_actors(
                 // Active text color for submenu rows.
                 let col_active_text = color::simply_love_rgba(state.active_color_index);
                 // Inactive option text color should be #808080 (alpha 1.0), match player options.
-                let sl_gray = color::rgba_hex("#808080");
+                const SL_GRAY: [f32; 4] = color::rgba_hex("#808080");
+                let sl_gray = SL_GRAY;
 
                 let total_rows = visible_rows.len() + 1; // + Exit row
 


### PR DESCRIPTION
Const-fold the literal hex background/text colors in `options::push_actors` so they are parsed at compile time instead of on every frame.