### PR TITLE
Remember last logged-in profile across reboots

### DIFF
--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -102,6 +102,8 @@ fn load_defaults_after_error() {
     ADDITIONAL_SONG_FOLDERS.lock().unwrap().clear();
     *SMX_P1_SERIAL.lock().unwrap() = None;
     *SMX_P2_SERIAL.lock().unwrap() = None;
+    *LAST_PROFILE_P1.lock().unwrap() = None;
+    *LAST_PROFILE_P2.lock().unwrap() = None;
     deadsync_audio_stream::set_replaygain_enabled(Config::default().enable_replaygain);
     deadsync_audio_stream::set_preserve_pitch_enabled(Config::default().rate_mod_preserves_pitch);
     pad_order::reset();
@@ -122,6 +124,8 @@ fn load_runtime_state(conf: &SimpleIni) {
     };
     *SMX_P1_SERIAL.lock().unwrap() = serial("SmxP1Serial");
     *SMX_P2_SERIAL.lock().unwrap() = serial("SmxP2Serial");
+    *LAST_PROFILE_P1.lock().unwrap() = serial("LastProfileP1");
+    *LAST_PROFILE_P2.lock().unwrap() = serial("LastProfileP2");
     pad_order::load_order_from_ini(conf);
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,7 +28,7 @@ pub use self::load::{bootstrap_log_to_file, bootstrap_show_console, load};
 pub use self::null_or_die_cfg::null_or_die_bias_cfg;
 pub use self::pad_order::pad_index_for_uuid;
 pub use self::runtime::{
-    additional_song_folder_roots, audio_mix_levels, flush_pending_saves, get,
+    additional_song_folder_roots, audio_mix_levels, flush_pending_saves, get, last_active_profiles,
     machine_default_noteskin, smx_pad_assignment, song_path_is_writable,
 };
 pub use self::theme::{
@@ -54,8 +54,8 @@ use self::null_or_die_cfg::{
     parse_null_or_die_kernel_target, parse_null_or_die_kernel_type,
 };
 use self::runtime::{
-    ADDITIONAL_SONG_FOLDERS, MACHINE_DEFAULT_NOTESKIN, SMX_P1_SERIAL, SMX_P2_SERIAL, lock_config,
-    queue_save_write, sync_audio_mix_levels_from_config,
+    ADDITIONAL_SONG_FOLDERS, LAST_PROFILE_P1, LAST_PROFILE_P2, MACHINE_DEFAULT_NOTESKIN,
+    SMX_P1_SERIAL, SMX_P2_SERIAL, lock_config, queue_save_write, sync_audio_mix_levels_from_config,
 };
 use self::store::{normalize_machine_default_noteskin, save_without_keymaps};
 use deadlib_platform::logging;

--- a/src/config/runtime.rs
+++ b/src/config/runtime.rs
@@ -20,6 +20,14 @@ pub(super) static SMX_P1_SERIAL: std::sync::LazyLock<Mutex<Option<String>>> =
     std::sync::LazyLock::new(|| Mutex::new(None));
 pub(super) static SMX_P2_SERIAL: std::sync::LazyLock<Mutex<Option<String>>> =
     std::sync::LazyLock::new(|| Mutex::new(None));
+/// Last logged-in local profile id per side (slot 0 = P1, slot 1 = P2). Stored
+/// outside the `Copy` `Config` because ids are owned strings. `None` = that side
+/// was last on Guest (or never logged in). Used to restore the profile-select
+/// default across reboots.
+pub(super) static LAST_PROFILE_P1: std::sync::LazyLock<Mutex<Option<String>>> =
+    std::sync::LazyLock::new(|| Mutex::new(None));
+pub(super) static LAST_PROFILE_P2: std::sync::LazyLock<Mutex<Option<String>>> =
+    std::sync::LazyLock::new(|| Mutex::new(None));
 static SAVE_TX: std::sync::LazyLock<Option<mpsc::Sender<SaveReq>>> =
     std::sync::LazyLock::new(start_save_worker);
 
@@ -215,6 +223,17 @@ pub fn smx_pad_assignment() -> (Option<String>, Option<String>) {
     (
         SMX_P1_SERIAL.lock().unwrap().clone(),
         SMX_P2_SERIAL.lock().unwrap().clone(),
+    )
+}
+
+/// The last logged-in local profile id per side: `(p1, p2)`. Either side is
+/// `None` when it was last on Guest (or never logged in). Used by the profile
+/// module to default the profile-select screen to the previous login after a
+/// reboot.
+pub fn last_active_profiles() -> (Option<String>, Option<String>) {
+    (
+        LAST_PROFILE_P1.lock().unwrap().clone(),
+        LAST_PROFILE_P2.lock().unwrap().clone(),
     )
 }
 

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -62,6 +62,8 @@ pub(super) fn current_save_content() -> String {
     let additional_song_folders = ADDITIONAL_SONG_FOLDERS.lock().unwrap().clone();
     let smx_p1_serial = SMX_P1_SERIAL.lock().unwrap().clone().unwrap_or_default();
     let smx_p2_serial = SMX_P2_SERIAL.lock().unwrap().clone().unwrap_or_default();
+    let last_profile_p1 = LAST_PROFILE_P1.lock().unwrap().clone().unwrap_or_default();
+    let last_profile_p2 = LAST_PROFILE_P2.lock().unwrap().clone().unwrap_or_default();
     save::build_content(
         &cfg,
         &keymap,
@@ -69,6 +71,8 @@ pub(super) fn current_save_content() -> String {
         additional_song_folders.as_slice(),
         &smx_p1_serial,
         &smx_p2_serial,
+        &last_profile_p1,
+        &last_profile_p2,
     )
 }
 

--- a/src/config/store/defaults.rs
+++ b/src/config/store/defaults.rs
@@ -130,6 +130,10 @@ fn push_default_options(content: &mut String, default: &Config) {
     // No pad→player assignment by default (slots follow the hardware jumper).
     push_line(content, "SmxP1Serial", "");
     push_line(content, "SmxP2Serial", "");
+    // No remembered profile-select login by default (defaults to the machine
+    // default profile / Guest until a profile is logged in).
+    push_line(content, "LastProfileP1", "");
+    push_line(content, "LastProfileP2", "");
     // Persisted pad ordering is empty until pads are seen; seeded at runtime.
     push_line(content, "PadOrderRawInput", "");
     push_line(content, "PadOrderWGI", "");

--- a/src/config/store/save.rs
+++ b/src/config/store/save.rs
@@ -8,6 +8,8 @@ pub(super) fn build_content(
     additional_song_folders: &[AdditionalSongFolder],
     smx_p1_serial: &str,
     smx_p2_serial: &str,
+    last_profile_p1: &str,
+    last_profile_p2: &str,
 ) -> String {
     let mut content = String::with_capacity(4096);
     push_saved_options(
@@ -17,6 +19,8 @@ pub(super) fn build_content(
         additional_song_folders,
         smx_p1_serial,
         smx_p2_serial,
+        last_profile_p1,
+        last_profile_p2,
     );
     push_saved_keymaps(&mut content, keymap);
     push_saved_theme(&mut content, cfg);
@@ -30,6 +34,8 @@ fn push_saved_options(
     additional_song_folders: &[AdditionalSongFolder],
     smx_p1_serial: &str,
     smx_p2_serial: &str,
+    last_profile_p1: &str,
+    last_profile_p2: &str,
 ) {
     let audio_output_device = cfg
         .audio_output_device_index
@@ -202,6 +208,8 @@ fn push_saved_options(
     );
     push_line(content, "SmxP1Serial", smx_p1_serial);
     push_line(content, "SmxP2Serial", smx_p2_serial);
+    push_line(content, "LastProfileP1", last_profile_p1);
+    push_line(content, "LastProfileP2", last_profile_p2);
     for backend in crate::config::pad_order::all_backends() {
         push_line(
             content,

--- a/src/config/update/machine.rs
+++ b/src/config/update/machine.rs
@@ -184,6 +184,22 @@ pub fn update_smx_pad_assignment(p1_serial: Option<String>, p2_serial: Option<St
     save_without_keymaps();
 }
 
+/// Persist the last logged-in local profile id per side so the profile-select
+/// screen can default to the previous login after a reboot. `None` means that
+/// side was last on Guest. No-op (and no disk write) when nothing changed.
+pub fn update_last_active_profiles(p1: Option<String>, p2: Option<String>) {
+    {
+        let mut a = LAST_PROFILE_P1.lock().unwrap();
+        let mut b = LAST_PROFILE_P2.lock().unwrap();
+        if *a == p1 && *b == p2 {
+            return;
+        }
+        *a = p1;
+        *b = p2;
+    }
+    save_without_keymaps();
+}
+
 /// Swap which physical pad is P1 vs P2. Uses the serials currently connected at
 /// slot 0 and slot 1 and pins them reversed, so the swap is immediate and works
 /// whether or not an assignment was already saved. Returns whether it swapped:

--- a/src/game/profile.rs
+++ b/src/game/profile.rs
@@ -1234,8 +1234,41 @@ fn load_for_side(side: PlayerSide) {
 }
 
 pub fn load() {
+    restore_last_active_profiles();
     load_for_side(PlayerSide::P1);
     load_for_side(PlayerSide::P2);
+}
+
+/// Seeds the session's active profiles from the last logged-in profile ids
+/// persisted in the machine config, so the profile-select screen defaults to the
+/// previous login after a reboot instead of resetting to Guest. Only applies a
+/// saved id when it still refers to an existing local profile; otherwise the
+/// built-in session default is kept.
+fn restore_last_active_profiles() {
+    let (p1, p2) = config::last_active_profiles();
+    let mut session = lock_session();
+    for (side, saved) in [(PlayerSide::P1, p1), (PlayerSide::P2, p2)] {
+        if let Some(id) = saved {
+            if is_local_profile_id(&id) && local_profile_dir(&id).is_dir() {
+                session.active_profiles[side_ix(side)] = ActiveProfile::Local { id };
+            }
+        }
+    }
+}
+
+/// Persists the currently active profile id of each side to the machine config
+/// so it can be restored on the next boot. Guest sides are stored as empty.
+fn persist_last_active_profiles() {
+    let (p1, p2) = {
+        let session = lock_session();
+        (
+            active_profile_local_id(&session.active_profiles[side_ix(PlayerSide::P1)])
+                .map(str::to_owned),
+            active_profile_local_id(&session.active_profiles[side_ix(PlayerSide::P2)])
+                .map(str::to_owned),
+        )
+    };
+    config::update_last_active_profiles(p1, p2);
 }
 
 /// Returns a copy of the currently loaded profile data.
@@ -1581,6 +1614,7 @@ pub fn set_active_profile_for_side(side: PlayerSide, profile: ActiveProfile) -> 
         *slot = profile;
     }
     load_for_side(side);
+    persist_last_active_profiles();
     get_for_side(side)
 }
 


### PR DESCRIPTION
## Why

The game never remembered the last logged-in profile: profile-select always defaulted to **Guest** on the first login after boot. Once you logged in during a session it worked, but a fresh launch reset back to Guest.

## Root cause

The profile-select screen seeds its default highlight from the in-memory session state (`get_active_profile_for_side`). That session was hardcoded at boot to a placeholder profile id (`"00000000"`) and was never persisted across reboots. Since the placeholder doesn't match any real profile, `selected_index_for` fell back to index 0 (Guest). After a manual login the in-memory session held the real profile, which is why the problem only showed up on the first login after boot.

## Approach

Persist the last logged-in local profile id per side to the machine config (`deadsync.ini`), mirroring the existing `SmxP1Serial`/`SmxP2Serial` pattern, and restore it at startup:

- **`src/config/`**: new `LastProfileP1`/`LastProfileP2` keys with a `last_active_profiles()` getter and an `update_last_active_profiles()` setter that writes through the existing async save worker (load, store, save, defaults, runtime statics, and re-exports wired up).
- **`src/game/profile.rs`**:
  - `set_active_profile_for_side` now persists the active ids whenever a profile changes. This is the single chokepoint for profile login (profile-select, profile management, etc.).
  - `profile::load()` restores the saved ids at boot, after `config::load()`.
