### PR TITLE
Hide console window by default on Windows

### DIFF
--- a/crates/deadsync-platform/Cargo.toml
+++ b/crates/deadsync-platform/Cargo.toml
@@ -17,6 +17,9 @@ windows = { version = "0.62.2", features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_Media",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Console",
     "Win32_System_Performance",
     "Win32_System_Threading",
 ] }

--- a/crates/deadsync-platform/src/console.rs
+++ b/crates/deadsync-platform/src/console.rs
@@ -30,13 +30,16 @@ pub fn init(show: bool) {
 
 #[cfg(windows)]
 mod imp {
-    use windows::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE, HANDLE};
+    use windows::Win32::Foundation::{
+        GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE,
+    };
     use windows::Win32::Storage::FileSystem::{
-        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_TYPE_DISK,
+        FILE_TYPE_PIPE, GetFileType, OPEN_EXISTING,
     };
     use windows::Win32::System::Console::{
-        ATTACH_PARENT_PROCESS, AllocConsole, AttachConsole, GetConsoleWindow, SetStdHandle,
-        STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+        ATTACH_PARENT_PROCESS, AllocConsole, AttachConsole, GetConsoleWindow, GetStdHandle,
+        STD_ERROR_HANDLE, STD_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, SetStdHandle,
     };
     use windows::core::{PCWSTR, w};
 
@@ -74,18 +77,46 @@ mod imp {
     ///
     /// SAFETY: callers must have an active console (just attached or allocated).
     unsafe fn bind_std_handles() {
-        if let Some(out) = open_console_handle(w!("CONOUT$")) {
-            // SAFETY: `out` is a valid console handle from `CreateFileW`.
+        // stdout and stderr each get their own `CONOUT$` handle: registering one
+        // shared handle in two slots means closing either (e.g. by FFI/C runtime
+        // code) would dangle the other.
+        bind_console_handle(STD_OUTPUT_HANDLE, w!("CONOUT$"));
+        bind_console_handle(STD_ERROR_HANDLE, w!("CONOUT$"));
+        bind_console_handle(STD_INPUT_HANDLE, w!("CONIN$"));
+    }
+
+    /// (Re)point a single std handle at the console device, opening a dedicated
+    /// handle for it. Skips handles the parent shell already redirected to a
+    /// file or pipe (e.g. `deadsync.exe > out.txt`), so attaching the console
+    /// doesn't silently clobber the redirection.
+    fn bind_console_handle(std_id: STD_HANDLE, device: PCWSTR) {
+        if is_redirected(std_id) {
+            return;
+        }
+        if let Some(handle) = open_console_handle(device) {
+            // SAFETY: `handle` is a valid console handle from `CreateFileW`.
             unsafe {
-                let _ = SetStdHandle(STD_OUTPUT_HANDLE, out);
-                let _ = SetStdHandle(STD_ERROR_HANDLE, out);
+                let _ = SetStdHandle(std_id, handle);
             }
         }
-        if let Some(input) = open_console_handle(w!("CONIN$")) {
-            // SAFETY: `input` is a valid console handle from `CreateFileW`.
-            unsafe {
-                let _ = SetStdHandle(STD_INPUT_HANDLE, input);
+    }
+
+    /// True if `std_id` already holds a valid file or pipe handle — i.e. the
+    /// parent process redirected this stream into us and we must not overwrite
+    /// it. A null/invalid handle (the normal GUI-subsystem case) is not a
+    /// redirect, and a console handle is replaced with our own.
+    fn is_redirected(std_id: STD_HANDLE) -> bool {
+        // SAFETY: both calls take only the handle id / a borrowed handle and
+        // return copies we inspect; nothing is retained.
+        unsafe {
+            let Ok(handle) = GetStdHandle(std_id) else {
+                return false;
+            };
+            if handle.0.is_null() || handle == INVALID_HANDLE_VALUE {
+                return false;
             }
+            let kind = GetFileType(handle);
+            kind == FILE_TYPE_DISK || kind == FILE_TYPE_PIPE
         }
     }
 

--- a/crates/deadsync-platform/src/console.rs
+++ b/crates/deadsync-platform/src/console.rs
@@ -1,0 +1,109 @@
+//! Console window management.
+//!
+//! The release binary is built with `windows_subsystem = "windows"`, so it has
+//! no console of its own — double-clicking the executable (or launching it from
+//! Steam/a frontend) shows the game with no stray terminal window, matching what
+//! players expect from a shipped game.
+//!
+//! [`init`] reconciles that with the two cases where output *is* wanted:
+//!   * Launched from an existing terminal (e.g. a developer running it from a
+//!     shell): we reattach to the parent console so logs print there, without
+//!     spawning a window.
+//!   * The user explicitly opts in (`ShowConsole=1` in `deadsync.ini` or the
+//!     `--console` flag): we allocate a fresh console window.
+//!
+//! On non-Windows platforms the process is always attached to its controlling
+//! terminal, so this is a no-op.
+
+/// Set up the console according to the user's preference.
+///
+/// `show` is the resolved `ShowConsole` preference (config value, possibly
+/// overridden by a CLI flag). Call this once, as early as possible during
+/// startup and before the logger is initialized, so the very first log lines
+/// land in the right place.
+pub fn init(show: bool) {
+    #[cfg(windows)]
+    imp::init(show);
+    #[cfg(not(windows))]
+    let _ = show;
+}
+
+#[cfg(windows)]
+mod imp {
+    use windows::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE, HANDLE};
+    use windows::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+    use windows::Win32::System::Console::{
+        ATTACH_PARENT_PROCESS, AllocConsole, AttachConsole, GetConsoleWindow, SetStdHandle,
+        STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+    };
+    use windows::core::{PCWSTR, w};
+
+    pub fn init(show: bool) {
+        // A console-subsystem build (e.g. debug) already owns a console that the
+        // OS wired up to our stdio handles — leave it alone.
+        if have_console() {
+            return;
+        }
+
+        // GUI-subsystem build. If we were launched from a terminal, reattach to
+        // it so CLI usage still prints; otherwise only create a window when the
+        // user asked for one.
+        // SAFETY: `AttachConsole`/`AllocConsole` take no Rust-owned pointers and
+        // we check their results; on success we rebind the process std handles to
+        // the now-current console below.
+        unsafe {
+            let attached = AttachConsole(ATTACH_PARENT_PROCESS).is_ok();
+            if attached || (show && AllocConsole().is_ok()) {
+                bind_std_handles();
+            }
+        }
+    }
+
+    fn have_console() -> bool {
+        // SAFETY: `GetConsoleWindow` takes no arguments and returns a borrowed
+        // window handle (or null) that we only test for nullness.
+        unsafe { !GetConsoleWindow().0.is_null() }
+    }
+
+    /// Point the process std handles at the freshly (re)attached console so
+    /// Rust's `std::io::{stdout, stderr, stdin}` and the `log` backend reach it.
+    /// Without this, a GUI-subsystem process has null std handles and all output
+    /// is silently discarded even after attaching a console.
+    ///
+    /// SAFETY: callers must have an active console (just attached or allocated).
+    unsafe fn bind_std_handles() {
+        if let Some(out) = open_console_handle(w!("CONOUT$")) {
+            // SAFETY: `out` is a valid console handle from `CreateFileW`.
+            unsafe {
+                let _ = SetStdHandle(STD_OUTPUT_HANDLE, out);
+                let _ = SetStdHandle(STD_ERROR_HANDLE, out);
+            }
+        }
+        if let Some(input) = open_console_handle(w!("CONIN$")) {
+            // SAFETY: `input` is a valid console handle from `CreateFileW`.
+            unsafe {
+                let _ = SetStdHandle(STD_INPUT_HANDLE, input);
+            }
+        }
+    }
+
+    fn open_console_handle(name: PCWSTR) -> Option<HANDLE> {
+        // SAFETY: `name` is a static, NUL-terminated wide string (`CONOUT$` /
+        // `CONIN$`); the remaining arguments are plain flag values and the call
+        // borrows nothing beyond the string for its duration.
+        unsafe {
+            CreateFileW(
+                name,
+                (GENERIC_READ | GENERIC_WRITE).0,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                None,
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL,
+                None,
+            )
+            .ok()
+        }
+    }
+}

--- a/crates/deadsync-platform/src/console.rs
+++ b/crates/deadsync-platform/src/console.rs
@@ -18,9 +18,9 @@
 /// Set up the console according to the user's preference.
 ///
 /// `show` is the resolved `ShowConsole` preference (config value, possibly
-/// overridden by a CLI flag). Call this once, as early as possible during
-/// startup and before the logger is initialized, so the very first log lines
-/// land in the right place.
+/// overridden by the `--console` CLI flag). Call this once, as early as possible
+/// during startup and before the logger is initialized, so the very first log
+/// lines land in the right place.
 pub fn init(show: bool) {
     #[cfg(windows)]
     imp::init(show);

--- a/crates/deadsync-platform/src/lib.rs
+++ b/crates/deadsync-platform/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod console;
 pub mod dirs;
 pub mod display;
 pub mod host_time;

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -20,6 +20,17 @@ pub fn bootstrap_log_to_file() -> bool {
         .unwrap_or(default)
 }
 
+pub fn bootstrap_show_console() -> bool {
+    let mut conf = SimpleIni::new();
+    let default = Config::default().show_console;
+    if conf.load(dirs::app_dirs().config_path()).is_err() {
+        return default;
+    }
+    conf.get("Options", "ShowConsole")
+        .and_then(|v| parse_bool_str(&v))
+        .unwrap_or(default)
+}
+
 pub fn load() {
     ensure_config_file();
 

--- a/src/config/load/options.rs
+++ b/src/config/load/options.rs
@@ -235,6 +235,10 @@ fn load_system_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
         .get("Options", "LogToFile")
         .and_then(|v| parse_bool_str(&v))
         .unwrap_or(default.log_to_file);
+    cfg.show_console = conf
+        .get("Options", "ShowConsole")
+        .and_then(|v| parse_bool_str(&v))
+        .unwrap_or(default.show_console);
 }
 
 fn load_null_or_die_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -24,7 +24,7 @@ pub(crate) use self::keybinds::{
     editable_key_binding_slot_indices, keycode_to_token, parse_keycode_to_key,
     protected_default_key_for_action,
 };
-pub use self::load::{bootstrap_log_to_file, load};
+pub use self::load::{bootstrap_log_to_file, bootstrap_show_console, load};
 pub use self::null_or_die_cfg::null_or_die_bias_cfg;
 pub use self::pad_order::pad_index_for_uuid;
 pub use self::runtime::{
@@ -97,6 +97,10 @@ pub struct Config {
     pub language_flag: LanguageFlag,
     pub log_level: LogLevel,
     pub log_to_file: bool,
+    /// Windows: open a console window for live log output. Off by default so the
+    /// game launches cleanly with no stray terminal. Ignored on other platforms,
+    /// which always inherit their controlling terminal. Applied at startup.
+    pub show_console: bool,
     /// Write the active screen name to save/current_screen.txt on each transition.
     pub write_current_screen: bool,
     /// Hold-Tab fast-forward (4×) for non-gameplay screens. Issue #174 / ITGmania parity.
@@ -372,6 +376,7 @@ impl Default for Config {
             language_flag: LanguageFlag::Auto,
             log_level: LogLevel::Warn,
             log_to_file: true,
+            show_console: false,
             write_current_screen: false,
             tab_acceleration: true,
             show_stats_mode: 0,

--- a/src/config/store/defaults.rs
+++ b/src/config/store/defaults.rs
@@ -148,6 +148,7 @@ fn push_default_options(content: &mut String, default: &Config) {
     push_line(content, "Language", default.language_flag.as_str());
     push_line(content, "LogLevel", default.log_level.as_str());
     push_bool(content, "LogToFile", default.log_to_file);
+    push_bool(content, "ShowConsole", default.show_console);
     push_line(
         content,
         "LinuxAudioBackend",

--- a/src/config/store/save.rs
+++ b/src/config/store/save.rs
@@ -216,6 +216,7 @@ fn push_saved_options(
     push_line(content, "Language", cfg.language_flag.as_str());
     push_line(content, "LogLevel", cfg.log_level.as_str());
     push_bool(content, "LogToFile", cfg.log_to_file);
+    push_bool(content, "ShowConsole", cfg.show_console);
     push_line(
         content,
         "LinuxAudioBackend",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,10 @@
+// Ship release builds as a Windows GUI-subsystem app so launching the game
+// doesn't pop up a console window. Debug builds keep the console for developer
+// convenience. Runtime output is still reachable: see `deadsync_platform::console`
+// (reattaches to a parent terminal, or opens a console when `ShowConsole`/
+// `--console` is set). No effect on non-Windows targets.
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 use deadsync::{app, assets, config, game};
 use deadsync_platform::logging::{self, StartupBuildInfo};
 use std::backtrace::Backtrace;
@@ -119,6 +126,20 @@ fn install_panic_hook() {
     }));
 }
 
+/// Resolve whether the console window should be shown at startup. An explicit
+/// `--console` / `--no-console` argument wins; otherwise fall back to the
+/// `ShowConsole` config preference (default off).
+fn resolve_show_console() -> bool {
+    for arg in std::env::args().skip(1) {
+        match arg.as_str() {
+            "--console" => return true,
+            "--no-console" => return false,
+            _ => {}
+        }
+    }
+    config::bootstrap_show_console()
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = deadsync_updater::cli::UpdaterCli::from_env();
     deadsync_platform::runtime_dir::set_current_dir_to_exe_dir()?;
@@ -126,6 +147,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Resolve and create platform-native data/cache directories.
     deadsync_platform::dirs::ensure_dirs_exist();
+
+    // Reconcile the GUI-subsystem release build with terminal/opt-in output
+    // before the logger starts, so the first log lines land in the console when
+    // one is wanted (and no window appears when it isn't).
+    deadsync_platform::console::init(resolve_show_console());
 
     // Install logger immediately, then set runtime max level from config after loading it.
     logging::init(

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,15 +127,11 @@ fn install_panic_hook() {
 }
 
 /// Resolve whether the console window should be shown at startup. An explicit
-/// `--console` / `--no-console` argument wins; otherwise fall back to the
-/// `ShowConsole` config preference (default off).
+/// `--console` argument wins; otherwise fall back to the `ShowConsole` config
+/// preference (default off).
 fn resolve_show_console() -> bool {
-    for arg in std::env::args().skip(1) {
-        match arg.as_str() {
-            "--console" => return true,
-            "--no-console" => return false,
-            _ => {}
-        }
+    if std::env::args().skip(1).any(|arg| arg == "--console") {
+        return true;
     }
     config::bootstrap_show_console()
 }


### PR DESCRIPTION
## Why

Launching the game on Windows pops up a stray console/terminal window alongside the game window, which looks unpolished and isn't what players expect from a shipped game. Virtually all released games run as GUI-subsystem apps so no console appears. This makes that the default while keeping log output reachable for developers and for anyone who wants it.

## Approach

- **Release builds compile as a Windows GUI-subsystem app** via `#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]`, so double-clicking the exe (or launching from Steam/a frontend) shows zero console. Debug builds keep the console for developer convenience.

- The `windows_subsystem` attribute is compile-time and all-or-nothing, so a new `deadsync_platform::console` module reconciles the two cases where output *is* wanted, running at startup before the logger initializes:
  - **Launched from a terminal:** reattaches to the parent console (`AttachConsole(ATTACH_PARENT_PROCESS)`) so CLI usage still prints, with no second window.
  - **Explicit opt-in:** allocates a fresh console (`AllocConsole`) only when requested. After attaching/allocating, it rebinds the process std handles (`CONOUT$`/`CONIN$`) so Rust's stdio and the `log` backend actually reach the console.

- **Two opt-in paths, both default off:** a `ShowConsole` key in `deadsync.ini` and a `--console` / `--no-console` CLI flag (the flag overrides the config).
