### PR TITLE
fix: faithful error bar intensity and single-sample handling

### DIFF
--- a/crates/deadsync-gameplay/src/lib.rs
+++ b/crates/deadsync-gameplay/src/lib.rs
@@ -7870,7 +7870,7 @@ pub fn error_bar_average_offset_s(
     music_time_s: f32,
     offset_s: f32,
     window_ms: u32,
-) -> f32 {
+) -> (f32, usize) {
     let now_ms = ((music_time_s * 100.0).round() * 10.0).max(0.0);
     samples.push_back((now_ms, offset_s));
 
@@ -7894,7 +7894,7 @@ pub fn error_bar_average_offset_s(
         oldest_in_window = Some(v);
     }
     if count == 0 {
-        return offset_s;
+        return (offset_s, 1);
     }
     if count > 1
         && (count & 1) == 1
@@ -7903,11 +7903,8 @@ pub fn error_bar_average_offset_s(
         sum -= oldest;
         count -= 1;
     }
-    let mut avg = sum / (count.max(1) as f32);
-    if count == 1 {
-        avg *= 0.75;
-    }
-    avg
+    let avg = sum / (count.max(1) as f32);
+    (avg, count)
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -9996,12 +9993,14 @@ mod tests {
     #[test]
     fn average_error_bar_interval_controls_sample_window() {
         let mut broad = VecDeque::from([(0.0, 0.010), (100.0, 0.020), (200.0, 0.030)]);
-        let broad_avg = error_bar_average_offset_s(&mut broad, 0.5, 0.050, 400);
+        let (broad_avg, broad_count) = error_bar_average_offset_s(&mut broad, 0.5, 0.050, 400);
         assert!((broad_avg - 0.040).abs() <= 1e-6);
+        assert_eq!(broad_count, 2);
 
         let mut narrow = VecDeque::from([(0.0, 0.010), (100.0, 0.020), (200.0, 0.030)]);
-        let narrow_avg = error_bar_average_offset_s(&mut narrow, 0.5, 0.050, 200);
-        assert!((narrow_avg - 0.0375).abs() <= 1e-6);
+        let (narrow_avg, narrow_count) = error_bar_average_offset_s(&mut narrow, 0.5, 0.050, 200);
+        assert!((narrow_avg - 0.050).abs() <= 1e-6);
+        assert_eq!(narrow_count, 1);
     }
 
     #[test]

--- a/src/game/gameplay.rs
+++ b/src/game/gameplay.rs
@@ -4236,6 +4236,8 @@ fn error_bar_register_tap(
     let error_bar_multi_tick = prof.error_bar_multi_tick;
     let error_ms_display = prof.error_ms_display;
     let short_avg_enabled = prof.short_average_error_bar_enabled;
+    let short_avg_intensity =
+        profile_data::clamp_average_error_bar_intensity(prof.average_error_bar_intensity);
     let long_avg_enabled = prof.long_error_bar_enabled;
     let long_avg_threshold_s =
         profile_data::clamp_long_error_bar_threshold_ms(prof.long_error_bar_threshold_ms) as f32
@@ -4357,24 +4359,26 @@ fn error_bar_register_tap(
 
     if show_average {
         if short_avg_enabled {
-            let avg = error_bar_average_offset_s(
+            let (avg_raw, avg_count) = error_bar_average_offset_s(
                 &mut p.error_bar_avg_samples,
                 tap_music_time_s,
                 offset_s,
                 average_interval_ms,
             );
-            let avg_clamped = if max_offset_s.is_finite() && max_offset_s > 0.0 {
-                avg.clamp(-max_offset_s, max_offset_s)
-            } else {
-                avg
-            };
+            let mut avg = avg_raw * short_avg_intensity;
+            if max_offset_s.is_finite() && max_offset_s > 0.0 {
+                avg = avg.clamp(-max_offset_s, max_offset_s);
+            }
+            if avg_count == 1 {
+                avg *= 0.75;
+            }
             error_bar_push_tick(
                 &mut p.error_bar_avg_ticks,
                 &mut p.error_bar_avg_next,
                 error_bar_multi_tick,
                 ErrorBarTick {
                     started_at: now,
-                    offset_s: avg_clamped,
+                    offset_s: avg,
                     window,
                 },
             );
@@ -8187,6 +8191,53 @@ return Def.ActorFrame{}
         }
 
         assert!(!state.players[0].error_bar_long_avg_visible);
+    }
+
+    #[test]
+    fn short_average_error_bar_applies_single_sample_correction_after_clamp() {
+        // Faithful to Average.lua: a single sample is scaled by intensity,
+        // clamped to the trim window, and only then multiplied by 0.75. With a
+        // large offset the intensity-scaled value saturates the clamp, so the
+        // stored offset must be clamp * 0.75 (not a pre-clamp 0.75).
+        let p1 = profile_data::Profile {
+            error_bar_active_mask: profile_data::ErrorBarMask::AVERAGE,
+            short_average_error_bar_enabled: true,
+            long_error_bar_enabled: false,
+            error_bar_trim: profile_data::ErrorBarTrim::Off,
+            average_error_bar_intensity: 2.0,
+            ..profile_data::Profile::default()
+        };
+        let mut state = regression_state([p1, profile_data::Profile::default()]);
+        state.total_elapsed_in_screen = 1.0;
+        let max_offset_s = state.timing_profile.windows_s[4];
+
+        error_bar_register_tap(
+            &mut state,
+            0,
+            &Judgment {
+                time_error_ms: 500.0,
+                time_error_music_ns: judgment::judgment_time_error_music_ns_from_ms(500.0, 1.0),
+                grade: JudgeGrade::Fantastic,
+                window: Some(TimingWindow::W1),
+                miss_because_held: false,
+            },
+            0.0,
+        );
+
+        let tick = state.players[0]
+            .error_bar_avg_ticks
+            .iter()
+            .flatten()
+            .next()
+            .copied()
+            .expect("a single tap should register a short average tick");
+        let expected = max_offset_s * 0.75;
+        assert!(
+            (tick.offset_s - expected).abs() <= 1e-6,
+            "single-sample offset {} should equal clamp(offset * intensity) * 0.75 = {}",
+            tick.offset_s,
+            expected
+        );
     }
 
     #[test]

--- a/src/game/gameplay.rs
+++ b/src/game/gameplay.rs
@@ -4240,6 +4240,8 @@ fn error_bar_register_tap(
     let long_avg_threshold_s =
         profile_data::clamp_long_error_bar_threshold_ms(prof.long_error_bar_threshold_ms) as f32
             / 1000.0;
+    let long_avg_intensity =
+        profile_data::clamp_long_error_bar_intensity(prof.long_error_bar_intensity);
     let long_avg_min_samples =
         profile_data::clamp_long_error_bar_min_samples(prof.long_error_bar_min_samples) as usize;
     let average_interval_ms =
@@ -4387,7 +4389,9 @@ fn error_bar_register_tap(
                 offset_s,
                 average_interval_ms,
             );
-            if long_len >= long_avg_min_samples && long_mean.abs() >= long_avg_threshold_s {
+            if long_len >= long_avg_min_samples
+                && long_mean.abs() * long_avg_intensity >= long_avg_threshold_s
+            {
                 p.error_bar_long_avg_tick = Some(ErrorBarTick {
                     started_at: now,
                     offset_s: long_mean,
@@ -8107,6 +8111,82 @@ return Def.ActorFrame{}
             .error_bar_long_avg_tick
             .expect("long-only Average should still emit the blue tick");
         assert!((long_tick.offset_s - 0.010).abs() <= 1e-6);
+    }
+
+    #[test]
+    fn long_error_bar_threshold_accounts_for_intensity() {
+        // Mean error of 2.5ms is below the 4ms threshold on its own, but with a
+        // 2x intensity the effective offset is 5ms, which should show the bar.
+        let p1 = profile_data::Profile {
+            error_bar_active_mask: profile_data::ErrorBarMask::AVERAGE,
+            short_average_error_bar_enabled: false,
+            long_error_bar_enabled: true,
+            long_error_bar_threshold_ms: 4,
+            long_error_bar_min_samples: 4,
+            long_error_bar_intensity: 2.0,
+            ..profile_data::Profile::default()
+        };
+        let mut state = regression_state([p1, profile_data::Profile::default()]);
+        state.total_elapsed_in_screen = 4.0;
+
+        for i in 0..4 {
+            error_bar_register_tap(
+                &mut state,
+                0,
+                &Judgment {
+                    time_error_ms: 2.5,
+                    time_error_music_ns: judgment::judgment_time_error_music_ns_from_ms(2.5, 1.0),
+                    grade: JudgeGrade::Fantastic,
+                    window: Some(TimingWindow::W1),
+                    miss_because_held: false,
+                },
+                i as f32 * 0.1,
+            );
+        }
+
+        let player = &state.players[0];
+        assert!(
+            player.error_bar_long_avg_visible,
+            "intensity should scale the long-term mean past the threshold"
+        );
+        let long_tick = player
+            .error_bar_long_avg_tick
+            .expect("blue long-term tick should be emitted once intensity-scaled");
+        // The stored offset stays raw; intensity is re-applied at render time.
+        assert!((long_tick.offset_s - 0.0025).abs() <= 1e-6);
+    }
+
+    #[test]
+    fn long_error_bar_stays_hidden_below_intensity_scaled_threshold() {
+        // 2.5ms mean with 1x intensity stays below the 4ms threshold.
+        let p1 = profile_data::Profile {
+            error_bar_active_mask: profile_data::ErrorBarMask::AVERAGE,
+            short_average_error_bar_enabled: false,
+            long_error_bar_enabled: true,
+            long_error_bar_threshold_ms: 4,
+            long_error_bar_min_samples: 4,
+            long_error_bar_intensity: 1.0,
+            ..profile_data::Profile::default()
+        };
+        let mut state = regression_state([p1, profile_data::Profile::default()]);
+        state.total_elapsed_in_screen = 4.0;
+
+        for i in 0..4 {
+            error_bar_register_tap(
+                &mut state,
+                0,
+                &Judgment {
+                    time_error_ms: 2.5,
+                    time_error_music_ns: judgment::judgment_time_error_music_ns_from_ms(2.5, 1.0),
+                    grade: JudgeGrade::Fantastic,
+                    window: Some(TimingWindow::W1),
+                    miss_because_held: false,
+                },
+                i as f32 * 0.1,
+            );
+        }
+
+        assert!(!state.players[0].error_bar_long_avg_visible);
     }
 
     #[test]

--- a/src/screens/components/gameplay/notefield.rs
+++ b/src/screens/components/gameplay/notefield.rs
@@ -9136,9 +9136,6 @@ pub(crate) fn build_bundles(
                         }
 
                         let multi_tick = profile.error_bar_multi_tick;
-                        let intensity = profile_data::clamp_average_error_bar_intensity(
-                            profile.average_error_bar_intensity,
-                        );
                         for tick_opt in &p.error_bar_avg_ticks {
                             let Some(tick) = tick_opt else {
                                 continue;
@@ -9151,9 +9148,10 @@ pub(crate) fn build_bundles(
                             if alpha <= 0.0 {
                                 continue;
                             }
-                            let scaled_offset =
-                                (tick.offset_s * intensity).clamp(-max_offset_s, max_offset_s);
-                            let x = scaled_offset * wscale;
+                            // Intensity scaling, clamping and the single-sample
+                            // 0.75 correction are baked into tick.offset_s when
+                            // the tick is registered (see error_bar_register_tap).
+                            let x = tick.offset_s * wscale;
                             if !x.is_finite() {
                                 continue;
                             }


### PR DESCRIPTION
## Why

The gameplay error bar has two ticks ported from Simply-Love-SM5-8ms's `Average.lua`: the short **average** tick and the long-term **blue** tick. Two port-fidelity bugs made them behave differently from the original.

## What changed

**1. Long (blue) error bar ignored the intensity multiplier at its visibility threshold.**
The original scales the long-term mean by the intensity factor before comparing against the threshold, so a 2.5ms mean at 2x intensity (= 5ms) clears the 4ms threshold and shows. The port compared the *raw* mean, so the blue bar rarely appeared. The threshold check now multiplies the mean by the clamped long-error-bar intensity, matching the original.

**2. Single-sample 0.75 correction was applied in the wrong order.**
`Average.lua` applies the "less jarring" single-sample correction last:

```
average -> * intensity -> clamp to trim window -> * 0.75
```

The port baked `* 0.75` inside the averaging helper, *before* intensity scaling and clamping, so the result diverged whenever the intensity-scaled value saturated the clamp. This fix bakes the full pipeline at tap-registration time (matching the original, which scales at tween time): the helper now reports the contributing sample count, the caller applies intensity, clamp, then the single-sample 0.75 in the correct order, and the stored tick offset is used directly at render time instead of re-applying intensity and clamp.