### PR TITLE
ITGmania import: in-game profile importer UI

### DIFF
--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -1469,6 +1469,23 @@ CannotBeUndone=This cannot be undone.
 YesNoPrompt=Start: Yes    Back: No
 CreateProfileButton=Create Profile
 ExitButton=Exit
+ImportItgButton=Import from ITGmania
+ImportItgTitle=Import a profile from ITGmania.
+ImportItgHelp1=Copies the profile, player options and offline scores.
+ImportItgHelp2=Press Start to scan for ITGmania profiles.
+ImportPickTitle=Select an ITGmania profile to import
+ImportPickPrompt=Start: Import    Back: Cancel
+ImportInProgress=Importing... this can take a moment.
+ImportNoneFoundTitle=No ITGmania profiles found
+ImportNoneFoundBody=Could not find any ITGmania local profiles. Make sure ITGmania is installed and has at least one local profile.
+ImportFailedTitle=Import failed
+ImportFailedBody=The profile could not be imported.
+ImportSummaryTitle=Import complete
+ImportSummaryName=Imported profile: {name}
+ImportSummaryScores=Scores imported: {imported} of {total}
+ImportSummarySkipped=Skipped {skipped} score(s) for charts not in your library.
+ImportSummaryExNote=Note: EX scores are not stored by ITGmania and start at 0.
+ImportMessageDismiss=Press Start to continue.
 
 ; ============================================================
 ; Select Profile screen

--- a/docs/migrating-from-itgmania.md
+++ b/docs/migrating-from-itgmania.md
@@ -1,9 +1,13 @@
 # Migrating from ITGmania to DeadSync
 
-There is no automatic ITGmania → DeadSync profile import. The two games use
-different on-disk formats, and DeadSync does not read ITGmania's `Stats.xml`.
-This guide explains what carries over by hand, what doesn't, and exactly which
-files to copy or edit.
+DeadSync can **automatically import** an ITGmania + Simply Love local profile —
+including your player options and offline scores — from inside the game. This is
+the recommended path; see [Automatic import](#automatic-import-recommended)
+below.
+
+If you'd rather move individual pieces by hand (or the automatic importer can't
+find your ITGmania install), the rest of this guide explains what carries over
+manually, what doesn't, and exactly which files to copy or edit.
 
 Throughout this doc:
 
@@ -40,7 +44,65 @@ Throughout this doc:
 You can jump straight to DeadSync's profile root from inside the game via
 **Options → Folders → Profiles → Open**.
 
