### PR TITLE
ci: install libudev-dev in translation status workflow

### DIFF
--- a/.github/workflows/update-translation-status.yml
+++ b/.github/workflows/update-translation-status.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev pkg-config
+
       - name: Cache cargo
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
## Why

The `update-translation-status` workflow has been failing on `main`. The `Generate TRANSLATION_STATUS.md` step panics with exit code 101 and `Unable to find libudev`.

## Root cause

The step runs `cargo run --bin lang_coverage`, and that binary depends on the full `deadsync` crate (it uses `deadsync::config::SimpleIni`). The crate's dependency graph pulls in `hidapi` on Linux, whose build script requires the `libudev` system library. The GitHub-hosted `ubuntu-latest` runner does not ship `libudev-dev`, so the build fails before the markdown report can be generated.

## Fix

Add a step that installs `libudev-dev` and `pkg-config` via apt before the cargo build runs, so `hidapi`'s build script can locate `libudev.pc`. This mirrors how the Linux release build already provides the dependency (inside its Debian container). No application code changes.