### PR TITLE
Add p2_start and p2_back actions to skip initial splash screen

### DIFF
--- a/src/screens/init.rs
+++ b/src/screens/init.rs
@@ -513,7 +513,10 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
     }
     if ev.pressed {
         match ev.action {
-            VirtualAction::p1_start | VirtualAction::p1_back => {
+            VirtualAction::p1_start
+            | VirtualAction::p1_back
+            | VirtualAction::p2_start
+            | VirtualAction::p2_back => {
                 return ScreenAction::Navigate(Screen::Menu);
             }
             _ => {}


### PR DESCRIPTION
Adds p2_start and p2_back to the list of actions that skips the initial splash screen before the main menu.

This provides a nice QoL change for those who play on the 2p side.