-## What you can actually migrate
+## Automatic import (recommended)
+
+DeadSync can read an ITGmania `LocalProfiles/<id>/` folder and create a brand
+new DeadSync profile from it in one step.
+
+1. In DeadSync, go to **Options → Manage Local Profiles**.
+2. Select **Import from ITGmania** and press **Start**.
+3. DeadSync scans for ITGmania profiles and lists the ones it finds. Pick the
+   profile you want and press **Start**.
+4. The import runs in the background; when it finishes, a summary shows how many
+   scores were imported and how many were skipped. The new profile is selected
+   in the list.
+
+### What it brings across
+
+- **Profile** — display name, weight, birth year, player initials, and your
+  avatar (`Avatar.png`).
+- **Online keys** — GrooveStats (API key, username, pad-player flag) and
+  ArrowCloud, written into the new profile's `groovestats.ini` /
+  `arrowcloud.ini`. Your online history can then be pulled via
+  **Options → Online Scoring → Score Import**.
+- **Player options** — your Simply Love per-profile mods (scroll speed and type,
+  mini, noteskin, note-field offsets, turn/reverse and other toggles) from
+  `Simply Love UserPrefs.ini`.
+- **Offline scores** — every high score in `Stats.xml` becomes a DeadSync local
+  play, matched to the chart in your library.
+
+### Where it looks
+
+The importer auto-detects ITGmania's per-user save directory:
+
+| OS      | Scanned location                                              |
+| ------- | ------------------------------------------------------------ |
+| Windows | `%APPDATA%\ITGmania\Save\LocalProfiles\`                      |
+| Linux   | `~/.itgmania/Save/LocalProfiles/`                            |
+| macOS   | `~/Library/Application Support/ITGmania/Save/LocalProfiles/`  |
+
+If your ITGmania uses a portable/custom save location that isn't found, fall
+back to the manual steps below (the importer always creates a *new* profile and
+never merges, so a manual top-up afterwards is safe).
+
+### Limitations
+
+- **Scores only attach to charts that exist in DeadSync's library.** ITGmania's
+  `Stats.xml` keys a chart by its song folder + steps type + difficulty, not by
+  hash, so DeadSync looks the chart up in your scanned songs to recover the
+  GrooveStats hash. Scan your packs *before* importing, and add your ITGmania
+  `Songs` folder (see [Songs folder](#7-songs-folder)) so more scores match.
+  Charts that aren't found are counted as skipped in the summary, not imported.
+- **EX / Hard-EX scores can't be recovered.** ITGmania doesn't store the FA+
+  (W0) split, so imported plays show the ITG percent and grade but start with an
+  EX score of 0.
+- **Holds and rolls aren't distinguished** in `Stats.xml`; all hold-type
+  judgments are folded together, and mine tallies are partial.
+
+## Manual migration
+
+If you prefer to move pieces by hand, the sections below cover each item
+individually.
 
 ### 1. Create a fresh DeadSync profile
 
@@ -136,8 +198,11 @@ Three ways to populate it:
   dropping the API key into the matching `.ini` (above) reconnects you to your
   existing online account. After that, **Options → Online Scoring →
   Score Import** can download your history.
-- **Offline scores** from ITGmania's `Stats.xml` have **no migration path**.
-  DeadSync does not read `Stats.xml`. Those scores stay in ITGmania.
+- **Offline scores** from ITGmania's `Stats.xml` are brought across by the
+  [automatic importer](#automatic-import-recommended) — there's no manual
+  equivalent, because each play has to be matched to a chart in your library to
+  recover its hash. If you migrate by hand, run the importer afterwards to pull
+  in your offline history (remember it creates a separate new profile).
 
 ### 7. Songs folder
 
@@ -166,6 +231,19 @@ Save and relaunch. DeadSync will scan those roots in addition to its default
 `songs/` folder.
 
 ## Quick checklist
+
+**Fastest path**
+
+- [ ] Scan your packs first — add your ITGmania `Songs` folder via
+      `AdditionalSongFoldersReadOnly` in `deadsync.ini`, or move packs into
+      `<data dir>/songs/`, so imported scores match.
+- [ ] **Options → Manage Local Profiles → Import from ITGmania**, pick your
+      profile, and let it copy the profile, options, avatar, online keys and
+      offline scores.
+- [ ] Run **Options → Online Scoring → Score Import** to pull down your online
+      history.
+
+**Manual path (if the importer can't find your install)**
 
 - [ ] Create a profile via **Options → Manage Local Profiles → Create**.
 - [ ] Drop ITGmania's `Avatar.png` into the new profile folder (rename to

--- a/src/game/import/detect.rs
+++ b/src/game/import/detect.rs
@@ -1,0 +1,92 @@
+//! Auto-discovery of ITGmania local profiles.
+//!
+//! ITGmania stores per-machine save data in a platform-specific directory, with
+//! local profiles under `<Save>/LocalProfiles/<id>/`. This module scans the
+//! likely save roots and returns every directory that looks like an ITGmania
+//! profile so the import UI can present a picker without asking the user to
+//! browse the filesystem manually.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use super::itg;
+
+/// One ITGmania local profile found on disk.
+#[derive(Debug, Clone)]
+pub struct ItgProfileCandidate {
+    /// Absolute path to the `LocalProfiles/<id>/` directory.
+    pub dir: PathBuf,
+    /// `DisplayName` from `Editable.ini`, falling back to the folder name.
+    pub display_name: String,
+}
+
+/// Scans the known ITGmania save locations and returns every local profile
+/// found, sorted by display name. Returns an empty list when ITGmania isn't
+/// installed or has no profiles.
+pub fn detect_itg_local_profiles() -> Vec<ItgProfileCandidate> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for root in local_profiles_roots() {
+        collect_from_root(&root, &mut out, &mut seen);
+    }
+    out.sort_by(|a, b| {
+        a.display_name
+            .to_lowercase()
+            .cmp(&b.display_name.to_lowercase())
+    });
+    out
+}
+
+fn collect_from_root(root: &Path, out: &mut Vec<ItgProfileCandidate>, seen: &mut HashSet<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        if !dir.is_dir() || !itg::is_itg_profile_dir(&dir) {
+            continue;
+        }
+        let key = std::fs::canonicalize(&dir).unwrap_or_else(|_| dir.clone());
+        if !seen.insert(key) {
+            continue;
+        }
+        let display_name = itg::read_display_name(&dir).unwrap_or_else(|| {
+            dir.file_name()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        });
+        out.push(ItgProfileCandidate { dir, display_name });
+    }
+}
+
+/// Candidate `LocalProfiles` directories across platforms. Most won't exist on
+/// any given machine; non-existent roots are silently skipped during scanning.
+fn local_profiles_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+
+    // Windows: %APPDATA%\ITGmania\Save\LocalProfiles
+    if let Some(appdata) = std::env::var_os("APPDATA") {
+        roots.push(
+            PathBuf::from(&appdata)
+                .join("ITGmania")
+                .join("Save")
+                .join("LocalProfiles"),
+        );
+    }
+
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        // Linux: ~/.itgmania/Save/LocalProfiles
+        roots.push(home.join(".itgmania").join("Save").join("LocalProfiles"));
+        // macOS: ~/Library/Application Support/ITGmania/Save/LocalProfiles
+        roots.push(
+            home.join("Library")
+                .join("Application Support")
+                .join("ITGmania")
+                .join("Save")
+                .join("LocalProfiles"),
+        );
+    }
+
+    roots
+}

--- a/src/game/import/itg.rs
+++ b/src/game/import/itg.rs
@@ -111,6 +111,20 @@ pub fn is_itg_profile_dir(dir: &Path) -> bool {
     find_case_insensitive(dir, "Editable.ini").is_some()
 }
 
+/// Cheaply reads just the `DisplayName` from a profile's `Editable.ini`,
+/// without parsing the (potentially large) `Stats.xml`. Used to label profiles
+/// in the import picker. Returns `None` when the file is missing or the name is
+/// blank.
+pub fn read_display_name(dir: &Path) -> Option<String> {
+    let path = find_case_insensitive(dir, "Editable.ini")?;
+    let name = read_editable(&path).display_name;
+    if name.trim().is_empty() {
+        None
+    } else {
+        Some(name)
+    }
+}
+
 /// Reads an entire ITGmania local profile directory into an [`ItgSource`].
 pub fn read_profile_dir(dir: &Path) -> Result<ItgSource, ItgReadError> {
     let editable_path = find_case_insensitive(dir, "Editable.ini")

--- a/src/game/import/mod.rs
+++ b/src/game/import/mod.rs
@@ -7,7 +7,9 @@
 //! Submodules:
 //! * [`xml`] — a tiny dependency-free XML reader for `Stats.xml`.
 //! * [`itg`] — readers that turn the ITGmania files into plain structs.
+//! * [`detect`] — auto-discovery of ITGmania local profiles on disk.
 
+pub mod detect;
 pub mod itg;
 pub mod options;
 pub mod resolver;

--- a/src/game/import/mod.rs
+++ b/src/game/import/mod.rs
@@ -15,3 +15,6 @@ pub mod options;
 pub mod resolver;
 pub mod run;
 pub mod xml;
+
+#[cfg(test)]
+mod pipeline_tests;

--- a/src/game/import/pipeline_tests.rs
+++ b/src/game/import/pipeline_tests.rs
@@ -1,0 +1,202 @@
+//! End-to-end integration test for the import pipeline: a fixture `Stats.xml`
+//! string is parsed, resolved against an in-memory song library, and mapped into
+//! [`LocalScoreEntry`] records — the same sequence [`super::run`] performs, but
+//! without touching any global engine state or the filesystem.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use deadsync_chart::{ChartData, SongData, SongPack};
+use deadsync_score::{decode_local_score_entry, encode_local_score_entry, local_score_from_itg};
+
+use super::itg::parse_song_scores;
+use super::resolver::{ChartResolver, Resolution};
+use super::xml;
+
+const STATS_XML: &str = r#"<Stats>
+  <SongScores>
+    <Song Dir="Songs/My Pack/Cool Song/">
+      <Steps StepsType="dance-single" Difficulty="Hard">
+        <HighScoreList>
+          <HighScore>
+            <Grade>Tier03</Grade>
+            <PercentDP>0.9421</PercentDP>
+            <DateTime>2023-04-15 21:07:33</DateTime>
+            <TapNoteScores>
+              <W1>410</W1><W2>52</W2><W3>11</W3><W4>3</W4><W5>1</W5>
+              <Miss>4</Miss><HitMine>2</HitMine><AvoidMine>7</AvoidMine>
+            </TapNoteScores>
+            <HoldNoteScores>
+              <Held>18</Held><LetGo>2</LetGo><MissedHold>1</MissedHold>
+            </HoldNoteScores>
+          </HighScore>
+        </HighScoreList>
+      </Steps>
+    </Song>
+    <Song Dir="Songs/Missing Pack/Ghost Song/">
+      <Steps StepsType="dance-single" Difficulty="Expert">
+        <HighScoreList>
+          <HighScore>
+            <Grade>Tier01</Grade>
+            <PercentDP>0.99</PercentDP>
+            <DateTime>2023-04-16 10:00:00</DateTime>
+          </HighScore>
+        </HighScoreList>
+      </Steps>
+    </Song>
+  </SongScores>
+</Stats>"#;
+
+fn chart(difficulty: &str, hash: &str) -> ChartData {
+    ChartData {
+        chart_type: "dance-single".into(),
+        difficulty: difficulty.into(),
+        description: String::new(),
+        chart_name: String::new(),
+        meter: 10,
+        step_artist: String::new(),
+        music_path: None,
+        short_hash: hash.into(),
+        stats: Default::default(),
+        tech_counts: Default::default(),
+        mines_nonfake: 0,
+        stamina_counts: Default::default(),
+        total_streams: 0,
+        matrix_rating: 0.0,
+        max_nps: 0.0,
+        sn_detailed_breakdown: String::new(),
+        sn_partial_breakdown: String::new(),
+        sn_simple_breakdown: String::new(),
+        detailed_breakdown: String::new(),
+        partial_breakdown: String::new(),
+        simple_breakdown: String::new(),
+        total_measures: 0,
+        measure_nps_vec: Vec::new(),
+        measure_seconds_vec: Vec::new(),
+        first_second: 0.0,
+        has_note_data: true,
+        has_chart_attacks: false,
+        possible_grade_points: 0,
+        holds_total: 0,
+        rolls_total: 0,
+        mines_total: 0,
+        display_bpm: None,
+        min_bpm: 150.0,
+        max_bpm: 150.0,
+    }
+}
+
+fn song(simfile_path: &str, charts: Vec<ChartData>) -> SongData {
+    SongData {
+        simfile_path: PathBuf::from(simfile_path),
+        title: "Cool Song".into(),
+        subtitle: String::new(),
+        translit_title: String::new(),
+        translit_subtitle: String::new(),
+        artist: String::new(),
+        genre: String::new(),
+        banner_path: None,
+        background_path: None,
+        background_changes: Vec::new(),
+        background_layer2_changes: Vec::new(),
+        foreground_changes: Vec::new(),
+        background_lua_changes: Vec::new(),
+        foreground_lua_changes: Vec::new(),
+        has_lua: false,
+        cdtitle_path: None,
+        music_path: None,
+        display_bpm: String::new(),
+        offset: 0.0,
+        sample_start: None,
+        sample_length: None,
+        min_bpm: 150.0,
+        max_bpm: 150.0,
+        normalized_bpms: String::new(),
+        music_length_seconds: 0.0,
+        first_second: 0.0,
+        total_length_seconds: 0,
+        precise_last_second_seconds: 0.0,
+        charts,
+    }
+}
+
+fn library() -> Vec<SongPack> {
+    vec![SongPack {
+        group_name: "My Pack".into(),
+        name: "My Pack".into(),
+        sort_title: String::new(),
+        translit_title: String::new(),
+        series: String::new(),
+        year: 0,
+        sync_pref: deadsync_chart::SyncPref::Default,
+        directory: PathBuf::from("Songs/My Pack"),
+        banner_path: None,
+        songs: vec![Arc::new(song(
+            "Songs/My Pack/Cool Song/cool.ssc",
+            vec![chart("Hard", "abc123def456")],
+        ))],
+    }]
+}
+
+#[test]
+fn imports_stats_xml_against_library_end_to_end() {
+    let root = xml::parse(STATS_XML).expect("parse Stats.xml");
+    let songs = parse_song_scores(&root);
+    assert_eq!(songs.len(), 2, "both <Song> blocks parsed");
+
+    let packs = library();
+    let resolver = ChartResolver::build(&packs);
+
+    let mut imported: Vec<(String, deadsync_score::LocalScoreEntry)> = Vec::new();
+    let mut song_not_found = 0usize;
+    let mut chart_not_found = 0usize;
+    let mut total = 0usize;
+
+    for s in &songs {
+        for steps in &s.steps {
+            for hs in &steps.high_scores {
+                total += 1;
+                match resolver.resolve(
+                    &s.dir,
+                    &steps.steps_type,
+                    &steps.difficulty,
+                    &steps.description,
+                ) {
+                    Resolution::Found(hash) => {
+                        let entry = local_score_from_itg(hs).expect("map high score");
+                        imported.push((hash.to_string(), entry));
+                    }
+                    Resolution::SongNotFound => song_not_found += 1,
+                    Resolution::ChartNotFound => chart_not_found += 1,
+                }
+            }
+        }
+    }
+
+    assert_eq!(total, 2);
+    assert_eq!(song_not_found, 1, "Ghost Song isn't in the library");
+    assert_eq!(chart_not_found, 0);
+    assert_eq!(imported.len(), 1, "Cool Song/Hard resolved and mapped");
+
+    let (hash, entry) = &imported[0];
+    assert_eq!(hash, "abc123def456");
+    assert_eq!(entry.judgment_counts, [410, 52, 11, 3, 1, 4]);
+    // Holds fold all hold-type tallies together: 18 + 2 + 1.
+    assert_eq!(entry.holds_held, 18);
+    assert_eq!(entry.holds_total, 21);
+    // Mines: hit + avoided.
+    assert_eq!(entry.mines_avoided, 7);
+    assert_eq!(entry.mines_total, 9);
+    assert!((entry.score_percent - 0.9421).abs() < 1e-6);
+    assert_eq!(
+        entry.ex_score_percent, 0.0,
+        "EX not recoverable from Stats.xml"
+    );
+    assert_ne!(entry.played_at_ms, 0, "DateTime parsed");
+
+    // The mapped entry must survive the on-disk bincode round-trip used by the
+    // local-score writer.
+    let bytes = encode_local_score_entry(entry).expect("encode");
+    let decoded = decode_local_score_entry(&bytes).expect("decode");
+    assert_eq!(&decoded, entry);
+}

--- a/src/screens/manage_local_profiles.rs
+++ b/src/screens/manage_local_profiles.rs
@@ -2,7 +2,10 @@ use crate::act;
 use crate::assets::AssetManager;
 use crate::assets::i18n::{tr, tr_fmt};
 use crate::assets::visual_styles;
+use crate::game::import::detect::{ItgProfileCandidate, detect_itg_local_profiles};
+use crate::game::import::run::{ImportSummary, import_itg_profile_dir};
 use crate::game::profile;
+use crate::screens::components::shared::loading_bar;
 use crate::screens::components::shared::screen_bar::{
     self, ScreenBarPosition, ScreenBarTitlePlacement,
 };
@@ -18,6 +21,8 @@ use deadsync_input::RawKeyboardEvent;
 use deadsync_input::{InputEvent, VirtualAction};
 use deadsync_profile as profile_data;
 use std::sync::Arc;
+use std::sync::mpsc::{Receiver, TryRecvError};
+use std::thread;
 use std::time::{Duration, Instant};
 use winit::keyboard::KeyCode;
 
@@ -68,6 +73,7 @@ const PROFILE_MENU_BORDER: f32 = 3.0;
 #[derive(Clone, Debug)]
 enum RowKind {
     CreateNew,
+    ImportItg,
     Profile { id: String, display_name: String },
     Exit,
 }
@@ -147,6 +153,45 @@ struct DeleteConfirmState {
     error: Option<Arc<str>>,
 }
 
+/// Modal listing ITGmania profiles found on disk, for the user to pick one to
+/// import.
+struct ImportPickerState {
+    candidates: Vec<ItgProfileCandidate>,
+    selected: usize,
+}
+
+/// A running import on a worker thread. The screen polls `rx` each frame and
+/// keeps the latest per-song progress snapshot for the progress bar.
+struct ImportJob {
+    rx: Receiver<ImportMsg>,
+    /// Latest `(done, total, song label)` reported by the worker, if any.
+    progress: Option<(usize, usize, Arc<str>)>,
+}
+
+/// Messages sent from the import worker thread to the screen.
+enum ImportMsg {
+    /// Per-song progress: `done` of `total` songs processed, current song label.
+    Progress {
+        done: usize,
+        total: usize,
+        label: String,
+    },
+    /// The import finished (success or failure).
+    Done(ImportOutcome),
+}
+
+enum ImportOutcome {
+    Ok(Box<ImportSummary>),
+    Err(String),
+}
+
+/// A simple centered message modal: an import summary, "none found", or an
+/// error. Dismissed with Start/Back.
+struct ImportMessageState {
+    title: Arc<str>,
+    lines: Vec<String>,
+}
+
 pub struct State {
     pub selected: usize,
     prev_selected: usize,
@@ -159,6 +204,9 @@ pub struct State {
     name_entry: Option<NameEntryState>,
     profile_menu: Option<ProfileMenuState>,
     delete_confirm: Option<DeleteConfirmState>,
+    import_picker: Option<ImportPickerState>,
+    import_job: Option<ImportJob>,
+    import_message: Option<ImportMessageState>,
     menu_lr_chord: screen_input::MenuLrChordTracker,
     menu_lr_undo: i8,
 }
@@ -177,6 +225,9 @@ pub fn init() -> State {
         name_entry: None,
         profile_menu: None,
         delete_confirm: None,
+        import_picker: None,
+        import_job: None,
+        import_message: None,
         menu_lr_chord: screen_input::MenuLrChordTracker::default(),
         menu_lr_undo: 0,
     }
@@ -187,6 +238,9 @@ fn build_rows() -> Vec<Row> {
     let mut out = Vec::with_capacity(profiles.len() + 2);
     out.push(Row {
         kind: RowKind::CreateNew,
+    });
+    out.push(Row {
+        kind: RowKind::ImportItg,
     });
     for p in profiles {
         out.push(Row {
@@ -313,6 +367,7 @@ fn update_name_entry_blink(state: &mut State, dt: f32) {
 pub fn update(state: &mut State, dt: f32) -> Option<ScreenAction> {
     update_hold_scroll(state);
     update_name_entry_blink(state, dt);
+    poll_import_job(state);
     None
 }
 
@@ -579,6 +634,210 @@ fn cancel_delete_confirm(state: &mut State) {
     reset_nav_hold(state);
 }
 
+/* ----------------------------- ITGmania import ---------------------------- */
+
+fn begin_import_picker(state: &mut State) {
+    reset_nav_hold(state);
+    audio::play_sfx("assets/sounds/start.ogg");
+    let candidates = detect_itg_local_profiles();
+    if candidates.is_empty() {
+        state.import_message = Some(ImportMessageState {
+            title: tr("Profiles", "ImportNoneFoundTitle"),
+            lines: vec![tr("Profiles", "ImportNoneFoundBody").to_string()],
+        });
+        return;
+    }
+    state.import_picker = Some(ImportPickerState {
+        candidates,
+        selected: 0,
+    });
+}
+
+fn cancel_import_picker(state: &mut State) {
+    state.import_picker = None;
+    reset_nav_hold(state);
+}
+
+fn move_import_picker_selected(state: &mut State, dir: NavDirection) {
+    let Some(picker) = state.import_picker.as_mut() else {
+        return;
+    };
+    let len = picker.candidates.len();
+    if len == 0 {
+        picker.selected = 0;
+        return;
+    }
+    picker.selected = match dir {
+        NavDirection::Up => {
+            if picker.selected == 0 {
+                len - 1
+            } else {
+                picker.selected - 1
+            }
+        }
+        NavDirection::Down => (picker.selected + 1) % len,
+    };
+}
+
+fn confirm_import_picker(state: &mut State) {
+    let Some(picker) = state.import_picker.take() else {
+        return;
+    };
+    let Some(candidate) = picker.candidates.get(picker.selected) else {
+        return;
+    };
+    let dir = candidate.dir.clone();
+    audio::play_sfx("assets/sounds/start.ogg");
+    reset_nav_hold(state);
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let progress_tx = tx.clone();
+    thread::spawn(move || {
+        let result = import_itg_profile_dir(&dir, |done, total, label| {
+            let _ = progress_tx.send(ImportMsg::Progress {
+                done,
+                total,
+                label: label.to_string(),
+            });
+        });
+        let outcome = match result {
+            Ok(summary) => ImportOutcome::Ok(Box::new(summary)),
+            Err(e) => ImportOutcome::Err(e.to_string()),
+        };
+        let _ = tx.send(ImportMsg::Done(outcome));
+    });
+    state.import_job = Some(ImportJob { rx, progress: None });
+}
+
+fn poll_import_job(state: &mut State) {
+    let Some(job) = state.import_job.as_mut() else {
+        return;
+    };
+    // Drain all pending messages this frame: update the progress snapshot, and
+    // finalize when the Done message arrives.
+    let mut outcome: Option<ImportOutcome> = None;
+    loop {
+        match job.rx.try_recv() {
+            Ok(ImportMsg::Progress { done, total, label }) => {
+                job.progress = Some((done, total, Arc::from(label.as_str())));
+            }
+            Ok(ImportMsg::Done(o)) => {
+                outcome = Some(o);
+                break;
+            }
+            Err(TryRecvError::Empty) => return,
+            Err(TryRecvError::Disconnected) => {
+                state.import_job = None;
+                state.import_message = Some(ImportMessageState {
+                    title: tr("Profiles", "ImportFailedTitle"),
+                    lines: vec![tr("Profiles", "ImportFailedBody").to_string()],
+                });
+                return;
+            }
+        }
+    }
+    let Some(outcome) = outcome else {
+        return;
+    };
+    state.import_job = None;
+    match outcome {
+        ImportOutcome::Ok(summary) => {
+            audio::play_sfx("assets/sounds/start.ogg");
+            refresh_rows(state);
+            select_profile_row(state, &summary.profile_id);
+            state.import_message = Some(import_summary_message(&summary));
+        }
+        ImportOutcome::Err(e) => {
+            state.import_message = Some(ImportMessageState {
+                title: tr("Profiles", "ImportFailedTitle"),
+                lines: vec![e],
+            });
+        }
+    }
+}
+
+fn select_profile_row(state: &mut State, profile_id: &str) {
+    if let Some(pos) = state
+        .rows
+        .iter()
+        .position(|r| matches!(&r.kind, RowKind::Profile { id, .. } if id == profile_id))
+    {
+        state.selected = pos;
+        state.prev_selected = pos;
+    }
+}
+
+fn import_summary_message(summary: &ImportSummary) -> ImportMessageState {
+    let mut lines = Vec::new();
+    lines.push(
+        tr_fmt(
+            "Profiles",
+            "ImportSummaryName",
+            &[("name", &summary.display_name)],
+        )
+        .to_string(),
+    );
+    lines.push(
+        tr_fmt(
+            "Profiles",
+            "ImportSummaryScores",
+            &[
+                ("imported", &summary.scores_imported.to_string()),
+                ("total", &summary.scores_total.to_string()),
+            ],
+        )
+        .to_string(),
+    );
+    let skipped =
+        summary.charts_song_not_found + summary.charts_chart_not_found + summary.scores_unmapped;
+    if skipped > 0 {
+        lines.push(
+            tr_fmt(
+                "Profiles",
+                "ImportSummarySkipped",
+                &[("skipped", &skipped.to_string())],
+            )
+            .to_string(),
+        );
+    }
+    lines.push(tr("Profiles", "ImportSummaryExNote").to_string());
+    ImportMessageState {
+        title: tr("Profiles", "ImportSummaryTitle"),
+        lines,
+    }
+}
+
+fn dismiss_import_message(state: &mut State) {
+    state.import_message = None;
+    reset_nav_hold(state);
+    audio::play_sfx("assets/sounds/start.ogg");
+}
+
+fn handle_import_picker_input(state: &mut State, ev: &InputEvent) {
+    if !ev.pressed {
+        return;
+    }
+    match ev.action {
+        VirtualAction::p1_back | VirtualAction::p2_back => cancel_import_picker(state),
+        VirtualAction::p1_up
+        | VirtualAction::p1_menu_up
+        | VirtualAction::p2_up
+        | VirtualAction::p2_menu_up => {
+            move_import_picker_selected(state, NavDirection::Up);
+            audio::play_sfx("assets/sounds/change.ogg");
+        }
+        VirtualAction::p1_down
+        | VirtualAction::p1_menu_down
+        | VirtualAction::p2_down
+        | VirtualAction::p2_menu_down => {
+            move_import_picker_selected(state, NavDirection::Down);
+            audio::play_sfx("assets/sounds/change.ogg");
+        }
+        VirtualAction::p1_start | VirtualAction::p2_start => confirm_import_picker(state),
+        _ => {}
+    }
+}
+
 #[inline(always)]
 fn activate_selected_row(state: &mut State) -> ScreenAction {
     let total = state.rows.len();
@@ -590,6 +849,10 @@ fn activate_selected_row(state: &mut State) -> ScreenAction {
     match start_row {
         RowKind::CreateNew => {
             begin_name_entry_create(state);
+            ScreenAction::None
+        }
+        RowKind::ImportItg => {
+            begin_import_picker(state);
             ScreenAction::None
         }
         RowKind::Exit => {
@@ -623,6 +886,24 @@ fn undo_profile_menu_move(state: &mut State, undo: i8) {
 }
 
 pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
+    if state.import_job.is_some() {
+        return ScreenAction::None;
+    }
+    if state.import_message.is_some() {
+        if ev.pressed
+            && matches!(
+                ev.action,
+                VirtualAction::p1_start
+                    | VirtualAction::p2_start
+                    | VirtualAction::p1_back
+                    | VirtualAction::p2_back
+            )
+        {
+            dismiss_import_message(state);
+        }
+        return ScreenAction::None;
+    }
+
     let three_key_action = screen_input::three_key_menu_action(&mut state.menu_lr_chord, ev);
     if screen_input::dedicated_three_key_nav_enabled() {
         match ev.action {
@@ -649,6 +930,21 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
             _ => {}
         }
         if let Some((_, nav)) = three_key_action {
+            if state.import_picker.is_some() {
+                match nav {
+                    screen_input::ThreeKeyMenuAction::Prev => {
+                        move_import_picker_selected(state, NavDirection::Up);
+                        audio::play_sfx("assets/sounds/change.ogg");
+                    }
+                    screen_input::ThreeKeyMenuAction::Next => {
+                        move_import_picker_selected(state, NavDirection::Down);
+                        audio::play_sfx("assets/sounds/change.ogg");
+                    }
+                    screen_input::ThreeKeyMenuAction::Confirm => confirm_import_picker(state),
+                    screen_input::ThreeKeyMenuAction::Cancel => cancel_import_picker(state),
+                }
+                return ScreenAction::None;
+            }
             if state.name_entry.is_some() {
                 match nav {
                     screen_input::ThreeKeyMenuAction::Confirm => confirm_name_entry(state),
@@ -721,6 +1017,10 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
                 }
             };
         }
+    }
+    if state.import_picker.is_some() {
+        handle_import_picker_input(state, ev);
+        return ScreenAction::None;
     }
     if state.name_entry.is_some() {
         match ev.action {
@@ -925,6 +1225,13 @@ fn help_for_selected(state: &State, p1_id: Option<&str>, p2_id: Option<&str>) ->
             (title.to_string(), bullets)
         }
         RowKind::Exit => (tr("Profiles", "ReturnToOptions").to_string(), String::new()),
+        RowKind::ImportItg => {
+            let title = tr("Profiles", "ImportItgTitle");
+            let b1 = tr("Profiles", "ImportItgHelp1");
+            let b2 = tr("Profiles", "ImportItgHelp2");
+            let bullets = make_bullets(&[&b1, &b2]);
+            (title.to_string(), bullets)
+        }
         RowKind::Profile { id, display_name } => {
             let title =
                 tr_fmt("Profiles", "LocalProfileFormat", &[("name", display_name)]).to_string();
@@ -1189,6 +1496,230 @@ fn push_overlay_error(
     ));
 }
 
+const IMPORT_PICK_MAX_VISIBLE: usize = 8;
+
+fn push_import_picker_overlay(ui: &mut Vec<Actor>, state: &State) {
+    let Some(picker) = &state.import_picker else {
+        return;
+    };
+
+    let w = screen_width();
+    let h = screen_height();
+    let box_w = 760.0_f32.min(w * 0.92);
+    let header_h = 56.0_f32;
+    let item_h = 34.0_f32;
+    let footer_h = 44.0_f32;
+    let total = picker.candidates.len();
+    let visible = total.min(IMPORT_PICK_MAX_VISIBLE);
+    let box_h = header_h + (visible as f32) * item_h + footer_h;
+    let cx = w * 0.5;
+    let cy = h * 0.5;
+    let top = cy - box_h * 0.5;
+
+    push_overlay_backdrop(ui, w, h);
+    push_overlay_box(ui, cx, cy, box_w, box_h);
+
+    let title = tr("Profiles", "ImportPickTitle");
+    ui.push(act!(text:
+        align(0.5, 0.0):
+        xy(cx, top + 14.0):
+        font("miso"):
+        zoom(1.05):
+        maxwidth(box_w - 40.0):
+        settext(title):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        z(1002):
+        horizalign(center)
+    ));
+
+    let offset = if total <= IMPORT_PICK_MAX_VISIBLE {
+        0
+    } else {
+        picker
+            .selected
+            .saturating_sub(IMPORT_PICK_MAX_VISIBLE - 1)
+            .min(total - IMPORT_PICK_MAX_VISIBLE)
+    };
+    let accent = color::simply_love_rgba(state.active_color_index);
+    let list_left = cx - box_w * 0.5 + 24.0;
+    let list_w = box_w - 48.0;
+
+    for i in 0..visible {
+        let idx = offset + i;
+        let Some(cand) = picker.candidates.get(idx) else {
+            break;
+        };
+        let row_y = (i as f32).mul_add(item_h, top + header_h);
+        let selected = idx == picker.selected;
+        if selected {
+            ui.push(act!(quad:
+                align(0.0, 0.0):
+                xy(list_left - 8.0, row_y):
+                zoomto(list_w + 16.0, item_h):
+                diffuse(0.17, 0.23, 0.28, 0.95):
+                z(1002)
+            ));
+        }
+        let text_col = if selected {
+            [accent[0], accent[1], accent[2], 1.0]
+        } else {
+            [1.0, 1.0, 1.0, 1.0]
+        };
+        ui.push(act!(text:
+            align(0.0, 0.5):
+            xy(list_left, row_y + item_h * 0.5):
+            font("miso"):
+            zoom(0.95):
+            maxwidth(list_w):
+            settext(cand.display_name.clone()):
+            diffuse(text_col[0], text_col[1], text_col[2], text_col[3]):
+            z(1003):
+            horizalign(left)
+        ));
+    }
+
+    let prompt = tr("Profiles", "ImportPickPrompt");
+    ui.push(act!(text:
+        align(0.5, 1.0):
+        xy(cx, cy + box_h * 0.5 - 12.0):
+        font("miso"):
+        zoom(0.85):
+        maxwidth(box_w - 40.0):
+        settext(prompt):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        z(1003):
+        horizalign(center)
+    ));
+}
+
+fn push_import_progress_overlay(ui: &mut Vec<Actor>, state: &State) {
+    let Some(job) = state.import_job.as_ref() else {
+        return;
+    };
+    let w = screen_width();
+    let h = screen_height();
+    let box_w = 560.0_f32.min(w * 0.92);
+    let box_h = 150.0_f32;
+    let cx = w * 0.5;
+    let cy = h * 0.5;
+    let top = cy - box_h * 0.5;
+
+    push_overlay_backdrop(ui, w, h);
+    push_overlay_box(ui, cx, cy, box_w, box_h);
+
+    // Heading.
+    ui.push(act!(text:
+        align(0.5, 0.0):
+        xy(cx, top + 16.0):
+        font("miso"):
+        zoom(1.05):
+        maxwidth(box_w - 40.0):
+        settext(tr("Profiles", "ImportInProgress")):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        z(1002):
+        horizalign(center)
+    ));
+
+    // Until the first song is reported (file read + resolver build), there's no
+    // determinate progress yet — leave just the heading. Once songs start
+    // processing, show the progress bar + current song label.
+    if let Some((done, total, label)) = &job.progress {
+        let progress = if *total > 0 {
+            (*done as f32 / *total as f32).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        let accent = color::simply_love_rgba(state.active_color_index);
+        let bar_w = (box_w - 64.0).max(0.0);
+        ui.push(loading_bar::build(loading_bar::LoadingBarParams {
+            align: [0.5, 0.5],
+            offset: [cx, cy],
+            width: bar_w,
+            height: 22.0,
+            progress,
+            label: crate::screens::progress_count_text(*done, *total).into(),
+            fill_rgba: [accent[0], accent[1], accent[2], 1.0],
+            bg_rgba: [0.0, 0.0, 0.0, 1.0],
+            border_rgba: [1.0, 1.0, 1.0, 1.0],
+            text_rgba: [1.0, 1.0, 1.0, 1.0],
+            text_zoom: 0.8,
+            z: 1002,
+        }));
+
+        if !label.is_empty() {
+            ui.push(act!(text:
+                align(0.5, 0.5):
+                xy(cx, cy + 34.0):
+                font("miso"):
+                zoom(0.78):
+                maxwidth(box_w - 40.0):
+                settext(label.to_string()):
+                diffuse(0.8, 0.8, 0.8, 1.0):
+                z(1003):
+                horizalign(center)
+            ));
+        }
+    }
+}
+
+fn push_import_message_overlay(ui: &mut Vec<Actor>, state: &State) {
+    let Some(message) = &state.import_message else {
+        return;
+    };
+
+    let w = screen_width();
+    let h = screen_height();
+    let box_w = 760.0_f32.min(w * 0.92);
+    let line_h = 28.0_f32;
+    let header_h = 52.0_f32;
+    let footer_h = 44.0_f32;
+    let box_h = header_h + (message.lines.len().max(1) as f32) * line_h + footer_h;
+    let cx = w * 0.5;
+    let cy = h * 0.5;
+    let top = cy - box_h * 0.5;
+
+    push_overlay_backdrop(ui, w, h);
+    push_overlay_box(ui, cx, cy, box_w, box_h);
+
+    ui.push(act!(text:
+        align(0.5, 0.0):
+        xy(cx, top + 14.0):
+        font("miso"):
+        zoom(1.05):
+        maxwidth(box_w - 40.0):
+        settext(message.title.clone()):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        z(1002):
+        horizalign(center)
+    ));
+
+    for (i, line) in message.lines.iter().enumerate() {
+        let line_y = (i as f32).mul_add(line_h, top + header_h);
+        ui.push(act!(text:
+            align(0.5, 0.0):
+            xy(cx, line_y):
+            font("miso"):
+            zoom(0.9):
+            maxwidth(box_w - 48.0):
+            settext(line.clone()):
+            diffuse(1.0, 1.0, 1.0, 1.0):
+            z(1002):
+            horizalign(center)
+        ));
+    }
+
+    ui.push(act!(text:
+        align(0.5, 1.0):
+        xy(cx, cy + box_h * 0.5 - 12.0):
+        font("miso"):
+        zoom(0.85):
+        settext(tr("Profiles", "ImportMessageDismiss")):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        z(1002):
+        horizalign(center)
+    ));
+}
+
 fn push_list_chrome(
     ui: &mut Vec<Actor>,
     col_active_bg: [f32; 4],
@@ -1228,6 +1759,7 @@ struct RowColors {
 fn row_label(kind: &RowKind) -> Arc<str> {
     match kind {
         RowKind::CreateNew => tr("Profiles", "CreateProfileButton"),
+        RowKind::ImportItg => tr("Profiles", "ImportItgButton"),
         RowKind::Exit => tr("Common", "Exit"),
         RowKind::Profile { display_name, .. } => Arc::from(display_name.as_str()),
     }
@@ -1549,6 +2081,9 @@ pub fn push_actors(
     push_profile_menu_overlay(actors, state, s, list_x, list_y);
     push_name_entry_overlay(actors, state);
     push_delete_confirm_overlay(actors, state);
+    push_import_picker_overlay(actors, state);
+    push_import_progress_overlay(actors, state);
+    push_import_message_overlay(actors, state);
 
     for actor in &mut actors[ui_start..] {
         actor.mul_alpha(alpha_multiplier);


### PR DESCRIPTION
Adds the in-game ITGmania profile importer UI on top of the import engine, plus an end-to-end pipeline test and user docs.

### What's here
- **Importer UI** (`src/screens/manage_local_profiles.rs`): detect candidate ITGmania profiles, list them for selection, and run an import from the manage-local-profiles screen.
- **Profile detection** (`src/game/import/detect.rs`): scan for importable ITGmania `LocalProfiles/<id>/` directories.
- **Cheap display-name read** (`src/game/import/itg.rs`): `read_display_name` labels picker rows without parsing the full `Stats.xml`.
- **i18n** (`assets/languages/en.ini`): importer strings.
- **End-to-end test** (`src/game/import/pipeline_tests.rs`): exercises the full read → resolve → write pipeline against a synthetic profile fixture.
- **Docs** (`docs/migrating-from-itgmania.md`): document the in-game importer flow.

Formatting matches `cargo fmt`. The picker/import flow is fleshed out further in later changes.