### PR TITLE
Embed a canonical GUID identity in local profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,6 +1359,7 @@ dependencies = [
  "chrono",
  "deadsync-rules",
  "deadsync-score",
+ "uuid",
 ]
 
 [[package]]
@@ -5169,6 +5170,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "v_frame"

--- a/crates/deadlib-platform/src/dirs.rs
+++ b/crates/deadlib-platform/src/dirs.rs
@@ -29,10 +29,6 @@ impl AppDirs {
         self.data_dir.join("save").join("profiles")
     }
 
-    pub fn profile_dir(&self, id: &str) -> PathBuf {
-        self.profiles_root().join(id)
-    }
-
     pub fn screenshots_dir(&self) -> PathBuf {
         self.data_dir.join("save").join("screenshots")
     }

--- a/crates/deadsync-profile/Cargo.toml
+++ b/crates/deadsync-profile/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0"
 bincode = "2.0.1"
 bitflags = "2.13.0"
 chrono = "0.4.45"
+uuid = { version = "1.18.1", features = ["v4"] }
 deadsync-rules = { path = "../deadsync-rules" }
 deadsync-score = { path = "../deadsync-score" }
 

--- a/crates/deadsync-profile/src/lib.rs
+++ b/crates/deadsync-profile/src/lib.rs
@@ -397,6 +397,104 @@ pub fn is_local_profile_id(s: &str) -> bool {
     !s.is_empty() && s.len() <= 64 && s != "." && s != ".." && !s.contains(['/', '\\', '\0'])
 }
 
