### PR TITLE
ITGmania import: expand Simply Love player-options coverage

### DIFF
--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -1469,6 +1469,23 @@ CannotBeUndone=This cannot be undone.
 YesNoPrompt=Start: Yes    Back: No
 CreateProfileButton=Create Profile
 ExitButton=Exit
+ImportItgButton=Import from ITGmania
+ImportItgTitle=Import a profile from ITGmania.
+ImportItgHelp1=Copies the profile, player options and offline scores.
+ImportItgHelp2=Press Start to scan for ITGmania profiles.
+ImportPickTitle=Select an ITGmania profile to import
+ImportPickPrompt=Start: Import    Back: Cancel
+ImportInProgress=Importing... this can take a moment.
+ImportNoneFoundTitle=No ITGmania profiles found
+ImportNoneFoundBody=Could not find any ITGmania local profiles. Make sure ITGmania is installed and has at least one local profile.
+ImportFailedTitle=Import failed
+ImportFailedBody=The profile could not be imported.
+ImportSummaryTitle=Import complete
+ImportSummaryName=Imported profile: {name}
+ImportSummaryScores=Scores imported: {imported} of {total}
+ImportSummarySkipped=Skipped {skipped} score(s) for charts not in your library.
+ImportSummaryExNote=Note: EX scores are not stored by ITGmania and start at 0.
+ImportMessageDismiss=Press Start to continue.
 
 ; ============================================================
 ; Select Profile screen

--- a/crates/deadsync-profile/src/lib.rs
+++ b/crates/deadsync-profile/src/lib.rs
@@ -2687,6 +2687,34 @@ fn normalize_graphic_key(
     Ok(format!("{folder}/{basename}"))
 }
 
+/// Like [`normalize_graphic_key`] but **only** resolves names DeadSync actually
+/// ships: a recognized stock alias or `"None"`. Returns `None` for unknown or
+/// custom graphic names instead of fabricating a `folder/basename` path that
+/// would point at a missing texture. Used by the ITGmania importer, where a
+/// Simply Love profile may reference a theme graphic DeadSync doesn't have.
+fn recognized_stock_key(raw: &str, stock_aliases: &[(&str, &str)]) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.eq_ignore_ascii_case("none") {
+        return Some("None".to_string());
+    }
+    let basename = Path::new(trimmed)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(trimmed)
+        .trim();
+    if basename.eq_ignore_ascii_case("none") {
+        return Some("None".to_string());
+    }
+    let normalized = basename.to_ascii_lowercase();
+    stock_aliases
+        .iter()
+        .find(|(alias, _)| alias.eq_ignore_ascii_case(&normalized))
+        .map(|(_, key)| (*key).to_string())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HoldJudgmentGraphic(String);
 
@@ -2726,6 +2754,14 @@ impl HoldJudgmentGraphic {
             normalize_graphic_key(raw, "hold_judgements", Self::STOCK_ALIASES)
                 .unwrap_or_else(|_| Self::DEFAULT_KEY.to_string()),
         )
+    }
+
+    /// Parse `raw` only if it names a graphic DeadSync ships (a recognized stock
+    /// alias or `"None"`), returning `None` for unknown/custom names. Use this
+    /// when importing external settings to avoid pointing at a missing texture.
+    #[inline(always)]
+    pub fn from_stock_name(raw: &str) -> Option<Self> {
+        recognized_stock_key(raw, Self::STOCK_ALIASES).map(Self)
     }
 
     #[inline(always)]
@@ -2784,6 +2820,14 @@ impl HeldMissGraphic {
             normalize_graphic_key(raw, "held_miss", Self::STOCK_ALIASES)
                 .unwrap_or_else(|_| Self::DEFAULT_KEY.to_string()),
         )
+    }
+
+    /// Parse `raw` only if it names a graphic DeadSync ships (a recognized stock
+    /// alias or `"None"`), returning `None` for unknown/custom names. Use this
+    /// when importing external settings to avoid pointing at a missing texture.
+    #[inline(always)]
+    pub fn from_stock_name(raw: &str) -> Option<Self> {
+        recognized_stock_key(raw, Self::STOCK_ALIASES).map(Self)
     }
 
     #[inline(always)]
@@ -3026,6 +3070,14 @@ impl JudgmentGraphic {
             normalize_graphic_key(raw, "judgements", Self::STOCK_ALIASES)
                 .unwrap_or_else(|_| Self::DEFAULT_KEY.to_string()),
         )
+    }
+
+    /// Parse `raw` only if it names a graphic DeadSync ships (a recognized stock
+    /// alias or `"None"`), returning `None` for unknown/custom names. Use this
+    /// when importing external settings to avoid pointing at a missing texture.
+    #[inline(always)]
+    pub fn from_stock_name(raw: &str) -> Option<Self> {
+        recognized_stock_key(raw, Self::STOCK_ALIASES).map(Self)
     }
 
     #[inline(always)]

--- a/crates/deadsync-score/src/import.rs
+++ b/crates/deadsync-score/src/import.rs
@@ -40,6 +40,34 @@ pub struct ImportedHighScore {
     pub missed_hold: u32,
     /// `<SurviveSeconds>` — how long the player lasted before failing (if any).
     pub survive_seconds: f32,
+    /// `<Modifiers>` text, e.g. `"1.5xMusic, Overhead"`. Used to recover the
+    /// music rate; empty/absent means the default rate of 1.0.
+    pub modifiers: String,
+}
+
+/// Recovers the music rate from an ITGmania `<Modifiers>` string.
+///
+/// ITGmania serialises a non-default rate as a `"<rate>xMusic"` token (see
+/// `itgmania/src/SongOptions.cpp` `GetMods`), e.g. `"1.5xMusic"`. The token is
+/// comma/space separated from the other modifiers. Returns `1.0` when no rate
+/// token is present or it can't be parsed into a positive number.
+pub fn music_rate_from_modifiers(modifiers: &str) -> f32 {
+    for token in modifiers.split([',', ' ', '\t']) {
+        let token = token.trim();
+        if token.len() < 7 {
+            continue;
+        }
+        let (num, suffix) = token.split_at(token.len() - 6);
+        if !suffix.eq_ignore_ascii_case("xmusic") {
+            continue;
+        }
+        if let Ok(rate) = num.parse::<f32>() {
+            if rate.is_finite() && rate > 0.0 {
+                return rate;
+            }
+        }
+    }
+    1.0
 }
 
 /// Maps an ITGmania `<Grade>` string to a DeadSync [`Grade`].
