### PR TITLE
Add live per-thread frame-statistics / timing overlay (Ctrl+F3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,14 @@ Legacy high-level bindings like `PadDir::Up`, `PadButton::Confirm`, and `PadN::D
 | `Tab` (hold) | Fast-forward menus and transitions at 4×. Disabled in gameplay. |
 | `` ` `` (hold) | Slow menus and transitions to 0.25×. Disabled in gameplay. |
 | `Tab` + `` ` `` | Halt menu animations. Disabled in gameplay. |
+| `F3` | Cycle the stats overlay (off → FPS → +stutter → +timing). |
+| `Ctrl`+`F3` | Toggle the live frame-statistics overlay: rolling per-phase frame-time graph (with idle/await-GPU segments and catch-up/spike markers), a frame-interval jitter histogram, and display-clock + audio sync-health readouts. Opens in the top-right corner, or the last position you moved it to. |
+| `Ctrl`+`Shift`+`F3` | Move the frame-statistics overlay to the next corner. The chosen corner is remembered across toggles and restarts. |
+| `Ctrl`+`Alt`+`F3` | Switch the frame-statistics overlay between the *detailed* presentation (stable decaying-histogram p99 + jitter histogram) and a *minimal* presentation (the graph is the jitter display — no histogram, no percentiles). Remembered across restarts. |
 
 These shortcuts mirror ITGmania's debug-loop modifiers and never affect timing-sensitive gameplay (note timing, scoring, music sync). Set `TabAcceleration=0` in `deadsync.ini` to disable them entirely.
+
+See [Frame-Statistics Overlay](docs/frame-stats-overlay.md) for how to read the colored graph, the marker and reference lines, and the readout cells.
 
 ### Profile & Online Features
 A `save` directory is created inside the data directory to store your personal data (see [Data Directories](#data-directories) for its location).

--- a/docs/frame-stats-overlay.md
+++ b/docs/frame-stats-overlay.md
@@ -1,0 +1,199 @@
+# Frame-Statistics Overlay
+
+DeadSync ships a live, on-screen timing HUD modeled on
+[osu!framework's FrameStatistics display](https://github.com/ppy/osu-framework).
+It surfaces the per-frame timing and audio/display sync telemetry the engine
+already captures, so you can *watch* a stutter happen instead of digging through
+logs after the fact.
+
+This document explains **what the overlay displays** and — the part that trips
+people up — **how to read the colored graph**.
+
+---
+
+## Hotkeys
+
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl`+`F3` | Toggle the overlay on/off. It opens in the top-right corner, or wherever you last moved it. |
+| `Ctrl`+`Shift`+`F3` | Move the overlay to the next corner. Remembered across toggles and restarts. |
+| `Ctrl`+`Alt`+`F3` | Switch between the **detailed** and **minimal** presentations (see [Presentation styles](#presentation-styles)). Remembered across restarts. |
+
+The overlay costs nothing when it's off: the per-frame samples are only captured
+while it's enabled, and there's no heap allocation on the hot path. It never
+touches note timing, scoring, or music sync.
+
+---
+
+## Anatomy of the panel
+
+```
++-------------------------------------------------------+
+|  ||| | ||  |        per-frame column graph            |   (1)
+|  ----------------       target / 2x ref lines         |   (2)
++-------------------------------------------------------+
+|  .:||||:.               jitter histogram              |   (3)
++--------+---------+---------+---------+-----------------+
+| FRAME  | LOAD    | STUTTER | DISPLAY | AUDIO           |   (4)
+| STATS  | cpu/gpu | hitches | CLOCK   |                 |
++--------+---------+---------+---------+-----------------+
+```
+
+1. **Column graph** — one column per frame, newest on the right.
+2. **Reference lines** — fixed horizontal yardsticks over the graph.
+3. **Jitter histogram** — distribution of recent frame times (detailed style only).
+4. **Readout cells** — five text panels: FRAME STATS, LOAD, STUTTER, DISPLAY CLOCK, AUDIO.
+
+The **graph** is the main event. Every vertical column is one rendered frame,
+newest on the right, scrolling left as time passes. The **height** of a column is
+how long that frame took — taller is slower. The column is split into colored
+**segments** showing *where* that time went.
+
+---
+
+## The graph colors
+
+Each column is a stack of phases, drawn from the **bottom up** in the order the
+engine executes them. The total height is the whole frame interval.
+
+| Color | Segment | What it measures |
+| --- | --- | --- |
+| ⬛ **Dark gray** | `idle` | Headroom — the part of the frame spent waiting for vsync / not doing work. **Big gray = healthy** (you have spare time). |
+| 🟦 **Light blue** | `input` | Draining and handling debounced input events. |
+| 🟩 **Green** | `update` | Game-logic update: screen transitions, gameplay stepping, animation. |
+| 🟨 **Yellow** | `compose` | Building the actor/draw list for the frame (composing the scene). |
+| 🟧 **Orange** | `upload` | Streaming textures, generated assets, and video frames to the GPU. |
+| 🟥 **Red** | `draw` | Recording and submitting the render commands. |
+| 🟪 **Purple** | `gpu-wait` | CPU blocked waiting on the GPU / swapchain to be ready. |
+
+Reading it at a glance:
+
+- **Mostly dark gray columns** → frames finishing early with lots of idle
+  headroom. This is what you want.
+- **A column suddenly grows a tall colored band** → that phase spiked. The color
+  tells you the culprit: a tall **orange** band is a texture-upload hitch, a tall
+  **purple** band is the GPU/swapchain making the CPU wait, a tall **green** band
+  is game logic, etc.
+- **A wall of color with little gray** → frames are using most of their budget;
+  you're close to dropping frames.
+
+### Marker lines (vertical, full-height)
+
+Some columns are overdrawn with a solid full-height vertical bar to flag an event
+on that frame:
+
+| Color | Marker | Meaning |
+| --- | --- | --- |
+| 🟡 **Amber bar** | catch-up | The display clock was actively *catching up* on this frame (resyncing to audio after falling behind). osu!'s GC-marker analog. |
+| 🔴 **Red bar** | spike | The frame blew well past the graph scale (≥ ⅔ of full height) — a dropped/long frame. |
+
+### Reference lines (horizontal)
+
+Two faint horizontal lines give the eye a **fixed yardstick** so you read jitter
+against a stable baseline instead of an auto-scaled one:
+
+| Color | Line | Meaning |
+| --- | --- | --- |
+| 🟢 **Green line** | target | The monitor's frame budget (refresh period — e.g. ~16.7 ms at 60 Hz, ~6.9 ms at 144 Hz). Columns reaching this line took a full refresh interval. |
+| 🟠 **Orange line** | 2× target | The "stutter" threshold — two refresh intervals. A column crossing this almost certainly dropped a frame. |
+
+A line is hidden when it would fall off the top of the current graph scale.
+
+---
+
+## The jitter histogram (detailed style)
+
+Below the graph, the light-blue **histogram** shows the *distribution* of recent
+frame times: the x-axis is frame-time buckets (fast on the left, slow on the
+right) and bar height is how often frames landed in that bucket.
+
+- A **single tall spike** = consistent frame pacing (most frames take the same
+  time). This is healthy.
+- A **wide smear or a second hump on the right** = inconsistent pacing / jitter.
+
+This panel is the osu! philosophy of "the graph *is* the jitter display," so the
+**minimal** presentation drops it (see below).
+
+---
+
+## The five readout cells
+
+| Cell | Field | Meaning |
+| --- | --- | --- |
+| **FRAME STATS** | `### FPS` | Smoothed frames per second. |
+| | `avg X ±Y ms` | EWMA-smoothed mean frame time ± jitter (standard deviation). |
+| | `p99 Z ms` | 99th-percentile frame time from a decaying histogram — a *stable* tail number (detailed only). |
+| | `max W ms` | Worst recent frame, slow-decay held (spike marker analog). |
+| | `tgt T ms` | Target frame time (the green reference line). |
+| **LOAD** | `cpu X ms` | Smoothed CPU work per frame (input → draw, excluding GPU wait). |
+| | `gpu X ms` | Smoothed GPU / swapchain wait per frame. |
+| | `idle N%` | Headroom — share of the frame spent idle (the dark-gray band). High = lots of spare time. |
+| | `lim CPU/GPU/none` | What's limiting the frame: the largest slice. `none` = idle dominates, so you're frame-capped (vsync), not bound by CPU or GPU. |
+| **STUTTER** | `over-budget N` | Frames in the recent window that crossed the 2× stutter threshold (the orange line) — a count of visible hitches. |
+| | `catch-ups N` | Distinct display-clock resync events in the window (a multi-frame catch-up counts once). |
+| | `worst X ms` | Worst recent frame, slow-decay held (same as FRAME STATS `max`). |
+| **DISPLAY CLOCK** | `err ±X ms` | Live display-clock error: how far the visual clock is from audio. `n/a (menu)` outside gameplay. |
+| | `p99 Z ms` | Stable 99th-percentile of the error magnitude (detailed only). |
+| | `jit Y ms` | Smoothed jitter (std dev) of the error. |
+| | `catch-up yes/no` | Whether the clock is currently resyncing. |
+| **AUDIO** | `gap X ms` | EWMA-smoothed audio callback interval (≈ the device period; steady = healthy). |
+| | `underruns N` | Count of audio output underruns (any increase = an audible dropout). |
+| | `out X ms` | Estimated audio output delay (device period + stream latency + queued frames). |
+| | `q N` | Frames currently queued to the audio device. |
+
+> **Why are the numbers smoothed?** Raw per-frame values jitter every frame and
+> are impossible to read. The averages use an EWMA, the percentiles use a
+> decaying histogram refreshed a few times a second, and `max` is slow-decay
+> held — so the text stays steady while the graph shows the raw per-frame detail.
+
+---
+
+## Presentation styles
+
+`Ctrl`+`Alt`+`F3` flips between two styles (the underlying stats keep running in
+both, so switching is instant and the percentiles stay warm):
+
+| | **Detailed** (default) | **Minimal** |
+| --- | --- | --- |
+| Per-phase graph + reference lines | ✓ | ✓ |
+| Jitter histogram | ✓ | dropped (the graph is the jitter display) |
+| `p99` readouts (frame + display) | ✓ | dropped |
+| `avg ± jitter`, `max`, `tgt` | ✓ | ✓ |
+| Panel height | full | shorter |
+
+**Detailed** keeps DeadSync's richer, stabilized telemetry (a trustworthy p99
+plus the histogram). **Minimal** mirrors osu!framework more closely: no
+percentiles, no histogram — you read jitter straight off the graph against the
+reference lines.
+
+---
+
+## A worked example
+
+> Columns are mostly dark gray and short, hugging well below the green line —
+> then one column shoots up past the orange line with a tall **purple** band and
+> a **red** spike bar, the histogram grows a small second hump on the right, and
+> `max` jumps to 33 ms.
+
+Read: frames are normally healthy (lots of idle headroom), but one frame stalled
+waiting on the GPU (`gpu-wait`), long enough to drop a frame (red spike, past 2×
+target). The histogram's second hump and the held `max` confirm it was a real
+outlier, not noise. If `underruns` also ticked up, the stall was long enough to
+starve audio.
+
+---
+
+## Where this comes from (for contributors)
+
+- Rendering + layout + the streaming statistics math:
+  `src/screens/components/shared/frame_stats_overlay.rs` (pure functions, unit
+  tested).
+- Per-frame sample capture, smoothing, and the toggle plumbing:
+  `src/app/mod.rs` (`record_frame_stats_sample`, `push_frame_stats_overlay`,
+  the `Ctrl`+`F3` family of handlers).
+- Data sources reused as-is: display-clock health
+  (`src/game/gameplay/clock.rs`) and audio output timing
+  (`crates/deadsync-audio*`).
+
+The colors, segment order, marker thresholds, and reference lines are all defined
+as constants at the top of `frame_stats_overlay.rs`; this document tracks those.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -122,6 +122,7 @@ const LIVE_TEXTURE_UPLOAD_MAX_BYTES: usize = 8 * 1024 * 1024;
 const STUTTER_DIAG_DUMP_WINDOW_NS: u64 = 500_000_000;
 const STUTTER_DIAG_MIN_DUMP_GAP_NS: u64 = 250_000_000;
 const STUTTER_DIAG_FRAME_SAMPLE_COUNT: usize = 128;
+const FRAME_STATS_SAMPLE_COUNT: usize = 128;
 const LIGHTS_AHEAD_NS: SongTimeNs = 50_000_000;
 const LIGHTS_MAX_CATCHUP_NS: SongTimeNs = 500_000_000;
 const LIGHTS_QUARTER_ROWS: usize = ROWS_PER_BEAT as usize;
@@ -1013,6 +1014,23 @@ fn seconds_to_us_u32(seconds: f32) -> u32 {
     }
 }
 
+/// Slow-decay "worst recent frame" hold for the overlay's max readout and graph scale.
+/// New highs latch instantly and hold for `SPIKE_HOLD_FRAMES`; afterwards the value eases
+/// down geometrically toward the current frame so it tracks recovery without snapping.
+#[inline(always)]
+fn update_frame_stats_spike_hold(spike_us: &mut u32, ttl: &mut u16, frame_us: u32) {
+    const SPIKE_HOLD_FRAMES: u16 = 90;
+    if frame_us >= *spike_us {
+        *spike_us = frame_us;
+        *ttl = SPIKE_HOLD_FRAMES;
+    } else if *ttl > 0 {
+        *ttl -= 1;
+    } else {
+        let decayed = (u64::from(*spike_us) * 31 / 32) as u32;
+        *spike_us = decayed.max(frame_us);
+    }
+}
+
 #[inline(always)]
 fn stutter_severity(frame_seconds: f32, expected_seconds: f32) -> u8 {
     if expected_seconds <= 0.0 {
@@ -1248,6 +1266,55 @@ impl StutterDiagRecorder {
             if now_host_nanos.saturating_sub(sample.host_nanos) <= window_ns {
                 out.push(sample);
             }
+        }
+    }
+}
+
+type FrameStatsSample = crate::screens::components::shared::frame_stats_overlay::FrameStatsSample;
+
+/// Fixed-size ring of per-phase frame timings feeding the live frame-stats overlay.
+/// `Copy` array, no heap; only written while the overlay is enabled.
+#[derive(Clone, Copy)]
+struct FrameStatsRing {
+    samples: [FrameStatsSample; FRAME_STATS_SAMPLE_COUNT],
+    cursor: usize,
+    len: usize,
+}
+
+impl FrameStatsRing {
+    #[inline(always)]
+    const fn new() -> Self {
+        Self {
+            samples: [FrameStatsSample::empty(); FRAME_STATS_SAMPLE_COUNT],
+            cursor: 0,
+            len: 0,
+        }
+    }
+
+    #[inline(always)]
+    fn clear(&mut self) {
+        self.samples = [FrameStatsSample::empty(); FRAME_STATS_SAMPLE_COUNT];
+        self.cursor = 0;
+        self.len = 0;
+    }
+
+    #[inline(always)]
+    fn push(&mut self, sample: FrameStatsSample) {
+        self.samples[self.cursor] = sample;
+        self.cursor = (self.cursor + 1) % FRAME_STATS_SAMPLE_COUNT;
+        self.len = self.len.saturating_add(1).min(FRAME_STATS_SAMPLE_COUNT);
+    }
+
+    /// Copy the ring into `out` in chronological (oldest-first) order.
+    fn snapshot(&self, out: &mut Vec<FrameStatsSample>) {
+        out.clear();
+        let start = self
+            .cursor
+            .saturating_add(FRAME_STATS_SAMPLE_COUNT)
+            .saturating_sub(self.len)
+            % FRAME_STATS_SAMPLE_COUNT;
+        for i in 0..self.len {
+            out.push(self.samples[(start + i) % FRAME_STATS_SAMPLE_COUNT]);
         }
     }
 }
@@ -1525,6 +1592,20 @@ pub struct ShellState {
     stutter_samples: [StutterSample; STUTTER_SAMPLE_COUNT],
     stutter_cursor: usize,
     stutter_diag: StutterDiagRecorder,
+    frame_stats: FrameStatsRing,
+    frame_stats_scratch: Vec<FrameStatsSample>,
+    frame_stats_long: crate::screens::components::shared::frame_stats_overlay::FrameStatsLong,
+    frame_stats_spike_us: u32,
+    frame_stats_spike_ttl: u16,
+    /// EWMA-smoothed audio callback gap (ms) so the readout stops bouncing frame-to-frame.
+    /// 0.0 = uninitialized (seeds from the first sample). Reset when the overlay is disabled.
+    frame_stats_audio_gap_ms: f32,
+    frame_stats_overlay_enabled: bool,
+    frame_stats_overlay_anchor: crate::screens::components::shared::frame_stats_overlay::OverlayAnchor,
+    /// True once the user has explicitly positioned the overlay (via the move-corner key or a
+    /// remembered config value). While false the anchor follows the play-context default.
+    frame_stats_overlay_anchor_user_set: bool,
+    frame_stats_overlay_style: crate::screens::components::shared::frame_stats_overlay::OverlayStyle,
     transition: TransitionState,
     display_width: u32,
     display_height: u32,
@@ -1717,6 +1798,30 @@ impl ShellState {
             stutter_samples: [StutterSample::empty(); STUTTER_SAMPLE_COUNT],
             stutter_cursor: 0,
             stutter_diag: StutterDiagRecorder::new(),
+            frame_stats: FrameStatsRing::new(),
+            frame_stats_scratch: Vec::new(),
+            frame_stats_long:
+                crate::screens::components::shared::frame_stats_overlay::FrameStatsLong::new(),
+            frame_stats_spike_us: 0,
+            frame_stats_spike_ttl: 0,
+            frame_stats_audio_gap_ms: 0.0,
+            frame_stats_overlay_enabled: false,
+            frame_stats_overlay_anchor:
+                crate::screens::components::shared::frame_stats_overlay::OverlayAnchor::from_key(
+                    cfg.frame_stats_overlay_anchor,
+                )
+                .unwrap_or(
+                    crate::screens::components::shared::frame_stats_overlay::OverlayAnchor::TopLeft,
+                ),
+            frame_stats_overlay_anchor_user_set:
+                crate::screens::components::shared::frame_stats_overlay::OverlayAnchor::from_key(
+                    cfg.frame_stats_overlay_anchor,
+                )
+                .is_some(),
+            frame_stats_overlay_style:
+                crate::screens::components::shared::frame_stats_overlay::OverlayStyle::from_key(
+                    cfg.frame_stats_overlay_style,
+                ),
             transition: TransitionState::Idle,
             display_width: cfg.display_width,
             display_height: cfg.display_height,
@@ -2016,6 +2121,42 @@ impl ShellState {
             self.clear_stutter_samples();
         }
         self.overlay_mode.code()
+    }
+
+    #[inline(always)]
+    fn toggle_frame_stats_overlay(&mut self) -> bool {
+        self.frame_stats_overlay_enabled = !self.frame_stats_overlay_enabled;
+        if !self.frame_stats_overlay_enabled {
+            self.frame_stats.clear();
+            self.frame_stats_long.reset();
+            self.frame_stats_spike_us = 0;
+            self.frame_stats_spike_ttl = 0;
+            self.frame_stats_audio_gap_ms = 0.0;
+        }
+        self.frame_stats_overlay_enabled
+    }
+
+    fn cycle_frame_stats_overlay_anchor(
+        &mut self,
+        compact: bool,
+    ) -> crate::screens::components::shared::frame_stats_overlay::OverlayAnchor {
+        use crate::screens::components::shared::frame_stats_overlay as fso;
+        self.frame_stats_overlay_anchor =
+            fso::next_anchor(self.frame_stats_overlay_anchor, compact);
+        // The user explicitly positioned it: remember this corner across toggles + restarts
+        // instead of snapping back to the play-context default.
+        self.frame_stats_overlay_anchor_user_set = true;
+        config::update_frame_stats_overlay_anchor(self.frame_stats_overlay_anchor.to_key());
+        self.frame_stats_overlay_anchor
+    }
+
+    #[inline(always)]
+    fn toggle_frame_stats_overlay_style(
+        &mut self,
+    ) -> crate::screens::components::shared::frame_stats_overlay::OverlayStyle {
+        self.frame_stats_overlay_style = self.frame_stats_overlay_style.toggle();
+        config::update_frame_stats_overlay_style(self.frame_stats_overlay_style.label());
+        self.frame_stats_overlay_style
     }
 
     #[inline(always)]
@@ -5060,6 +5201,16 @@ impl App {
             .as_secs_f32();
         let frame_host_nanos = deadsync_platform::host_time::now_nanos();
         self.update_stutter_samples(frame_seconds, total_elapsed_end);
+        self.record_frame_stats_sample(
+            frame_host_nanos,
+            frame_seconds,
+            input_us,
+            update_us,
+            compose_us,
+            upload_us,
+            draw_us,
+            draw_stats,
+        );
         self.record_stutter_diag_frame(
             frame_host_nanos,
             self.state.screens.current_screen,
@@ -7128,6 +7279,8 @@ impl App {
             }
         }
 
+        self.push_frame_stats_overlay(&mut actors);
+
         // Bottom-corner build watermark so videos / screenshots always
         // carry the running version. Default on; user-toggleable via
         // Options, with a separate Left/Right side preference.
@@ -7243,6 +7396,198 @@ impl App {
         self.state
             .shell
             .push_stutter_sample(total_elapsed, frame_seconds, expected, severity);
+    }
+
+    #[inline(always)]
+    fn record_frame_stats_sample(
+        &mut self,
+        frame_host_nanos: u64,
+        frame_seconds: f32,
+        input_us: u32,
+        update_us: u32,
+        compose_us: u32,
+        upload_us: u32,
+        draw_us: u32,
+        draw_stats: renderer::DrawStats,
+    ) {
+        if !self.state.shell.frame_stats_overlay_enabled {
+            return;
+        }
+        let display_clock = self
+            .state
+            .screens
+            .gameplay_state
+            .as_ref()
+            .map(|gs| crate::game::gameplay::display_clock_health(gs))
+            .unwrap_or_default();
+        let display_error_us = (f64::from(display_clock.error_seconds) * 1_000_000.0)
+            .round()
+            .clamp(f64::from(i32::MIN), f64::from(i32::MAX)) as i32;
+        let sample = FrameStatsSample {
+            host_nanos: frame_host_nanos.max(1),
+            frame_us: seconds_to_us_u32(frame_seconds),
+            input_us,
+            update_us,
+            compose_us,
+            upload_us,
+            draw_us,
+            gpu_wait_us: draw_stats.gpu_wait_us,
+            display_error_us,
+            catching_up: display_clock.catching_up,
+        };
+        self.state.shell.frame_stats.push(sample);
+        self.state.shell.frame_stats_long.push(&sample);
+        update_frame_stats_spike_hold(
+            &mut self.state.shell.frame_stats_spike_us,
+            &mut self.state.shell.frame_stats_spike_ttl,
+            sample.frame_us,
+        );
+    }
+
+    fn push_frame_stats_overlay(&mut self, actors: &mut Vec<Actor>) {
+        use crate::screens::components::shared::frame_stats_overlay;
+
+        if !self.state.shell.frame_stats_overlay_enabled {
+            return;
+        }
+        self.state
+            .shell
+            .frame_stats
+            .snapshot(&mut self.state.shell.frame_stats_scratch);
+        let samples = &self.state.shell.frame_stats_scratch;
+
+        // Graph scale still tracks the live ring max; all displayed numbers come from the
+        // long-window streaming stats (decaying-histogram p99 + EWMA mean/jitter) so they
+        // stay steady instead of sawtoothing as outliers enter and leave a short window.
+        let mut max_us: u32 = 0;
+        for s in samples.iter() {
+            if s.host_nanos == 0 {
+                continue;
+            }
+            max_us = max_us.max(s.frame_us);
+        }
+        let long = &self.state.shell.frame_stats_long;
+        let avg_frame_us = long.avg_frame_us();
+        let p99_frame_us = long.p99_frame_us();
+        let frame_jitter_us = long.frame_jitter_us();
+        let display_error_jitter_us = long.error_jitter_us();
+        let display_error_p99_ms = f64::from(long.p99_error_us()) as f32 / 1000.0;
+        let cpu_work_us = long.avg_cpu_us();
+        let gpu_wait_us = long.avg_gpu_us();
+        let spike_hold_us = self.state.shell.frame_stats_spike_us.max(max_us);
+
+        // Target frame time for the graph reference lines: the monitor refresh period if
+        // known, else the configured max-FPS cap, else the smoothed average.
+        let refresh_ns = self.state.shell.last_present_stats.refresh_ns;
+        let target_frame_us = if refresh_ns != 0 {
+            (refresh_ns / 1000) as u32
+        } else if let Some(iv) = self.effective_frame_interval() {
+            iv.as_micros().min(u128::from(u32::MAX)) as u32
+        } else {
+            avg_frame_us
+        };
+
+        // Stutter tally over the rolling ring window: frames past the 2× stutter threshold
+        // (the orange reference line), and distinct display-clock catch-up events (rising
+        // edges so a multi-frame resync counts once). Cheap single pass, gated to overlay-on.
+        let over_budget_threshold = target_frame_us.saturating_mul(2).max(1);
+        let mut over_budget_count: u32 = 0;
+        let mut catch_up_count: u32 = 0;
+        let mut prev_catch = false;
+        for s in samples.iter() {
+            if s.host_nanos == 0 {
+                continue;
+            }
+            if s.frame_us >= over_budget_threshold {
+                over_budget_count = over_budget_count.saturating_add(1);
+            }
+            if s.catching_up && !prev_catch {
+                catch_up_count = catch_up_count.saturating_add(1);
+            }
+            prev_catch = s.catching_up;
+        }
+
+        let in_gameplay = self.state.screens.current_screen == CurrentScreen::Gameplay;
+        let display_clock = self
+            .state
+            .screens
+            .gameplay_state
+            .as_ref()
+            .map(|gs| crate::game::gameplay::display_clock_health(gs))
+            .unwrap_or_default();
+
+        let audio = deadsync_audio_stream::get_output_timing_snapshot();
+        let raw_callback_gap_ms =
+            deadsync_audio_stream::timing_diag_last_callback_gap_ns() as f32 / 1_000_000.0;
+        // Smooth the callback gap so the readout stops bouncing between e.g. 9.xx and 10.xx
+        // every frame. Seed on the first sample, then EWMA at the same rate as the frame
+        // average. Negative/zero raw values (no data yet) pass through unsmoothed.
+        let callback_gap_ms = if raw_callback_gap_ms > 0.0 {
+            let prev = self.state.shell.frame_stats_audio_gap_ms;
+            let smoothed = if prev > 0.0 {
+                prev + frame_stats_overlay::EWMA_ALPHA_MEAN * (raw_callback_gap_ms - prev)
+            } else {
+                raw_callback_gap_ms
+            };
+            self.state.shell.frame_stats_audio_gap_ms = smoothed;
+            smoothed
+        } else {
+            raw_callback_gap_ms
+        };
+
+        let summary = frame_stats_overlay::FrameStatsSummary {
+            avg_frame_us,
+            p99_frame_us,
+            max_frame_us: max_us,
+            fps: self.state.shell.last_fps,
+            display_error_ms: display_clock.error_seconds * 1000.0,
+            display_error_p99_ms,
+            display_catching_up: display_clock.catching_up,
+            in_gameplay,
+            audio_callback_gap_ms: callback_gap_ms,
+            audio_underruns: audio.underrun_count,
+            audio_output_delay_ms: audio.estimated_output_delay_ns as f32 / 1_000_000.0,
+            audio_queued_frames: audio.queued_frames,
+            frame_jitter_us,
+            display_error_jitter_us,
+            spike_hold_us,
+            target_frame_us,
+            cpu_work_us,
+            gpu_wait_us,
+            over_budget_count,
+            catch_up_count,
+        };
+        let anchor = self.state.shell.frame_stats_overlay_anchor;
+        let style = self.state.shell.frame_stats_overlay_style;
+        let screen_w = deadsync_present::space::screen_width();
+        let screen_h = deadsync_present::space::screen_height();
+        // Always render the full overlay, including 2 players — the panel is narrow enough
+        // (~half-screen) to sit in a corner or the bottom-center seam without covering either
+        // notefield, so there's no need to drop to the stripped compact layout.
+        actors.extend(frame_stats_overlay::build(
+            samples, summary, anchor, false, style, screen_w, screen_h,
+        ));
+    }
+
+    /// Current play context for overlay placement: `(in_gameplay, two_player, player_is_p2)`.
+    /// Two-player covers Versus/Double or any 2+ active notefields (both sides occupied).
+    fn frame_stats_play_context(&self) -> (bool, bool, bool) {
+        let in_gameplay = self.state.screens.current_screen == CurrentScreen::Gameplay;
+        let play_style = crate::game::profile::get_session_play_style();
+        let side = crate::game::profile::get_session_player_side();
+        let num_players = self
+            .state
+            .screens
+            .gameplay_state
+            .as_ref()
+            .map(|gs| gs.num_players)
+            .unwrap_or(1);
+        let two_player = matches!(
+            play_style,
+            profile_data::PlayStyle::Versus | profile_data::PlayStyle::Double
+        ) || num_players >= 2;
+        let player_is_p2 = matches!(side, profile_data::PlayerSide::P2);
+        (in_gameplay, two_player, player_is_p2)
     }
 
     #[inline(always)]
@@ -8117,10 +8462,36 @@ impl App {
         );
 
         if raw_key.pressed && raw_key.code == KeyCode::F3 {
-            let mode = self.state.shell.cycle_overlay_mode();
-            debug!("Overlay {}", self.state.shell.overlay_mode.label());
-            config::update_show_stats_mode(mode);
-            options::sync_show_stats_mode(&mut self.state.screens.options_state, mode);
+            if self.state.shell.ctrl_held && self.state.shell.shift_held {
+                // Ctrl+Shift+F3: move the frame-stats overlay to the next corner (runtime only).
+                if !raw_key.repeat && self.state.shell.frame_stats_overlay_enabled {
+                    let (_, two_player, _) = self.frame_stats_play_context();
+                    let anchor = self.state.shell.cycle_frame_stats_overlay_anchor(two_player);
+                    debug!("Frame stats overlay corner {anchor:?}");
+                }
+            } else if self.state.shell.ctrl_held && self.state.shell.alt_held {
+                // Ctrl+Alt+F3: switch the overlay presentation (detailed ↔ minimal).
+                if !raw_key.repeat && self.state.shell.frame_stats_overlay_enabled {
+                    let style = self.state.shell.toggle_frame_stats_overlay_style();
+                    debug!("Frame stats overlay style {}", style.label());
+                }
+            } else if self.state.shell.ctrl_held {
+                if !raw_key.repeat {
+                    let on = self.state.shell.toggle_frame_stats_overlay();
+                    // Only auto-place when the user hasn't positioned it themselves; otherwise
+                    // restore the remembered corner (persisted across toggles and restarts).
+                    if on && !self.state.shell.frame_stats_overlay_anchor_user_set {
+                        self.state.shell.frame_stats_overlay_anchor =
+                            crate::screens::components::shared::frame_stats_overlay::default_anchor();
+                    }
+                    debug!("Frame stats overlay {}", if on { "ON" } else { "OFF" });
+                }
+            } else {
+                let mode = self.state.shell.cycle_overlay_mode();
+                debug!("Overlay {}", self.state.shell.overlay_mode.label());
+                config::update_show_stats_mode(mode);
+                options::sync_show_stats_mode(&mut self.state.screens.options_state, mode);
+            }
         }
         if raw_key.pressed && !raw_key.repeat && raw_key.code == KeyCode::F9 {
             let new_value = !config::get().translated_titles;

--- a/src/config/load/options.rs
+++ b/src/config/load/options.rs
@@ -3,6 +3,31 @@ use deadsync_lights::{
     SerialPortName, parse_driver_or_default, parse_gameplay_pad_lights_or_default,
 };
 
+/// Normalize a persisted frame-stats overlay anchor to a canonical static key, mapping
+/// "auto"/empty/unknown to "auto" (the engine then follows the play-context default).
+fn canonical_overlay_anchor(value: &str) -> &'static str {
+    const KEYS: &[&str] = &[
+        "top-left",
+        "top-right",
+        "bottom-left",
+        "bottom-right",
+        "top-center",
+        "bottom-center",
+    ];
+    let value = value.trim().to_ascii_lowercase();
+    KEYS.iter().copied().find(|&k| k == value).unwrap_or("auto")
+}
+
+/// Normalize a persisted frame-stats overlay style to a canonical static key; anything other
+/// than "minimal" falls back to "detailed".
+fn canonical_overlay_style(value: &str) -> &'static str {
+    if value.trim().eq_ignore_ascii_case("minimal") {
+        "minimal"
+    } else {
+        "detailed"
+    }
+}
+
 pub(super) fn load(conf: &SimpleIni, default: Config, cfg: &mut Config) {
     load_system_opts(conf, default, cfg);
     load_null_or_die_opts(conf, default, cfg);
@@ -105,6 +130,14 @@ fn load_system_opts(conf: &SimpleIni, default: Config, cfg: &mut Config) {
                 .map(|v| if v != 0 { 1 } else { 0 })
         })
         .unwrap_or(default.show_stats_mode);
+    cfg.frame_stats_overlay_anchor = conf
+        .get("Options", "FrameStatsOverlayAnchor")
+        .map(|v| canonical_overlay_anchor(&v))
+        .unwrap_or(default.frame_stats_overlay_anchor);
+    cfg.frame_stats_overlay_style = conf
+        .get("Options", "FrameStatsOverlayStyle")
+        .map(|v| canonical_overlay_style(&v))
+        .unwrap_or(default.frame_stats_overlay_style);
     cfg.translated_titles = conf
         .get("Options", "TranslatedTitles")
         .or_else(|| conf.get("Options", "translatedtitles"))

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -104,6 +104,12 @@ pub struct Config {
     pub tab_acceleration: bool,
     /// 0=Off, 1=FPS, 2=FPS+Stutter.
     pub show_stats_mode: u8,
+    /// Last frame-statistics overlay corner (`OverlayAnchor::to_key`, e.g. "bottom-right"),
+    /// or "auto" = follow play context until the user moves it. Remembered across sessions.
+    pub frame_stats_overlay_anchor: &'static str,
+    /// Frame-statistics overlay presentation style (`OverlayStyle::label`): "detailed" or
+    /// "minimal". Remembered across sessions.
+    pub frame_stats_overlay_style: &'static str,
     pub translated_titles: bool,
     pub mine_hit_sound: bool,
     // Global background brightness during gameplay (ITGmania: Pref "BGBrightness").
@@ -371,6 +377,8 @@ impl Default for Config {
             write_current_screen: false,
             tab_acceleration: true,
             show_stats_mode: 0,
+            frame_stats_overlay_anchor: "auto",
+            frame_stats_overlay_style: "detailed",
             translated_titles: false,
             mine_hit_sound: true,
             bg_brightness: 0.7,

--- a/src/config/store/save.rs
+++ b/src/config/store/save.rs
@@ -389,6 +389,8 @@ fn push_saved_options(
     );
     push_bool(content, "ShowStats", cfg.show_stats_mode != 0);
     push_line(content, "ShowStatsMode", cfg.show_stats_mode.min(3));
+    push_line(content, "FrameStatsOverlayAnchor", cfg.frame_stats_overlay_anchor);
+    push_line(content, "FrameStatsOverlayStyle", cfg.frame_stats_overlay_style);
     push_bool(content, "SmoothHistogram", cfg.smooth_histogram);
     push_bool(
         content,

--- a/src/config/update/system.rs
+++ b/src/config/update/system.rs
@@ -180,6 +180,28 @@ pub fn update_show_stats_mode(mode: u8) {
     save_without_keymaps();
 }
 
+pub fn update_frame_stats_overlay_anchor(key: &'static str) {
+    {
+        let mut cfg = lock_config();
+        if cfg.frame_stats_overlay_anchor == key {
+            return;
+        }
+        cfg.frame_stats_overlay_anchor = key;
+    }
+    save_without_keymaps();
+}
+
+pub fn update_frame_stats_overlay_style(key: &'static str) {
+    {
+        let mut cfg = lock_config();
+        if cfg.frame_stats_overlay_style == key {
+            return;
+        }
+        cfg.frame_stats_overlay_style = key;
+    }
+    save_without_keymaps();
+}
+
 pub fn update_log_level(level: LogLevel) {
     log::set_max_level(level.as_level_filter());
     {

--- a/src/screens/components/shared/frame_stats_overlay.rs
+++ b/src/screens/components/shared/frame_stats_overlay.rs
@@ -1,0 +1,1610 @@
+use crate::act;
+use deadsync_present::actors::Actor;
+
+const DEBUG_OVERLAY_Z: i16 = 32030;
+
+/// Number of bins in the frame-interval (jitter) histogram.
+pub const HISTOGRAM_BINS: usize = 32;
+
+/// Gap between the panel and the nearest screen edge (logical px).
+const MARGIN: f32 = 16.0;
+/// Top margin for top-anchored panels. Sized so the panel clears the gameplay song-meter/
+/// progress bar (centered at y≈20, height 22 → bottom ≈31) plus a small gap. Applied on
+/// every screen so the overlay keeps a steady position between menus and gameplay.
+const TOP_PROGRESS_OFFSET: f32 = 38.0;
+
+// Full (1-player) panel geometry: graph (and optional histogram) stacked on top, with the
+// five data cells in a single row below. Each cell is sized to its own text (not a shared
+// fixed width) so columns hug their content — tight gaps between panes and no wasted space
+// after the last one — while the whole panel stays within half the screen.
+const DATA_COLS: usize = 5;
+const GRAPH_H: f32 = 96.0;
+const HIST_GAP: f32 = 10.0;
+const HIST_H: f32 = 56.0;
+const PANEL_PAD: f32 = 6.0;
+const GRAPH_TEXT_GAP: f32 = 12.0;
+/// Gap between the histogram and the data row below it.
+const DATA_GAP: f32 = 12.0;
+/// miso line pitch at zoom 0.5 (font LineSpacing 24 × 0.5). The data block height is sized
+/// from the tallest cell's line count so there's no fixed over-budget margin below the text.
+const DATA_LINE_PITCH: f32 = 12.0;
+/// Visible height of the final text line (≈ miso Baseline 19 × 0.5), added once on top of
+/// the inter-line pitches so the block hugs the last line without clipping it.
+const DATA_LINE_CAP: f32 = 10.0;
+/// Estimated horizontal advance per character of the readout text at zoom 0.5 (miso is a
+/// narrow proportional font). Used to size each data cell to its own longest line.
+const DATA_CELL_CHAR_W: f32 = 4.5;
+/// Padding added to a data cell's estimated text width.
+const DATA_CELL_PAD: f32 = 4.0;
+/// Horizontal gap between adjacent data cells.
+const DATA_CELL_GAP: f32 = 10.0;
+
+/// Height of a data block with `lines` text rows (0 → 0). One cap height plus one pitch per
+/// additional line.
+#[inline(always)]
+fn data_block_h(lines: usize) -> f32 {
+    if lines == 0 {
+        0.0
+    } else {
+        DATA_LINE_CAP + DATA_LINE_PITCH * (lines as f32 - 1.0)
+    }
+}
+
+/// Number of text lines in a block (newlines + 1; empty → 0).
+#[inline(always)]
+fn line_count(s: &str) -> usize {
+    if s.is_empty() {
+        0
+    } else {
+        s.bytes().filter(|&b| b == b'\n').count() + 1
+    }
+}
+
+/// Estimated rendered width (px) of a data cell: its longest line's character count times the
+/// per-character advance, plus a little padding. Empty text → 0.
+#[inline(always)]
+fn data_cell_width(text: &str) -> f32 {
+    let max_chars = text.lines().map(|l| l.chars().count()).max().unwrap_or(0);
+    if max_chars == 0 {
+        0.0
+    } else {
+        max_chars as f32 * DATA_CELL_CHAR_W + DATA_CELL_PAD
+    }
+}
+
+/// Total width of the data row given each cell's width: the cells plus the inter-cell gaps.
+#[inline(always)]
+fn data_row_width(cell_widths: &[f32; DATA_COLS]) -> f32 {
+    cell_widths.iter().sum::<f32>() + DATA_CELL_GAP * (DATA_COLS as f32 - 1.0)
+}
+
+// Compact (2-player) panel geometry: small graph + one inline readout line.
+const COMPACT_GRAPH_W: f32 = 160.0;
+const COMPACT_GRAPH_H: f32 = 40.0;
+const COMPACT_TEXT_W: f32 = 230.0;
+const COMPACT_W: f32 = COMPACT_GRAPH_W + GRAPH_TEXT_GAP + COMPACT_TEXT_W;
+const COMPACT_H: f32 = COMPACT_GRAPH_H;
+
+// Per-phase segment colors (stacked from the bottom of each column).
+const COLOR_INPUT: [f32; 3] = [0.35, 0.70, 1.00];
+const COLOR_UPDATE: [f32; 3] = [0.40, 0.90, 0.45];
+const COLOR_COMPOSE: [f32; 3] = [0.95, 0.85, 0.30];
+const COLOR_UPLOAD: [f32; 3] = [0.95, 0.60, 0.25];
+const COLOR_DRAW: [f32; 3] = [0.95, 0.35, 0.35];
+const COLOR_GPU_WAIT: [f32; 3] = [0.75, 0.45, 0.95];
+const COLOR_IDLE: [f32; 3] = [0.30, 0.30, 0.34];
+
+const COLOR_HIST: [f32; 4] = [0.55, 0.80, 1.00, 0.95];
+const COLOR_MARKER_CATCHUP: [f32; 4] = [1.00, 0.85, 0.20, 0.85];
+const COLOR_MARKER_SPIKE: [f32; 4] = [1.00, 0.30, 0.30, 0.85];
+
+// osu!-style horizontal reference lines drawn over the graph: the monitor's target frame
+// time and twice that (the "stutter" threshold). They give the eye a fixed yardstick so
+// jitter is read against a stable baseline instead of an auto-scaled one.
+const COLOR_REF_TARGET: [f32; 4] = [0.55, 0.95, 0.55, 0.55];
+const COLOR_REF_DOUBLE: [f32; 4] = [0.95, 0.55, 0.30, 0.45];
+
+// Streaming-statistics tuning. The decaying histogram keeps a stable p99 over a long
+// effective window without storing a long ring; the EWMA pair tracks a smoothed mean and
+// jitter (standard deviation). All allocation-free and only touched while the overlay runs.
+/// Bin count for the decaying histogram (covers up to `DHIST_BINS * DHIST_BUCKET_US`).
+pub const DHIST_BINS: usize = 256;
+/// Histogram bin resolution in microseconds.
+pub const DHIST_BUCKET_US: u32 = 200;
+/// Per-frame decay applied to every bin. `1/(1-gamma)` ≈ effective sample count (~1024).
+pub const DHIST_GAMMA: f32 = 1023.0 / 1024.0;
+/// EWMA smoothing factor for the displayed mean frame time (half-life ≈ 34 frames).
+pub const EWMA_ALPHA_MEAN: f32 = 0.02;
+/// EWMA smoothing factor for the jitter (variance) estimate (slower than the mean).
+pub const EWMA_ALPHA_VAR: f32 = 0.01;
+/// Recompute the cached percentiles every Nth sample (≈3–6 Hz) to keep the text steady.
+pub const STATS_REFRESH_PERIOD: u8 = 20;
+
+/// Which screen corner (or center seam) the overlay anchors to. The engine recomputes a
+/// sensible default the first time the overlay is shown; once the user moves it, the chosen
+/// position is remembered (persisted to config) and restored on later toggles and restarts.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum OverlayAnchor {
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+    TopCenter,
+    BottomCenter,
+}
+
+impl OverlayAnchor {
+    /// Stable string key for persistence (config ini). Keep these values fixed.
+    #[inline(always)]
+    pub fn to_key(self) -> &'static str {
+        match self {
+            OverlayAnchor::TopLeft => "top-left",
+            OverlayAnchor::TopRight => "top-right",
+            OverlayAnchor::BottomLeft => "bottom-left",
+            OverlayAnchor::BottomRight => "bottom-right",
+            OverlayAnchor::TopCenter => "top-center",
+            OverlayAnchor::BottomCenter => "bottom-center",
+        }
+    }
+
+    /// Inverse of `to_key`; `None` for "auto"/empty/unknown (engine picks a play-context
+    /// default until the user positions it). Case/whitespace tolerant.
+    #[inline(always)]
+    pub fn from_key(key: &str) -> Option<Self> {
+        match key.trim().to_ascii_lowercase().as_str() {
+            "top-left" => Some(OverlayAnchor::TopLeft),
+            "top-right" => Some(OverlayAnchor::TopRight),
+            "bottom-left" => Some(OverlayAnchor::BottomLeft),
+            "bottom-right" => Some(OverlayAnchor::BottomRight),
+            "top-center" => Some(OverlayAnchor::TopCenter),
+            "bottom-center" => Some(OverlayAnchor::BottomCenter),
+            _ => None,
+        }
+    }
+}
+
+/// Presentation style for the overlay, toggleable at runtime so the two can be compared
+/// side by side. The names describe how much is shown: `Detailed` is DeadSync's richer
+/// readout (stable decaying-histogram p99 + the jitter histogram); `Minimal` strips both —
+/// mirroring osu!framework, where the graph *is* the jitter display — and shows only the
+/// smoothed averages, jitter, and a held worst spike.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum OverlayStyle {
+    Detailed,
+    Minimal,
+}
+
+impl OverlayStyle {
+    /// Flip to the other style.
+    #[inline(always)]
+    pub fn toggle(self) -> Self {
+        match self {
+            OverlayStyle::Detailed => OverlayStyle::Minimal,
+            OverlayStyle::Minimal => OverlayStyle::Detailed,
+        }
+    }
+
+    /// Short label, also used as the persistence key in the config ini. Keep fixed.
+    #[inline(always)]
+    pub fn label(self) -> &'static str {
+        match self {
+            OverlayStyle::Detailed => "detailed",
+            OverlayStyle::Minimal => "minimal",
+        }
+    }
+
+    /// Parse a persisted style key; unknown/empty falls back to `Detailed`. Case tolerant.
+    #[inline(always)]
+    pub fn from_key(key: &str) -> Self {
+        match key.trim().to_ascii_lowercase().as_str() {
+            "minimal" => OverlayStyle::Minimal,
+            _ => OverlayStyle::Detailed,
+        }
+    }
+
+    /// Whether percentile (p99) readouts are shown in this style.
+    #[inline(always)]
+    fn show_p99(self) -> bool {
+        matches!(self, OverlayStyle::Detailed)
+    }
+
+    /// Whether the jitter histogram panel is shown in this style (full mode only).
+    #[inline(always)]
+    fn show_histogram(self) -> bool {
+        matches!(self, OverlayStyle::Detailed)
+    }
+}
+
+/// Default anchor when the overlay is first switched on, before the user has positioned it:
+/// the top-right corner. Once moved (Ctrl+Shift+F3) the chosen corner is remembered instead.
+pub fn default_anchor() -> OverlayAnchor {
+    OverlayAnchor::TopRight
+}
+
+/// Advance to the next anchor in a mode-specific cycle. Compact (2-player) mode includes
+/// the top/bottom-center seams; full mode walks the four corners.
+pub fn next_anchor(current: OverlayAnchor, compact: bool) -> OverlayAnchor {
+    use OverlayAnchor::*;
+    let order: &[OverlayAnchor] = if compact {
+        &[BottomCenter, TopCenter, BottomLeft, BottomRight, TopLeft, TopRight]
+    } else {
+        &[TopLeft, TopRight, BottomRight, BottomLeft]
+    };
+    let idx = order.iter().position(|a| *a == current).unwrap_or(usize::MAX);
+    order[(idx.wrapping_add(1)) % order.len()]
+}
+
+#[inline(always)]
+fn anchor_is_right(a: OverlayAnchor) -> bool {
+    matches!(a, OverlayAnchor::TopRight | OverlayAnchor::BottomRight)
+}
+
+#[inline(always)]
+fn anchor_is_bottom(a: OverlayAnchor) -> bool {
+    matches!(
+        a,
+        OverlayAnchor::BottomLeft | OverlayAnchor::BottomRight | OverlayAnchor::BottomCenter
+    )
+}
+
+#[inline(always)]
+fn anchor_is_center(a: OverlayAnchor) -> bool {
+    matches!(a, OverlayAnchor::TopCenter | OverlayAnchor::BottomCenter)
+}
+
+/// Resolved pixel rectangles for one overlay layout. The graph and (optional) histogram
+/// are stacked; the readout text sits to one side of the graph (mirrored to the left for
+/// right-anchored panels so it never runs off-screen).
+struct Layout {
+    graph_x: f32,
+    graph_y: f32,
+    graph_w: f32,
+    graph_h: f32,
+    hist_x: f32,
+    hist_y: f32,
+    hist_w: f32,
+    hist_h: f32,
+    text_x: f32,
+    text_y: f32,
+    text_right: bool,
+    // Full-mode data row: four cell x-origins at a shared y. Unused (0) in compact mode.
+    data_cols: [f32; DATA_COLS],
+    data_y: f32,
+}
+
+/// Top-left origin of the panel bounding box for `anchor`, given the box size and screen.
+/// Top-anchored panels start below the song-meter/progress-bar band (≈y 31) so they don't
+/// overlap it during gameplay; this offset is applied on every screen so the overlay keeps a
+/// consistent position when moving between menus and gameplay. Bottom anchors hug the margin.
+fn panel_origin(
+    anchor: OverlayAnchor,
+    box_w: f32,
+    box_h: f32,
+    screen_w: f32,
+    screen_h: f32,
+) -> (f32, f32) {
+    let x = if anchor_is_center(anchor) {
+        (screen_w - box_w) * 0.5
+    } else if anchor_is_right(anchor) {
+        screen_w - MARGIN - box_w
+    } else {
+        MARGIN
+    };
+    let y = if anchor_is_bottom(anchor) {
+        screen_h - MARGIN - box_h
+    } else {
+        TOP_PROGRESS_OFFSET
+    };
+    (x.max(0.0), y.max(0.0))
+}
+
+fn compute_layout(
+    anchor: OverlayAnchor,
+    compact: bool,
+    show_histogram: bool,
+    data_h: f32,
+    cell_widths: [f32; DATA_COLS],
+    screen_w: f32,
+    screen_h: f32,
+) -> Layout {
+    let right = anchor_is_right(anchor);
+    if compact {
+        let (ox, oy) = panel_origin(anchor, COMPACT_W, COMPACT_H, screen_w, screen_h);
+        // Right-anchored: text on the left, graph on the right. Otherwise graph then text.
+        let (graph_x, text_x) = if right {
+            (ox + COMPACT_TEXT_W + GRAPH_TEXT_GAP, ox + COMPACT_TEXT_W)
+        } else {
+            (ox, ox + COMPACT_GRAPH_W + GRAPH_TEXT_GAP)
+        };
+        Layout {
+            graph_x,
+            graph_y: oy,
+            graph_w: COMPACT_GRAPH_W,
+            graph_h: COMPACT_GRAPH_H,
+            hist_x: 0.0,
+            hist_y: 0.0,
+            hist_w: 0.0,
+            hist_h: 0.0,
+            text_x,
+            text_y: oy,
+            text_right: right,
+            data_cols: [0.0; DATA_COLS],
+            data_y: 0.0,
+        }
+    } else {
+        // Vertical stack: graph, optional histogram, then a single row of content-sized data
+        // cells laid left to right with a fixed gap. The graph and histogram span the same
+        // total width, so the panel hugs its content with no wasted space on the right. In
+        // minimal style the histogram is dropped, so the panel is shorter and the data row
+        // slides up under the graph.
+        let content_w = data_row_width(&cell_widths);
+        let hist_h = if show_histogram { HIST_H } else { 0.0 };
+        let stack_after_graph = if show_histogram { HIST_GAP + HIST_H } else { 0.0 };
+        let full_h = GRAPH_H + stack_after_graph + DATA_GAP + data_h;
+        let (ox, oy) = panel_origin(anchor, content_w, full_h, screen_w, screen_h);
+        let hist_y = oy + GRAPH_H + HIST_GAP;
+        let data_y = oy + GRAPH_H + stack_after_graph + DATA_GAP;
+        let mut data_cols = [0.0; DATA_COLS];
+        let mut cx = ox;
+        for (i, col) in data_cols.iter_mut().enumerate() {
+            *col = cx;
+            cx += cell_widths[i] + DATA_CELL_GAP;
+        }
+        Layout {
+            graph_x: ox,
+            graph_y: oy,
+            graph_w: content_w,
+            graph_h: GRAPH_H,
+            hist_x: ox,
+            hist_y,
+            hist_w: content_w,
+            hist_h,
+            text_x: ox,
+            text_y: oy,
+            text_right: false,
+            data_cols,
+            data_y,
+        }
+    }
+}
+
+/// One captured frame's per-phase timing plus sync state. `Copy`, no heap.
+#[derive(Clone, Copy, Debug)]
+pub struct FrameStatsSample {
+    pub host_nanos: u64,
+    pub frame_us: u32,
+    pub input_us: u32,
+    pub update_us: u32,
+    pub compose_us: u32,
+    pub upload_us: u32,
+    pub draw_us: u32,
+    pub gpu_wait_us: u32,
+    pub display_error_us: i32,
+    pub catching_up: bool,
+}
+
+impl FrameStatsSample {
+    #[inline(always)]
+    pub const fn empty() -> Self {
+        Self {
+            host_nanos: 0,
+            frame_us: 0,
+            input_us: 0,
+            update_us: 0,
+            compose_us: 0,
+            upload_us: 0,
+            draw_us: 0,
+            gpu_wait_us: 0,
+            display_error_us: 0,
+            catching_up: false,
+        }
+    }
+
+    #[inline(always)]
+    const fn is_empty(&self) -> bool {
+        self.host_nanos == 0
+    }
+
+    /// Sum of the explicitly measured phases (everything that isn't idle headroom).
+    #[inline(always)]
+    const fn measured_us(&self) -> u32 {
+        self.input_us
+            .saturating_add(self.update_us)
+            .saturating_add(self.compose_us)
+            .saturating_add(self.upload_us)
+            .saturating_add(self.draw_us)
+            .saturating_add(self.gpu_wait_us)
+    }
+
+    /// Idle / "sleep" headroom: the slice of the frame interval not spent in a measured
+    /// phase. Mirrors osu!'s Sleep segment so each column fills the full frame interval.
+    #[inline(always)]
+    const fn idle_us(&self) -> u32 {
+        self.frame_us.saturating_sub(self.measured_us())
+    }
+
+    /// CPU work this frame: every measured phase except the GPU/swapchain wait. This is the
+    /// real CPU cost (input → draw); `gpu_wait_us` is tracked separately as the GPU side.
+    #[inline(always)]
+    const fn cpu_work_us(&self) -> u32 {
+        self.input_us
+            .saturating_add(self.update_us)
+            .saturating_add(self.compose_us)
+            .saturating_add(self.upload_us)
+            .saturating_add(self.draw_us)
+    }
+}
+
+/// Precomputed sync-health readouts supplied by the caller (engine-side snapshots).
+#[derive(Clone, Copy, Debug)]
+pub struct FrameStatsSummary {
+    pub avg_frame_us: u32,
+    pub p99_frame_us: u32,
+    pub max_frame_us: u32,
+    pub fps: f32,
+    pub display_error_ms: f32,
+    pub display_error_p99_ms: f32,
+    pub display_catching_up: bool,
+    pub in_gameplay: bool,
+    pub audio_callback_gap_ms: f32,
+    pub audio_underruns: u64,
+    pub audio_output_delay_ms: f32,
+    pub audio_queued_frames: u32,
+    /// Smoothed jitter (EWMA standard deviation) of the frame interval, in microseconds.
+    pub frame_jitter_us: u32,
+    /// Smoothed jitter of the display-clock error, in microseconds.
+    pub display_error_jitter_us: u32,
+    /// Slow-decay "worst recent frame" hold, in microseconds (osu! spike marker analog).
+    pub spike_hold_us: u32,
+    /// Monitor target frame time for the graph reference lines, in microseconds (0 = none).
+    pub target_frame_us: u32,
+    /// Smoothed CPU work per frame (input → draw, excluding GPU wait), in microseconds.
+    pub cpu_work_us: u32,
+    /// Smoothed GPU/swapchain wait per frame, in microseconds.
+    pub gpu_wait_us: u32,
+    /// Frames in the recent ring window that exceeded the stutter threshold (the 2× target
+    /// reference line) — a count of visible hitches.
+    pub over_budget_count: u32,
+    /// Distinct display-clock catch-up events (rising edges) in the recent ring window.
+    pub catch_up_count: u32,
+}
+
+/// Exponentially-decaying bucketed histogram. Each `update` decays every bin by `gamma`
+/// and adds 1.0 to the sample's bin, so old frames fade and the effective window is
+/// `~1/(1-gamma)` samples. Percentiles are read by walking the weighted bins — no sort,
+/// no heap, `Copy`. This is what gives a *stable* p99 (unlike a short sliding window,
+/// which sawtooths as single outliers enter and leave it).
+#[derive(Clone, Copy)]
+pub struct DecayingHist {
+    bins: [f32; DHIST_BINS],
+    total: f32,
+}
+
+impl DecayingHist {
+    #[inline(always)]
+    pub const fn new() -> Self {
+        Self {
+            bins: [0.0; DHIST_BINS],
+            total: 0.0,
+        }
+    }
+
+    #[inline(always)]
+    pub fn reset(&mut self) {
+        self.bins = [0.0; DHIST_BINS];
+        self.total = 0.0;
+    }
+
+    /// Decay all bins and add the new `value_us` to its bucket.
+    #[inline]
+    pub fn update(&mut self, value_us: u32, gamma: f32, bucket_us: u32) {
+        let bucket_us = bucket_us.max(1);
+        let idx = (value_us / bucket_us).min(DHIST_BINS as u32 - 1) as usize;
+        for b in self.bins.iter_mut() {
+            *b *= gamma;
+        }
+        self.bins[idx] += 1.0;
+        self.total = self.total * gamma + 1.0;
+    }
+
+    /// Weighted percentile in microseconds (bucket-quantized). Returns 0 until warmed up.
+    #[inline]
+    pub fn percentile_us(&self, pct: f32, bucket_us: u32) -> u32 {
+        if self.total <= 0.0 {
+            return 0;
+        }
+        let bucket_us = bucket_us.max(1);
+        let target = (self.total * pct.clamp(0.0, 1.0)).max(f32::MIN_POSITIVE);
+        let mut cumulative = 0.0f32;
+        for (idx, &b) in self.bins.iter().enumerate() {
+            cumulative += b;
+            if cumulative >= target {
+                return (idx as u32 + 1) * bucket_us;
+            }
+        }
+        (DHIST_BINS as u32) * bucket_us
+    }
+
+    /// Effective sample count currently represented (≈ `1/(1-gamma)` once warmed up).
+    #[inline(always)]
+    pub fn effective_n(&self) -> u32 {
+        self.total.round().max(0.0) as u32
+    }
+}
+
+impl Default for DecayingHist {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Exponentially-weighted mean and variance (West's incremental EWMA). Tracks a smoothed
+/// average and a jitter (standard deviation) estimate without storing samples. `Copy`.
+#[derive(Clone, Copy)]
+pub struct EwmaStats {
+    mean: f32,
+    var: f32,
+    count: u32,
+}
+
+impl EwmaStats {
+    #[inline(always)]
+    pub const fn new() -> Self {
+        Self {
+            mean: 0.0,
+            var: 0.0,
+            count: 0,
+        }
+    }
+
+    #[inline(always)]
+    pub fn reset(&mut self) {
+        self.mean = 0.0;
+        self.var = 0.0;
+        self.count = 0;
+    }
+
+    #[inline]
+    pub fn update(&mut self, value: f32, alpha_mean: f32, alpha_var: f32) {
+        if self.count == 0 {
+            self.mean = value;
+            self.var = 0.0;
+        } else {
+            let delta = value - self.mean;
+            self.mean += alpha_mean * delta;
+            self.var = (1.0 - alpha_var) * (self.var + alpha_var * delta * delta);
+        }
+        self.count = self.count.saturating_add(1);
+    }
+
+    #[inline(always)]
+    pub fn mean(&self) -> f32 {
+        self.mean
+    }
+
+    #[inline(always)]
+    pub fn std_dev(&self) -> f32 {
+        self.var.max(0.0).sqrt()
+    }
+}
+
+impl Default for EwmaStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Long-window streaming statistics for the overlay: decaying histograms (frame time and
+/// display-clock error) for stable percentiles, plus EWMA mean/jitter for both signals.
+/// Percentiles are cached and refreshed at a low cadence so the readout text stays steady.
+/// All inline arrays — `Copy`, no heap — and only fed while the overlay is enabled.
+#[derive(Clone, Copy)]
+pub struct FrameStatsLong {
+    frame_hist: DecayingHist,
+    error_hist: DecayingHist,
+    frame_ewma: EwmaStats,
+    error_ewma: EwmaStats,
+    cpu_ewma: EwmaStats,
+    gpu_ewma: EwmaStats,
+    cached_p99_frame_us: u32,
+    cached_p99_error_us: u32,
+    refresh_counter: u8,
+}
+
+impl FrameStatsLong {
+    #[inline(always)]
+    pub const fn new() -> Self {
+        Self {
+            frame_hist: DecayingHist::new(),
+            error_hist: DecayingHist::new(),
+            frame_ewma: EwmaStats::new(),
+            error_ewma: EwmaStats::new(),
+            cpu_ewma: EwmaStats::new(),
+            gpu_ewma: EwmaStats::new(),
+            cached_p99_frame_us: 0,
+            cached_p99_error_us: 0,
+            refresh_counter: 0,
+        }
+    }
+
+    #[inline(always)]
+    pub fn reset(&mut self) {
+        self.frame_hist.reset();
+        self.error_hist.reset();
+        self.frame_ewma.reset();
+        self.error_ewma.reset();
+        self.cpu_ewma.reset();
+        self.gpu_ewma.reset();
+        self.cached_p99_frame_us = 0;
+        self.cached_p99_error_us = 0;
+        self.refresh_counter = 0;
+    }
+
+    /// Feed one captured frame (hot path while the overlay is on). Refreshes the cached
+    /// percentiles every `STATS_REFRESH_PERIOD` calls.
+    #[inline]
+    pub fn push(&mut self, sample: &FrameStatsSample) {
+        let abs_err = sample.display_error_us.unsigned_abs();
+        self.frame_hist
+            .update(sample.frame_us, DHIST_GAMMA, DHIST_BUCKET_US);
+        self.error_hist
+            .update(abs_err, DHIST_GAMMA, DHIST_BUCKET_US);
+        self.frame_ewma
+            .update(sample.frame_us as f32, EWMA_ALPHA_MEAN, EWMA_ALPHA_VAR);
+        self.error_ewma
+            .update(abs_err as f32, EWMA_ALPHA_MEAN, EWMA_ALPHA_VAR);
+        self.cpu_ewma
+            .update(sample.cpu_work_us() as f32, EWMA_ALPHA_MEAN, EWMA_ALPHA_VAR);
+        self.gpu_ewma
+            .update(sample.gpu_wait_us as f32, EWMA_ALPHA_MEAN, EWMA_ALPHA_VAR);
+
+        self.refresh_counter = self.refresh_counter.wrapping_add(1);
+        if self.refresh_counter >= STATS_REFRESH_PERIOD {
+            self.refresh_counter = 0;
+            self.cached_p99_frame_us = self.frame_hist.percentile_us(0.99, DHIST_BUCKET_US);
+            self.cached_p99_error_us = self.error_hist.percentile_us(0.99, DHIST_BUCKET_US);
+        }
+    }
+
+    #[inline(always)]
+    pub fn p99_frame_us(&self) -> u32 {
+        self.cached_p99_frame_us
+    }
+
+    #[inline(always)]
+    pub fn p99_error_us(&self) -> u32 {
+        self.cached_p99_error_us
+    }
+
+    #[inline(always)]
+    pub fn avg_frame_us(&self) -> u32 {
+        self.frame_ewma.mean().max(0.0).round() as u32
+    }
+
+    /// Smoothed CPU work per frame (input → draw, excluding GPU wait), in microseconds.
+    #[inline(always)]
+    pub fn avg_cpu_us(&self) -> u32 {
+        self.cpu_ewma.mean().max(0.0).round() as u32
+    }
+
+    /// Smoothed GPU/swapchain wait per frame, in microseconds.
+    #[inline(always)]
+    pub fn avg_gpu_us(&self) -> u32 {
+        self.gpu_ewma.mean().max(0.0).round() as u32
+    }
+
+    #[inline(always)]
+    pub fn frame_jitter_us(&self) -> u32 {
+        self.frame_ewma.std_dev().round() as u32
+    }
+
+    #[inline(always)]
+    pub fn error_jitter_us(&self) -> u32 {
+        self.error_ewma.std_dev().round() as u32
+    }
+
+    #[inline(always)]
+    pub fn effective_n(&self) -> u32 {
+        self.frame_hist.effective_n()
+    }
+}
+
+impl Default for FrameStatsLong {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Single-pass bucketed percentile of `frame_us` across `samples`, in microseconds.
+/// Avoids sorting/allocation; resolution is `bucket_us`.
+pub fn percentile_us(samples: &[FrameStatsSample], pct: f32, bucket_us: u32) -> u32 {
+    const BUCKETS: usize = 256;
+    let bucket_us = bucket_us.max(1);
+    let mut hist = [0u32; BUCKETS];
+    let mut count: u32 = 0;
+    for s in samples {
+        if s.is_empty() {
+            continue;
+        }
+        let idx = (s.frame_us / bucket_us).min(BUCKETS as u32 - 1) as usize;
+        hist[idx] = hist[idx].saturating_add(1);
+        count = count.saturating_add(1);
+    }
+    if count == 0 {
+        return 0;
+    }
+    let target = (f64::from(count) * f64::from(pct.clamp(0.0, 1.0))).ceil() as u32;
+    let target = target.max(1);
+    let mut cumulative: u32 = 0;
+    for (idx, bin) in hist.iter().enumerate() {
+        cumulative = cumulative.saturating_add(*bin);
+        if cumulative >= target {
+            return (idx as u32 + 1) * bucket_us;
+        }
+    }
+    (BUCKETS as u32) * bucket_us
+}
+
+/// Fill `out` with a frame-interval histogram. Bin `i` counts frames whose interval falls
+/// in `[i*bin_width_us, (i+1)*bin_width_us)`; the final bin absorbs the overflow.
+pub fn histogram(samples: &[FrameStatsSample], out: &mut [u32; HISTOGRAM_BINS], bin_width_us: u32) {
+    *out = [0; HISTOGRAM_BINS];
+    let bin_width_us = bin_width_us.max(1);
+    for s in samples {
+        if s.is_empty() {
+            continue;
+        }
+        let idx = (s.frame_us / bin_width_us).min(HISTOGRAM_BINS as u32 - 1) as usize;
+        out[idx] = out[idx].saturating_add(1);
+    }
+}
+
+#[inline(always)]
+fn quad(x: f32, y: f32, w: f32, h: f32, c: [f32; 4], z: i16) -> Actor {
+    act!(quad:
+        align(0.0, 0.0):
+        xy(x, y):
+        zoomto(w.max(0.0), h.max(0.0)):
+        diffuse(c[0], c[1], c[2], c[3]):
+        z(z)
+    )
+}
+
+#[inline(always)]
+fn segment(
+    actors: &mut Vec<Actor>,
+    x: f32,
+    baseline: f32,
+    drawn: &mut f32,
+    seg_us: u32,
+    px_per_us: f32,
+    col_w: f32,
+    rgb: [f32; 3],
+) {
+    if seg_us == 0 {
+        return;
+    }
+    let h = seg_us as f32 * px_per_us;
+    if h < 0.25 {
+        return;
+    }
+    let top = baseline - *drawn - h;
+    actors.push(quad(x, top, col_w, h, [rgb[0], rgb[1], rgb[2], 0.95], DEBUG_OVERLAY_Z + 1));
+    *drawn += h;
+}
+
+fn build_graph(
+    actors: &mut Vec<Actor>,
+    samples: &[FrameStatsSample],
+    scale_us: u32,
+    target_frame_us: u32,
+    gx: f32,
+    gy: f32,
+    gw: f32,
+    gh: f32,
+) {
+    let baseline = gy + gh;
+    let n = samples.len().max(1);
+    let col_w = gw / n as f32;
+    let px_per_us = gh / scale_us.max(1) as f32;
+    let spike_us = scale_us.max(1) * 2 / 3;
+
+    for (i, s) in samples.iter().enumerate() {
+        if s.is_empty() {
+            continue;
+        }
+        let x = gx + i as f32 * col_w;
+        let mut drawn = 0.0f32;
+        segment(actors, x, baseline, &mut drawn, s.idle_us(), px_per_us, col_w, COLOR_IDLE);
+        segment(actors, x, baseline, &mut drawn, s.input_us, px_per_us, col_w, COLOR_INPUT);
+        segment(actors, x, baseline, &mut drawn, s.update_us, px_per_us, col_w, COLOR_UPDATE);
+        segment(actors, x, baseline, &mut drawn, s.compose_us, px_per_us, col_w, COLOR_COMPOSE);
+        segment(actors, x, baseline, &mut drawn, s.upload_us, px_per_us, col_w, COLOR_UPLOAD);
+        segment(actors, x, baseline, &mut drawn, s.draw_us, px_per_us, col_w, COLOR_DRAW);
+        segment(actors, x, baseline, &mut drawn, s.gpu_wait_us, px_per_us, col_w, COLOR_GPU_WAIT);
+
+        // Event markers (osu! GC-marker analog): a full-height vertical line on frames
+        // where the display clock is actively catching up, or that spiked well past scale.
+        if s.catching_up {
+            actors.push(quad(x, gy, col_w.max(1.0), gh, COLOR_MARKER_CATCHUP, DEBUG_OVERLAY_Z + 2));
+        } else if s.frame_us >= spike_us {
+            actors.push(quad(x, gy, col_w.max(1.0), gh, COLOR_MARKER_SPIKE, DEBUG_OVERLAY_Z + 2));
+        }
+    }
+
+    // osu!-style fixed reference lines: the monitor's target frame time and twice it.
+    // Drawn last so they sit above the bars and markers; skipped if off the graph.
+    ref_line(actors, target_frame_us, scale_us, gx, baseline, gw, gh, COLOR_REF_TARGET);
+    ref_line(
+        actors,
+        target_frame_us.saturating_mul(2),
+        scale_us,
+        gx,
+        baseline,
+        gw,
+        gh,
+        COLOR_REF_DOUBLE,
+    );
+}
+
+/// Draw a horizontal reference line at `value_us` over the graph, if it falls on-scale.
+#[inline]
+fn ref_line(
+    actors: &mut Vec<Actor>,
+    value_us: u32,
+    scale_us: u32,
+    gx: f32,
+    baseline: f32,
+    gw: f32,
+    gh: f32,
+    color: [f32; 4],
+) {
+    if value_us == 0 || value_us >= scale_us {
+        return;
+    }
+    let px_per_us = gh / scale_us.max(1) as f32;
+    let y = baseline - value_us as f32 * px_per_us;
+    actors.push(quad(gx, y - 0.5, gw, 1.0, color, DEBUG_OVERLAY_Z + 3));
+}
+
+fn build_histogram(
+    actors: &mut Vec<Actor>,
+    samples: &[FrameStatsSample],
+    bin_width_us: u32,
+    hx: f32,
+    hy: f32,
+    hw: f32,
+    hh: f32,
+) {
+    let mut bins = [0u32; HISTOGRAM_BINS];
+    histogram(samples, &mut bins, bin_width_us);
+    let peak = bins.iter().copied().max().unwrap_or(0).max(1) as f32;
+    let baseline = hy + hh;
+    let col_w = hw / HISTOGRAM_BINS as f32;
+    for (i, &count) in bins.iter().enumerate() {
+        if count == 0 {
+            continue;
+        }
+        let h = (count as f32 / peak) * hh;
+        let x = hx + i as f32 * col_w;
+        actors.push(quad(x, baseline - h, col_w - 0.5, h, COLOR_HIST, DEBUG_OVERLAY_Z + 1));
+    }
+}
+
+#[inline(always)]
+fn ms(us: u32) -> f32 {
+    us as f32 / 1000.0
+}
+
+/// Top-left data cell: rolling frame-time summary. Numbers are smoothed (EWMA mean/jitter,
+/// decaying-histogram p99, slow-decay max-hold) so they read steadily instead of flickering.
+/// In minimal style the p99 line is omitted (osu! reports no percentile).
+fn summary_text(summary: &FrameStatsSummary, show_p99: bool) -> String {
+    use std::fmt::Write;
+    let mut text = String::with_capacity(96);
+    let _ = write!(
+        text,
+        "FRAME STATS\n{:.0} FPS\navg {:.2} \u{00b1}{:.2}ms",
+        summary.fps.max(0.0),
+        ms(summary.avg_frame_us),
+        ms(summary.frame_jitter_us),
+    );
+    if show_p99 {
+        let _ = write!(text, "\np99 {:.2}ms", ms(summary.p99_frame_us));
+    }
+    let _ = write!(text, "\nmax {:.2}ms", ms(summary.spike_hold_us));
+    if summary.target_frame_us > 0 {
+        let _ = write!(text, "\ntgt {:.2}ms", ms(summary.target_frame_us));
+    }
+    text
+}
+
+/// Second data cell: live CPU/GPU load breakdown. Shows the smoothed CPU work and GPU/swap
+/// wait per frame, the idle headroom as a percentage, and which slice currently dominates
+/// the frame ("lim CPU/GPU", or "none" when idle headroom dominates = frame-rate capped).
+/// Replaces the old static color legend with numbers that actually move.
+fn load_text(summary: &FrameStatsSummary) -> String {
+    use std::fmt::Write;
+    let cpu = summary.cpu_work_us;
+    let gpu = summary.gpu_wait_us;
+    let frame = summary.avg_frame_us.max(1);
+    // Idle = whatever of the frame isn't CPU work or GPU wait (the graph's dark-gray band).
+    let idle = frame.saturating_sub(cpu).saturating_sub(gpu);
+    let idle_pct = (idle as f32 / frame as f32 * 100.0).clamp(0.0, 100.0);
+    // What's limiting the frame: the largest of the three slices. Idle largest → not bound
+    // by either CPU or GPU (hitting the frame cap / vsync), so report "none".
+    let lim = if idle >= cpu && idle >= gpu {
+        "none"
+    } else if gpu >= cpu {
+        "GPU"
+    } else {
+        "CPU"
+    };
+    let mut text = String::with_capacity(64);
+    let _ = write!(
+        text,
+        "LOAD\ncpu {:.2}ms\ngpu {:.2}ms\nidle {:.0}%\nlim {}",
+        ms(cpu),
+        ms(gpu),
+        idle_pct,
+        lim,
+    );
+    text
+}
+
+/// Third data cell: stutter tally — how often and how badly the frame loop hitched recently.
+/// `over-budget` counts frames past the 2× stutter threshold in the rolling ring window,
+/// `catch-ups` counts distinct display-clock resync events, and `worst` is the slow-decay
+/// worst-frame hold. All a steady "did I hitch?" readout that matches the graph's markers.
+fn stutter_text(summary: &FrameStatsSummary) -> String {
+    use std::fmt::Write;
+    let mut text = String::with_capacity(64);
+    let _ = write!(
+        text,
+        "STUTTER\nover-budget {}\ncatch-ups {}\nworst {:.2}ms",
+        summary.over_budget_count,
+        summary.catch_up_count,
+        ms(summary.spike_hold_us),
+    );
+    text
+}
+
+/// Bottom-left data cell: display-clock sync health. The p99 line is omitted in minimal style.
+fn display_text(summary: &FrameStatsSummary, show_p99: bool) -> String {
+    use std::fmt::Write;
+    let mut text = String::with_capacity(64);
+    if summary.in_gameplay {
+        let _ = write!(text, "DISPLAY CLOCK\nerr {:+.2}ms", summary.display_error_ms);
+        if show_p99 {
+            let _ = write!(text, "\np99 {:.2}ms", summary.display_error_p99_ms);
+        }
+        let _ = write!(
+            text,
+            "\njit {:.2}ms\ncatch-up {}",
+            ms(summary.display_error_jitter_us),
+            if summary.display_catching_up { "YES" } else { "no" },
+        );
+    } else {
+        let _ = write!(text, "DISPLAY CLOCK\nn/a (menu)");
+    }
+    text
+}
+
+/// Bottom-right data cell: audio output health.
+fn audio_text(summary: &FrameStatsSummary) -> String {
+    use std::fmt::Write;
+    let mut text = String::with_capacity(64);
+    let _ = write!(
+        text,
+        "AUDIO\ngap {:.2}ms\nunderruns {}\nout {:.2}ms\nq {}",
+        summary.audio_callback_gap_ms,
+        summary.audio_underruns,
+        summary.audio_output_delay_ms,
+        summary.audio_queued_frames,
+    );
+    text
+}
+
+/// Push a left-aligned miso text block at `(x, y)`.
+fn push_text_block(actors: &mut Vec<Actor>, x: f32, y: f32, zoom: f32, text: String) {
+    actors.push(act!(text:
+        align(0.0, 0.0):
+        xy(x, y):
+        zoom(zoom):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        font("miso"):
+        settext(text):
+        horizalign(left):
+        z(DEBUG_OVERLAY_Z + 1)
+    ));
+}
+
+fn compact_readout_text(summary: &FrameStatsSummary, show_p99: bool) -> String {
+    use std::fmt::Write;
+
+    let mut text = String::with_capacity(96);
+    let _ = write!(
+        text,
+        "{:.0} FPS  avg {:.2}\u{00b1}{:.2}",
+        summary.fps.max(0.0),
+        ms(summary.avg_frame_us),
+        ms(summary.frame_jitter_us),
+    );
+    if show_p99 {
+        let _ = write!(text, "  p99 {:.2}", ms(summary.p99_frame_us));
+    }
+    let _ = write!(text, "  max {:.2} ms", ms(summary.spike_hold_us));
+    if summary.in_gameplay {
+        let _ = write!(
+            text,
+            "\nerr {:+.2} ms  catch-up {}  underruns {}  out {:.1} ms",
+            summary.display_error_ms,
+            if summary.display_catching_up { "YES" } else { "no" },
+            summary.audio_underruns,
+            summary.audio_output_delay_ms,
+        );
+    } else {
+        let _ = write!(
+            text,
+            "\nunderruns {}  out {:.1} ms  gap {:.2} ms",
+            summary.audio_underruns,
+            summary.audio_output_delay_ms,
+            summary.audio_callback_gap_ms,
+        );
+    }
+    text
+}
+
+/// Build the frame-statistics overlay actors anchored at `anchor`. Full mode draws a
+/// rolling per-phase stacked column graph (with idle, await-GPU and event-marker overlays),
+/// a jitter histogram, and a multi-line sync-health readout. Compact mode (2 players) drops
+/// the histogram for a small graph plus a two-line inline readout so it covers less of
+/// either notefield. `style` selects the presentation: `Detailed` shows the histogram and
+/// p99 readouts; `Minimal` drops both (the graph is the jitter display). Allocation-light:
+/// one pre-sized `Vec`, no per-sample heap.
+pub fn build(
+    samples: &[FrameStatsSample],
+    summary: FrameStatsSummary,
+    anchor: OverlayAnchor,
+    compact: bool,
+    style: OverlayStyle,
+    screen_w: f32,
+    screen_h: f32,
+) -> Vec<Actor> {
+    let show_p99 = style.show_p99();
+    // The histogram is a full-mode-only panel; minimal style drops it entirely.
+    let show_histogram = !compact && style.show_histogram();
+
+    // Scale the graph to the worst recent frame (held briefly via spike-hold so the scale
+    // doesn't snap back the instant a spike leaves the ring), with a sane floor.
+    let scale_us = summary
+        .max_frame_us
+        .max(summary.spike_hold_us)
+        .max(20_000);
+    let bin_width_us = (scale_us / HISTOGRAM_BINS as u32).max(250);
+
+    // Build the full-mode data-cell strings up front so the data block is sized to the
+    // tallest cell that's actually rendered (varies by style + gameplay/menu), leaving no
+    // fixed over-budget margin below the text. Skipped entirely in compact mode.
+    let data_cells: Option<[String; DATA_COLS]> = if compact {
+        None
+    } else {
+        Some([
+            summary_text(&summary, show_p99),
+            load_text(&summary),
+            stutter_text(&summary),
+            display_text(&summary, show_p99),
+            audio_text(&summary),
+        ])
+    };
+    let data_h = match &data_cells {
+        None => 0.0,
+        Some(cells) => {
+            let max_lines = cells.iter().map(|s| line_count(s)).max().unwrap_or(0);
+            data_block_h(max_lines)
+        }
+    };
+    // Per-cell widths so each data column hugs its own text (no shared fixed width).
+    let cell_widths: [f32; DATA_COLS] = match &data_cells {
+        None => [0.0; DATA_COLS],
+        Some(cells) => {
+            let mut w = [0.0; DATA_COLS];
+            for (i, c) in cells.iter().enumerate() {
+                w[i] = data_cell_width(c);
+            }
+            w
+        }
+    };
+
+    let layout = compute_layout(
+        anchor,
+        compact,
+        show_histogram,
+        data_h,
+        cell_widths,
+        screen_w,
+        screen_h,
+    );
+    let mut actors = Vec::with_capacity(samples.len() * 7 + HISTOGRAM_BINS + 16);
+
+    // Panel background behind the graph.
+    actors.push(quad(
+        layout.graph_x - PANEL_PAD,
+        layout.graph_y - PANEL_PAD,
+        layout.graph_w + PANEL_PAD * 2.0,
+        layout.graph_h + PANEL_PAD * 2.0,
+        [0.0, 0.0, 0.0, 0.55],
+        DEBUG_OVERLAY_Z,
+    ));
+    if layout.hist_h > 0.0 {
+        actors.push(quad(
+            layout.hist_x - PANEL_PAD,
+            layout.hist_y - PANEL_PAD,
+            layout.hist_w + PANEL_PAD * 2.0,
+            layout.hist_h + PANEL_PAD * 2.0,
+            [0.0, 0.0, 0.0, 0.55],
+            DEBUG_OVERLAY_Z,
+        ));
+    }
+
+    build_graph(
+        &mut actors,
+        samples,
+        scale_us,
+        summary.target_frame_us,
+        layout.graph_x,
+        layout.graph_y,
+        layout.graph_w,
+        layout.graph_h,
+    );
+    if layout.hist_h > 0.0 {
+        build_histogram(
+            &mut actors,
+            samples,
+            bin_width_us,
+            layout.hist_x,
+            layout.hist_y,
+            layout.hist_w,
+            layout.hist_h,
+        );
+    }
+
+    if compact {
+        // Compact: a single inline readout beside the small graph (mirrored when right-anchored).
+        let text = compact_readout_text(&summary, show_p99);
+        let text_y = layout.text_y - PANEL_PAD;
+        if layout.text_right {
+            actors.push(act!(text:
+                align(1.0, 0.0):
+                xy(layout.text_x, text_y):
+                zoom(0.5):
+                diffuse(1.0, 1.0, 1.0, 1.0):
+                font("miso"):
+                settext(text):
+                horizalign(right):
+                z(DEBUG_OVERLAY_Z + 1)
+            ));
+        } else {
+            push_text_block(&mut actors, layout.text_x, text_y, 0.5, text);
+        }
+    } else {
+        // Full: a single row of content-sized data cells stacked under the graph (and optional
+        // histogram). The background spans the same width as the graph (the total content
+        // width) and is sized to the tallest cell (data_h), so it hugs the text on every side.
+        actors.push(quad(
+            layout.graph_x - PANEL_PAD,
+            layout.data_y - PANEL_PAD,
+            layout.graph_w + PANEL_PAD * 2.0,
+            data_h + PANEL_PAD * 2.0,
+            [0.0, 0.0, 0.0, 0.55],
+            DEBUG_OVERLAY_Z,
+        ));
+        let [c0, c1, c2, c3, c4] = data_cells.expect("full mode builds data_cells");
+        push_text_block(&mut actors, layout.data_cols[0], layout.data_y, 0.5, c0);
+        push_text_block(&mut actors, layout.data_cols[1], layout.data_y, 0.5, c1);
+        push_text_block(&mut actors, layout.data_cols[2], layout.data_y, 0.5, c2);
+        push_text_block(&mut actors, layout.data_cols[3], layout.data_y, 0.5, c3);
+        push_text_block(&mut actors, layout.data_cols[4], layout.data_y, 0.5, c4);
+    }
+
+    actors
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(frame_us: u32) -> FrameStatsSample {
+        FrameStatsSample {
+            host_nanos: 1,
+            frame_us,
+            ..FrameStatsSample::empty()
+        }
+    }
+
+    fn sample_summary() -> FrameStatsSummary {
+        FrameStatsSummary {
+            avg_frame_us: 16_600,
+            p99_frame_us: 22_000,
+            max_frame_us: 30_000,
+            fps: 60.0,
+            display_error_ms: 0.4,
+            display_error_p99_ms: 1.2,
+            display_catching_up: false,
+            in_gameplay: true,
+            audio_callback_gap_ms: 0.1,
+            audio_underruns: 0,
+            audio_output_delay_ms: 12.0,
+            audio_queued_frames: 1024,
+            frame_jitter_us: 800,
+            display_error_jitter_us: 300,
+            spike_hold_us: 30_000,
+            target_frame_us: 16_667,
+            cpu_work_us: 1_800,
+            gpu_wait_us: 2_300,
+            over_budget_count: 2,
+            catch_up_count: 1,
+        }
+    }
+
+    #[test]
+    fn percentile_ignores_empty_and_picks_high_bucket() {
+        let mut samples = vec![FrameStatsSample::empty(); 4];
+        samples.push(sample(16_000));
+        samples.push(sample(16_000));
+        samples.push(sample(16_000));
+        samples.push(sample(50_000));
+        // p99 should land in the bucket covering the 50ms spike.
+        let p99 = percentile_us(&samples, 0.99, 1_000);
+        assert!(p99 >= 50_000, "p99 was {p99}");
+        // p50 should sit at the common 16ms frames.
+        let p50 = percentile_us(&samples, 0.5, 1_000);
+        assert!((16_000..=17_000).contains(&p50), "p50 was {p50}");
+    }
+
+    #[test]
+    fn percentile_empty_is_zero() {
+        let samples = [FrameStatsSample::empty(); 3];
+        assert_eq!(percentile_us(&samples, 0.99, 1_000), 0);
+    }
+
+    #[test]
+    fn histogram_buckets_and_overflow() {
+        let mut bins = [0u32; HISTOGRAM_BINS];
+        let samples = [sample(0), sample(1_000), sample(1_500), sample(10_000_000)];
+        histogram(&samples, &mut bins, 1_000);
+        assert_eq!(bins[0], 1); // 0us
+        assert_eq!(bins[1], 2); // 1000us and 1500us both land in bin 1
+        assert_eq!(bins[HISTOGRAM_BINS - 1], 1); // huge value clamps to last bin
+    }
+
+    #[test]
+    fn idle_is_frame_minus_measured() {
+        let s = FrameStatsSample {
+            host_nanos: 1,
+            frame_us: 16_000,
+            input_us: 1_000,
+            update_us: 2_000,
+            compose_us: 1_000,
+            upload_us: 500,
+            draw_us: 3_000,
+            gpu_wait_us: 1_500,
+            ..FrameStatsSample::empty()
+        };
+        assert_eq!(s.measured_us(), 9_000);
+        assert_eq!(s.idle_us(), 7_000);
+    }
+
+    #[test]
+    fn default_anchor_is_top_right() {
+        // The overlay opens in the top-right corner until the user moves it.
+        assert_eq!(default_anchor(), OverlayAnchor::TopRight);
+    }
+
+    #[test]
+    fn next_anchor_cycles_and_wraps() {
+        // Full-mode cycle walks the four corners and wraps.
+        assert_eq!(next_anchor(OverlayAnchor::TopLeft, false), OverlayAnchor::TopRight);
+        assert_eq!(next_anchor(OverlayAnchor::TopRight, false), OverlayAnchor::BottomRight);
+        assert_eq!(next_anchor(OverlayAnchor::BottomRight, false), OverlayAnchor::BottomLeft);
+        assert_eq!(next_anchor(OverlayAnchor::BottomLeft, false), OverlayAnchor::TopLeft);
+        // Compact-mode cycle starts at the seams.
+        assert_eq!(next_anchor(OverlayAnchor::BottomCenter, true), OverlayAnchor::TopCenter);
+        // An anchor outside the active list falls back to the first entry.
+        assert_eq!(next_anchor(OverlayAnchor::TopCenter, false), OverlayAnchor::TopLeft);
+    }
+
+    #[test]
+    fn decaying_hist_percentile_tracks_distribution() {
+        let mut h = DecayingHist::new();
+        // Feed a steady 16ms stream with an occasional 50ms spike (~2%).
+        for i in 0..2000 {
+            let v = if i % 50 == 0 { 50_000 } else { 16_000 };
+            h.update(v, DHIST_GAMMA, DHIST_BUCKET_US);
+        }
+        let p50 = h.percentile_us(0.50, DHIST_BUCKET_US);
+        let p99 = h.percentile_us(0.99, DHIST_BUCKET_US);
+        // Median sits on the common 16ms frames; p99 reaches the 50ms spike bucket.
+        assert!((16_000..=16_200).contains(&p50), "p50 was {p50}");
+        assert!(p99 >= 49_800, "p99 was {p99}");
+        // Effective window is bounded near 1/(1-gamma) (~1024), not the 2000 fed.
+        assert!(h.effective_n() <= 1100, "effective_n was {}", h.effective_n());
+    }
+
+    #[test]
+    fn decaying_hist_is_stable_against_single_outlier() {
+        // A short sliding-window p99 sawtooths when one outlier enters/leaves; the decaying
+        // histogram should barely move when a lone spike ages out of relevance.
+        let mut h = DecayingHist::new();
+        for _ in 0..2000 {
+            h.update(16_000, DHIST_GAMMA, DHIST_BUCKET_US);
+        }
+        let before = h.percentile_us(0.99, DHIST_BUCKET_US);
+        h.update(80_000, DHIST_GAMMA, DHIST_BUCKET_US);
+        for _ in 0..200 {
+            h.update(16_000, DHIST_GAMMA, DHIST_BUCKET_US);
+        }
+        let after = h.percentile_us(0.99, DHIST_BUCKET_US);
+        // One spike in ~1000 effective samples stays under the 99th percentile → no jump.
+        assert_eq!(before, after, "p99 moved {before}->{after} on a single outlier");
+    }
+
+    #[test]
+    fn ewma_converges_to_mean_and_reports_jitter() {
+        let mut e = EwmaStats::new();
+        for _ in 0..1000 {
+            e.update(16_000.0, EWMA_ALPHA_MEAN, EWMA_ALPHA_VAR);
+        }
+        assert!((e.mean() - 16_000.0).abs() < 1.0, "mean was {}", e.mean());
+        assert!(e.std_dev() < 50.0, "constant input should have ~0 jitter");
+
+        let mut j = EwmaStats::new();
+        for i in 0..4000 {
+            let v = if i % 2 == 0 { 14_000.0 } else { 18_000.0 };
+            j.update(v, EWMA_ALPHA_MEAN, EWMA_ALPHA_VAR);
+        }
+        // Alternating ±2ms around 16ms → mean ~16ms, non-trivial jitter.
+        assert!((j.mean() - 16_000.0).abs() < 500.0, "mean was {}", j.mean());
+        assert!(j.std_dev() > 500.0, "jitter was {}", j.std_dev());
+    }
+
+    #[test]
+    fn frame_stats_long_caches_percentiles_at_cadence() {
+        let mut long = FrameStatsLong::new();
+        let mut s = sample(16_000);
+        // Below the refresh period the cache stays cold (0); it populates once it ticks over.
+        for _ in 0..(STATS_REFRESH_PERIOD - 1) {
+            long.push(&s);
+        }
+        assert_eq!(long.p99_frame_us(), 0, "cache should be cold before first refresh");
+        long.push(&s);
+        assert!(long.p99_frame_us() > 0, "cache should populate at the refresh cadence");
+
+        s.display_error_us = 1_200;
+        for _ in 0..STATS_REFRESH_PERIOD {
+            long.push(&s);
+        }
+        assert!(long.p99_error_us() > 0, "error percentile should populate too");
+        long.reset();
+        assert_eq!(long.p99_frame_us(), 0);
+        assert_eq!(long.effective_n(), 0);
+    }
+
+    #[test]
+    fn ref_line_clips_off_scale_values() {
+        let mut actors = Vec::new();
+        // Target above the graph scale draws nothing; on-scale draws one line quad.
+        ref_line(&mut actors, 40_000, 20_000, 0.0, 100.0, 200.0, 100.0, COLOR_REF_TARGET);
+        assert!(actors.is_empty(), "off-scale reference line should be skipped");
+        ref_line(&mut actors, 16_700, 33_400, 0.0, 100.0, 200.0, 100.0, COLOR_REF_TARGET);
+        assert_eq!(actors.len(), 1, "on-scale reference line should draw one quad");
+    }
+
+    #[test]
+    fn layout_stacks_graph_over_content_sized_data_row() {
+        let sw = 854.0;
+        let sh = 480.0;
+        let data_h = data_block_h(6);
+        // Representative per-cell widths (FRAME STATS widest, the rest narrower).
+        let widths: [f32; DATA_COLS] = [80.0, 48.0, 62.0, 62.0, 52.0];
+        let content_w = data_row_width(&widths);
+        // Detailed mode: graph, histogram and a single content-sized data row stack vertically.
+        let l = compute_layout(OverlayAnchor::TopLeft, false, true, data_h, widths, sw, sh);
+        assert!((l.graph_x - MARGIN).abs() < 0.01);
+        // Top anchors start at the fixed progress-bar offset (applied on every screen so the
+        // overlay keeps a steady position between menus and gameplay).
+        assert!((l.graph_y - TOP_PROGRESS_OFFSET).abs() < 0.01);
+        assert!(!l.text_right);
+        // Histogram sits directly below the graph; data row below the histogram.
+        assert!(l.hist_y > l.graph_y);
+        assert!((l.hist_x - l.graph_x).abs() < 0.01);
+        assert!(l.data_y > l.hist_y);
+        // The graph spans the total content width and stays under half the screen.
+        assert!((l.graph_w - content_w).abs() < 0.01);
+        assert!(l.graph_w <= sw * 0.5 + 0.01, "graph_w {} should be <= half screen", l.graph_w);
+        // Cells are laid left to right: each starts after the previous cell's width + the gap.
+        assert!((l.data_cols[0] - l.graph_x).abs() < 0.01);
+        for i in 1..DATA_COLS {
+            let expected = l.data_cols[i - 1] + widths[i - 1] + DATA_CELL_GAP;
+            assert!((l.data_cols[i] - expected).abs() < 0.01);
+        }
+        // The last cell ends right at the panel's right edge (no wasted trailing space).
+        let last_end = l.data_cols[DATA_COLS - 1] + widths[DATA_COLS - 1];
+        assert!((last_end - (l.graph_x + l.graph_w)).abs() < 0.01);
+        // Right anchor: whole panel shifts right but layout stays left-aligned (no mirror).
+        let r = compute_layout(OverlayAnchor::TopRight, false, true, data_h, widths, sw, sh);
+        assert!(r.graph_x > l.graph_x);
+        assert!(!r.text_right);
+        assert!((r.hist_x - r.graph_x).abs() < 0.01);
+        assert!(r.graph_x + r.graph_w <= sw - MARGIN + 0.01);
+        // Bottom anchor grows upward from the bottom margin.
+        let b = compute_layout(OverlayAnchor::BottomLeft, false, true, data_h, widths, sw, sh);
+        let full_h = GRAPH_H + HIST_GAP + HIST_H + DATA_GAP + data_h;
+        assert!((b.graph_y + full_h - (sh - MARGIN)).abs() < 0.01);
+        // Compact mode drops the histogram and the data row.
+        let c = compute_layout(OverlayAnchor::BottomCenter, true, true, 0.0, widths, sw, sh);
+        assert_eq!(c.hist_h, 0.0);
+        assert_eq!(c.data_y, 0.0);
+    }
+
+    #[test]
+    fn data_cell_width_hugs_longest_line() {
+        assert_eq!(data_cell_width(""), 0.0);
+        // Width tracks the longest line's character count.
+        let one = data_cell_width("abc");
+        let two = data_cell_width("abc\nlonger line");
+        assert!(two > one);
+        assert!((data_cell_width("abc") - (3.0 * DATA_CELL_CHAR_W + DATA_CELL_PAD)).abs() < 0.01);
+        // The row width is the cells plus the inter-cell gaps.
+        let widths = [10.0, 20.0, 30.0, 40.0, 50.0];
+        assert!((data_row_width(&widths) - (150.0 + 4.0 * DATA_CELL_GAP)).abs() < 0.01);
+    }
+
+    #[test]
+    fn data_block_height_hugs_line_count() {
+        // Empty block has no height; otherwise one cap plus one pitch per extra line.
+        assert_eq!(data_block_h(0), 0.0);
+        assert_eq!(data_block_h(1), DATA_LINE_CAP);
+        assert!((data_block_h(6) - (DATA_LINE_CAP + DATA_LINE_PITCH * 5.0)).abs() < 0.01);
+        // Fewer lines → a shorter block (e.g. minimal style's 5-line cell vs detailed's 6).
+        assert!(data_block_h(5) < data_block_h(6));
+        // Line counting: newlines + 1, empty string → 0.
+        assert_eq!(line_count(""), 0);
+        assert_eq!(line_count("one"), 1);
+        assert_eq!(line_count("a\nb\nc"), 3);
+    }
+
+    #[test]
+    fn minimal_data_block_is_shorter_than_detailed() {
+        // The minimal-style FRAME STATS / DISPLAY cells drop their p99 line, so the tallest
+        // cell is shorter and the data block hugs it more tightly than detailed.
+        let s = sample_summary();
+        let detailed_lines = [
+            summary_text(&s, true),
+            load_text(&s),
+            stutter_text(&s),
+            display_text(&s, true),
+            audio_text(&s),
+        ]
+        .iter()
+        .map(|t| line_count(t))
+        .max()
+        .unwrap();
+        let minimal_lines = [
+            summary_text(&s, false),
+            load_text(&s),
+            stutter_text(&s),
+            display_text(&s, false),
+            audio_text(&s),
+        ]
+        .iter()
+        .map(|t| line_count(t))
+        .max()
+        .unwrap();
+        assert!(
+            minimal_lines < detailed_lines,
+            "minimal {minimal_lines} should be < detailed {detailed_lines}"
+        );
+        assert!(data_block_h(minimal_lines) < data_block_h(detailed_lines));
+    }
+
+    #[test]
+    fn stutter_text_reports_counts_and_worst() {
+        let mut s = sample_summary();
+        s.over_budget_count = 4;
+        s.catch_up_count = 2;
+        s.spike_hold_us = 33_200;
+        let t = stutter_text(&s);
+        assert!(t.contains("over-budget 4"), "{t}");
+        assert!(t.contains("catch-ups 2"), "{t}");
+        assert!(t.contains("worst 33.20ms"), "{t}");
+    }
+
+    #[test]
+    fn load_text_reports_dominant_limiter() {
+        // GPU wait dominates → gpu-bound, low idle.
+        let mut s = sample_summary();
+        s.avg_frame_us = 5_000;
+        s.cpu_work_us = 1_000;
+        s.gpu_wait_us = 3_500;
+        let t = load_text(&s);
+        assert!(t.contains("lim GPU"), "{t}");
+        assert!(t.contains("cpu 1.00ms") && t.contains("gpu 3.50ms"), "{t}");
+        // CPU work dominates → cpu-bound.
+        s.cpu_work_us = 3_500;
+        s.gpu_wait_us = 1_000;
+        assert!(load_text(&s).contains("lim CPU"));
+        // Lots of idle headroom → frame-capped, not bound by either.
+        s.avg_frame_us = 16_667;
+        s.cpu_work_us = 1_000;
+        s.gpu_wait_us = 1_000;
+        let t = load_text(&s);
+        assert!(t.contains("lim none"), "{t}");
+        assert!(t.contains("idle 88%"), "{t}");
+    }
+
+    #[test]
+    fn anchor_and_style_keys_round_trip() {
+        use OverlayAnchor::*;
+        for a in [TopLeft, TopRight, BottomLeft, BottomRight, TopCenter, BottomCenter] {
+            assert_eq!(OverlayAnchor::from_key(a.to_key()), Some(a));
+        }
+        // "auto"/empty/unknown map to None so the engine falls back to the default.
+        assert_eq!(OverlayAnchor::from_key("auto"), None);
+        assert_eq!(OverlayAnchor::from_key(""), None);
+        assert_eq!(OverlayAnchor::from_key("nonsense"), None);
+        // Keys are case/whitespace tolerant.
+        assert_eq!(OverlayAnchor::from_key("  TOP-LEFT "), Some(TopLeft));
+        // Styles round-trip; unknown/empty falls back to detailed.
+        assert_eq!(OverlayStyle::from_key(OverlayStyle::Detailed.label()), OverlayStyle::Detailed);
+        assert_eq!(OverlayStyle::from_key(OverlayStyle::Minimal.label()), OverlayStyle::Minimal);
+        assert_eq!(OverlayStyle::from_key("MINIMAL"), OverlayStyle::Minimal);
+        assert_eq!(OverlayStyle::from_key("???"), OverlayStyle::Detailed);
+    }
+
+    #[test]
+    fn minimal_layout_drops_histogram_and_shortens_panel() {
+        let sw = 854.0;
+        let sh = 480.0;
+        let data_h = data_block_h(6);
+        let widths: [f32; DATA_COLS] = [80.0, 48.0, 62.0, 62.0, 52.0];
+        let detailed = compute_layout(OverlayAnchor::TopLeft, false, true, data_h, widths, sw, sh);
+        let minimal = compute_layout(OverlayAnchor::TopLeft, false, false, data_h, widths, sw, sh);
+        // Minimal style has no histogram band...
+        assert_eq!(minimal.hist_h, 0.0);
+        assert!(detailed.hist_h > 0.0);
+        // ...so the data row slides up directly under the graph (shorter overall panel).
+        assert!(minimal.data_y < detailed.data_y);
+        assert!((minimal.data_y - (minimal.graph_y + GRAPH_H + DATA_GAP)).abs() < 0.01);
+        // Bottom-anchored minimal panel is shorter, so its graph starts lower than detailed.
+        let detailed_b = compute_layout(OverlayAnchor::BottomLeft, false, true, data_h, widths, sw, sh);
+        let minimal_b = compute_layout(OverlayAnchor::BottomLeft, false, false, data_h, widths, sw, sh);
+        assert!(minimal_b.graph_y > detailed_b.graph_y);
+    }
+
+    #[test]
+    fn overlay_style_toggle_round_trips() {
+        assert_eq!(OverlayStyle::Detailed.toggle(), OverlayStyle::Minimal);
+        assert_eq!(OverlayStyle::Minimal.toggle(), OverlayStyle::Detailed);
+        assert_eq!(OverlayStyle::Detailed.toggle().toggle(), OverlayStyle::Detailed);
+        assert!(OverlayStyle::Detailed.show_p99());
+        assert!(!OverlayStyle::Minimal.show_p99());
+        assert!(OverlayStyle::Detailed.show_histogram());
+        assert!(!OverlayStyle::Minimal.show_histogram());
+    }
+
+    #[test]
+    fn style_controls_p99_in_readout_text() {
+        let s = sample_summary();
+        // Detailed shows p99 in every readout; minimal omits it everywhere.
+        assert!(summary_text(&s, true).contains("p99"));
+        assert!(!summary_text(&s, false).contains("p99"));
+        assert!(display_text(&s, true).contains("p99"));
+        assert!(!display_text(&s, false).contains("p99"));
+        assert!(compact_readout_text(&s, true).contains("p99"));
+        assert!(!compact_readout_text(&s, false).contains("p99"));
+        // Averages and spike-hold max survive in both styles.
+        assert!(summary_text(&s, false).contains("avg"));
+        assert!(summary_text(&s, false).contains("max"));
+    }
+}

--- a/src/screens/components/shared/mod.rs
+++ b/src/screens/components/shared/mod.rs
@@ -1,5 +1,6 @@
 pub mod banner;
 pub mod ffmpeg_overlay;
+pub mod frame_stats_overlay;
 pub mod gamepad_overlay;
 pub mod gs_scorebox;
 pub mod loading_bar;


### PR DESCRIPTION
## Why

DeadSync already captures a lot of timing telemetry (display-clock health, audio callback gaps / underruns / output delay, per-phase frame timing), but it was mostly log- and trace-gated and invisible at runtime. This surfaces that existing data as a live on-screen HUD so a dev or player can *watch* a stutter happen instead of reconstructing it from logs afterward. It is modeled on osu!framework's FrameStatistics overlay.

## What it does

Press `Ctrl`+`F3` in-game to toggle a panel showing:

- A rolling **per-phase frame-time graph** (one stacked column per frame: idle / input / update / compose / upload / draw / gpu-wait), with osu-style catch-up and spike markers plus fixed target / 2x reference lines.
- A **jitter histogram** of recent frame intervals.
- Five live readout cells: **FRAME STATS** (FPS, avg +/- jitter, stable p99, max, target), **LOAD** (CPU vs GPU split, idle headroom %, what's limiting the frame), **STUTTER** (over-budget frames, catch-up events, worst recent), **DISPLAY CLOCK** (error, jitter, p99, catch-up state), and **AUDIO** (callback gap, underruns, output delay, queued frames).

Two more shortcuts: `Ctrl`+`Shift`+`F3` moves it between corners, `Ctrl`+`Alt`+`F3` switches between a **detailed** presentation (histogram + percentiles) and a **minimal** one (graph is the jitter display, osu-faithful). Chosen corner and style persist across restarts (stored as readable string keys in the ini); the overlay defaults to the top-right corner.