### PR TITLE
perf(smx): bump rustmaniax-sdk to 1.4.0 (input-latency fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,9 +4258,9 @@ dependencies = [
 
 [[package]]
 name = "rustmaniax-sdk"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ee8d7b2cfbece20aea972b97048bf6162dc339f834abc78cc25c8a9a799d69"
+checksum = "531ad16b16fbc977ed3a0d77ef7f3b3389a7d1ae82cd0598f939b121e5e530fb"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",

--- a/crates/deadsync-smx/Cargo.toml
+++ b/crates/deadsync-smx/Cargo.toml
@@ -9,7 +9,7 @@ deadsync-input = { path = "../deadsync-input" }
 deadsync-input-native = { path = "../deadsync-input-native" }
 deadsync-platform = { path = "../deadsync-platform" }
 log = "0.4.32"
-rustmaniax-sdk = "1.3.0"
+rustmaniax-sdk = "1.4.0"
 
 [lints.clippy]
 perf = { level = "warn", priority = -1 }


### PR DESCRIPTION
Bumps `deadsync-smx` from rustmaniax-sdk 1.3.0 to 1.4.0. Dependency bump only — no deadsync source changes; the fix is entirely in the SDK and consumed through the existing manager API.

## What 1.4.0 fixes

SMX input latency during gameplay. Lock profiling on hardware showed the SDK's USB poll thread (which reads input and fires the input callback) was starved by the SDK's main thread holding a shared lock ~50% of the time for blocking USB writes (panel lights / sensor requests). 1.4.0:

- takes input polling off the SDK's global state lock, and
- gives the read and write paths **separate HID handles**, so a read never waits behind a multi-millisecond blocking write.

## Measured on hardware (StepManiaX stage, gameplay)

- Worst-case input-read delay: **~8–11 ms → ~0.1 ms**.
- Poll-thread throughput recovered to near-idle.

Validated on hardware via this build before bumping. macOS needs hidapi's non-exclusive open (handled inside the SDK); Linux/Windows already allow it.

## Testing

`cargo check -p deadsync-smx` against the published 1.4.0. No API changes on the deadsync side.