### PR TITLE
fix(gameplay): align crossover cues with ITGmania parity

### DIFF
--- a/src/game/gameplay.rs
+++ b/src/game/gameplay.rs
@@ -571,20 +571,35 @@ fn build_crossover_rows<const LANES: usize>(
         if note.column < col_start || note.column - col_start >= LANES {
             continue;
         }
-        if note.is_fake {
-            continue;
-        }
         let lane = note.column - col_start;
-        let ch = match note.note_type {
-            NoteType::Tap | NoteType::Lift => b'1',
-            NoteType::Hold => b'2',
-            NoteType::Roll => b'4',
-            NoteType::Mine | NoteType::Fake => continue,
+        let ch = if note.is_fake {
+            // Fake mines still bias parity foot placement (ITGMania feeds them
+            // to the solver); fake taps/holds/lifts are skipped.
+            match note.note_type {
+                NoteType::Mine => b'M',
+                _ => continue,
+            }
+        } else {
+            match note.note_type {
+                NoteType::Tap => b'1',
+                NoteType::Lift => b'L',
+                NoteType::Hold => b'2',
+                NoteType::Roll => b'4',
+                NoteType::Mine => b'M',
+                NoteType::Fake => continue,
+            }
         };
         let entry = rows
             .entry(note.row_index)
             .or_insert(([b'0'; LANES], note.beat));
-        entry.0[lane] = ch;
+        // A real arrow outranks a mine sharing the same row+lane.
+        if ch == b'M' {
+            if entry.0[lane] == b'0' {
+                entry.0[lane] = b'M';
+            }
+        } else {
+            entry.0[lane] = ch;
+        }
         if let Some(hold) = note.hold.as_ref() {
             let tail = rows
                 .entry(hold.end_row_index)
@@ -668,10 +683,14 @@ fn build_crossover_cues_core(
         let is_scooby = next.is_some_and(|a| a.is_active_crossover(include_brackets));
         let first_condition = current.beat - prev.beat <= spacing_threshold;
         let second_condition = next.is_some_and(|n| n.beat - current.beat <= spacing_threshold);
-        let third_condition = match (next, next_next) {
-            (Some(n), Some(nn)) => nn.beat - n.beat <= spacing_threshold,
-            _ => false,
-        };
+        // Only a scooby chain looks two steps ahead; otherwise the step after
+        // next is irrelevant to whether this crossover gets a cue. Evaluating it
+        // unconditionally emits cues the reference builder never would.
+        let third_condition = is_scooby
+            && match (next, next_next) {
+                (Some(n), Some(nn)) => nn.beat - n.beat <= spacing_threshold,
+                _ => false,
+            };
         if !(first_condition || second_condition || third_condition) {
             continue;
         }


### PR DESCRIPTION
## Why

The Crossover Cues assist was showing cues that ITGmania / Simply Love never display. The most visible case was ITL Online 2026's **"Drop In" (SX)**, whose chart contains **zero real crossovers** yet rendered 24 spurious cues.

Root cause: deadsync has two paths into rssp's StepParity solver. `rssp::analyze()` uses rssp's own parser (validated 0-mismatch vs ITGmania over 179k+ rows), but the **runtime** path re-encodes already-parsed gameplay `Note`s back into the solver via `build_crossover_rows`, and that re-encoder dropped/misrepresented inputs the solver needs for correct foot placement. Wrong foot placement invents crossovers that aren't there.

## What changed

All in `src/game/gameplay.rs`:

**`build_crossover_rows`** now mirrors the reference parity input exactly:
- **Mines** are encoded as `'M'` (were dropped). Mines bias StepParity foot placement; omitting them was the direct cause of Drop In's phantom crossovers.
- **Lifts** are encoded as `'L'`, distinct from taps `'1'` (were collapsed to `'1'`). Lifts don't anchor a foot the way taps do.
- **Fake mines** are fed through as `'M'` (fake taps/holds/lifts are still skipped). ITGmania feeds fake mines to the solver; dropping them flipped crossover classification on bracket rows.

**`build_crossover_cues_core`** now gates the third spacing condition behind `is_scooby`, matching the reference cue builder where the step after `next` is only considered inside a scooby chain. It was evaluated unconditionally, emitting extra cues on ~30 charts.