+/// INI key (under `[userprofile]`) holding the profile's canonical GUID.
+pub const PROFILE_GUID_KEY: &str = "Guid";
+
+/// Stable per-profile identity so the on-disk folder can be freely renamed
+/// without losing scores, settings, or online logins.
+pub fn generate_profile_guid() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+/// Recognise an already-assigned identity; `generate_profile_guid` always emits
+/// this canonical dashed-lowercase form.
+pub fn is_valid_profile_guid(s: &str) -> bool {
+    let groups = [8usize, 4, 4, 4, 12];
+    let mut parts = s.split('-');
+    for &len in &groups {
+        let Some(part) = parts.next() else {
+            return false;
+        };
+        if part.len() != len || !part.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return false;
+        }
+    }
+    parts.next().is_none()
+}
+
+const FOLDER_NAME_MAX_LEN: usize = 48;
+
+fn is_windows_reserved_name(name: &str) -> bool {
+    const RESERVED: [&str; 22] = [
+        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
+        "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    ];
+    RESERVED.iter().any(|r| name.eq_ignore_ascii_case(r))
+}
+
+/// Derive a safe single-segment folder name from a display name. `None` (caller
+/// falls back to the GUID) when nothing usable survives sanitizing or the result
+/// would hit a Windows reserved device name.
+pub fn sanitize_folder_base(display_name: &str) -> Option<String> {
+    let mut out = String::with_capacity(display_name.len());
+    let mut last_was_space = false;
+    for ch in display_name.chars() {
+        let mapped = match ch {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' | '\0' => None,
+            c if c.is_control() => None,
+            c if c.is_whitespace() => Some(' '),
+            c => Some(c),
+        };
+        let Some(c) = mapped else {
+            continue;
+        };
+        if c == ' ' {
+            if last_was_space || out.is_empty() {
+                continue;
+            }
+            last_was_space = true;
+        } else {
+            last_was_space = false;
+        }
+        out.push(c);
+        if out.len() >= FOLDER_NAME_MAX_LEN {
+            break;
+        }
+    }
+
+    let trimmed = out.trim_matches(|c: char| c == ' ' || c == '.');
+    if trimmed.is_empty() || is_windows_reserved_name(trimmed) {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+/// Collision-free folder name for a profile; falls back to `guid` (assumed
+/// unique) when the display name yields nothing usable or every suffix is taken.
+pub fn folder_name_for_display(display_name: &str, guid: &str, existing: &[String]) -> String {
+    let taken = |candidate: &str| {
+        existing
+            .iter()
+            .any(|e| e.eq_ignore_ascii_case(candidate))
+    };
+
+    let Some(base) = sanitize_folder_base(display_name) else {
+        return guid.to_string();
+    };
+
+    if !taken(&base) {
+        return base;
+    }
+    for n in 2..=9999u32 {
+        let candidate = format!("{base}-{n}");
+        if !taken(&candidate) {
+            return candidate;
+        }
+    }
+    guid.to_string()
+}
+
+
 #[inline(always)]
 pub fn cmp_profile_ids_case_insensitive(a: &str, b: &str) -> core::cmp::Ordering {
     a.chars()
@@ -460,6 +558,67 @@ pub fn rewrite_profile_display_name_content(src: &str, display_name: &str) -> St
     } else if in_userprofile && !wrote_display {
         out.push_str("DisplayName=");
         out.push_str(display_name);
+        out.push('\n');
+    }
+
+    out
+}
+
+/// Backfill identity into a legacy `profile.ini`: ensure a single canonical
+/// `Guid` under `[userprofile]`, replacing any stale value and creating the
+/// section when missing.
+pub fn upsert_profile_guid_content(src: &str, guid: &str) -> String {
+    let mut out = String::with_capacity(src.len() + guid.len() + 32);
+    let mut in_userprofile = false;
+    let mut saw_userprofile = false;
+    let mut wrote_guid = false;
+
+    for raw_line in src.lines() {
+        let trimmed = raw_line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            // Section had no Guid: keep it inside before moving on.
+            if in_userprofile && !wrote_guid {
+                out.push_str(PROFILE_GUID_KEY);
+                out.push('=');
+                out.push_str(guid);
+                out.push('\n');
+                wrote_guid = true;
+            }
+            let section = trimmed[1..trimmed.len() - 1].trim();
+            in_userprofile = section.eq_ignore_ascii_case("userprofile");
+            out.push_str(raw_line);
+            out.push('\n');
+            if in_userprofile {
+                saw_userprofile = true;
+                out.push_str(PROFILE_GUID_KEY);
+                out.push('=');
+                out.push_str(guid);
+                out.push('\n');
+                wrote_guid = true;
+            }
+            continue;
+        }
+
+        // Stale Guid: superseded by the one written above.
+        if in_userprofile && let Some(eq) = trimmed.find('=') {
+            let key = trimmed[..eq].trim();
+            if key.eq_ignore_ascii_case(PROFILE_GUID_KEY) {
+                continue;
+            }
+        }
+
+        out.push_str(raw_line);
+        out.push('\n');
+    }
+
+    if !saw_userprofile {
+        if !out.is_empty() && !out.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str("[userprofile]\n");
+        out.push_str(PROFILE_GUID_KEY);
+        out.push('=');
+        out.push_str(guid);
         out.push('\n');
     }
 
@@ -6039,6 +6198,108 @@ mod tests {
         assert!(!is_local_profile_id("a\\b"));
         assert!(!is_local_profile_id("a\0b"));
         assert!(!is_local_profile_id(&"a".repeat(65)));
+    }
+
+    #[test]
+    fn generated_profile_guid_is_valid_uuid_v4() {
+        for _ in 0..64 {
+            let guid = generate_profile_guid();
+            assert_eq!(guid.len(), 36, "guid `{guid}` should be 36 chars");
+            assert!(is_valid_profile_guid(&guid), "guid `{guid}` should be valid");
+            assert!(is_local_profile_id(&guid), "guid should be a usable id");
+            // Version nibble (char 14) is '4'; variant nibble (char 19) in 8..=b.
+            let bytes = guid.as_bytes();
+            assert_eq!(bytes[14], b'4');
+            assert!(matches!(bytes[19], b'8' | b'9' | b'a' | b'b'));
+        }
+        // Distinct draws should not collide.
+        let a = generate_profile_guid();
+        let b = generate_profile_guid();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn invalid_profile_guids_are_rejected() {
+        assert!(!is_valid_profile_guid(""));
+        assert!(!is_valid_profile_guid("00000000"));
+        assert!(!is_valid_profile_guid("17c7b8a2-3b73-4e8a-9d7d-cfa7e783c00")); // short tail
+        assert!(!is_valid_profile_guid("17c7b8a2-3b73-4e8a-9d7d-cfa7e783c00bb")); // long tail
+        assert!(!is_valid_profile_guid("17c7b8a2_3b73_4e8a_9d7d_cfa7e783c00b")); // wrong sep
+        assert!(!is_valid_profile_guid("g7c7b8a2-3b73-4e8a-9d7d-cfa7e783c00b")); // non-hex
+    }
+
+    #[test]
+    fn sanitize_folder_base_strips_invalid_chars_and_collapses_space() {
+        assert_eq!(sanitize_folder_base("Alice").as_deref(), Some("Alice"));
+        assert_eq!(
+            sanitize_folder_base("  Bob   Smith  ").as_deref(),
+            Some("Bob Smith")
+        );
+        assert_eq!(
+            sanitize_folder_base("a/b:c*?\"<>|d").as_deref(),
+            Some("abcd")
+        );
+        assert_eq!(sanitize_folder_base("...").as_deref(), None);
+        assert_eq!(sanitize_folder_base("").as_deref(), None);
+        assert_eq!(sanitize_folder_base("   ").as_deref(), None);
+        // Windows reserved device names are rejected (callers fall back to GUID).
+        assert_eq!(sanitize_folder_base("CON").as_deref(), None);
+        assert_eq!(sanitize_folder_base("lpt1").as_deref(), None);
+    }
+
+    #[test]
+    fn folder_name_for_display_resolves_collisions_and_falls_back_to_guid() {
+        let guid = "17c7b8a2-3b73-4e8a-9d7d-cfa7e783c00b";
+        let existing = vec!["Alice".to_string(), "alice-2".to_string()];
+        assert_eq!(folder_name_for_display("Bob", guid, &existing), "Bob");
+        // Case-insensitive collision -> next free suffix.
+        assert_eq!(folder_name_for_display("alice", guid, &existing), "alice-3");
+        // Unusable display name -> GUID.
+        assert_eq!(folder_name_for_display("***", guid, &existing), guid);
+    }
+
+    #[test]
+    fn upsert_profile_guid_inserts_replaces_and_creates_section() {
+        let guid = "17c7b8a2-3b73-4e8a-9d7d-cfa7e783c00b";
+
+        // Inserts into an existing [userprofile] section as the first key.
+        let src = "[userprofile]\nDisplayName=Alice\nPlayerInitials=ALC\n";
+        let out = upsert_profile_guid_content(src, guid);
+        assert_eq!(
+            out,
+            format!("[userprofile]\nGuid={guid}\nDisplayName=Alice\nPlayerInitials=ALC\n")
+        );
+        assert_eq!(read_userprofile_guid(&out).as_deref(), Some(guid));
+
+        // Replaces a pre-existing Guid value, keeping a single key.
+        let src = format!("[userprofile]\nGuid=old-value\nDisplayName=Bob\n");
+        let out = upsert_profile_guid_content(&src, guid);
+        assert_eq!(out.matches("Guid=").count(), 1);
+        assert_eq!(read_userprofile_guid(&out).as_deref(), Some(guid));
+
+        // Creates the section when missing.
+        let src = "[Editable]\nWeightPounds=0\n";
+        let out = upsert_profile_guid_content(src, guid);
+        assert!(out.contains("[userprofile]\nGuid="));
+        assert_eq!(read_userprofile_guid(&out).as_deref(), Some(guid));
+    }
+
+    fn read_userprofile_guid(content: &str) -> Option<String> {
+        let mut in_section = false;
+        for line in content.lines() {
+            let t = line.trim();
+            if t.starts_with('[') && t.ends_with(']') {
+                in_section = t[1..t.len() - 1].trim().eq_ignore_ascii_case("userprofile");
+                continue;
+            }
+            if in_section
+                && let Some(eq) = t.find('=')
+                && t[..eq].trim().eq_ignore_ascii_case(PROFILE_GUID_KEY)
+            {
+                return Some(t[eq + 1..].trim().to_string());
+            }
+        }
+        None
     }
 
     #[test]

--- a/docs/migrating-from-itgmania.md
+++ b/docs/migrating-from-itgmania.md
@@ -13,8 +13,17 @@ Throughout this doc:
   **Options → Folders → Data Directory → Open**.
 - `<itg profile>` is your ITGmania profile folder
   (`<itg save dir>/LocalProfiles/<id>/`).
-- `<your id>` is the opaque per-profile folder name DeadSync assigned when you
-  created the profile. The id does not need to match ITGmania's.
+- `<your folder>` is the name of your DeadSync profile folder. DeadSync names it
+  after your display name (e.g. `Alice`), so it can change when you rename the
+  profile. The folder name is *not* the profile's identity — see below.
+
+> **Identity lives inside the profile.** Each DeadSync profile carries its own
+> canonical id, a randomly generated GUID stored as `Guid=` under
+> `[userprofile]` in `profile.ini`.
+> DeadSync finds profiles by that embedded GUID, so you are free to rename a
+> profile folder on disk without breaking scores, settings, or online logins.
+> Existing profiles created before this scheme are assigned a GUID automatically
+> the first time DeadSync loads them.
 
 > **Heads up.** DeadSync's **Options → Online Scoring → Score Import** screen
 > only downloads past scores from accounts that are *already* configured (i.e.
@@ -26,7 +35,7 @@ Throughout this doc:
 | Game     | Profile root                                |
 | -------- | ------------------------------------------- |
 | ITGmania | `<itg save dir>/LocalProfiles/<id>/`        |
-| DeadSync | `<data dir>/save/profiles/<id>/`            |
+| DeadSync | `<data dir>/save/profiles/<your folder>/`   |
 
 You can jump straight to DeadSync's profile root from inside the game via
 **Options → Folders → Profiles → Open**.
@@ -51,7 +60,7 @@ Some fields are editable in-game, some live only in the config file:
 **Config file only**
 - Weight (pounds) and birth year. There is no in-game screen for these.
   With the game closed, edit
-  `<data dir>/save/profiles/<your id>/profile.ini` and adjust the values
+  `<data dir>/save/profiles/<your folder>/profile.ini` and adjust the values
   under `[userprofile]`:
 
   ```ini
@@ -71,7 +80,7 @@ folder and DeadSync will pick it up automatically on launch.
 DeadSync prefers `profile.png`; if that is missing it falls back to
 `avatar.png` (matching is case-insensitive, so ITGmania's `Avatar.png` works
 as-is). To bring across your ITGmania avatar, copy `<itg profile>/Avatar.png`
-into `<data dir>/save/profiles/<your id>/` and (optionally) rename it to
+into `<data dir>/save/profiles/<your folder>/` and (optionally) rename it to
 `profile.png`.
 
 ### 4. GrooveStats API key
@@ -79,7 +88,7 @@ into `<data dir>/save/profiles/<your id>/` and (optionally) rename it to
 The key does **not** go in `profile.ini`. It lives in its own file inside the
 profile folder:
 
-- **Path:** `<data dir>/save/profiles/<your id>/groovestats.ini`
+- **Path:** `<data dir>/save/profiles/<your folder>/groovestats.ini`
 - **Contents:**
 
   ```ini
@@ -94,7 +103,7 @@ Use `IsPadPlayer = 1` for pad, `0` for keyboard.
 You have two ways to populate this:
 
 - **Copy from ITGmania.** Place `<itg profile>/GrooveStats.ini` into
-  `<data dir>/save/profiles/<your id>/` and rename it to lowercase
+  `<data dir>/save/profiles/<your folder>/` and rename it to lowercase
   `groovestats.ini`. Same section, same keys, done.
 - **QR-code login.** **Options → Manage Local Profiles → (select profile) →
   Link GrooveStats**. DeadSync writes the resulting key into
@@ -104,7 +113,7 @@ You have two ways to populate this:
 
 Same pattern, sibling file in the profile folder:
 
-- **Path:** `<data dir>/save/profiles/<your id>/arrowcloud.ini`
+- **Path:** `<data dir>/save/profiles/<your folder>/arrowcloud.ini`
 - **Contents:**
 
   ```ini
@@ -115,7 +124,7 @@ Same pattern, sibling file in the profile folder:
 Three ways to populate it:
 
 - **Copy from ITGmania.** If `<itg profile>/ArrowCloud.ini` exists, copy it
-  into `<data dir>/save/profiles/<your id>/` and rename it to lowercase
+  into `<data dir>/save/profiles/<your folder>/` and rename it to lowercase
   `arrowcloud.ini`.
 - **Create by hand.** Make the file above with your key.
 - **QR-code login.** **Options → Manage Local Profiles → (select profile) →

--- a/src/game/profile.rs
+++ b/src/game/profile.rs
@@ -3,7 +3,7 @@ use chrono::Local;
 use deadlib_platform::dirs;
 use deadsync_rules::scroll::{GUEST_SCROLL_SPEED, ScrollSpeedSetting};
 use log::{debug, info, warn};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -16,35 +16,147 @@ mod update;
 use deadsync_profile::{
     AccelEffectsMask, ActiveProfile, AppearanceEffectsMask, AttackMode, ColumnFlashBrightness,
     ColumnFlashMask, ColumnFlashSize, DEFAULT_PROFILE_ID, GameplayHudPlayerSnapshot,
-    GameplayHudSnapshot, HideLightType, HoldsMask, InsertMask, LOCAL_PROFILE_MAX_ID, LastPlayed,
+    GameplayHudSnapshot, HideLightType, HoldsMask, InsertMask, LastPlayed,
     LastPlayedCourse, LifeMeterType, LocalProfileSummary, MeasureCounter, MeasureLines,
     MiniIndicator, MiniIndicatorColor, MiniIndicatorPosition, MiniIndicatorScoreType,
-    MiniIndicatorSize, MiniIndicatorSubtractiveDisplay, NoteSkin, PLAYER_SLOTS, PlayMode,
+    MiniIndicatorSize, MiniIndicatorSubtractiveDisplay, NoteSkin, PLAYER_SLOTS, PROFILE_GUID_KEY,
+    PlayMode,
     PlayStyle, PlayerOptionsData, PlayerSide, Profile, ProfileStats, ProfileStatsDecodeError,
     RemoveMask, ScrollOption, StepStatisticsMask, StepStatsExtra, TargetScoreSetting,
     TimingTickMode, TimingWindowsOption, TurnOption, VisualEffectsMask, active_profile_is_guest,
     active_profile_local_id, add_known_pack_names, append_last_played_course_section,
     append_last_played_section, append_player_options_section, clamp_weight_pounds,
     cmp_profile_ids_case_insensitive, decode_profile_stats as decode_profile_stats_bytes,
-    encode_profile_stats, find_profile_avatar_path, initials_from_name, is_local_profile_id,
+    encode_profile_stats, find_profile_avatar_path, folder_name_for_display, generate_profile_guid,
+    initials_from_name, is_local_profile_id, is_valid_profile_guid,
     joined_player_mask, load_error_bar_options, load_last_played_course_section,
     load_last_played_section, load_timing_feedback_options, load_visual_player_options,
-    next_local_profile_id, parse_favorited_packs_content, parse_favorites_content,
+    parse_favorited_packs_content, parse_favorites_content,
     parse_groovestats_is_pad_player, player_options_section, player_side_index as side_ix,
     player_side_is_joined, render_favorited_packs_content, render_favorites_content,
     rewrite_profile_display_name_content, sanitize_player_initials, unknown_pack_names,
+    upsert_profile_guid_content,
 };
 pub use update::*;
 
 #[inline(always)]
+fn profiles_root() -> PathBuf {
+    dirs::app_dirs().profiles_root()
+}
+
+/// Path for a literal folder name, bypassing GUID resolution (creation only).
+#[inline(always)]
+fn profile_dir_by_folder(folder: &str) -> PathBuf {
+    profiles_root().join(folder)
+}
+
+/// Lazily-built GUID -> folder map; avoids re-reading every `profile.ini` per
+/// path lookup. Invalidated on profile create/delete/rename.
+static PROFILE_DIR_CACHE: Mutex<Option<HashMap<String, PathBuf>>> = Mutex::new(None);
+
+fn read_profile_guid(dir: &Path) -> Option<String> {
+    let mut ini = SimpleIni::new();
+    ini.load(dir.join("profile.ini")).ok()?;
+    ini.get("userprofile", PROFILE_GUID_KEY)
+        .map(|s| s.trim().to_string())
+        .filter(|s| is_valid_profile_guid(s))
+}
+
+fn read_profile_display_name(dir: &Path) -> Option<String> {
+    let mut ini = SimpleIni::new();
+    ini.load(dir.join("profile.ini")).ok()?;
+    ini.get("userprofile", "DisplayName")
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn build_profile_dir_map() -> HashMap<String, PathBuf> {
+    let mut map = HashMap::new();
+    let Ok(read_dir) = fs::read_dir(profiles_root()) else {
+        return map;
+    };
+    for entry in read_dir.flatten() {
+        if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let path = entry.path();
+        if let Some(guid) = read_profile_guid(&path) {
+            map.entry(guid).or_insert(path);
+        }
+    }
+    map
+}
+
+/// Drop the cached map so the next lookup rescans disk.
+fn invalidate_profile_dir_cache() {
+    *PROFILE_DIR_CACHE.lock().unwrap() = None;
+}
+
+fn resolve_profile_dir(guid: &str) -> Option<PathBuf> {
+    {
+        let mut guard = PROFILE_DIR_CACHE.lock().unwrap();
+        if guard.is_none() {
+            *guard = Some(build_profile_dir_map());
+        }
+        if let Some(path) = guard.as_ref().unwrap().get(guid)
+            && path.is_dir()
+        {
+            return Some(path.clone());
+        }
+    }
+    // Cache miss or stale entry: rebuild once and retry.
+    let fresh = build_profile_dir_map();
+    let result = fresh.get(guid).cloned();
+    *PROFILE_DIR_CACHE.lock().unwrap() = Some(fresh);
+    result
+}
+
+/// Folder for a profile id. Falls back to a folder whose name equals the id so
+/// freshly-created and not-yet-migrated profiles still resolve.
+#[inline(always)]
 fn local_profile_dir(id: &str) -> PathBuf {
-    dirs::app_dirs().profiles_root().join(id)
+    resolve_profile_dir(id).unwrap_or_else(|| profile_dir_by_folder(id))
 }
 
 #[inline(always)]
 pub fn local_profile_dir_for_id(id: &str) -> PathBuf {
     local_profile_dir(id)
 }
+
+fn existing_profile_folder_names() -> Vec<String> {
+    let Ok(read_dir) = fs::read_dir(profiles_root()) else {
+        return Vec::new();
+    };
+    read_dir
+        .flatten()
+        .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
+        .filter_map(|e| e.file_name().to_str().map(str::to_string))
+        .collect()
+}
+
+/// GUID for a profile folder, minting one for profiles that predate the
+/// embedded-identity scheme. `None` when the folder isn't a profile or the
+/// backfill write fails.
+fn ensure_profile_guid_in_dir(dir: &Path) -> Option<String> {
+    if let Some(guid) = read_profile_guid(dir) {
+        return Some(guid);
+    }
+    let ini_path = dir.join("profile.ini");
+    let src = fs::read_to_string(&ini_path).ok()?;
+    let guid = generate_profile_guid();
+    let updated = upsert_profile_guid_content(&src, &guid);
+    match fs::write(&ini_path, updated) {
+        Ok(()) => {
+            info!("Assigned profile GUID {guid} to '{}'.", dir.display());
+            Some(guid)
+        }
+        Err(e) => {
+            warn!("Failed to backfill GUID for '{}': {e}", dir.display());
+            None
+        }
+    }
+}
+
 
 #[inline(always)]
 fn profile_ini_path(id: &str) -> PathBuf {
@@ -586,6 +698,7 @@ fn ensure_local_profile_files(id: &str) -> Result<(), std::io::Error> {
         );
 
         content.push_str("[userprofile]\n");
+        content.push_str(&format!("Guid = {id}\n"));
         content.push_str(&format!("DisplayName = {}\n", default_profile.display_name));
         content.push_str(&format!(
             "PlayerInitials = {}\n",
@@ -678,6 +791,7 @@ fn save_profile_ini_for_side(side: PlayerSide) {
     );
 
     content.push_str("[userprofile]\n");
+    content.push_str(&format!("Guid={profile_id}\n"));
     content.push_str(&format!("DisplayName={}\n", profile.display_name));
     content.push_str(&format!("PlayerInitials={}\n", profile.player_initials));
     content.push('\n');
@@ -1234,9 +1348,103 @@ fn load_for_side(side: PlayerSide) {
 }
 
 pub fn load() {
+    migrate_local_profiles();
     restore_default_profiles();
     load_for_side(PlayerSide::P1);
     load_for_side(PlayerSide::P2);
+}
+
+/// Idempotent startup migration to embedded-GUID identity: backfill GUIDs into
+/// legacy profiles, rewrite stored default ids that still hold a folder name, and
+/// rename legacy folders to match their display name.
+fn migrate_local_profiles() {
+    let _ = scan_local_profiles(); // side effect: backfills GUIDs
+    invalidate_profile_dir_cache();
+
+    let mut folder_to_guid: HashMap<String, String> = HashMap::new();
+    if let Ok(read_dir) = fs::read_dir(profiles_root()) {
+        for entry in read_dir.flatten() {
+            if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let path = entry.path();
+            if let Some(folder) = path.file_name().and_then(|s| s.to_str())
+                && let Some(guid) = read_profile_guid(&path)
+            {
+                folder_to_guid.insert(folder.to_string(), guid);
+            }
+        }
+    }
+
+    let heal = |stored: Option<String>| -> Option<String> {
+        let s = stored?;
+        if is_valid_profile_guid(&s) {
+            return Some(s);
+        }
+        // Legacy folder-name id: map to that folder's GUID when known.
+        folder_to_guid.get(&s).cloned().or(Some(s))
+    };
+
+    let (p1, p2) = config::default_profiles();
+    let new_p1 = heal(p1.clone());
+    let new_p2 = heal(p2.clone());
+    if new_p1 != p1 || new_p2 != p2 {
+        info!("Migrated default profile ids to embedded GUIDs.");
+        config::update_default_profiles(new_p1, new_p2);
+    }
+
+    rename_profiles_to_display_names();
+    invalidate_profile_dir_cache();
+}
+
+/// Best-effort: rename profile folders to match their display name so legacy
+/// numeric folders become human-readable. Safe because identity is the embedded
+/// GUID, not the folder name.
+fn rename_profiles_to_display_names() {
+    // Snapshot every folder up front; `taken` tracks live names for collisions.
+    let mut renamable: Vec<(String, String)> = Vec::new();
+    let mut taken: Vec<String> = Vec::new();
+    if let Ok(read_dir) = fs::read_dir(profiles_root()) {
+        for entry in read_dir.flatten() {
+            if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let path = entry.path();
+            let Some(folder) = path.file_name().and_then(|s| s.to_str()).map(str::to_string) else {
+                continue;
+            };
+            taken.push(folder.clone());
+            // Only touch real, already-migrated profiles.
+            if read_profile_guid(&path).is_some()
+                && let Some(display) = read_profile_display_name(&path)
+            {
+                renamable.push((folder, display));
+            }
+        }
+    }
+
+    for (folder, display) in renamable {
+        let others: Vec<String> = taken
+            .iter()
+            .filter(|f| !f.eq_ignore_ascii_case(&folder))
+            .cloned()
+            .collect();
+        // Pass the current folder as the fallback: an unusable display name keeps
+        // the existing name rather than churning to a GUID.
+        let desired = folder_name_for_display(&display, &folder, &others);
+        if desired.eq_ignore_ascii_case(&folder) {
+            continue;
+        }
+        match fs::rename(profile_dir_by_folder(&folder), profile_dir_by_folder(&desired)) {
+            Ok(()) => {
+                info!("Renamed profile folder '{folder}' -> '{desired}'.");
+                if let Some(slot) = taken.iter_mut().find(|f| f.eq_ignore_ascii_case(&folder)) {
+                    *slot = desired;
+                }
+            }
+            Err(e) => warn!("Failed to rename profile folder '{folder}' -> '{desired}': {e}"),
+        }
+    }
 }
 
 /// Seeds the session's active profiles from the configured default local
@@ -1513,10 +1721,7 @@ pub fn mark_packs_known<'a>(profile_ids: &[String], pack_names: impl IntoIterato
 // --- Favorites ---
 
 fn favorites_path(profile_id: &str) -> PathBuf {
-    dirs::app_dirs()
-        .profiles_root()
-        .join(profile_id)
-        .join("favorites.txt")
+    local_profile_dir(profile_id).join("favorites.txt")
 }
 
 fn load_favorites(profile_id: &str) -> HashSet<String> {
@@ -1578,10 +1783,7 @@ pub fn seed_session_favorite(side: PlayerSide, chart_hash: &str) {
 }
 
 fn favorited_packs_path(profile_id: &str) -> PathBuf {
-    dirs::app_dirs()
-        .profiles_root()
-        .join(profile_id)
-        .join("favorited_packs.txt")
+    local_profile_dir(profile_id).join("favorited_packs.txt")
 }
 
 fn load_favorited_packs(profile_id: &str) -> HashSet<String> {
@@ -1674,8 +1876,7 @@ pub fn set_active_profiles(p1: ActiveProfile, p2: ActiveProfile) -> [Profile; PL
 }
 
 pub fn scan_local_profiles() -> Vec<LocalProfileSummary> {
-    let root = dirs::app_dirs().profiles_root();
-    let Ok(read_dir) = fs::read_dir(&root) else {
+    let Ok(read_dir) = fs::read_dir(profiles_root()) else {
         return Vec::new();
     };
 
@@ -1687,21 +1888,16 @@ pub fn scan_local_profiles() -> Vec<LocalProfileSummary> {
         if !ft.is_dir() {
             continue;
         }
-        let Some(id) = entry
-            .file_name()
-            .to_str()
-            .map(std::string::ToString::to_string)
-        else {
-            continue;
-        };
-        if !is_local_profile_id(&id) {
-            continue;
-        }
-
-        let ini_path = entry.path().join("profile.ini");
+        let dir = entry.path();
+        let ini_path = dir.join("profile.ini");
         if !ini_path.is_file() {
             continue;
         }
+
+        // Identity is the embedded GUID; backfill one for legacy profiles.
+        let Some(id) = ensure_profile_guid_in_dir(&dir) else {
+            continue;
+        };
 
         let mut display_name = id.clone();
         let mut ini = SimpleIni::new();
@@ -1712,7 +1908,7 @@ pub fn scan_local_profiles() -> Vec<LocalProfileSummary> {
             display_name = name;
         }
 
-        let avatar_path = find_profile_avatar_path(&entry.path());
+        let avatar_path = find_profile_avatar_path(&dir);
 
         out.push(LocalProfileSummary {
             id,
@@ -1721,44 +1917,12 @@ pub fn scan_local_profiles() -> Vec<LocalProfileSummary> {
         });
     }
 
-    out.sort_by(|a, b| cmp_profile_ids_case_insensitive(&a.id, &b.id));
+    // Folder name is no longer the identity, so order by display name.
+    out.sort_by(|a, b| {
+        cmp_profile_ids_case_insensitive(&a.display_name, &b.display_name)
+            .then_with(|| a.id.cmp(&b.id))
+    });
     out
-}
-
-fn scan_local_profile_numbers() -> Vec<u32> {
-    let root = dirs::app_dirs().profiles_root();
-    let Ok(read_dir) = fs::read_dir(&root) else {
-        return Vec::new();
-    };
-
-    let mut out = Vec::new();
-    for entry in read_dir.flatten() {
-        let Ok(ft) = entry.file_type() else {
-            continue;
-        };
-        if !ft.is_dir() {
-            continue;
-        }
-        let file_name = entry.file_name();
-        let Some(name) = file_name.to_str() else {
-            continue;
-        };
-        if name.len() != 8 {
-            continue;
-        }
-        let Ok(n) = name.parse::<u32>() else {
-            continue;
-        };
-        if n <= LOCAL_PROFILE_MAX_ID {
-            out.push(n);
-        }
-    }
-    out
-}
-
-fn allocate_local_profile_id() -> Result<String, std::io::Error> {
-    next_local_profile_id(scan_local_profile_numbers())
-        .ok_or_else(|| std::io::Error::other("Too many profiles"))
 }
 
 pub fn create_local_profile(display_name: &str) -> Result<String, std::io::Error> {
@@ -1770,8 +1934,9 @@ pub fn create_local_profile(display_name: &str) -> Result<String, std::io::Error
         ));
     }
 
-    let id = allocate_local_profile_id()?;
-    let dir = local_profile_dir(&id);
+    let id = generate_profile_guid();
+    let folder = folder_name_for_display(name, &id, &existing_profile_folder_names());
+    let dir = profile_dir_by_folder(&folder);
     fs::create_dir_all(&dir)?;
 
     let mut default_profile = Profile::default();
@@ -1791,6 +1956,7 @@ pub fn create_local_profile(display_name: &str) -> Result<String, std::io::Error
         &default_profile.player_options_doubles,
     );
     content.push_str("[userprofile]\n");
+    content.push_str(&format!("Guid={id}\n"));
     content.push_str(&format!("DisplayName={name}\n"));
     content.push_str(&format!("PlayerInitials={initials}\n"));
     content.push('\n');
@@ -1806,7 +1972,7 @@ pub fn create_local_profile(display_name: &str) -> Result<String, std::io::Error
     content.push_str(&format!("CaloriesBurnedDate={today}\n"));
     content.push_str("CaloriesBurnedToday=0\n");
     content.push('\n');
-    fs::write(profile_ini_path(&id), content)?;
+    fs::write(dir.join("profile.ini"), content)?;
 
     let mut gs = String::new();
     gs.push_str("[GrooveStats]\n");
@@ -1814,13 +1980,16 @@ pub fn create_local_profile(display_name: &str) -> Result<String, std::io::Error
     gs.push_str("IsPadPlayer=0\n");
     gs.push_str("Username=\n");
     gs.push('\n');
-    fs::write(groovestats_ini_path(&id), gs)?;
+    fs::write(dir.join("groovestats.ini"), gs)?;
 
     let mut ac = String::new();
     ac.push_str("[ArrowCloud]\n");
     ac.push_str("ApiKey=\n");
     ac.push('\n');
-    fs::write(arrowcloud_ini_path(&id), ac)?;
+    fs::write(dir.join("arrowcloud.ini"), ac)?;
+
+    // Make the new GUID -> folder mapping visible to later path lookups.
+    invalidate_profile_dir_cache();
 
     let (p1_default, p2_default) = config::default_profiles();
     if p1_default.is_none() {
@@ -1865,6 +2034,26 @@ pub fn rename_local_profile(id: &str, display_name: &str) -> Result<(), std::io:
     }
     rewrite_profile_display_name(&ini_path, name)?;
 
+    // Keep the folder readable; safe because identity is the GUID, not the name.
+    let current_dir = local_profile_dir(id);
+    if let Some(current_folder) = current_dir.file_name().and_then(|s| s.to_str()) {
+        let others: Vec<String> = existing_profile_folder_names()
+            .into_iter()
+            .filter(|f| !f.eq_ignore_ascii_case(current_folder))
+            .collect();
+        let desired = folder_name_for_display(name, id, &others);
+        if !desired.eq_ignore_ascii_case(current_folder) {
+            let target = profile_dir_by_folder(&desired);
+            match fs::rename(&current_dir, &target) {
+                Ok(()) => info!("Renamed profile folder '{current_folder}' -> '{desired}'."),
+                Err(e) => {
+                    warn!("Failed to rename profile folder '{current_folder}' -> '{desired}': {e}");
+                }
+            }
+        }
+    }
+    invalidate_profile_dir_cache();
+
     let p1_active = active_local_profile_id_for_side(PlayerSide::P1)
         .as_deref()
         .is_some_and(|active_id| active_id == id);
@@ -1901,6 +2090,7 @@ pub fn delete_local_profile(id: &str) -> Result<(), std::io::Error> {
     }
 
     fs::remove_dir_all(&dir)?;
+    invalidate_profile_dir_cache();
 
     let (p1_default, p2_default) = config::default_profiles();
     let next_p1 = p1_default.filter(|profile_id| profile_id != id);

--- a/src/game/scores.rs
+++ b/src/game/scores.rs
@@ -84,9 +84,7 @@ static GS_SCORE_CACHE: std::sync::LazyLock<Mutex<GsScoreCacheState>> =
     std::sync::LazyLock::new(|| Mutex::new(GsScoreCacheState::default()));
 
 fn gs_scores_dir_for_profile(profile_id: &str) -> PathBuf {
-    dirs::app_dirs()
-        .profiles_root()
-        .join(profile_id)
+    profile::local_profile_dir_for_id(profile_id)
         .join("scores")
         .join("gs")
 }
@@ -437,9 +435,7 @@ static MACHINE_LOCAL_SCORE_CACHE: std::sync::LazyLock<Mutex<MachineLocalScoreCac
     std::sync::LazyLock::new(|| Mutex::new(MachineLocalScoreCacheState::default()));
 
 fn local_scores_root_for_profile(profile_id: &str) -> PathBuf {
-    dirs::app_dirs()
-        .profiles_root()
-        .join(profile_id)
+    profile::local_profile_dir_for_id(profile_id)
         .join("scores")
         .join("local")
 }
@@ -659,8 +655,7 @@ pub fn played_chart_counts_for_machine() -> Vec<(String, u32)> {
 
 /// Returns chart hashes ordered by latest local play time for a single profile.
 pub fn recent_played_chart_hashes_for_profile(profile_id: &str) -> Vec<String> {
-    let profiles_root = dirs::app_dirs().profiles_root();
-    let local_root = profiles_root.join(profile_id).join("scores").join("local");
+    let local_root = local_scores_root_for_profile(profile_id);
     if !local_root.is_dir() {
         return Vec::new();
     }
@@ -682,8 +677,7 @@ pub fn recent_played_chart_hashes_for_profile(profile_id: &str) -> Vec<String> {
 /// Returns `(chart_hash, play_count)` pairs for a single profile, ordered by
 /// play count descending.
 pub fn played_chart_counts_for_profile(profile_id: &str) -> Vec<(String, u32)> {
-    let profiles_root = dirs::app_dirs().profiles_root();
-    let local_root = profiles_root.join(profile_id).join("scores").join("local");
+    let local_root = local_scores_root_for_profile(profile_id);
     if !local_root.is_dir() {
         return Vec::new();
     }
@@ -724,10 +718,7 @@ fn ensure_local_score_cache_loaded(profile_id: &str) {
 }
 
 fn profile_initials_for_id(profile_id: &str) -> Option<String> {
-    let ini_path = dirs::app_dirs()
-        .profiles_root()
-        .join(profile_id)
-        .join("profile.ini");
+    let ini_path = profile::local_profile_dir_for_id(profile_id).join("profile.ini");
     if !ini_path.is_file() {
         return None;
     }

--- a/src/game/scores/itl.rs
+++ b/src/game/scores/itl.rs
@@ -9,7 +9,6 @@ use crate::game::online::downloads;
 use crate::game::profile;
 use crate::game::song::{get_song_cache, song_cache_generation};
 use chrono::Local;
-use deadlib_platform::dirs;
 use deadsync_core::input::MAX_PLAYERS;
 use deadsync_online::groovestats::{
     GrooveStatsSubmitApiAchievement, GrooveStatsSubmitApiEvent, GrooveStatsSubmitApiPlayer,
@@ -202,18 +201,14 @@ struct ItlPointTotals {
 }
 
 fn online_itl_self_score_index_path_for_profile(profile_id: &str) -> PathBuf {
-    dirs::app_dirs()
-        .profiles_root()
-        .join(profile_id)
+    profile::local_profile_dir_for_id(profile_id)
         .join("scores")
         .join("gs")
         .join("itl_self.bin")
 }
 
 fn online_itl_self_rank_index_path_for_profile(profile_id: &str) -> PathBuf {
-    dirs::app_dirs()
-        .profiles_root()
-        .join(profile_id)
+    profile::local_profile_dir_for_id(profile_id)
         .join("scores")
         .join("gs")
         .join("itl_rank.bin")

--- a/src/screens/components/shared/profile_boxes.rs
+++ b/src/screens/components/shared/profile_boxes.rs
@@ -11,7 +11,7 @@ use crate::screens::components::shared::screen_bar::{
 use crate::screens::components::shared::{screen_bar, visual_style_bg};
 use crate::screens::input as screen_input;
 use crate::screens::{Screen, ScreenAction};
-use deadlib_platform::dirs;
+
 use deadlib_present::actors::{self, Actor};
 use deadlib_present::color;
 use deadlib_present::space::{screen_center_x, screen_center_y};
@@ -319,10 +319,7 @@ fn build_choices() -> Vec<Choice> {
         let mut mini_indicator = profile_data::MiniIndicator::None;
         let mut noteskin = profile_data::NoteSkin::default();
         let mut judgment = profile_data::JudgmentGraphic::default();
-        let ini_path = dirs::app_dirs()
-            .profiles_root()
-            .join(&p.id)
-            .join("profile.ini");
+        let ini_path = profile::local_profile_dir_for_id(&p.id).join("profile.ini");
         let mut ini = crate::config::SimpleIni::new();
         if ini.load(&ini_path).is_ok() {
             let get_player_option = |key: &str| ini.get(player_options_section, key);

--- a/src/screens/options/score_import.rs
+++ b/src/screens/options/score_import.rs
@@ -1,5 +1,4 @@
 use super::*;
-use deadlib_platform::dirs;
 
 #[derive(Clone, Debug)]
 pub(super) struct ScoreImportProfileConfig {
@@ -412,7 +411,7 @@ pub(super) fn sync_pack_options() -> (Vec<String>, Vec<Option<String>>) {
 pub(super) fn load_score_import_profiles() -> Vec<ScoreImportProfileConfig> {
     let mut profiles = Vec::new();
     for summary in profile::scan_local_profiles() {
-        let profile_dir = dirs::app_dirs().profiles_root().join(summary.id.as_str());
+        let profile_dir = profile::local_profile_dir_for_id(summary.id.as_str());
         let mut gs = SimpleIni::new();
         let mut ac = SimpleIni::new();
         let gs_api_key = if gs.load(profile_dir.join("groovestats.ini")).is_ok() {

--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -2976,7 +2976,7 @@ fn build_playlist_library(grouped_entries: &[MusicWheelEntry]) -> Vec<PlaylistCa
             continue;
         }
         let playlist_dir = find_child_dir_ci(
-            dirs::app_dirs().profile_dir(&profile_id).as_path(),
+            profile::local_profile_dir_for_id(&profile_id).as_path(),
             "playlists",
         );
         let Some(playlist_dir) = playlist_dir else {


### PR DESCRIPTION
## Why

A local profile's identity used to be its on-disk folder name (an 8-digit number like `00000000`). That name was the key used everywhere: file paths, the active/default profile config, scores, and online services. As a result, renaming a profile folder on disk silently broke the profile.

This change moves identity *into* the profile so the folder name stops being load-bearing. Each profile now carries a canonical GUID stored as `Guid=` under `[userprofile]` in `profile.ini`. This matches the StepMania/ITGmania lineage (numeric folders with the real id stored inside) that this project already mirrors.

## Approach

- **`deadsync-profile` crate (pure, unit tested):** GUID generation/validation (`uuid` v4, dashed lowercase), display-name folder sanitizing with collision suffixes and Windows reserved-name guards, and a `Guid` upsert helper for backfilling legacy `profile.ini` files.
- **Resolver:** a cached `guid -> folder` map in `game::profile` that scans the profiles root and reads each `profile.ini`'s `Guid`. All per-profile paths (scores, ITL, favorites, pad config, and the relevant UI/score-import paths) now resolve the folder by GUID instead of `profiles_root().join(id)`. It falls back to a folder whose name equals the id, so freshly created and not-yet-migrated profiles still resolve.
- **Human-readable folders:** new profiles are named after the display name; renaming a profile renames the folder too (best-effort, since identity is the GUID).
- **Startup migration (idempotent):** backfills a GUID into any legacy profile that lacks one, self-heals the stored `DefaultLocalProfileIDP1/P2` config ids from folder name to GUID, and renames legacy numeric folders to their display name.
- **Docs:** the ITGmania migration guide now describes embedded-GUID identity and renameable folders.