### PR TITLE
fix(select-music): resolve song-wheel deadlock when scrolling songs

### DIFF
--- a/src/game/scores.rs
+++ b/src/game/scores.rs
@@ -3274,4 +3274,95 @@ mod tests {
             Instant::now(),
         ));
     }
+
+    #[test]
+    fn wheel_score_read_does_not_deadlock_with_leaderboard_worker() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::mpsc;
+
+        let profile_id = "test-deadlock-wheel-profile";
+        let chart_hash = "feedface";
+        let seeded = CachedScore {
+            grade: Grade::Tier01,
+            score_percent: 0.9123,
+            lamp_index: Some(2),
+            lamp_judge_count: Some(7),
+        };
+        // Seed every cache the read path consults so it never hits disk and the
+        // `ensure_*_loaded` helpers become no-ops during the run.
+        seed_session_local_itg_score(profile_id, chart_hash, seeded);
+        seed_session_gs_score(profile_id, chart_hash, seeded);
+        ensure_ac_score_cache_loaded_for_profile(profile_id);
+
+        let stop = Arc::new(AtomicBool::new(false));
+
+        // Worker: reproduce the pre-fix lock order
+        // (`PLAYER_LEADERBOARD_CACHE -> LOCAL -> GS -> AC`). If the wheel read
+        // ever again held a score cache across the leaderboard lock, this
+        // ordering would close the cycle and deadlock.
+        let worker_stop = Arc::clone(&stop);
+        let worker = std::thread::spawn(move || {
+            while !worker_stop.load(Ordering::Relaxed) {
+                let lb = PLAYER_LEADERBOARD_CACHE.lock().unwrap();
+                let local = LOCAL_SCORE_CACHE.lock().unwrap();
+                let gs = GS_SCORE_CACHE.lock().unwrap();
+                let ac = AC_SCORE_CACHE.lock().unwrap();
+                drop((ac, gs, local, lb));
+            }
+        });
+
+        // Wheel: the fixed read path, hammered on a watchdog-guarded thread.
+        const ITERS: usize = 20_000;
+        let (done_tx, done_rx) = mpsc::channel();
+        let wheel_profile = profile_id.to_string();
+        let wheel_chart = chart_hash.to_string();
+        let wheel = std::thread::spawn(move || {
+            let mut last = None;
+            for _ in 0..ITERS {
+                last = get_cached_score_with_profile(&wheel_chart, &wheel_profile);
+            }
+            let _ = done_tx.send(last);
+        });
+
+        let result = done_rx.recv_timeout(std::time::Duration::from_secs(30));
+        stop.store(true, Ordering::Relaxed);
+
+        match result {
+            Ok(last) => {
+                wheel.join().expect("wheel thread panicked");
+                worker.join().expect("worker thread panicked");
+                assert_eq!(
+                    last,
+                    Some(seeded),
+                    "wheel read returned an unexpected merged score"
+                );
+            }
+            Err(_) => {
+                // The wheel thread is blocked on a lock; joining would hang, so
+                // we deliberately leak it and fail loudly. This is the deadlock.
+                panic!(
+                    "song-wheel score read deadlocked against the leaderboard worker \
+                     no progress within 30s"
+                );
+            }
+        }
+
+        // Leave the shared caches clean for other tests in this process.
+        LOCAL_SCORE_CACHE
+            .lock()
+            .unwrap()
+            .loaded_profiles
+            .remove(profile_id);
+        GS_SCORE_CACHE
+            .lock()
+            .unwrap()
+            .loaded_profiles
+            .remove(profile_id);
+        AC_SCORE_CACHE
+            .lock()
+            .unwrap()
+            .loaded_profiles
+            .remove(profile_id);
+    }
 }

--- a/src/screens/components/select_music/music_wheel.rs
+++ b/src/screens/components/select_music/music_wheel.rs
@@ -625,9 +625,6 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
     if let Some(pid) = score_profile_p2.as_deref() {
         scores::ensure_score_caches_loaded(pid);
     }
-    let held_score_caches = (score_lookups_active
-        && (score_profile_p1.is_some() || score_profile_p2.is_some()))
-    .then(scores::lock_score_caches);
 
     if itl_ctx_p1.is_some()
         && let Some(pid) = local_profile_id(profile_data::PlayerSide::P1)
@@ -929,10 +926,8 @@ pub fn push(actors: &mut Vec<Actor>, p: MusicWheelParams) {
                             let Some(profile_id) = score_profile_for_side(side) else {
                                 continue;
                             };
-                            let Some(held) = held_score_caches.as_ref() else {
-                                continue;
-                            };
-                            let Some(cached_score) = held.merged(profile_id, &chart.short_hash)
+                            let Some(cached_score) =
+                                scores::get_cached_score_with_profile(&chart.short_hash, profile_id)
                             else {
                                 continue;
                             };


### PR DESCRIPTION
## Why

Players on the Select Music song wheel could hit a hard lockup that required force-quitting the game (issue #539). It reproduced when scrolling between songs in a pack with Double + GrooveStats enabled + GS auto score import enabled. The maintainer's earlier fix (fa94b482) closed one half of the problem but the hang persisted.

## Root cause

A classic AB/BA lock-ordering cycle between two lock groups:

- **Score caches** (`LOCAL` / `GS` / `AC`)
- **`PLAYER_LEADERBOARD_CACHE`**

The song wheel acquired all three score-cache mutexes via `lock_score_caches()` and held them across its entire per-slot render loop. Inside that loop it calls the ITL/leaderboard fetch helpers, which take `PLAYER_LEADERBOARD_CACHE` (plus `PROFILES` / `SESSION` / `CONFIG`). Meanwhile the GrooveStats auto-import / leaderboard worker held `PLAYER_LEADERBOARD_CACHE` and then needed a score cache. Wheel order was `score-caches -> leaderboard`; worker order was `leaderboard -> score-caches`. Run concurrently, the cycle could close and freeze the UI thread.

`fa94b482` fixed only the worker side (it now writes the imported score caches after dropping the leaderboard guard). The wheel still held its guards across the fetches, so the cycle remained reachable from the other direction.

## The fix

Drop the held score-cache guards in the wheel. Each slot''s merged grade/lamp is now read via `get_cached_score_with_profile`, which locks each score cache briefly and releases it before any fetch runs. The wheel never holds a score-cache lock across another lock, making the select-music lock graph acyclic. Merge semantics are unchanged (identical logic to the former `HeldScoreCaches::merged`), and the perf cost is negligible (a handful of uncontended brief locks per frame).

## Validation

Added a watchdog-guarded concurrency regression test (`wheel_score_read_does_not_deadlock_with_leaderboard_worker`). A worker thread takes the locks in the pre-fix order (`PLAYER_LEADERBOARD_CACHE -> LOCAL -> GS -> AC`) while the test hammers the real fixed read path; the pair must make progress within a 30s watchdog or the test fails loudly instead of hanging.

- Passes in ~0.05s with the fix.
- Proven non-vacuous: temporarily reverting the read to the old held-lock order makes the watchdog fire and the test fail in 8s.

Closes #539