### PR TITLE
perf(smx): keep the FSR sensor overlay off the SDK state lock

### DIFF
--- a/crates/deadsync-smx/src/lib.rs
+++ b/crates/deadsync-smx/src/lib.rs
@@ -109,6 +109,17 @@ struct SmxShared {
     uuid: [Mutex<[u8; 16]>; 2],
     /// Per-pad serial string, cached at connect, used for friendly trigger labels.
     serial: [Mutex<String>; 2],
+    /// Latest sensor test data per pad, pushed from the SDK's `SensorTestData`
+    /// event (~30Hz while test mode is active) and read by `get_test_data`.
+    ///
+    /// This decouples the per-frame reader (the gameplay FSR overlay) from the
+    /// SDK's global state mutex, which is contended by the USB/main/animation
+    /// threads. Reading that shared lock once per render frame was costing
+    /// milliseconds with vsync off. This is our own mutex, held only for a tiny
+    /// copy and contended only by the 30Hz writer, so the reader never waits on
+    /// SDK USB/light work. Safe to write from the callback for the same reason
+    /// the `uuid`/`serial` caches are (see above).
+    sensor_data: [Mutex<Option<SensorTestData>>; 2],
     p1_assigned: AtomicBool,
     p2_assigned: AtomicBool,
     /// Set while a deferred `set_serial_numbers()` is in flight, so a burst of
@@ -167,6 +178,7 @@ pub fn init(config: InitConfig) -> bool {
             prev_input: [AtomicU16::new(0), AtomicU16::new(0)],
             uuid: [Mutex::new([0u8; 16]), Mutex::new([0u8; 16])],
             serial: [Mutex::new(String::new()), Mutex::new(String::new())],
+            sensor_data: [Mutex::new(None), Mutex::new(None)],
             p1_assigned: AtomicBool::new(config.p1_serial.is_some()),
             p2_assigned: AtomicBool::new(config.p2_serial.is_some()),
             serial_assign_inflight: AtomicBool::new(false),
@@ -618,12 +630,24 @@ pub fn apply_preset(pad: usize, preset: SmxPadPreset) -> bool {
 pub fn set_test_mode(pad: usize, mode: SensorTestMode) {
     if let Some(s) = SHARED.get() {
         s.manager.set_test_mode(pad, mode);
+        // Streaming stopped: drop the snapshot so a later session can't read a
+        // stale value before the first fresh sample arrives.
+        if mode == SensorTestMode::Off
+            && let Some(slot) = s.sensor_data.get(pad)
+        {
+            *slot.lock().unwrap() = None;
+        }
     }
 }
 
-/// Get sensor test data for a pad.
+/// Get the latest sensor test data for a pad. Reads our local snapshot (fed by
+/// the SDK's `SensorTestData` event), so it never touches the SDK's global state
+/// mutex. Returns `None` until the first sample arrives after test mode is on.
 pub fn get_test_data(pad: usize) -> Option<SensorTestData> {
-    SHARED.get().and_then(|s| s.manager.get_test_data(pad))
+    SHARED
+        .get()
+        .and_then(|s| s.sensor_data.get(pad))
+        .and_then(|slot| slot.lock().unwrap().clone())
 }
 
 /// Assign serial numbers to any connected pads that don't have one.
@@ -847,6 +871,9 @@ fn dispatch_event(shared: &SmxShared, event: SmxEvent) {
                 return;
             }
             shared.prev_input[pad].store(0, Ordering::Relaxed);
+            if let Some(slot) = shared.sensor_data.get(pad) {
+                *slot.lock().unwrap() = None;
+            }
             log::info!("SMX: pad {pad} disconnected");
             let sys_event = GpSystemEvent::Disconnected {
                 name: format!("StepManiaX pad {pad}"),
@@ -897,6 +924,13 @@ fn dispatch_event(shared: &SmxShared, event: SmxEvent) {
                 for listener in listeners.iter() {
                     listener(event);
                 }
+            }
+        }
+        SmxEvent::SensorTestData { pad, data } => {
+            // Publish to the local snapshot so the per-frame reader stays off the
+            // SDK state mutex. Fired ~30Hz while sensor test mode is active.
+            if let Some(slot) = shared.sensor_data.get(pad) {
+                *slot.lock().unwrap() = Some(data);
             }
         }
         _ => {}

--- a/docs/stepmaniax.md
+++ b/docs/stepmaniax.md
@@ -14,6 +14,21 @@ report.
 > FSRio pads share the same Configure Pads UI and profile system; most of this
 > applies to them too. SMX-specific behavior is called out where it matters.
 
+## Contents
+
+- [Why connect to the pads directly?](#why-connect-to-the-pads-directly)
+- [1. Quick start](#1-quick-start)
+- [2. The StepManiaX options page](#2-the-stepmaniax-options-page)
+  - [2a. Which pad is P1 vs P2?](#2a-which-pad-is-p1-vs-p2)
+- [3. Two ways to configure a pad](#3-two-ways-to-configure-a-pad)
+- [4. The Configure Pads screen](#4-the-configure-pads-screen)
+- [5. Pad profiles (Song Select)](#5-pad-profiles-song-select)
+- [6. How configs are stored](#6-how-configs-are-stored)
+- [7. Pad types & firmware](#7-pad-types--firmware)
+- [8. Architecture (for contributors)](#8-architecture-for-contributors)
+- [9. Diagnostics & bug reports](#9-diagnostics--bug-reports)
+- [10. Troubleshooting cheatsheet](#10-troubleshooting-cheatsheet)
+
 ---
 
 ## Why connect to the pads directly?
@@ -351,7 +366,8 @@ mutexes instead. See the comments in `engine/smx.rs`.
 ## 9. Diagnostics & bug reports
 
 Because much of the SMX path is hardware-dependent (firmware revisions, FSR vs
-load-cell, connect timing), two tools make remote debugging possible.
+load-cell, connect timing), and the in-gameplay overlays run on the per-frame
+render path, a few tools make remote debugging and performance triage possible.
 
 ### Trace logs
 
@@ -404,6 +420,50 @@ the `.smxhid` files — they can be replayed through the SDK to reproduce the
 exact device behavior offline.
 
 > Leave `SMX_CAPTURE_DIR` unset for normal play; it's purely a debugging aid.
+
+### Performance profiling (`DEADSYNC_SMX_PROFILE`)
+
+If the in-gameplay FSR sensor overlay seems to cost frame rate (most noticeable
+with vsync off, where the per-frame budget is tiny), this opt-in profiler shows
+where the time goes. Launch DeadSync with the env var set:
+
+```sh
+# Linux / macOS
+DEADSYNC_SMX_PROFILE=1 ./deadsync
+```
+
+```powershell
+# Windows (PowerShell)
+$env:DEADSYNC_SMX_PROFILE = '1'
+.\deadsync.exe
+```
+
+```cmd
+# Windows (Command Prompt / cmd.exe)
+set DEADSYNC_SMX_PROFILE=1
+deadsync.exe
+```
+
+Then play a song with the FSR sensor overlay enabled. Once a second, the log
+prints a `smx-profile:` line timing the overlay's two per-frame costs, in
+microseconds:
+
+```
+smx-profile: read avg=4.6us max=29.9us n=60 | draw avg=15.1us max=42.5us n=60
+```
+
+- **read**: fetching the latest pad sensor values each frame.
+- **draw**: building the on-screen sensor bars and value text.
+- **avg / max**: the average and the worst single sample over the last second.
+- **n**: how many samples fell in that second (read is sampled at a fixed rate,
+  draw tracks the frame rate).
+
+The line logs at `warn`, so it shows at the default log level without raising it
+to Trace, and it only prints while you are in a song with the overlay active. If
+you are reporting an overlay performance issue, a few seconds of these lines is
+the data to send.
+
+> Leave `DEADSYNC_SMX_PROFILE` unset for normal play; it's purely a diagnostic.
 
 ---
 

--- a/src/screens/gameplay.rs
+++ b/src/screens/gameplay.rs
@@ -443,6 +443,9 @@ pub struct State {
     pub song_lua_sound_paths: Vec<PathBuf>,
     smx_sensor_data: [Option<deadsync_smx::SensorTestData>; 2],
     smx_sensor_config: [Option<deadsync_smx::SmxConfig>; 2],
+    // Time banked toward the next throttled sensor refresh (see
+    // `maybe_refresh_smx_sensor_data`). Seeded to fire on the first frame.
+    smx_sensor_refresh_accum: f32,
     song_lua_overlay_order: SongLuaOverlayOrderCache,
     song_lua_background_visual_layer_orders: Vec<SongLuaOverlayOrderCache>,
     song_lua_foreground_visual_layer_orders: Vec<SongLuaOverlayOrderCache>,
@@ -560,6 +563,7 @@ impl State {
             song_lua_sound_paths,
             smx_sensor_data: [None, None],
             smx_sensor_config: [None, None],
+            smx_sensor_refresh_accum: SMX_SENSOR_REFRESH_INTERVAL,
             song_lua_overlay_order,
             song_lua_background_visual_layer_orders,
             song_lua_foreground_visual_layer_orders,
@@ -1777,7 +1781,8 @@ pub fn update(state: &mut State, delta_time: f32) -> ScreenAction {
         state.lobby_music_started = true;
     }
     update_lobby_machine_state(state);
-    refresh_smx_sensor_data(state);
+    maybe_refresh_smx_sensor_data(state, delta_time);
+    smx_profile::maybe_report();
     let previous_song_lua_time = state.current_music_time_display;
     let action = gameplay_update(state, delta_time, audio_snapshot());
     if matches!(action, GameplayAction::None) {
@@ -1884,6 +1889,26 @@ fn smx_fsr_display_pads(state: &State) -> [Option<(usize, usize)>; 2] {
         n += 1;
     }
     out
+}
+
+// The pad streams sensor data at ~30Hz on the wire (the SDK requests it on a
+// fixed interval), so reading it once per render frame is wasted work that
+// scales with the (vsync-off) frame rate and needlessly contends the SDK's
+// shared state lock. Sample on a fixed timer instead. 60Hz comfortably
+// oversamples the 30Hz source while decoupling the read cost from frame rate.
+const SMX_SENSOR_REFRESH_HZ: f32 = 60.0;
+const SMX_SENSOR_REFRESH_INTERVAL: f32 = 1.0 / SMX_SENSOR_REFRESH_HZ;
+
+fn maybe_refresh_smx_sensor_data(state: &mut State, delta_time: f32) {
+    state.smx_sensor_refresh_accum += delta_time;
+    if state.smx_sensor_refresh_accum < SMX_SENSOR_REFRESH_INTERVAL {
+        return;
+    }
+    // Keep the leftover so cadence stays steady, but cap it so a long stall
+    // (load spike, alt-tab) can't bank up a burst of catch-up refreshes.
+    state.smx_sensor_refresh_accum =
+        (state.smx_sensor_refresh_accum - SMX_SENSOR_REFRESH_INTERVAL).min(SMX_SENSOR_REFRESH_INTERVAL);
+    smx_profile::time_read(|| refresh_smx_sensor_data(state));
 }
 
 fn refresh_smx_sensor_data(state: &mut State) {
@@ -9339,13 +9364,15 @@ pub fn push_actors(
             }
             if state.player_profiles[0].smx_fsr_display || state.player_profiles[1].smx_fsr_display
             {
-                push_smx_sensor_display(
-                    &mut actors,
-                    state,
-                    &field_geom,
-                    is_doubles,
-                    is_centered_single,
-                );
+                smx_profile::time_draw(|| {
+                    push_smx_sensor_display(
+                        &mut actors,
+                        state,
+                        &field_geom,
+                        is_doubles,
+                        is_centered_single,
+                    )
+                });
             }
             if state.player_profiles[0].smx_pad_input_display
                 || state.player_profiles[1].smx_pad_input_display
@@ -10234,6 +10261,108 @@ pub fn push_actors(
     state.notefield_actor_scratch = notefield_actor_scratch;
     state.notefield_hud_actor_scratch = notefield_hud_actor_scratch;
     state.player_actor_scratch = player_actor_scratch;
+}
+
+// ─── SMX sensor display profiling ──────────────────────────────────────────────
+//
+// Opt-in, zero-cost-when-off instrumentation to attribute the FSR visualizer's
+// per-frame cost. Enable by running with `DEADSYNC_SMX_PROFILE=1`. Once a second
+// it logs the rolling average and max for two regions:
+//   read  — the throttled SDK get_test_data call (captures shared-state lock
+//           wait + the clone); shows whether lock contention is the cost.
+//   draw  — building the bar/text actors each frame.
+// `n` is the sample count in the window (read should sit near 60/s after the
+// throttle; draw tracks the frame rate).
+mod smx_profile {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Mutex, OnceLock};
+    use std::time::Instant;
+
+    struct Bucket {
+        sum_ns: AtomicU64,
+        max_ns: AtomicU64,
+        count: AtomicU64,
+    }
+
+    impl Bucket {
+        const fn new() -> Self {
+            Self {
+                sum_ns: AtomicU64::new(0),
+                max_ns: AtomicU64::new(0),
+                count: AtomicU64::new(0),
+            }
+        }
+
+        fn record(&self, ns: u64) {
+            self.sum_ns.fetch_add(ns, Ordering::Relaxed);
+            self.max_ns.fetch_max(ns, Ordering::Relaxed);
+            self.count.fetch_add(1, Ordering::Relaxed);
+        }
+
+        // Average (µs), max (µs), and sample count over the window, resetting it.
+        fn take(&self) -> (f64, f64, u64) {
+            let sum = self.sum_ns.swap(0, Ordering::Relaxed);
+            let max = self.max_ns.swap(0, Ordering::Relaxed);
+            let count = self.count.swap(0, Ordering::Relaxed);
+            let avg_us = if count == 0 {
+                0.0
+            } else {
+                sum as f64 / count as f64 / 1000.0
+            };
+            (avg_us, max as f64 / 1000.0, count)
+        }
+    }
+
+    static READ: Bucket = Bucket::new();
+    static DRAW: Bucket = Bucket::new();
+
+    fn enabled() -> bool {
+        static ENABLED: OnceLock<bool> = OnceLock::new();
+        *ENABLED.get_or_init(|| {
+            std::env::var("DEADSYNC_SMX_PROFILE").is_ok_and(|v| !v.is_empty() && v != "0")
+        })
+    }
+
+    fn time<T>(bucket: &Bucket, f: impl FnOnce() -> T) -> T {
+        if !enabled() {
+            return f();
+        }
+        let start = Instant::now();
+        let out = f();
+        bucket.record(start.elapsed().as_nanos() as u64);
+        out
+    }
+
+    pub fn time_read<T>(f: impl FnOnce() -> T) -> T {
+        time(&READ, f)
+    }
+
+    pub fn time_draw<T>(f: impl FnOnce() -> T) -> T {
+        time(&DRAW, f)
+    }
+
+    /// Log the rolling window once a second. Cheap no-op when profiling is off.
+    pub fn maybe_report() {
+        if !enabled() {
+            return;
+        }
+        static LAST: OnceLock<Mutex<Instant>> = OnceLock::new();
+        let clock = LAST.get_or_init(|| Mutex::new(Instant::now()));
+        let mut last = clock.lock().unwrap();
+        if last.elapsed().as_secs_f32() < 1.0 {
+            return;
+        }
+        *last = Instant::now();
+        drop(last);
+
+        let (read_avg, read_max, read_n) = READ.take();
+        let (draw_avg, draw_max, draw_n) = DRAW.take();
+        // `warn` so this opt-in diagnostic is visible at the default log level.
+        log::warn!(
+            "smx-profile: read avg={read_avg:.1}us max={read_max:.1}us n={read_n} | \
+             draw avg={draw_avg:.1}us max={draw_max:.1}us n={draw_n}"
+        );
+    }
 }
 
 // ─── SMX sensor display ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The in-gameplay FSR sensor overlay read sensor values **every render frame** by calling `deadsync_smx::get_test_data`, which goes through the SDK's global `state` mutex. That mutex is contended by the SDK's USB-poll, main, and animation threads, so with vsync off the per-frame read was spending **milliseconds waiting on the lock**, not doing work.

Measured on SMX hardware (release build, pad connected):

| | read avg | read max |
|---|---|---|
| before | ~1700us | up to ~13000us |
| after | ~5us | ~30us |

A user reported a solid 500fps dropping to a choppy ~430 when enabling the overlay; that regression is this lock wait (a fixed ~1.7ms/frame plus multi-ms spikes, which is a large fraction of a 2ms frame).

## Changes

1. **Throttle the sensor refresh to 60Hz.** The pad only streams sensor data at ~30Hz on the wire, so reading it once per render frame is wasted work that scales with the (vsync-off) frame rate. A small time accumulator decouples the read cadence from the frame rate; 60Hz comfortably oversamples the 30Hz source with no visible change.
2. **Serve `get_test_data` from a local snapshot.** Cache the latest `SensorTestData` per pad from the SDK's existing `SensorTestData` event (fired ~30Hz while test mode is active) into a dedicated per-pad mutex, matching the existing `uuid`/`serial` caches. The reader no longer touches the SDK state lock, so it can no longer be stalled behind USB or light work. Cleared on disconnect and when test mode is turned off so a later session can't read a stale value.
3. **Opt-in profiling.** `DEADSYNC_SMX_PROFILE=1` logs per-frame `read` vs `draw` timing once a second, for attributing overlay cost.

## Notes

- No behavior change to the overlay. The displayed data is still at most one ~33ms sensor frame old, exactly as before.
- The overlay's draw cost (bars + text) was already negligible (~15-25us); after this change the read is smaller than the draw, so the overlay is effectively free.
- Hardware-validated on SMX hardware.
- Fixes #559 