@@ -99,6 +127,7 @@ pub fn parse_itg_datetime_ms(date_time: &str) -> Option<i64> {
 /// * Holds and rolls are not distinguished in `Stats.xml`; all hold-type tallies
 ///   are folded into the hold fields (`rolls_* = 0`).
 /// * `score_percent` is taken from `PercentDP` directly (both are 0.0–1.0).
+/// * `music_rate` is recovered from the `<Modifiers>` rate token (default 1.0).
 /// * EX / Hard-EX are unrecoverable → `0.0`.
 /// * The lamp is recomputed from the judgment counts (W0 split unknown).
 pub fn local_score_from_itg(hs: &ImportedHighScore) -> Option<LocalScoreEntry> {
@@ -122,7 +151,7 @@ pub fn local_score_from_itg(hs: &ImportedHighScore) -> Option<LocalScoreEntry> {
     Some(LocalScoreEntry {
         version: LOCAL_SCORE_VERSION,
         played_at_ms: parse_itg_datetime_ms(&hs.date_time).unwrap_or(0),
-        music_rate: 1.0,
+        music_rate: music_rate_from_modifiers(&hs.modifiers),
         score_percent: hs.percent_dp.clamp(0.0, 1.0),
         grade_code: grade_to_code(grade),
         lamp_index,
@@ -208,6 +237,7 @@ mod tests {
             let_go: 0,
             missed_hold: 0,
             survive_seconds: 0.0,
+            modifiers: String::new(),
         };
         let e = local_score_from_itg(&hs).expect("entry");
         assert_eq!(e.grade_code, grade_to_code(Grade::Tier01));
@@ -220,6 +250,7 @@ mod tests {
         assert!((e.score_percent - 0.9912).abs() < 1e-9);
         assert_eq!(e.ex_score_percent, 0.0);
         assert_eq!(e.fail_time, None);
+        assert_eq!(e.music_rate, 1.0);
         // No misses/way-offs/etc beyond excellents → "excellent" lamp tier.
         assert_eq!(e.lamp_index, Some(2));
         assert_eq!(e.lamp_judge_count, None); // 12 excellents > 9 → no judge count
@@ -254,5 +285,31 @@ mod tests {
         let e = local_score_from_itg(&hs).expect("entry");
         assert_eq!(e.holds_held, 10);
         assert_eq!(e.holds_total, 15);
+    }
+
+    #[test]
+    fn parses_music_rate_from_modifiers() {
+        assert_eq!(music_rate_from_modifiers(""), 1.0);
+        assert_eq!(music_rate_from_modifiers("Overhead, Mirror"), 1.0);
+        assert_eq!(music_rate_from_modifiers("1.5xMusic"), 1.5);
+        assert_eq!(
+            music_rate_from_modifiers("Overhead, 2.0xMusic, Mirror"),
+            2.0
+        );
+        assert_eq!(music_rate_from_modifiers("0.8xmusic"), 0.8);
+        // Malformed / non-positive rate falls back to 1.0.
+        assert_eq!(music_rate_from_modifiers("xMusic"), 1.0);
+        assert_eq!(music_rate_from_modifiers("0xMusic"), 1.0);
+    }
+
+    #[test]
+    fn applies_music_rate_to_entry() {
+        let hs = ImportedHighScore {
+            grade: "Grade_Tier03".into(),
+            modifiers: "1.5xMusic, Reverse".into(),
+            ..Default::default()
+        };
+        let e = local_score_from_itg(&hs).expect("entry");
+        assert_eq!(e.music_rate, 1.5);
     }
 }

--- a/docs/itgmania-import-mapping.md
+++ b/docs/itgmania-import-mapping.md
@@ -1,0 +1,310 @@
+# ITGmania / Simply Love → DeadSync import mapping
+
+This is the authoritative field-by-field reference for what DeadSync's profile
+importer (**Options → Manage Local Profiles → Import from ITGmania**) reads from
+an ITGmania + Simply Love local profile and where each value lands in DeadSync.
+
+For the end-user walkthrough see
+[migrating-from-itgmania.md](./migrating-from-itgmania.md); this document is for
+contributors maintaining the importer.
+
+## Source files in an ITGmania profile
+
+An ITGmania `LocalProfiles/<id>/` directory contains:
+
+| File | What the importer reads from it |
+| --- | --- |
+| `Editable.ini` | Display name, weight, birth year, player initials |
+| `GrooveStats.ini` | GrooveStats API key, username, pad-player flag |
+| `ArrowCloud.ini` | ArrowCloud API key |
+| `Simply Love UserPrefs.ini` | `[Simply Love]` section → player options |
+| `Avatar.png` (or `.jpg`/`.jpeg`) | Profile avatar image |
+| `Stats.xml` (or `Stats.xml.gz`) | Per-chart high scores |
+
+Reader code: `src/game/import/itg.rs`. Each reader degrades gracefully — a
+missing file or key yields an empty/default value rather than failing the whole
+import.
+
+## Pipeline overview
+
+```
+Editable.ini ─┐
+GrooveStats ──┤
+ArrowCloud  ──┼─► itg.rs (readers) ─► ItgSource ─► run.rs (orchestration)
+UserPrefs.ini ┤                                        │
+Avatar.png  ──┤                          options.rs ◄──┤ player options
+Stats.xml ────┘                          resolver.rs ◄─┤ chart → GS hash
+                                         import.rs   ◄──┘ score → LocalScoreEntry
+```
+
+- **`options.rs`** translates Simply Love mods → `PlayerOptionsData`.
+- **`resolver.rs`** matches a `Stats.xml` chart (song dir + steps type +
+  difficulty + description) to a chart in DeadSync's scanned library, recovering
+  the GrooveStats `short_hash`.
+- **`deadsync-score/src/import.rs`** maps one `<HighScore>` → `LocalScoreEntry`.
+- **`run.rs`** writes the new profile and imported scores.
+
+## 1. Profile metadata
+
+Source: `Editable.ini` `[Editable]`. Writer: `src/game/profile.rs`
+(`ImportProfileData`).
+
+| ITGmania key | DeadSync field | Notes |
+| --- | --- | --- |
+| `DisplayName` | display name | |
+| `WeightPounds` | weight (lbs) | parsed `u32`, `0` if absent |
+| `BirthYear` | birth year | parsed `u32`, `0` if absent |
+| `LastUsedHighScoreName` | player initials | sanitised; falls back to initials derived from the display name |
+
+## 2. Online service keys
+
+Sources: `GrooveStats.ini` `[GrooveStats]`, `ArrowCloud.ini` `[ArrowCloud]`.
+Written into the new profile's lowercase `groovestats.ini` / `arrowcloud.ini`.
+
+| ITGmania source | DeadSync target |
+| --- | --- |
+| `GrooveStats.ApiKey` | `groovestats.ini` ApiKey |
+| `GrooveStats.Username` | `groovestats.ini` Username |
+| `GrooveStats.IsPadPlayer` | `groovestats.ini` IsPadPlayer |
+| `ArrowCloud.ApiKey` | `arrowcloud.ini` ApiKey |
+
+The importer copies **credentials only**; it does not enable the services. The
+machine-level toggles (`enable_groovestats`, `enable_arrowcloud`,
+`enable_boogiestats`) live in global config and must still be turned on under
+**Options → Online Scoring**. BoogieStats has no separate credential — it reuses
+the GrooveStats key (`is_boogiestats_active()` is just
+`enable_groovestats && enable_boogiestats`), so importing the GrooveStats key is
+all that's needed for it.
+
+## 3. Avatar
+
+`Avatar.png` / `avatar.png` / `Avatar.jpg` / `Avatar.jpeg` (first match,
+case-insensitive) is copied into the new profile directory as `profile.png`.
+
+## 4. Player options (Simply Love)
+
+Source: `Simply Love UserPrefs.ini` `[Simply Love]`. Translator:
+`src/game/import/options.rs` (`translate_player_options`).
+
+**Design rule:** only settings that map with high confidence are translated.
+Anything DeadSync doesn't recognise — including custom theme graphics/fonts it
+doesn't ship — is left at the DeadSync default rather than guessed. Simply Love
+serialises with Lua `tostring`, so booleans are `true`/`false`.
+
+### 4.1 Scalar / parsed values
+
+| Simply Love key | Value format | DeadSync field | Translation |
+| --- | --- | --- | --- |
+| `SpeedModType` + `SpeedMod` | `X`/`C`/`M` + number | `scroll_speed` | → `ScrollSpeedSetting::{XMod,CMod,MMod}`; ignored if rate ≤ 0 |
+| `Mini` | `"50%"` | `mini_percent` | leading signed int |
+| `Spacing` | `"-25%"` | `spacing_percent` | leading signed int |
+| `NoteFieldOffsetX` | int | `note_field_offset_x` | leading signed int |
+| `NoteFieldOffsetY` | int | `note_field_offset_y` | leading signed int |
+| `VisualDelay` | `"12ms"` | `visual_delay_ms` | leading signed int |
+| `TiltMultiplier` | float | `tilt_multiplier` | parsed `f32` |
+| `MeasureCounterLookahead` | int | `measure_counter_lookahead` | clamped `0..=255` |
+| `NoteSkin` | name | `noteskin` | `NoteSkin::new` (passthrough) |
+
+### 4.2 Theme graphics & font
+
+Simply Love stores the **full sprite filename** for the graphics and the **font
+directory name** for the combo font. These resolve through DeadSync's stock
+alias tables via a *stock-only* parse (`from_stock_name`): a name DeadSync
+doesn't ship resolves to `None` and the base default is kept (so the profile
+never points at a missing texture).
+
+| Simply Love key | Example value | DeadSync field |
+| --- | --- | --- |
+| `JudgmentGraphic` | `Love 2x7 (doubleres).png` | `judgment_graphic` |
+| `HeldGraphic` | `Love (doubleres).png` | `held_miss_graphic` |
+| `HoldJudgment` | `ITG2 1x2 (doubleres).png` | `hold_judgment_graphic` |
+| `ComboFont` | `Wendy`, `Bebas Neue` | `combo_font` (`FromStr`; unknown → default) |
+
+### 4.3 Enum-valued settings
+
+Translated via DeadSync's `FromStr`, which normalises case/punctuation and
+rejects unknown vocabularies (unknown → default preserved).
+
+| Simply Love key | DeadSync field | Accepted values |
+| --- | --- | --- |
+| `BackgroundFilter` | `background_filter` | `0`–`100` (or `Off`/`Dark`/`Darker`/`Darkest`) |
+| `ComboColors` | `combo_colors` | `Glow`, `Solid`, `Rainbow`, `RainbowScroll`, `None` |
+| `ComboMode` | `combo_mode` | `FullCombo`, `CurrentCombo` |
+| `LifeMeterType` | `lifemeter_type` | `Standard`, `Surround`, `Vertical` |
+| `MeasureCounter` | `measure_counter` | `None`, `8th`, `12th`, `16th`, `24th`, `32nd` |
+| `MeasureLines` | `measure_lines` | `Off`, `Measure`, `Quarter`, `Eighth` |
+| `ErrorBarTrim` | `error_bar_trim` | `Off`, `Fantastic`, `Excellent`, `Great` |
+| `MiniIndicator` | `mini_indicator` | `None`, `SubtractiveScoring`, `PredictiveScoring`, `PaceScoring`, `RivalScoring`, `Pacemaker`, `StreamProg` |
+| `DataVisualizations` | `step_statistics` | `None`/`Target Score Graph` → empty; `Step Statistics` → all widgets |
+
+### 4.4 SelectMultiple flag groups → bitmasks
+
+Applied only when at least one flag of the group is present (otherwise the
+DeadSync default is kept).
+
+**Error-bar style** → `error_bar_active_mask` (then `error_bar` and
+`error_bar_text` are derived from the mask):
+
+| Simply Love flag | `ErrorBarMask` bit |
+| --- | --- |
+| `Colorful` | `COLORFUL` |
+| `Monochrome` | `MONOCHROME` |
+| `Text` | `TEXT` |
+| `Highlight` | `HIGHLIGHT` |
+| `Average` | `AVERAGE` |
+
+**Judgment flash** → `column_flash_mask`:
+
+| Simply Love flag | `ColumnFlashMask` bit |
+| --- | --- |
+| `FlashMiss` | `MISS` |
+| `FlashWayOff` | `WAY_OFF` |
+| `FlashDecent` | `DECENT` |
+| `FlashGreat` | `GREAT` |
+| `FlashExcellent` | `EXCELLENT` |
+| `FlashFantastic` | `BLUE_FANTASTIC` **and** `WHITE_FANTASTIC` |
+
+> Simply Love has a single "Fantastic" flash; DeadSync splits fantastic into
+> blue (W0/FA+) and white (W1) columns, so a single `FlashFantastic` enables
+> both bits.
+
+### 4.5 Engine modifier string
+
+`PlayerOptionsString` (comma-separated engine mods, e.g.
+`"1.5x, Reverse, Mirror"`) contributes:
+
+| Token(s) | DeadSync field |
+| --- | --- |
+| `reverse` | `scroll_option |= Reverse`, `reverse_scroll = true` |
+| `split` / `alternate` / `cross` / `centered` | corresponding `ScrollOption` bit |
+| a parseable `TurnOption` (e.g. `mirror`, `left`, `right`, `shuffle`) | `turn_option` |
+
+### 4.6 Boolean toggles (1:1)
+
+These Simply Love booleans map directly to the same-meaning DeadSync field:
+
+| Simply Love key | DeadSync field |
+| --- | --- |
+| `HideTargets` | `hide_targets` |
+| `HideSongBG` | `hide_song_bg` |
+| `HideCombo` | `hide_combo` |
+| `HideLifebar` | `hide_lifebar` |
+| `HideScore` | `hide_score` |
+| `HideDanger` | `hide_danger` |
+| `HideComboExplosions` | `hide_combo_explosions` |
+| `MeasureCounterLeft` | `measure_counter_left` |
+| `MeasureCounterUp` | `measure_counter_up` |
+| `MeasureCounterVert` | `measure_counter_vert` |
+| `BrokenRun` | `broken_run` |
+| `RunTimer` | `run_timer` |
+| `RainbowMax` | `rainbow_max` |
+| `ResponsiveColors` | `responsive_colors` |
+| `ShowLifePercent` | `show_life_percent` |
+| `ColumnFlashOnMiss` | `column_flash_on_miss` |
+| `SubtractiveScoring` | `subtractive_scoring` |
+| `Pacemaker` | `pacemaker` |
+| `TrackEarlyJudgments` | `track_early_judgments` |
+| `ScaleGraph` | `scale_scatterplot` |
+| `NPSGraphAtTop` | `nps_graph_at_top` |
+| `JudgmentTilt` | `judgment_tilt` |
+| `ColumnCues` | `column_cues` |
+| `ColumnCountdown` | `column_countdown` |
+| `ErrorBarUp` | `error_bar_up` |
+| `ErrorBarMultiTick` | `error_bar_multi_tick` |
+| `ShowFaPlusWindow` | `show_fa_plus_window` |
+| `ShowExScore` | `show_ex_score` |
+| `ShowFaPlusPane` | `show_fa_plus_pane` |
+| `SmallerWhite` | `fa_plus_10ms_blue_window` |
+| `SplitWhites` | `split_15_10ms` |
+| `HideEarlyDecentWayOffJudgments` | `hide_early_dw_judgments` |
+| `HideEarlyDecentWayOffFlash` | `hide_early_dw_flash` |
+| `DisplayScorebox` | `display_scorebox` |
+| `JudgmentBack` | `judgment_back` |
+| `ErrorMSDisplay` | `error_ms_display` |
+
+## 5. Offline scores
+
+Source: `Stats.xml`
+`SongScores/Song[@Dir]/Steps[@StepsType,@Difficulty,@Description]/HighScoreList/HighScore`.
+Mapper: `deadsync-score/src/import.rs` (`local_score_from_itg`).
+
+### Chart resolution (`resolver.rs`)
+
+`Stats.xml` keys a chart by song folder + steps type + difficulty (+ optional
+edit description), **not** by hash. The resolver normalises the song directory
+and looks it up in DeadSync's scanned song library to recover the GrooveStats
+`short_hash`. Outcomes:
+
+- **Found** → the score is mapped and attached to that chart.
+- **SongNotFound** / **ChartNotFound** → counted in the import summary and
+  skipped. Scan your packs (and add your ITGmania `Songs` folder) before
+  importing so more scores match.
+
+### `<HighScore>` → `LocalScoreEntry`
+
+| ITGmania element | DeadSync field | Notes |
+| --- | --- | --- |
+| `Grade` (`Tier01`…`Failed`, with or without a `Grade_` prefix) | `grade_code` | via `grade_from_itg`; unrecognised grade → score skipped |
+| `PercentDP` (0.0–1.0) | `score_percent` | clamped `0.0..=1.0` |
+| `DateTime` (`YYYY-MM-DD HH:MM:SS`, local) | `played_at_ms` | epoch ms; `0` if unparseable |
+| `Modifiers` (`"1.5xMusic, …"`) | `music_rate` | parsed `xMusic` token; default `1.0` |
+| `TapNoteScores/{W1,W2,W3,W4,W5,Miss}` | `judgment_counts` | `[W1, W2, W3, W4, W5, Miss]` |
+| `TapNoteScores/AvoidMine` | `mines_avoided` | |
+| `TapNoteScores/HitMine` + `AvoidMine` | `mines_total` | |
+| `HoldNoteScores/Held` | `holds_held` | |
+| `HoldNoteScores/{Held,LetGo,MissedHold}` | `holds_total` | summed |
+| `SurviveSeconds` | `fail_time` | only for `Grade_Failed` |
+| (recomputed from judgments) | `lamp_index`, `lamp_judge_count` | `compute_local_lamp` |
+
+**Always defaulted (not recoverable from `Stats.xml`):**
+
+| DeadSync field | Value | Why |
+| --- | --- | --- |
+| `ex_score_percent` | `0.0` | ITGmania stores no FA+ (W0) split |
+| `hard_ex_score_percent` | `0.0` | same |
+| `rolls_held`, `rolls_total` | `0` | `Stats.xml` folds holds and rolls together |
+| `hands_achieved` | `0` | not stored per high score |
+| `beat0_time_ns` | `0` | no replay data |
+| `replay` | empty | no per-tap offset data in `Stats.xml` |
+
+## Known limitations
+
+- **Scores only attach to charts present in DeadSync's library** (hash recovered
+  via the resolver); unmatched charts are reported and skipped.
+- **EX / Hard-EX can't be reconstructed** — ITGmania records only bucketed
+  judgments (no W0 split, no per-tap timing), so EX starts at 0.
+- **Holds vs rolls aren't distinguished**, and mine tallies are partial.
+- **Auto-detection** covers the per-user save dirs only
+  (`%APPDATA%\ITGmania\Save\LocalProfiles`, `~/.itgmania/...`,
+  `~/Library/Application Support/ITGmania/...`); portable installs aren't found
+  automatically.
+
+## Deliberately not (yet) imported
+
+Present in an ITGmania profile but currently left to DeadSync defaults — see the
+audit notes in the session history for rationale:
+
+- **Profile/stats:** `IgnoreStepCountCalories`, `CharacterID`, `Voomax`,
+  `IsMale`, `CurrentCombo`, lifetime totals (`TotalDancePoints`,
+  `TotalSessions`, step/jump/hold totals), play-count histograms, last
+  song/difficulty, calorie history.
+- **Per-chart:** `HighScoreList/NumTimesPlayed`, `LastPlayed`, `HighGrade`;
+  per-score `MaxCombo`, `Name`, `RadarValues`, `Disqualified`.
+- **Simply Love extras:** `favorites.txt`, `ITL2026.json`, `SL-Scores/*.json`.
+- **Player options judged risky:** numeric/`Ghost Data` `TargetScore`,
+  `MiniIndicatorColor` (color-name vocabulary), scorebox sub-options
+  (`SBITGScore`/`SBExScore`/`SBEvents`), and SL-only aesthetic effects with no
+  DeadSync equivalent.
+
+## Source-of-truth code
+
+| Concern | File |
+| --- | --- |
+| ITGmania file readers | `src/game/import/itg.rs` |
+| `Stats.xml` parser | `src/game/import/xml.rs` |
+| Player-options translation | `src/game/import/options.rs` |
+| Chart resolver | `src/game/import/resolver.rs` |
+| Score mapping | `crates/deadsync-score/src/import.rs` |
+| Orchestration / profile writer | `src/game/import/run.rs`, `src/game/profile.rs` |
+| Auto-detection | `src/game/import/detect.rs` |
+| In-game UI | `src/screens/manage_local_profiles.rs` |

--- a/docs/migrating-from-itgmania.md
+++ b/docs/migrating-from-itgmania.md
@@ -102,6 +102,10 @@ never merges, so a manual top-up afterwards is safe).
 - **Holds and rolls aren't distinguished** in `Stats.xml`; all hold-type
   judgments are folded together, and mine tallies are partial.
 
+Rate-modded plays keep their music rate (DeadSync reads the `xMusic` modifier
+from each score), and your judgment counts, grade, combo lamp, and play date all
+carry across.
+
 ## Manual migration
 
 If you prefer to move pieces by hand, the sections below cover each item

--- a/docs/migrating-from-itgmania.md
+++ b/docs/migrating-from-itgmania.md
@@ -67,9 +67,11 @@ new DeadSync profile from it in one step.
   **Options → Online Scoring → Score Import**.
 - **Player options** — your Simply Love per-profile mods from
   `Simply Love UserPrefs.ini`: scroll speed and type, mini, spacing, noteskin,
-  note-field offsets, visual delay, tilt, life-meter type, measure counter and
-  lines, combo mode/colors, mini-indicator, error-bar trim, data-visualization
-  mode, and the many on/off display toggles. Settings DeadSync doesn't recognise
+  judgment / held / hold-judgment graphics, combo font, note-field offsets,
+  visual delay, tilt, life-meter type, measure counter and lines, combo
+  mode/colors, mini-indicator, error-bar style and trim, column-flash, data-
+  visualization mode, and the many on/off display toggles. Settings DeadSync
+  doesn't recognise — including custom theme graphics/fonts it doesn't ship —
   are left at their default rather than guessed.
 - **Offline scores** — every high score in `Stats.xml` becomes a DeadSync local
   play, matched to the chart in your library.

--- a/docs/migrating-from-itgmania.md
+++ b/docs/migrating-from-itgmania.md
@@ -65,9 +65,12 @@ new DeadSync profile from it in one step.
   ArrowCloud, written into the new profile's `groovestats.ini` /
   `arrowcloud.ini`. Your online history can then be pulled via
   **Options → Online Scoring → Score Import**.
-- **Player options** — your Simply Love per-profile mods (scroll speed and type,
-  mini, noteskin, note-field offsets, turn/reverse and other toggles) from
-  `Simply Love UserPrefs.ini`.
+- **Player options** — your Simply Love per-profile mods from
+  `Simply Love UserPrefs.ini`: scroll speed and type, mini, spacing, noteskin,
+  note-field offsets, visual delay, tilt, life-meter type, measure counter and
+  lines, combo mode/colors, mini-indicator, error-bar trim, data-visualization
+  mode, and the many on/off display toggles. Settings DeadSync doesn't recognise
+  are left at their default rather than guessed.
 - **Offline scores** — every high score in `Stats.xml` becomes a DeadSync local
   play, matched to the chart in your library.
 

--- a/docs/migrating-from-itgmania.md
+++ b/docs/migrating-from-itgmania.md
@@ -1,9 +1,13 @@
 # Migrating from ITGmania to DeadSync
 
-There is no automatic ITGmania → DeadSync profile import. The two games use
-different on-disk formats, and DeadSync does not read ITGmania's `Stats.xml`.
-This guide explains what carries over by hand, what doesn't, and exactly which
-files to copy or edit.
+DeadSync can **automatically import** an ITGmania + Simply Love local profile —
+including your player options and offline scores — from inside the game. This is
+the recommended path; see [Automatic import](#automatic-import-recommended)
+below.
+
+If you'd rather move individual pieces by hand (or the automatic importer can't
+find your ITGmania install), the rest of this guide explains what carries over
+manually, what doesn't, and exactly which files to copy or edit.
 
 Throughout this doc:
 
@@ -40,7 +44,65 @@ Throughout this doc:
 You can jump straight to DeadSync's profile root from inside the game via
 **Options → Folders → Profiles → Open**.
 
-## What you can actually migrate
+## Automatic import (recommended)
+
+DeadSync can read an ITGmania `LocalProfiles/<id>/` folder and create a brand
+new DeadSync profile from it in one step.
+
+1. In DeadSync, go to **Options → Manage Local Profiles**.
+2. Select **Import from ITGmania** and press **Start**.
+3. DeadSync scans for ITGmania profiles and lists the ones it finds. Pick the
+   profile you want and press **Start**.
+4. The import runs in the background; when it finishes, a summary shows how many
+   scores were imported and how many were skipped. The new profile is selected
+   in the list.
+
+### What it brings across
+
+- **Profile** — display name, weight, birth year, player initials, and your
+  avatar (`Avatar.png`).
+- **Online keys** — GrooveStats (API key, username, pad-player flag) and
+  ArrowCloud, written into the new profile's `groovestats.ini` /
+  `arrowcloud.ini`. Your online history can then be pulled via
+  **Options → Online Scoring → Score Import**.
+- **Player options** — your Simply Love per-profile mods (scroll speed and type,
+  mini, noteskin, note-field offsets, turn/reverse and other toggles) from
+  `Simply Love UserPrefs.ini`.
+- **Offline scores** — every high score in `Stats.xml` becomes a DeadSync local
+  play, matched to the chart in your library.
+
+### Where it looks
+
+The importer auto-detects ITGmania's per-user save directory:
+
+| OS      | Scanned location                                              |
+| ------- | ------------------------------------------------------------ |
+| Windows | `%APPDATA%\ITGmania\Save\LocalProfiles\`                      |
+| Linux   | `~/.itgmania/Save/LocalProfiles/`                            |
+| macOS   | `~/Library/Application Support/ITGmania/Save/LocalProfiles/`  |
+
+If your ITGmania uses a portable/custom save location that isn't found, fall
+back to the manual steps below (the importer always creates a *new* profile and
+never merges, so a manual top-up afterwards is safe).
+
+### Limitations
+
+- **Scores only attach to charts that exist in DeadSync's library.** ITGmania's
+  `Stats.xml` keys a chart by its song folder + steps type + difficulty, not by
+  hash, so DeadSync looks the chart up in your scanned songs to recover the
+  GrooveStats hash. Scan your packs *before* importing, and add your ITGmania
+  `Songs` folder (see [Songs folder](#7-songs-folder)) so more scores match.
+  Charts that aren't found are counted as skipped in the summary, not imported.
+- **EX / Hard-EX scores can't be recovered.** ITGmania doesn't store the FA+
+  (W0) split, so imported plays show the ITG percent and grade but start with an
+  EX score of 0.
+- **Holds and rolls aren't distinguished** in `Stats.xml`; all hold-type
+  judgments are folded together, and mine tallies are partial.
+
+## Manual migration
+
+If you prefer to move pieces by hand, the sections below cover each item
+individually.
 
 ### 1. Create a fresh DeadSync profile
 
@@ -136,8 +198,11 @@ Three ways to populate it:
   dropping the API key into the matching `.ini` (above) reconnects you to your
   existing online account. After that, **Options → Online Scoring →
   Score Import** can download your history.
-- **Offline scores** from ITGmania's `Stats.xml` have **no migration path**.
-  DeadSync does not read `Stats.xml`. Those scores stay in ITGmania.
+- **Offline scores** from ITGmania's `Stats.xml` are brought across by the
+  [automatic importer](#automatic-import-recommended) — there's no manual
+  equivalent, because each play has to be matched to a chart in your library to
+  recover its hash. If you migrate by hand, run the importer afterwards to pull
+  in your offline history (remember it creates a separate new profile).
 
 ### 7. Songs folder
 
@@ -166,6 +231,19 @@ Save and relaunch. DeadSync will scan those roots in addition to its default
 `songs/` folder.
 
 ## Quick checklist
+
+**Fastest path**
+
+- [ ] Scan your packs first — add your ITGmania `Songs` folder via
+      `AdditionalSongFoldersReadOnly` in `deadsync.ini`, or move packs into
+      `<data dir>/songs/`, so imported scores match.
+- [ ] **Options → Manage Local Profiles → Import from ITGmania**, pick your
+      profile, and let it copy the profile, options, avatar, online keys and
+      offline scores.
+- [ ] Run **Options → Online Scoring → Score Import** to pull down your online
+      history.
+
+**Manual path (if the importer can't find your install)**
 
 - [ ] Create a profile via **Options → Manage Local Profiles → Create**.
 - [ ] Drop ITGmania's `Avatar.png` into the new profile folder (rename to

--- a/docs/migrating-from-itgmania.md
+++ b/docs/migrating-from-itgmania.md
@@ -108,6 +108,10 @@ Rate-modded plays keep their music rate (DeadSync reads the `xMusic` modifier
 from each score), and your judgment counts, grade, combo lamp, and play date all
 carry across.
 
+For the exact field-by-field mapping (every Simply Love setting and `Stats.xml`
+element and where it lands in DeadSync), see
+[itgmania-import-mapping.md](./itgmania-import-mapping.md).
+
 ## Manual migration
 
 If you prefer to move pieces by hand, the sections below cover each item

--- a/src/game/import/detect.rs
+++ b/src/game/import/detect.rs
@@ -1,0 +1,92 @@
+//! Auto-discovery of ITGmania local profiles.
+//!
+//! ITGmania stores per-machine save data in a platform-specific directory, with
+//! local profiles under `<Save>/LocalProfiles/<id>/`. This module scans the
+//! likely save roots and returns every directory that looks like an ITGmania
+//! profile so the import UI can present a picker without asking the user to
+//! browse the filesystem manually.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use super::itg;
+
+/// One ITGmania local profile found on disk.
+#[derive(Debug, Clone)]
+pub struct ItgProfileCandidate {
+    /// Absolute path to the `LocalProfiles/<id>/` directory.
+    pub dir: PathBuf,
+    /// `DisplayName` from `Editable.ini`, falling back to the folder name.
+    pub display_name: String,
+}
+
+/// Scans the known ITGmania save locations and returns every local profile
+/// found, sorted by display name. Returns an empty list when ITGmania isn't
+/// installed or has no profiles.
+pub fn detect_itg_local_profiles() -> Vec<ItgProfileCandidate> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for root in local_profiles_roots() {
+        collect_from_root(&root, &mut out, &mut seen);
+    }
+    out.sort_by(|a, b| {
+        a.display_name
+            .to_lowercase()
+            .cmp(&b.display_name.to_lowercase())
+    });
+    out
+}
+
+fn collect_from_root(root: &Path, out: &mut Vec<ItgProfileCandidate>, seen: &mut HashSet<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        if !dir.is_dir() || !itg::is_itg_profile_dir(&dir) {
+            continue;
+        }
+        let key = std::fs::canonicalize(&dir).unwrap_or_else(|_| dir.clone());
+        if !seen.insert(key) {
+            continue;
+        }
+        let display_name = itg::read_display_name(&dir).unwrap_or_else(|| {
+            dir.file_name()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        });
+        out.push(ItgProfileCandidate { dir, display_name });
+    }
+}
+
+/// Candidate `LocalProfiles` directories across platforms. Most won't exist on
+/// any given machine; non-existent roots are silently skipped during scanning.
+fn local_profiles_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+
+    // Windows: %APPDATA%\ITGmania\Save\LocalProfiles
+    if let Some(appdata) = std::env::var_os("APPDATA") {
+        roots.push(
+            PathBuf::from(&appdata)
+                .join("ITGmania")
+                .join("Save")
+                .join("LocalProfiles"),
+        );
+    }
+
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        // Linux: ~/.itgmania/Save/LocalProfiles
+        roots.push(home.join(".itgmania").join("Save").join("LocalProfiles"));
+        // macOS: ~/Library/Application Support/ITGmania/Save/LocalProfiles
+        roots.push(
+            home.join("Library")
+                .join("Application Support")
+                .join("ITGmania")
+                .join("Save")
+                .join("LocalProfiles"),
+        );
+    }
+
+    roots
+}

--- a/src/game/import/itg.rs
+++ b/src/game/import/itg.rs
@@ -111,6 +111,20 @@ pub fn is_itg_profile_dir(dir: &Path) -> bool {
     find_case_insensitive(dir, "Editable.ini").is_some()
 }
 
+/// Cheaply reads just the `DisplayName` from a profile's `Editable.ini`,
+/// without parsing the (potentially large) `Stats.xml`. Used to label profiles
+/// in the import picker. Returns `None` when the file is missing or the name is
+/// blank.
+pub fn read_display_name(dir: &Path) -> Option<String> {
+    let path = find_case_insensitive(dir, "Editable.ini")?;
+    let name = read_editable(&path).display_name;
+    if name.trim().is_empty() {
+        None
+    } else {
+        Some(name)
+    }
+}
+
 /// Reads an entire ITGmania local profile directory into an [`ItgSource`].
 pub fn read_profile_dir(dir: &Path) -> Result<ItgSource, ItgReadError> {
     let editable_path = find_case_insensitive(dir, "Editable.ini")

--- a/src/game/import/itg.rs
+++ b/src/game/import/itg.rs
@@ -327,6 +327,7 @@ fn parse_high_score(node: &XmlNode) -> ImportedHighScore {
         let_go: hold_count("LetGo"),
         missed_hold: hold_count("MissedHold"),
         survive_seconds: node.child_parse::<f32>("SurviveSeconds").unwrap_or(0.0),
+        modifiers: node.child_text("Modifiers").to_string(),
     }
 }
 

--- a/src/game/import/mod.rs
+++ b/src/game/import/mod.rs
@@ -7,7 +7,9 @@
 //! Submodules:
 //! * [`xml`] — a tiny dependency-free XML reader for `Stats.xml`.
 //! * [`itg`] — readers that turn the ITGmania files into plain structs.
+//! * [`detect`] — auto-discovery of ITGmania local profiles on disk.
 
+pub mod detect;
 pub mod itg;
 pub mod options;
 pub mod resolver;

--- a/src/game/import/mod.rs
+++ b/src/game/import/mod.rs
@@ -15,3 +15,6 @@ pub mod options;
 pub mod resolver;
 pub mod run;
 pub mod xml;
+
+#[cfg(test)]
+mod pipeline_tests;

--- a/src/game/import/options.rs
+++ b/src/game/import/options.rs
@@ -13,6 +13,9 @@
 //! * `SpeedModType` + `SpeedMod` -> [`ScrollSpeedSetting`]
 //! * `Mini` -> `mini_percent`, `Spacing` -> `spacing_percent`
 //! * `NoteSkin` -> `noteskin`
+//! * `JudgmentGraphic` / `HeldGraphic` / `HoldJudgment` -> the matching graphic
+//!   (stock graphics only; custom theme graphics fall back to the default) and
+//!   `ComboFont` -> `combo_font`
 //! * `NoteFieldOffsetX` / `NoteFieldOffsetY` -> note-field offsets
 //! * `VisualDelay` -> `visual_delay_ms`
 //! * `TiltMultiplier`, `MeasureCounterLookahead`
@@ -32,10 +35,10 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use deadsync_profile::{
-    BackgroundFilter, ColumnFlashMask, ComboColors, ComboMode, ErrorBarMask, ErrorBarTrim,
-    LifeMeterType, MeasureCounter, MeasureLines, MiniIndicator, NoteSkin, PlayerOptionsData,
-    ScrollOption, StepStatisticsMask, TurnOption, error_bar_style_from_mask,
-    error_bar_text_from_mask,
+    BackgroundFilter, ColumnFlashMask, ComboColors, ComboFont, ComboMode, ErrorBarMask,
+    ErrorBarTrim, HeldMissGraphic, HoldJudgmentGraphic, JudgmentGraphic, LifeMeterType,
+    MeasureCounter, MeasureLines, MiniIndicator, NoteSkin, PlayerOptionsData, ScrollOption,
+    StepStatisticsMask, TurnOption, error_bar_style_from_mask, error_bar_text_from_mask,
 };
 use deadsync_rules::scroll::ScrollSpeedSetting;
 
@@ -163,6 +166,23 @@ pub fn translate_player_options(map: &SlSettings, base: &PlayerOptionsData) -> P
     }
     if let Some(skin) = sl_str(map, "NoteSkin") {
         out.noteskin = NoteSkin::new(skin);
+    }
+    // Theme graphic / font names. These resolve only to graphics DeadSync ships
+    // (via the stock-only parse); a Simply Love profile referencing a custom
+    // theme graphic is left at the default rather than pointing at a missing
+    // texture. Simply Love stores the full sprite filename for the three
+    // graphics and the font directory name for ComboFont.
+    if let Some(g) = sl_str(map, "JudgmentGraphic").and_then(JudgmentGraphic::from_stock_name) {
+        out.judgment_graphic = g;
+    }
+    if let Some(g) = sl_str(map, "HeldGraphic").and_then(HeldMissGraphic::from_stock_name) {
+        out.held_miss_graphic = g;
+    }
+    if let Some(g) = sl_str(map, "HoldJudgment").and_then(HoldJudgmentGraphic::from_stock_name) {
+        out.hold_judgment_graphic = g;
+    }
+    if let Some(font) = sl_enum::<ComboFont>(map, "ComboFont") {
+        out.combo_font = font;
     }
     if let Some(x) = sl_str(map, "NoteFieldOffsetX").and_then(leading_i32) {
         out.note_field_offset_x = x;
@@ -439,6 +459,46 @@ mod tests {
             translate_player_options(&sl(&[("Spacing", "-25%"), ("VisualDelay", "12ms")]), &base);
         assert_eq!(out.spacing_percent, -25);
         assert_eq!(out.visual_delay_ms, 12);
+    }
+
+    #[test]
+    fn translates_stock_graphics_and_font() {
+        let base = PlayerOptionsData::default();
+        let out = translate_player_options(
+            &sl(&[
+                ("JudgmentGraphic", "Wendy 2x7 (doubleres).png"),
+                ("HoldJudgment", "ITG2 1x2 (doubleres).png"),
+                ("HeldGraphic", "None"),
+                ("ComboFont", "Bebas Neue"),
+            ]),
+            &base,
+        );
+        assert_eq!(
+            out.judgment_graphic.as_str(),
+            "judgements/Wendy 2x7 (doubleres).png"
+        );
+        assert_eq!(
+            out.hold_judgment_graphic.as_str(),
+            "hold_judgements/ITG2 1x2 (doubleres).png"
+        );
+        assert!(out.held_miss_graphic.is_none());
+        assert_eq!(out.combo_font, ComboFont::BebasNeue);
+    }
+
+    #[test]
+    fn ignores_unknown_custom_graphics() {
+        let mut base = PlayerOptionsData::default();
+        base.judgment_graphic = JudgmentGraphic::new("Wendy");
+        let out = translate_player_options(
+            &sl(&[
+                ("JudgmentGraphic", "MyCustomTheme 2x7 (doubleres).png"),
+                ("ComboFont", "SomeCustomFont"),
+            ]),
+            &base,
+        );
+        // Unknown graphic/font must not fabricate a path — keep the base value.
+        assert_eq!(out.judgment_graphic, base.judgment_graphic);
+        assert_eq!(out.combo_font, base.combo_font);
     }
 
     #[test]

--- a/src/game/import/options.rs
+++ b/src/game/import/options.rs
@@ -21,6 +21,8 @@
 //!   `MeasureCounter`, `MeasureLines`, `ErrorBarTrim`, `MiniIndicator`,
 //!   `DataVisualizations` -> `step_statistics`
 //! * `PlayerOptionsString` -> turn + scroll (reverse) modifiers
+//! * SelectMultiple flag groups: `Colorful`/`Monochrome`/`Text`/`Highlight`/
+//!   `Average` -> `error_bar_active_mask`; `Flash*` -> `column_flash_mask`
 //! * a set of boolean toggles whose name and meaning match 1:1
 //!
 //! Everything is pure (no disk / engine state) so it can be unit-tested with a
@@ -30,9 +32,10 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use deadsync_profile::{
-    BackgroundFilter, ComboColors, ComboMode, ErrorBarTrim, LifeMeterType, MeasureCounter,
-    MeasureLines, MiniIndicator, NoteSkin, PlayerOptionsData, ScrollOption, StepStatisticsMask,
-    TurnOption,
+    BackgroundFilter, ColumnFlashMask, ComboColors, ComboMode, ErrorBarMask, ErrorBarTrim,
+    LifeMeterType, MeasureCounter, MeasureLines, MiniIndicator, NoteSkin, PlayerOptionsData,
+    ScrollOption, StepStatisticsMask, TurnOption, error_bar_style_from_mask,
+    error_bar_text_from_mask,
 };
 use deadsync_rules::scroll::ScrollSpeedSetting;
 
@@ -208,12 +211,83 @@ pub fn translate_player_options(map: &SlSettings, base: &PlayerOptionsData) -> P
     }
 
     apply_bool_toggles(&mut out, map);
+    apply_error_bar_flags(&mut out, map);
+    apply_column_flash_flags(&mut out, map);
 
     if let Some(pos) = sl_str(map, "PlayerOptionsString") {
         apply_player_options_string(&mut out, pos);
     }
 
     out
+}
+
+/// Translate Simply Love's `JudgmentFlash` SelectMultiple booleans
+/// (`FlashMiss`/`FlashWayOff`/…/`FlashFantastic`) into a [`ColumnFlashMask`].
+/// Only applied when at least one flag is present so an absent group keeps the
+/// DeadSync default.
+fn apply_column_flash_flags(out: &mut PlayerOptionsData, map: &SlSettings) {
+    let single_bits = [
+        ("FlashMiss", ColumnFlashMask::MISS),
+        ("FlashWayOff", ColumnFlashMask::WAY_OFF),
+        ("FlashDecent", ColumnFlashMask::DECENT),
+        ("FlashGreat", ColumnFlashMask::GREAT),
+        ("FlashExcellent", ColumnFlashMask::EXCELLENT),
+    ];
+
+    let mut mask = ColumnFlashMask::empty();
+    let mut seen = false;
+    for (key, bit) in single_bits {
+        if let Some(v) = sl_bool(map, key) {
+            seen = true;
+            if v {
+                mask |= bit;
+            }
+        }
+    }
+    // Simply Love exposes a single "Fantastic" flash; DeadSync splits fantastic
+    // into blue (W0/FA+) and white (W1) columns, so enable both.
+    if let Some(v) = sl_bool(map, "FlashFantastic") {
+        seen = true;
+        if v {
+            mask |= ColumnFlashMask::BLUE_FANTASTIC | ColumnFlashMask::WHITE_FANTASTIC;
+        }
+    }
+
+    if seen {
+        out.column_flash_mask = mask;
+    }
+}
+
+/// Translate Simply Love's error-bar style SelectMultiple booleans
+/// (`Colorful`/`Monochrome`/`Text`/`Highlight`/`Average`) into the
+/// [`ErrorBarMask`], deriving the legacy `error_bar` / `error_bar_text` fields
+/// from the resulting mask (mirroring the DeadSync profile loader). Only applied
+/// when at least one flag is present.
+fn apply_error_bar_flags(out: &mut PlayerOptionsData, map: &SlSettings) {
+    let flags = [
+        ("Colorful", ErrorBarMask::COLORFUL),
+        ("Monochrome", ErrorBarMask::MONOCHROME),
+        ("Text", ErrorBarMask::TEXT),
+        ("Highlight", ErrorBarMask::HIGHLIGHT),
+        ("Average", ErrorBarMask::AVERAGE),
+    ];
+
+    let mut mask = ErrorBarMask::empty();
+    let mut seen = false;
+    for (key, bit) in flags {
+        if let Some(v) = sl_bool(map, key) {
+            seen = true;
+            if v {
+                mask |= bit;
+            }
+        }
+    }
+
+    if seen {
+        out.error_bar_active_mask = mask;
+        out.error_bar = error_bar_style_from_mask(mask);
+        out.error_bar_text = error_bar_text_from_mask(mask);
+    }
 }
 
 /// Boolean toggles whose Simply Love key and meaning match a DeadSync field 1:1.
@@ -420,6 +494,62 @@ mod tests {
         let none =
             translate_player_options(&sl(&[("DataVisualizations", "Target Score Graph")]), &base);
         assert_eq!(none.step_statistics, StepStatisticsMask::empty());
+    }
+
+    #[test]
+    fn translates_error_bar_flags() {
+        let base = PlayerOptionsData::default();
+        let out = translate_player_options(
+            &sl(&[
+                ("Colorful", "true"),
+                ("Monochrome", "false"),
+                ("Text", "true"),
+                ("Highlight", "false"),
+                ("Average", "false"),
+            ]),
+            &base,
+        );
+        assert!(
+            out.error_bar_active_mask
+                .contains(ErrorBarMask::COLORFUL | ErrorBarMask::TEXT)
+        );
+        assert!(!out.error_bar_active_mask.contains(ErrorBarMask::MONOCHROME));
+        assert_eq!(
+            out.error_bar,
+            error_bar_style_from_mask(out.error_bar_active_mask)
+        );
+        assert!(out.error_bar_text);
+    }
+
+    #[test]
+    fn translates_column_flash_flags_splitting_fantastic() {
+        let base = PlayerOptionsData::default();
+        let out = translate_player_options(
+            &sl(&[
+                ("FlashMiss", "true"),
+                ("FlashWayOff", "false"),
+                ("FlashDecent", "false"),
+                ("FlashGreat", "false"),
+                ("FlashExcellent", "true"),
+                ("FlashFantastic", "true"),
+            ]),
+            &base,
+        );
+        assert!(out.column_flash_mask.contains(ColumnFlashMask::MISS));
+        assert!(out.column_flash_mask.contains(ColumnFlashMask::EXCELLENT));
+        assert!(
+            out.column_flash_mask
+                .contains(ColumnFlashMask::BLUE_FANTASTIC | ColumnFlashMask::WHITE_FANTASTIC)
+        );
+        assert!(!out.column_flash_mask.contains(ColumnFlashMask::WAY_OFF));
+    }
+
+    #[test]
+    fn flag_groups_absent_keep_default() {
+        let base = PlayerOptionsData::default();
+        let out = translate_player_options(&sl(&[("SpeedMod", "300")]), &base);
+        assert_eq!(out.column_flash_mask, base.column_flash_mask);
+        assert_eq!(out.error_bar_active_mask, base.error_bar_active_mask);
     }
 
     #[test]

--- a/src/game/import/options.rs
+++ b/src/game/import/options.rs
@@ -11,10 +11,15 @@
 //! DeadSync default:
 //!
 //! * `SpeedModType` + `SpeedMod` -> [`ScrollSpeedSetting`]
-//! * `Mini` -> `mini_percent`
+//! * `Mini` -> `mini_percent`, `Spacing` -> `spacing_percent`
 //! * `NoteSkin` -> `noteskin`
 //! * `NoteFieldOffsetX` / `NoteFieldOffsetY` -> note-field offsets
+//! * `VisualDelay` -> `visual_delay_ms`
 //! * `TiltMultiplier`, `MeasureCounterLookahead`
+//! * enum-valued settings whose value vocabulary matches a DeadSync `FromStr`:
+//!   `BackgroundFilter`, `ComboColors`, `ComboMode`, `LifeMeterType`,
+//!   `MeasureCounter`, `MeasureLines`, `ErrorBarTrim`, `MiniIndicator`,
+//!   `DataVisualizations` -> `step_statistics`
 //! * `PlayerOptionsString` -> turn + scroll (reverse) modifiers
 //! * a set of boolean toggles whose name and meaning match 1:1
 //!
@@ -22,8 +27,13 @@
 //! plain map of strings.
 
 use std::collections::HashMap;
+use std::str::FromStr;
 
-use deadsync_profile::{NoteSkin, PlayerOptionsData, ScrollOption, TurnOption};
+use deadsync_profile::{
+    BackgroundFilter, ComboColors, ComboMode, ErrorBarTrim, LifeMeterType, MeasureCounter,
+    MeasureLines, MiniIndicator, NoteSkin, PlayerOptionsData, ScrollOption, StepStatisticsMask,
+    TurnOption,
+};
 use deadsync_rules::scroll::ScrollSpeedSetting;
 
 /// Settings read from a `[Simply Love]` INI section.
@@ -46,6 +56,14 @@ fn sl_str<'a>(map: &'a SlSettings, key: &str) -> Option<&'a str> {
 
 fn sl_f32(map: &SlSettings, key: &str) -> Option<f32> {
     sl_str(map, key)?.parse::<f32>().ok()
+}
+
+/// Parse a Simply Love value into a DeadSync enum via its [`FromStr`]. Returns
+/// `None` (leaving the caller's default in place) when the key is absent or the
+/// value isn't one DeadSync recognises — the DeadSync `FromStr` impls normalise
+/// case/punctuation and reject unknown vocabularies, so this never guesses.
+fn sl_enum<T: FromStr>(map: &SlSettings, key: &str) -> Option<T> {
+    sl_str(map, key)?.parse::<T>().ok()
 }
 
 /// Parse a signed integer out of a value that may carry trailing units, e.g.
@@ -137,6 +155,9 @@ pub fn translate_player_options(map: &SlSettings, base: &PlayerOptionsData) -> P
     if let Some(mini) = sl_str(map, "Mini").and_then(leading_i32) {
         out.mini_percent = mini;
     }
+    if let Some(spacing) = sl_str(map, "Spacing").and_then(leading_i32) {
+        out.spacing_percent = spacing;
+    }
     if let Some(skin) = sl_str(map, "NoteSkin") {
         out.noteskin = NoteSkin::new(skin);
     }
@@ -146,11 +167,44 @@ pub fn translate_player_options(map: &SlSettings, base: &PlayerOptionsData) -> P
     if let Some(y) = sl_str(map, "NoteFieldOffsetY").and_then(leading_i32) {
         out.note_field_offset_y = y;
     }
+    if let Some(delay) = sl_str(map, "VisualDelay").and_then(leading_i32) {
+        out.visual_delay_ms = delay;
+    }
     if let Some(mult) = sl_f32(map, "TiltMultiplier") {
         out.tilt_multiplier = mult;
     }
     if let Some(look) = sl_str(map, "MeasureCounterLookahead").and_then(leading_i32) {
         out.measure_counter_lookahead = look.clamp(0, i32::from(u8::MAX)) as u8;
+    }
+
+    // Enum-valued settings whose Simply Love vocabulary matches DeadSync's
+    // `FromStr`. Unknown values are ignored (default preserved).
+    if let Some(v) = sl_enum::<BackgroundFilter>(map, "BackgroundFilter") {
+        out.background_filter = v;
+    }
+    if let Some(v) = sl_enum::<ComboColors>(map, "ComboColors") {
+        out.combo_colors = v;
+    }
+    if let Some(v) = sl_enum::<ComboMode>(map, "ComboMode") {
+        out.combo_mode = v;
+    }
+    if let Some(v) = sl_enum::<LifeMeterType>(map, "LifeMeterType") {
+        out.lifemeter_type = v;
+    }
+    if let Some(v) = sl_enum::<MeasureCounter>(map, "MeasureCounter") {
+        out.measure_counter = v;
+    }
+    if let Some(v) = sl_enum::<MeasureLines>(map, "MeasureLines") {
+        out.measure_lines = v;
+    }
+    if let Some(v) = sl_enum::<ErrorBarTrim>(map, "ErrorBarTrim") {
+        out.error_bar_trim = v;
+    }
+    if let Some(v) = sl_enum::<MiniIndicator>(map, "MiniIndicator") {
+        out.mini_indicator = v;
+    }
+    if let Some(v) = sl_enum::<StepStatisticsMask>(map, "DataVisualizations") {
+        out.step_statistics = v;
     }
 
     apply_bool_toggles(&mut out, map);
@@ -191,6 +245,7 @@ fn apply_bool_toggles(out: &mut PlayerOptionsData, map: &SlSettings) {
     set_bool!("SubtractiveScoring" => subtractive_scoring);
     set_bool!("Pacemaker" => pacemaker);
     set_bool!("TrackEarlyJudgments" => track_early_judgments);
+    set_bool!("ScaleGraph" => scale_scatterplot);
     set_bool!("NPSGraphAtTop" => nps_graph_at_top);
     set_bool!("JudgmentTilt" => judgment_tilt);
     set_bool!("ColumnCues" => column_cues);
@@ -301,6 +356,70 @@ mod tests {
         assert_eq!(out.turn_option, TurnOption::Mirror);
         assert!(out.reverse_scroll);
         assert!(out.scroll_option.contains(ScrollOption::Reverse));
+    }
+
+    #[test]
+    fn parses_spacing_and_visual_delay() {
+        let base = PlayerOptionsData::default();
+        let out =
+            translate_player_options(&sl(&[("Spacing", "-25%"), ("VisualDelay", "12ms")]), &base);
+        assert_eq!(out.spacing_percent, -25);
+        assert_eq!(out.visual_delay_ms, 12);
+    }
+
+    #[test]
+    fn translates_enum_settings() {
+        let base = PlayerOptionsData::default();
+        let out = translate_player_options(
+            &sl(&[
+                ("BackgroundFilter", "50"),
+                ("ComboColors", "RainbowScroll"),
+                ("ComboMode", "CurrentCombo"),
+                ("LifeMeterType", "Surround"),
+                ("MeasureCounter", "16th"),
+                ("MeasureLines", "Quarter"),
+                ("ErrorBarTrim", "Great"),
+                ("MiniIndicator", "Pacemaker"),
+                ("ScaleGraph", "true"),
+            ]),
+            &base,
+        );
+        assert_eq!(
+            out.background_filter,
+            BackgroundFilter::from_str("50").unwrap()
+        );
+        assert_eq!(out.combo_colors, ComboColors::RainbowScroll);
+        assert_eq!(out.combo_mode, ComboMode::CurrentCombo);
+        assert_eq!(out.lifemeter_type, LifeMeterType::Surround);
+        assert_eq!(out.measure_counter, MeasureCounter::Sixteenth);
+        assert_eq!(out.measure_lines, MeasureLines::Quarter);
+        assert_eq!(out.error_bar_trim, ErrorBarTrim::Great);
+        assert_eq!(out.mini_indicator, MiniIndicator::Pacemaker);
+        assert!(out.scale_scatterplot);
+    }
+
+    #[test]
+    fn ignores_unknown_enum_values() {
+        let base = PlayerOptionsData::default();
+        let out = translate_player_options(
+            &sl(&[("ComboColors", "NotARealValue"), ("MeasureCounter", "99th")]),
+            &base,
+        );
+        assert_eq!(out.combo_colors, base.combo_colors);
+        assert_eq!(out.measure_counter, base.measure_counter);
+    }
+
+    #[test]
+    fn translates_data_visualizations_legacy_values() {
+        let base = PlayerOptionsData::default();
+
+        let stats =
+            translate_player_options(&sl(&[("DataVisualizations", "Step Statistics")]), &base);
+        assert_eq!(stats.step_statistics, StepStatisticsMask::all_widgets());
+
+        let none =
+            translate_player_options(&sl(&[("DataVisualizations", "Target Score Graph")]), &base);
+        assert_eq!(none.step_statistics, StepStatisticsMask::empty());
     }
 
     #[test]

--- a/src/game/import/pipeline_tests.rs
+++ b/src/game/import/pipeline_tests.rs
@@ -22,6 +22,7 @@ const STATS_XML: &str = r#"<Stats>
             <Grade>Tier03</Grade>
             <PercentDP>0.9421</PercentDP>
             <DateTime>2023-04-15 21:07:33</DateTime>
+            <Modifiers>Overhead, 1.5xMusic, Reverse</Modifiers>
             <TapNoteScores>
               <W1>410</W1><W2>52</W2><W3>11</W3><W4>3</W4><W5>1</W5>
               <Miss>4</Miss><HitMine>2</HitMine><AvoidMine>7</AvoidMine>
@@ -193,6 +194,7 @@ fn imports_stats_xml_against_library_end_to_end() {
         "EX not recoverable from Stats.xml"
     );
     assert_ne!(entry.played_at_ms, 0, "DateTime parsed");
+    assert_eq!(entry.music_rate, 1.5, "music rate recovered from Modifiers");
 
     // The mapped entry must survive the on-disk bincode round-trip used by the
     // local-score writer.

--- a/src/game/import/pipeline_tests.rs
+++ b/src/game/import/pipeline_tests.rs
@@ -1,0 +1,202 @@
+//! End-to-end integration test for the import pipeline: a fixture `Stats.xml`
+//! string is parsed, resolved against an in-memory song library, and mapped into
+//! [`LocalScoreEntry`] records — the same sequence [`super::run`] performs, but
+//! without touching any global engine state or the filesystem.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use deadsync_chart::{ChartData, SongData, SongPack};
+use deadsync_score::{decode_local_score_entry, encode_local_score_entry, local_score_from_itg};
+
+use super::itg::parse_song_scores;
+use super::resolver::{ChartResolver, Resolution};
+use super::xml;
+
+const STATS_XML: &str = r#"<Stats>
+  <SongScores>
+    <Song Dir="Songs/My Pack/Cool Song/">
+      <Steps StepsType="dance-single" Difficulty="Hard">
+        <HighScoreList>
+          <HighScore>
+            <Grade>Tier03</Grade>
+            <PercentDP>0.9421</PercentDP>
+            <DateTime>2023-04-15 21:07:33</DateTime>
+            <TapNoteScores>
+              <W1>410</W1><W2>52</W2><W3>11</W3><W4>3</W4><W5>1</W5>
+              <Miss>4</Miss><HitMine>2</HitMine><AvoidMine>7</AvoidMine>
+            </TapNoteScores>
+            <HoldNoteScores>
+              <Held>18</Held><LetGo>2</LetGo><MissedHold>1</MissedHold>
+            </HoldNoteScores>
+          </HighScore>
+        </HighScoreList>
+      </Steps>
+    </Song>
+    <Song Dir="Songs/Missing Pack/Ghost Song/">
+      <Steps StepsType="dance-single" Difficulty="Expert">
+        <HighScoreList>
+          <HighScore>
+            <Grade>Tier01</Grade>
+            <PercentDP>0.99</PercentDP>
+            <DateTime>2023-04-16 10:00:00</DateTime>
+          </HighScore>
+        </HighScoreList>
+      </Steps>
+    </Song>
+  </SongScores>
+</Stats>"#;
+
+fn chart(difficulty: &str, hash: &str) -> ChartData {
+    ChartData {
+        chart_type: "dance-single".into(),
+        difficulty: difficulty.into(),
+        description: String::new(),
+        chart_name: String::new(),
+        meter: 10,
+        step_artist: String::new(),
+        music_path: None,
+        short_hash: hash.into(),
+        stats: Default::default(),
+        tech_counts: Default::default(),
+        mines_nonfake: 0,
+        stamina_counts: Default::default(),
+        total_streams: 0,
+        matrix_rating: 0.0,
+        max_nps: 0.0,
+        sn_detailed_breakdown: String::new(),
+        sn_partial_breakdown: String::new(),
+        sn_simple_breakdown: String::new(),
+        detailed_breakdown: String::new(),
+        partial_breakdown: String::new(),
+        simple_breakdown: String::new(),
+        total_measures: 0,
+        measure_nps_vec: Vec::new(),
+        measure_seconds_vec: Vec::new(),
+        first_second: 0.0,
+        has_note_data: true,
+        has_chart_attacks: false,
+        possible_grade_points: 0,
+        holds_total: 0,
+        rolls_total: 0,
+        mines_total: 0,
+        display_bpm: None,
+        min_bpm: 150.0,
+        max_bpm: 150.0,
+    }
+}
+
+fn song(simfile_path: &str, charts: Vec<ChartData>) -> SongData {
+    SongData {
+        simfile_path: PathBuf::from(simfile_path),
+        title: "Cool Song".into(),
+        subtitle: String::new(),
+        translit_title: String::new(),
+        translit_subtitle: String::new(),
+        artist: String::new(),
+        genre: String::new(),
+        banner_path: None,
+        background_path: None,
+        background_changes: Vec::new(),
+        background_layer2_changes: Vec::new(),
+        foreground_changes: Vec::new(),
+        background_lua_changes: Vec::new(),
+        foreground_lua_changes: Vec::new(),
+        has_lua: false,
+        cdtitle_path: None,
+        music_path: None,
+        display_bpm: String::new(),
+        offset: 0.0,
+        sample_start: None,
+        sample_length: None,
+        min_bpm: 150.0,
+        max_bpm: 150.0,
+        normalized_bpms: String::new(),
+        music_length_seconds: 0.0,
+        first_second: 0.0,
+        total_length_seconds: 0,
+        precise_last_second_seconds: 0.0,
+        charts,
+    }
+}
+
+fn library() -> Vec<SongPack> {
+    vec![SongPack {
+        group_name: "My Pack".into(),
+        name: "My Pack".into(),
+        sort_title: String::new(),
+        translit_title: String::new(),
+        series: String::new(),
+        year: 0,
+        sync_pref: deadsync_chart::SyncPref::Default,
+        directory: PathBuf::from("Songs/My Pack"),
+        banner_path: None,
+        songs: vec![Arc::new(song(
+            "Songs/My Pack/Cool Song/cool.ssc",
+            vec![chart("Hard", "abc123def456")],
+        ))],
+    }]
+}
+
+#[test]
+fn imports_stats_xml_against_library_end_to_end() {
+    let root = xml::parse(STATS_XML).expect("parse Stats.xml");
+    let songs = parse_song_scores(&root);
+    assert_eq!(songs.len(), 2, "both <Song> blocks parsed");
+
+    let packs = library();
+    let resolver = ChartResolver::build(&packs);
+
+    let mut imported: Vec<(String, deadsync_score::LocalScoreEntry)> = Vec::new();
+    let mut song_not_found = 0usize;
+    let mut chart_not_found = 0usize;
+    let mut total = 0usize;
+
+    for s in &songs {
+        for steps in &s.steps {
+            for hs in &steps.high_scores {
+                total += 1;
+                match resolver.resolve(
+                    &s.dir,
+                    &steps.steps_type,
+                    &steps.difficulty,
+                    &steps.description,
+                ) {
+                    Resolution::Found(hash) => {
+                        let entry = local_score_from_itg(hs).expect("map high score");
+                        imported.push((hash.to_string(), entry));
+                    }
+                    Resolution::SongNotFound => song_not_found += 1,
+                    Resolution::ChartNotFound => chart_not_found += 1,
+                }
+            }
+        }
+    }
+
+    assert_eq!(total, 2);
+    assert_eq!(song_not_found, 1, "Ghost Song isn't in the library");
+    assert_eq!(chart_not_found, 0);
+    assert_eq!(imported.len(), 1, "Cool Song/Hard resolved and mapped");
+
+    let (hash, entry) = &imported[0];
+    assert_eq!(hash, "abc123def456");
+    assert_eq!(entry.judgment_counts, [410, 52, 11, 3, 1, 4]);
+    // Holds fold all hold-type tallies together: 18 + 2 + 1.
+    assert_eq!(entry.holds_held, 18);
+    assert_eq!(entry.holds_total, 21);
+    // Mines: hit + avoided.
+    assert_eq!(entry.mines_avoided, 7);
+    assert_eq!(entry.mines_total, 9);
+    assert!((entry.score_percent - 0.9421).abs() < 1e-6);
+    assert_eq!(
+        entry.ex_score_percent, 0.0,
+        "EX not recoverable from Stats.xml"
+    );
+    assert_ne!(entry.played_at_ms, 0, "DateTime parsed");
+
+    // The mapped entry must survive the on-disk bincode round-trip used by the
+    // local-score writer.
+    let bytes = encode_local_score_entry(entry).expect("encode");
+    let decoded = decode_local_score_entry(&bytes).expect("decode");
+    assert_eq!(&decoded, entry);
+}

--- a/src/screens/manage_local_profiles.rs
+++ b/src/screens/manage_local_profiles.rs
@@ -2,7 +2,10 @@ use crate::act;
 use crate::assets::AssetManager;
 use crate::assets::i18n::{tr, tr_fmt};
 use crate::assets::visual_styles;
+use crate::game::import::detect::{ItgProfileCandidate, detect_itg_local_profiles};
+use crate::game::import::run::{ImportSummary, import_itg_profile_dir};
 use crate::game::profile;
+use crate::screens::components::shared::loading_bar;
 use crate::screens::components::shared::screen_bar::{
     self, ScreenBarPosition, ScreenBarTitlePlacement,
 };
@@ -18,6 +21,8 @@ use deadsync_input::RawKeyboardEvent;
 use deadsync_input::{InputEvent, VirtualAction};
 use deadsync_profile as profile_data;
 use std::sync::Arc;
+use std::sync::mpsc::{Receiver, TryRecvError};
+use std::thread;
 use std::time::{Duration, Instant};
 use winit::keyboard::KeyCode;
 
@@ -68,6 +73,7 @@ const PROFILE_MENU_BORDER: f32 = 3.0;
 #[derive(Clone, Debug)]
 enum RowKind {
     CreateNew,
+    ImportItg,
     Profile { id: String, display_name: String },
     Exit,
 }
@@ -147,6 +153,45 @@ struct DeleteConfirmState {
     error: Option<Arc<str>>,
 }
 
+/// Modal listing ITGmania profiles found on disk, for the user to pick one to
+/// import.
+struct ImportPickerState {
+    candidates: Vec<ItgProfileCandidate>,
+    selected: usize,
+}
+
+/// A running import on a worker thread. The screen polls `rx` each frame and
+/// keeps the latest per-song progress snapshot for the progress bar.
+struct ImportJob {
+    rx: Receiver<ImportMsg>,
+    /// Latest `(done, total, song label)` reported by the worker, if any.
+    progress: Option<(usize, usize, Arc<str>)>,
+}
+
+/// Messages sent from the import worker thread to the screen.
+enum ImportMsg {
+    /// Per-song progress: `done` of `total` songs processed, current song label.
+    Progress {
+        done: usize,
+        total: usize,
+        label: String,
+    },
+    /// The import finished (success or failure).
+    Done(ImportOutcome),
+}
+
+enum ImportOutcome {
+    Ok(Box<ImportSummary>),
+    Err(String),
+}
+
+/// A simple centered message modal: an import summary, "none found", or an
+/// error. Dismissed with Start/Back.
+struct ImportMessageState {
+    title: Arc<str>,
+    lines: Vec<String>,
+}
+
 pub struct State {
     pub selected: usize,
     prev_selected: usize,
@@ -159,6 +204,9 @@ pub struct State {
     name_entry: Option<NameEntryState>,
     profile_menu: Option<ProfileMenuState>,
     delete_confirm: Option<DeleteConfirmState>,
+    import_picker: Option<ImportPickerState>,
+    import_job: Option<ImportJob>,
+    import_message: Option<ImportMessageState>,
     menu_lr_chord: screen_input::MenuLrChordTracker,
     menu_lr_undo: i8,
 }
@@ -177,6 +225,9 @@ pub fn init() -> State {
         name_entry: None,
         profile_menu: None,
         delete_confirm: None,
+        import_picker: None,
+        import_job: None,
+        import_message: None,
         menu_lr_chord: screen_input::MenuLrChordTracker::default(),
         menu_lr_undo: 0,
     }
@@ -187,6 +238,9 @@ fn build_rows() -> Vec<Row> {
     let mut out = Vec::with_capacity(profiles.len() + 2);
     out.push(Row {
         kind: RowKind::CreateNew,
+    });
+    out.push(Row {
+        kind: RowKind::ImportItg,
     });
     for p in profiles {
         out.push(Row {
@@ -313,6 +367,7 @@ fn update_name_entry_blink(state: &mut State, dt: f32) {
 pub fn update(state: &mut State, dt: f32) -> Option<ScreenAction> {
     update_hold_scroll(state);
     update_name_entry_blink(state, dt);
+    poll_import_job(state);
     None
 }
 
@@ -579,6 +634,210 @@ fn cancel_delete_confirm(state: &mut State) {
     reset_nav_hold(state);
 }
 
+/* ----------------------------- ITGmania import ---------------------------- */
+
+fn begin_import_picker(state: &mut State) {
+    reset_nav_hold(state);
+    audio::play_sfx("assets/sounds/start.ogg");
+    let candidates = detect_itg_local_profiles();
+    if candidates.is_empty() {
+        state.import_message = Some(ImportMessageState {
+            title: tr("Profiles", "ImportNoneFoundTitle"),
+            lines: vec![tr("Profiles", "ImportNoneFoundBody").to_string()],
+        });
+        return;
+    }
+    state.import_picker = Some(ImportPickerState {
+        candidates,
+        selected: 0,
+    });
+}
+
+fn cancel_import_picker(state: &mut State) {
+    state.import_picker = None;
+    reset_nav_hold(state);
+}
+
+fn move_import_picker_selected(state: &mut State, dir: NavDirection) {
+    let Some(picker) = state.import_picker.as_mut() else {
+        return;
+    };
+    let len = picker.candidates.len();
+    if len == 0 {
+        picker.selected = 0;
+        return;
+    }
+    picker.selected = match dir {
+        NavDirection::Up => {
+            if picker.selected == 0 {
+                len - 1
+            } else {
+                picker.selected - 1
+            }
+        }
+        NavDirection::Down => (picker.selected + 1) % len,
+    };
+}
+
+fn confirm_import_picker(state: &mut State) {
+    let Some(picker) = state.import_picker.take() else {
+        return;
+    };
+    let Some(candidate) = picker.candidates.get(picker.selected) else {
+        return;
+    };
+    let dir = candidate.dir.clone();
+    audio::play_sfx("assets/sounds/start.ogg");
+    reset_nav_hold(state);
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let progress_tx = tx.clone();
+    thread::spawn(move || {
+        let result = import_itg_profile_dir(&dir, |done, total, label| {
+            let _ = progress_tx.send(ImportMsg::Progress {
+                done,
+                total,
+                label: label.to_string(),
+            });
+        });
+        let outcome = match result {
+            Ok(summary) => ImportOutcome::Ok(Box::new(summary)),
+            Err(e) => ImportOutcome::Err(e.to_string()),
+        };
+        let _ = tx.send(ImportMsg::Done(outcome));
+    });
+    state.import_job = Some(ImportJob { rx, progress: None });
+}
+
+fn poll_import_job(state: &mut State) {
+    let Some(job) = state.import_job.as_mut() else {
+        return;
+    };
+    // Drain all pending messages this frame: update the progress snapshot, and
+    // finalize when the Done message arrives.
+    let mut outcome: Option<ImportOutcome> = None;
+    loop {
+        match job.rx.try_recv() {
+            Ok(ImportMsg::Progress { done, total, label }) => {
+                job.progress = Some((done, total, Arc::from(label.as_str())));
+            }
+            Ok(ImportMsg::Done(o)) => {
+                outcome = Some(o);
+                break;
+            }
+            Err(TryRecvError::Empty) => return,
+            Err(TryRecvError::Disconnected) => {
+                state.import_job = None;
+                state.import_message = Some(ImportMessageState {
+                    title: tr("Profiles", "ImportFailedTitle"),
+                    lines: vec![tr("Profiles", "ImportFailedBody").to_string()],
+                });
+                return;
+            }
+        }
+    }
+    let Some(outcome) = outcome else {
+        return;
+    };
+    state.import_job = None;
+    match outcome {
+        ImportOutcome::Ok(summary) => {
+            audio::play_sfx("assets/sounds/start.ogg");
+            refresh_rows(state);
+            select_profile_row(state, &summary.profile_id);
+            state.import_message = Some(import_summary_message(&summary));
+        }
+        ImportOutcome::Err(e) => {
+            state.import_message = Some(ImportMessageState {
+                title: tr("Profiles", "ImportFailedTitle"),
+                lines: vec![e],
+            });
+        }
+    }
+}
+
+fn select_profile_row(state: &mut State, profile_id: &str) {
+    if let Some(pos) = state
+        .rows
+        .iter()
+        .position(|r| matches!(&r.kind, RowKind::Profile { id, .. } if id == profile_id))
+    {
+        state.selected = pos;
+        state.prev_selected = pos;
+    }
+}
+
+fn import_summary_message(summary: &ImportSummary) -> ImportMessageState {
+    let mut lines = Vec::new();
+    lines.push(
+        tr_fmt(
+            "Profiles",
+            "ImportSummaryName",
+            &[("name", &summary.display_name)],
+        )
+        .to_string(),
+    );
+    lines.push(
+        tr_fmt(
+            "Profiles",
+            "ImportSummaryScores",
+            &[
+                ("imported", &summary.scores_imported.to_string()),
+                ("total", &summary.scores_total.to_string()),
+            ],
+        )
+        .to_string(),
+    );
+    let skipped =
+        summary.charts_song_not_found + summary.charts_chart_not_found + summary.scores_unmapped;
+    if skipped > 0 {
+        lines.push(
+            tr_fmt(
+                "Profiles",
+                "ImportSummarySkipped",
+                &[("skipped", &skipped.to_string())],
+            )
+            .to_string(),
+        );
+    }
+    lines.push(tr("Profiles", "ImportSummaryExNote").to_string());
+    ImportMessageState {
+        title: tr("Profiles", "ImportSummaryTitle"),
+        lines,
+    }
+}
+
+fn dismiss_import_message(state: &mut State) {
+    state.import_message = None;
+    reset_nav_hold(state);
+    audio::play_sfx("assets/sounds/start.ogg");
+}
+
+fn handle_import_picker_input(state: &mut State, ev: &InputEvent) {
+    if !ev.pressed {
+        return;
+    }
+    match ev.action {
+        VirtualAction::p1_back | VirtualAction::p2_back => cancel_import_picker(state),
+        VirtualAction::p1_up
+        | VirtualAction::p1_menu_up
+        | VirtualAction::p2_up
+        | VirtualAction::p2_menu_up => {
+            move_import_picker_selected(state, NavDirection::Up);
+            audio::play_sfx("assets/sounds/change.ogg");
+        }
+        VirtualAction::p1_down
+        | VirtualAction::p1_menu_down
+        | VirtualAction::p2_down
+        | VirtualAction::p2_menu_down => {
+            move_import_picker_selected(state, NavDirection::Down);
+            audio::play_sfx("assets/sounds/change.ogg");
+        }
+        VirtualAction::p1_start | VirtualAction::p2_start => confirm_import_picker(state),
+        _ => {}
+    }
+}
+
 #[inline(always)]
 fn activate_selected_row(state: &mut State) -> ScreenAction {
     let total = state.rows.len();
@@ -590,6 +849,10 @@ fn activate_selected_row(state: &mut State) -> ScreenAction {
     match start_row {
         RowKind::CreateNew => {
             begin_name_entry_create(state);
+            ScreenAction::None
+        }
+        RowKind::ImportItg => {
+            begin_import_picker(state);
             ScreenAction::None
         }
         RowKind::Exit => {
@@ -623,6 +886,24 @@ fn undo_profile_menu_move(state: &mut State, undo: i8) {
 }
 
 pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
+    if state.import_job.is_some() {
+        return ScreenAction::None;
+    }
+    if state.import_message.is_some() {
+        if ev.pressed
+            && matches!(
+                ev.action,
+                VirtualAction::p1_start
+                    | VirtualAction::p2_start
+                    | VirtualAction::p1_back
+                    | VirtualAction::p2_back
+            )
+        {
+            dismiss_import_message(state);
+        }
+        return ScreenAction::None;
+    }
+
     let three_key_action = screen_input::three_key_menu_action(&mut state.menu_lr_chord, ev);
     if screen_input::dedicated_three_key_nav_enabled() {
         match ev.action {
@@ -649,6 +930,21 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
             _ => {}
         }
         if let Some((_, nav)) = three_key_action {
+            if state.import_picker.is_some() {
+                match nav {
+                    screen_input::ThreeKeyMenuAction::Prev => {
+                        move_import_picker_selected(state, NavDirection::Up);
+                        audio::play_sfx("assets/sounds/change.ogg");
+                    }
+                    screen_input::ThreeKeyMenuAction::Next => {
+                        move_import_picker_selected(state, NavDirection::Down);
+                        audio::play_sfx("assets/sounds/change.ogg");
+                    }
+                    screen_input::ThreeKeyMenuAction::Confirm => confirm_import_picker(state),
+                    screen_input::ThreeKeyMenuAction::Cancel => cancel_import_picker(state),
+                }
+                return ScreenAction::None;
+            }
             if state.name_entry.is_some() {
                 match nav {
                     screen_input::ThreeKeyMenuAction::Confirm => confirm_name_entry(state),
@@ -721,6 +1017,10 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
                 }
             };
         }
+    }
+    if state.import_picker.is_some() {
+        handle_import_picker_input(state, ev);
+        return ScreenAction::None;
     }
     if state.name_entry.is_some() {
         match ev.action {
@@ -925,6 +1225,13 @@ fn help_for_selected(state: &State, p1_id: Option<&str>, p2_id: Option<&str>) ->
             (title.to_string(), bullets)
         }
         RowKind::Exit => (tr("Profiles", "ReturnToOptions").to_string(), String::new()),
+        RowKind::ImportItg => {
+            let title = tr("Profiles", "ImportItgTitle");
+            let b1 = tr("Profiles", "ImportItgHelp1");
+            let b2 = tr("Profiles", "ImportItgHelp2");
+            let bullets = make_bullets(&[&b1, &b2]);
+            (title.to_string(), bullets)
+        }
         RowKind::Profile { id, display_name } => {
             let title =
                 tr_fmt("Profiles", "LocalProfileFormat", &[("name", display_name)]).to_string();
@@ -1189,6 +1496,230 @@ fn push_overlay_error(
     ));
 }
 
+const IMPORT_PICK_MAX_VISIBLE: usize = 8;
+
+fn push_import_picker_overlay(ui: &mut Vec<Actor>, state: &State) {
+    let Some(picker) = &state.import_picker else {
+        return;
+    };
+
+    let w = screen_width();
+    let h = screen_height();
+    let box_w = 760.0_f32.min(w * 0.92);
+    let header_h = 56.0_f32;
+    let item_h = 34.0_f32;
+    let footer_h = 44.0_f32;
+    let total = picker.candidates.len();
+    let visible = total.min(IMPORT_PICK_MAX_VISIBLE);
+    let box_h = header_h + (visible as f32) * item_h + footer_h;
+    let cx = w * 0.5;
+    let cy = h * 0.5;
+    let top = cy - box_h * 0.5;
+
+    push_overlay_backdrop(ui, w, h);
+    push_overlay_box(ui, cx, cy, box_w, box_h);
+
+    let title = tr("Profiles", "ImportPickTitle");
+    ui.push(act!(text:
+        align(0.5, 0.0):
+        xy(cx, top + 14.0):
+        font("miso"):
+        zoom(1.05):
+        maxwidth(box_w - 40.0):
+        settext(title):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        z(1002):
+        horizalign(center)
+    ));
+
+    let offset = if total <= IMPORT_PICK_MAX_VISIBLE {
+        0
+    } else {
+        picker
+            .selected
+            .saturating_sub(IMPORT_PICK_MAX_VISIBLE - 1)
+            .min(total - IMPORT_PICK_MAX_VISIBLE)
+    };
+    let accent = color::simply_love_rgba(state.active_color_index);
+    let list_left = cx - box_w * 0.5 + 24.0;
+    let list_w = box_w - 48.0;
+
+    for i in 0..visible {
+        let idx = offset + i;
+        let Some(cand) = picker.candidates.get(idx) else {
+            break;
+        };
+        let row_y = (i as f32).mul_add(item_h, top + header_h);
+        let selected = idx == picker.selected;
+        if selected {
+            ui.push(act!(quad:
+                align(0.0, 0.0):
+                xy(list_left - 8.0, row_y):
+                zoomto(list_w + 16.0, item_h):
+                diffuse(0.17, 0.23, 0.28, 0.95):
+                z(1002)
+            ));
+        }
+        let text_col = if selected {
+            [accent[0], accent[1], accent[2], 1.0]
+        } else {
+            [1.0, 1.0, 1.0, 1.0]
+        };
+        ui.push(act!(text:
+            align(0.0, 0.5):
+            xy(list_left, row_y + item_h * 0.5):
+            font("miso"):
+            zoom(0.95):
+            maxwidth(list_w):
+            settext(cand.display_name.clone()):
+            diffuse(text_col[0], text_col[1], text_col[2], text_col[3]):
+            z(1003):
+            horizalign(left)
+        ));
+    }
+
+    let prompt = tr("Profiles", "ImportPickPrompt");
+    ui.push(act!(text:
+        align(0.5, 1.0):
+        xy(cx, cy + box_h * 0.5 - 12.0):
+        font("miso"):
+        zoom(0.85):
+        maxwidth(box_w - 40.0):
+        settext(prompt):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        z(1003):
+        horizalign(center)
+    ));
+}
+
+fn push_import_progress_overlay(ui: &mut Vec<Actor>, state: &State) {
+    let Some(job) = state.import_job.as_ref() else {
+        return;
+    };
+    let w = screen_width();
+    let h = screen_height();
+    let box_w = 560.0_f32.min(w * 0.92);
+    let box_h = 150.0_f32;
+    let cx = w * 0.5;
+    let cy = h * 0.5;
+    let top = cy - box_h * 0.5;
+
+    push_overlay_backdrop(ui, w, h);
+    push_overlay_box(ui, cx, cy, box_w, box_h);
+
+    // Heading.
+    ui.push(act!(text:
+        align(0.5, 0.0):
+        xy(cx, top + 16.0):
+        font("miso"):
+        zoom(1.05):
+        maxwidth(box_w - 40.0):
+        settext(tr("Profiles", "ImportInProgress")):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        z(1002):
+        horizalign(center)
+    ));
+
+    // Until the first song is reported (file read + resolver build), there's no
+    // determinate progress yet — leave just the heading. Once songs start
+    // processing, show the progress bar + current song label.
+    if let Some((done, total, label)) = &job.progress {
+        let progress = if *total > 0 {
+            (*done as f32 / *total as f32).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        let accent = color::simply_love_rgba(state.active_color_index);
+        let bar_w = (box_w - 64.0).max(0.0);
+        ui.push(loading_bar::build(loading_bar::LoadingBarParams {
+            align: [0.5, 0.5],
+            offset: [cx, cy],
+            width: bar_w,
+            height: 22.0,
+            progress,
+            label: crate::screens::progress_count_text(*done, *total).into(),
+            fill_rgba: [accent[0], accent[1], accent[2], 1.0],
+            bg_rgba: [0.0, 0.0, 0.0, 1.0],
+            border_rgba: [1.0, 1.0, 1.0, 1.0],
+            text_rgba: [1.0, 1.0, 1.0, 1.0],
+            text_zoom: 0.8,
+            z: 1002,
+        }));
+
+        if !label.is_empty() {
+            ui.push(act!(text:
+                align(0.5, 0.5):
+                xy(cx, cy + 34.0):
+                font("miso"):
+                zoom(0.78):
+                maxwidth(box_w - 40.0):
+                settext(label.to_string()):
+                diffuse(0.8, 0.8, 0.8, 1.0):
+                z(1003):
+                horizalign(center)
+            ));
+        }
+    }
+}
+
+fn push_import_message_overlay(ui: &mut Vec<Actor>, state: &State) {
+    let Some(message) = &state.import_message else {
+        return;
+    };
+
+    let w = screen_width();
+    let h = screen_height();
+    let box_w = 760.0_f32.min(w * 0.92);
+    let line_h = 28.0_f32;
+    let header_h = 52.0_f32;
+    let footer_h = 44.0_f32;
+    let box_h = header_h + (message.lines.len().max(1) as f32) * line_h + footer_h;
+    let cx = w * 0.5;
+    let cy = h * 0.5;
+    let top = cy - box_h * 0.5;
+
+    push_overlay_backdrop(ui, w, h);
+    push_overlay_box(ui, cx, cy, box_w, box_h);
+
+    ui.push(act!(text:
+        align(0.5, 0.0):
+        xy(cx, top + 14.0):
+        font("miso"):
+        zoom(1.05):
+        maxwidth(box_w - 40.0):
+        settext(message.title.clone()):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        z(1002):
+        horizalign(center)
+    ));
+
+    for (i, line) in message.lines.iter().enumerate() {
+        let line_y = (i as f32).mul_add(line_h, top + header_h);
+        ui.push(act!(text:
+            align(0.5, 0.0):
+            xy(cx, line_y):
+            font("miso"):
+            zoom(0.9):
+            maxwidth(box_w - 48.0):
+            settext(line.clone()):
+            diffuse(1.0, 1.0, 1.0, 1.0):
+            z(1002):
+            horizalign(center)
+        ));
+    }
+
+    ui.push(act!(text:
+        align(0.5, 1.0):
+        xy(cx, cy + box_h * 0.5 - 12.0):
+        font("miso"):
+        zoom(0.85):
+        settext(tr("Profiles", "ImportMessageDismiss")):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        z(1002):
+        horizalign(center)
+    ));
+}
+
 fn push_list_chrome(
     ui: &mut Vec<Actor>,
     col_active_bg: [f32; 4],
@@ -1228,6 +1759,7 @@ struct RowColors {
 fn row_label(kind: &RowKind) -> Arc<str> {
     match kind {
         RowKind::CreateNew => tr("Profiles", "CreateProfileButton"),
+        RowKind::ImportItg => tr("Profiles", "ImportItgButton"),
         RowKind::Exit => tr("Common", "Exit"),
         RowKind::Profile { display_name, .. } => Arc::from(display_name.as_str()),
     }
@@ -1549,6 +2081,9 @@ pub fn push_actors(
     push_profile_menu_overlay(actors, state, s, list_x, list_y);
     push_name_entry_overlay(actors, state);
     push_delete_confirm_overlay(actors, state);
+    push_import_picker_overlay(actors, state);
+    push_import_progress_overlay(actors, state);
+    push_import_message_overlay(actors, state);
 
     for actor in &mut actors[ui_start..] {
         actor.mul_alpha(alpha_multiplier);


### PR DESCRIPTION
Expands how much of a player''s Simply Love setup carries over during ITGmania import, and adds a field-by-field mapping reference.

> [!NOTE]
> **Stacked on #571.** Based on the in-game importer UI branch, which isn''t yet in `main`, so the diff below temporarily includes #571''s commits. Please review/merge **after #571**; once that lands, this diff collapses to just the commits below.

### What''s here
- **Expanded player-options coverage** (`src/game/import/options.rs`): translate many more Simply Love player options during import.
- **Error-bar/column-flash masks and music rate** (`crates/deadsync-score/src/import.rs`, `options.rs`): carry the error-bar and column-flash mask preferences and the per-score music rate.
- **Judgment graphics and combo font** (`crates/deadsync-profile/src/lib.rs`, `options.rs`): import the selected Simply Love judgment graphic and combo font.
- **Mapping reference** (`docs/itgmania-import-mapping.md`): a new document enumerating how ITGmania/Simply Love fields map into DeadSync.