### PR TITLE
Extend long-term (blue) error bar intensity range to 4.0x

### DIFF
--- a/crates/deadsync-profile/src/lib.rs
+++ b/crates/deadsync-profile/src/lib.rs
@@ -36,7 +36,7 @@ pub const TILT_THRESHOLD_MAX_MS: u32 = 100;
 pub const TILT_MIN_THRESHOLD_DEFAULT_MS: u32 = 0;
 pub const TILT_MAX_THRESHOLD_DEFAULT_MS: u32 = 50;
 pub const LONG_ERROR_BAR_INTENSITY_MIN: f32 = 1.0;
-pub const LONG_ERROR_BAR_INTENSITY_MAX: f32 = 2.0;
+pub const LONG_ERROR_BAR_INTENSITY_MAX: f32 = 4.0;
 pub const LONG_ERROR_BAR_INTENSITY_STEP: f32 = 0.25;
 pub const LONG_ERROR_BAR_INTENSITY_DEFAULT: f32 = 2.0;
 pub const AVERAGE_ERROR_BAR_INTENSITY_MIN: f32 = 1.0;
@@ -6113,7 +6113,7 @@ mod tests {
             / LONG_ERROR_BAR_INTENSITY_STEP)
             .round() as usize
             + 1;
-        assert_eq!(count, 5);
+        assert_eq!(count, 13);
     }
 
     #[test]


### PR DESCRIPTION
## Why

The Long-term (blue) Average error bar tick can be visually amplified so smaller timing drifts are easier to spot. The multiplier was previously capped at 2.0x, which limits how much players can exaggerate the tick. This raises the ceiling for players who want a more pronounced long-term drift indicator.

## What

- Raise `LONG_ERROR_BAR_INTENSITY_MAX` from `2.0` to `4.0` in `crates/deadsync-profile/src/lib.rs`.

The supported range is now 1.0x - 4.0x in 0.25 steps (13 options). Everything downstream (the player-options choice list, clamping, and profile serialization) is derived from these constants, so no other code needed changing. The grid-count unit test assertion was updated from 5 to 13 to match the wider range.