### PR TITLE
ITGmania import: import favorites, ITL, profile stats, and dedup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4356,6 +4356,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5148,6 +5154,7 @@ checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -1484,6 +1484,7 @@ ImportSummaryTitle=Import complete
 ImportSummaryName=Imported profile: {name}
 ImportSummaryScores=Scores imported: {imported} of {total}
 ImportSummarySkipped=Skipped {skipped} score(s) for charts not in your library.
+ImportSummaryFavorites=Favorites imported: {imported} of {total}
 ImportSummaryExNote=Note: EX scores are not stored by ITGmania and start at 0.
 ImportMessageDismiss=Press Start to continue.
 

--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -1485,6 +1485,7 @@ ImportSummaryName=Imported profile: {name}
 ImportSummaryScores=Scores imported: {imported} of {total}
 ImportSummarySkipped=Skipped {skipped} score(s) for charts not in your library.
 ImportSummaryFavorites=Favorites imported: {imported} of {total}
+ImportSummaryItl=ITL event scores imported: {count}
 ImportSummaryExNote=Note: EX scores are not stored by ITGmania and start at 0.
 ImportMessageDismiss=Press Start to continue.
 

--- a/assets/languages/en.ini
+++ b/assets/languages/en.ini
@@ -1469,6 +1469,23 @@ CannotBeUndone=This cannot be undone.
 YesNoPrompt=Start: Yes    Back: No
 CreateProfileButton=Create Profile
 ExitButton=Exit
+ImportItgButton=Import from ITGmania
+ImportItgTitle=Import a profile from ITGmania.
+ImportItgHelp1=Copies the profile, player options and offline scores.
+ImportItgHelp2=Press Start to scan for ITGmania profiles.
+ImportPickTitle=Select an ITGmania profile to import
+ImportPickPrompt=Start: Import    Back: Cancel
+ImportInProgress=Importing... this can take a moment.
+ImportNoneFoundTitle=No ITGmania profiles found
+ImportNoneFoundBody=Could not find any ITGmania local profiles. Make sure ITGmania is installed and has at least one local profile.
+ImportFailedTitle=Import failed
+ImportFailedBody=The profile could not be imported.
+ImportSummaryTitle=Import complete
+ImportSummaryName=Imported profile: {name}
+ImportSummaryScores=Scores imported: {imported} of {total}
+ImportSummarySkipped=Skipped {skipped} score(s) for charts not in your library.
+ImportSummaryExNote=Note: EX scores are not stored by ITGmania and start at 0.
+ImportMessageDismiss=Press Start to continue.
 
 ; ============================================================
 ; Select Profile screen

--- a/crates/deadsync-profile/Cargo.toml
+++ b/crates/deadsync-profile/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 bincode = "2.0.1"
 bitflags = "2.13.0"
 chrono = "0.4.45"
-uuid = { version = "1.18.1", features = ["v4"] }
+uuid = { version = "1.18.1", features = ["v4", "v5"] }
 deadsync-rules = { path = "../deadsync-rules" }
 deadsync-score = { path = "../deadsync-score" }
 

--- a/crates/deadsync-profile/src/lib.rs
+++ b/crates/deadsync-profile/src/lib.rs
@@ -2687,6 +2687,34 @@ fn normalize_graphic_key(
     Ok(format!("{folder}/{basename}"))
 }
 
+/// Like [`normalize_graphic_key`] but **only** resolves names DeadSync actually
+/// ships: a recognized stock alias or `"None"`. Returns `None` for unknown or
+/// custom graphic names instead of fabricating a `folder/basename` path that
+/// would point at a missing texture. Used by the ITGmania importer, where a
+/// Simply Love profile may reference a theme graphic DeadSync doesn't have.
+fn recognized_stock_key(raw: &str, stock_aliases: &[(&str, &str)]) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.eq_ignore_ascii_case("none") {
+        return Some("None".to_string());
+    }
+    let basename = Path::new(trimmed)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(trimmed)
+        .trim();
+    if basename.eq_ignore_ascii_case("none") {
+        return Some("None".to_string());
+    }
+    let normalized = basename.to_ascii_lowercase();
+    stock_aliases
+        .iter()
+        .find(|(alias, _)| alias.eq_ignore_ascii_case(&normalized))
+        .map(|(_, key)| (*key).to_string())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HoldJudgmentGraphic(String);
 
@@ -2726,6 +2754,14 @@ impl HoldJudgmentGraphic {
             normalize_graphic_key(raw, "hold_judgements", Self::STOCK_ALIASES)
                 .unwrap_or_else(|_| Self::DEFAULT_KEY.to_string()),
         )
+    }
+
+    /// Parse `raw` only if it names a graphic DeadSync ships (a recognized stock
+    /// alias or `"None"`), returning `None` for unknown/custom names. Use this
+    /// when importing external settings to avoid pointing at a missing texture.
+    #[inline(always)]
+    pub fn from_stock_name(raw: &str) -> Option<Self> {
+        recognized_stock_key(raw, Self::STOCK_ALIASES).map(Self)
     }
 
     #[inline(always)]
@@ -2784,6 +2820,14 @@ impl HeldMissGraphic {
             normalize_graphic_key(raw, "held_miss", Self::STOCK_ALIASES)
                 .unwrap_or_else(|_| Self::DEFAULT_KEY.to_string()),
         )
+    }
+
+    /// Parse `raw` only if it names a graphic DeadSync ships (a recognized stock
+    /// alias or `"None"`), returning `None` for unknown/custom names. Use this
+    /// when importing external settings to avoid pointing at a missing texture.
+    #[inline(always)]
+    pub fn from_stock_name(raw: &str) -> Option<Self> {
+        recognized_stock_key(raw, Self::STOCK_ALIASES).map(Self)
     }
 
     #[inline(always)]
@@ -3026,6 +3070,14 @@ impl JudgmentGraphic {
             normalize_graphic_key(raw, "judgements", Self::STOCK_ALIASES)
                 .unwrap_or_else(|_| Self::DEFAULT_KEY.to_string()),
         )
+    }
+
+    /// Parse `raw` only if it names a graphic DeadSync ships (a recognized stock
+    /// alias or `"None"`), returning `None` for unknown/custom names. Use this
+    /// when importing external settings to avoid pointing at a missing texture.
+    #[inline(always)]
+    pub fn from_stock_name(raw: &str) -> Option<Self> {
+        recognized_stock_key(raw, Self::STOCK_ALIASES).map(Self)
     }
 
     #[inline(always)]

--- a/crates/deadsync-profile/src/lib.rs
+++ b/crates/deadsync-profile/src/lib.rs
@@ -434,6 +434,33 @@ pub fn is_valid_profile_guid(s: &str) -> bool {
     parts.next().is_none()
 }
 
+/// Fixed namespace UUID for deriving DeadSync profile GUIDs from ITGmania
+/// profile GUIDs. Chosen once and never changed so the mapping stays stable.
+const ITGMANIA_GUID_NAMESPACE: uuid::Uuid =
+    uuid::Uuid::from_u128(0x9d3f7c12_4b8e_5a96_b2d1_e7f4a06c83ddu128);
+
+/// Derives a stable DeadSync profile GUID from an ITGmania profile `Guid`
+/// (the 16-hex string stored in `Stats.xml` `GeneralData/Guid`).
+///
+/// ITGmania GUIDs aren't UUIDs, so they can't be used as DeadSync identities
+/// directly. We map them through a fixed namespace with UUID v5, which is
+/// deterministic: the same ITGmania GUID always yields the same DeadSync GUID
+/// (so re-importing the same profile produces a matching identity), and the
+/// result is a canonical UUID that satisfies [`is_valid_profile_guid`].
+///
+/// Returns `None` when `itg_guid` is blank.
+pub fn profile_guid_from_itgmania_guid(itg_guid: &str) -> Option<String> {
+    let trimmed = itg_guid.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let derived = uuid::Uuid::new_v5(
+        &ITGMANIA_GUID_NAMESPACE,
+        trimmed.to_ascii_lowercase().as_bytes(),
+    );
+    Some(derived.to_string())
+}
+
 const FOLDER_NAME_MAX_LEN: usize = 48;
 
 fn is_windows_reserved_name(name: &str) -> bool {
@@ -6307,6 +6334,27 @@ mod tests {
         assert!(!is_valid_profile_guid(
             "g7c7b8a2-3b73-4e8a-9d7d-cfa7e783c00b"
         )); // non-hex
+    }
+
+    #[test]
+    fn itgmania_guid_maps_to_stable_valid_uuid() {
+        // Blank source → no derived identity.
+        assert_eq!(profile_guid_from_itgmania_guid(""), None);
+        assert_eq!(profile_guid_from_itgmania_guid("   "), None);
+
+        // Deterministic: same ITGmania GUID always yields the same DeadSync GUID.
+        let a = profile_guid_from_itgmania_guid("99f55b745304ebcf").expect("guid");
+        let b = profile_guid_from_itgmania_guid("99f55b745304ebcf").expect("guid");
+        assert_eq!(a, b);
+        // Case/whitespace-insensitive.
+        let c = profile_guid_from_itgmania_guid("  99F55B745304EBCF  ").expect("guid");
+        assert_eq!(a, c);
+        // The derived value is a canonical, accepted DeadSync GUID.
+        assert!(is_valid_profile_guid(&a));
+
+        // Different ITGmania GUIDs map to different DeadSync GUIDs.
+        let other = profile_guid_from_itgmania_guid("0247fbc7e366cf9f").expect("guid");
+        assert_ne!(a, other);
     }
 
     #[test]

--- a/crates/deadsync-score/src/import.rs
+++ b/crates/deadsync-score/src/import.rs
@@ -40,6 +40,34 @@ pub struct ImportedHighScore {
     pub missed_hold: u32,
     /// `<SurviveSeconds>` — how long the player lasted before failing (if any).
     pub survive_seconds: f32,
+    /// `<Modifiers>` text, e.g. `"1.5xMusic, Overhead"`. Used to recover the
+    /// music rate; empty/absent means the default rate of 1.0.
+    pub modifiers: String,
+}
+
+/// Recovers the music rate from an ITGmania `<Modifiers>` string.
+///
+/// ITGmania serialises a non-default rate as a `"<rate>xMusic"` token (see
+/// `itgmania/src/SongOptions.cpp` `GetMods`), e.g. `"1.5xMusic"`. The token is
+/// comma/space separated from the other modifiers. Returns `1.0` when no rate
+/// token is present or it can't be parsed into a positive number.
+pub fn music_rate_from_modifiers(modifiers: &str) -> f32 {
+    for token in modifiers.split([',', ' ', '\t']) {
+        let token = token.trim();
+        if token.len() < 7 {
+            continue;
+        }
+        let (num, suffix) = token.split_at(token.len() - 6);
+        if !suffix.eq_ignore_ascii_case("xmusic") {
+            continue;
+        }
+        if let Ok(rate) = num.parse::<f32>() {
+            if rate.is_finite() && rate > 0.0 {
+                return rate;
+            }
+        }
+    }
+    1.0
 }
 
 /// Maps an ITGmania `<Grade>` string to a DeadSync [`Grade`].
@@ -99,6 +127,7 @@ pub fn parse_itg_datetime_ms(date_time: &str) -> Option<i64> {
 /// * Holds and rolls are not distinguished in `Stats.xml`; all hold-type tallies
 ///   are folded into the hold fields (`rolls_* = 0`).
 /// * `score_percent` is taken from `PercentDP` directly (both are 0.0–1.0).
+/// * `music_rate` is recovered from the `<Modifiers>` rate token (default 1.0).
 /// * EX / Hard-EX are unrecoverable → `0.0`.
 /// * The lamp is recomputed from the judgment counts (W0 split unknown).
 pub fn local_score_from_itg(hs: &ImportedHighScore) -> Option<LocalScoreEntry> {
@@ -122,7 +151,7 @@ pub fn local_score_from_itg(hs: &ImportedHighScore) -> Option<LocalScoreEntry> {
     Some(LocalScoreEntry {
         version: LOCAL_SCORE_VERSION,
         played_at_ms: parse_itg_datetime_ms(&hs.date_time).unwrap_or(0),
-        music_rate: 1.0,
+        music_rate: music_rate_from_modifiers(&hs.modifiers),
         score_percent: hs.percent_dp.clamp(0.0, 1.0),
         grade_code: grade_to_code(grade),
         lamp_index,
@@ -208,6 +237,7 @@ mod tests {
             let_go: 0,
             missed_hold: 0,
             survive_seconds: 0.0,
+            modifiers: String::new(),
         };
         let e = local_score_from_itg(&hs).expect("entry");
         assert_eq!(e.grade_code, grade_to_code(Grade::Tier01));
@@ -220,6 +250,7 @@ mod tests {
         assert!((e.score_percent - 0.9912).abs() < 1e-9);
         assert_eq!(e.ex_score_percent, 0.0);
         assert_eq!(e.fail_time, None);
+        assert_eq!(e.music_rate, 1.0);
         // No misses/way-offs/etc beyond excellents → "excellent" lamp tier.
         assert_eq!(e.lamp_index, Some(2));
         assert_eq!(e.lamp_judge_count, None); // 12 excellents > 9 → no judge count
@@ -254,5 +285,31 @@ mod tests {
         let e = local_score_from_itg(&hs).expect("entry");
         assert_eq!(e.holds_held, 10);
         assert_eq!(e.holds_total, 15);
+    }
+
+    #[test]
+    fn parses_music_rate_from_modifiers() {
+        assert_eq!(music_rate_from_modifiers(""), 1.0);
+        assert_eq!(music_rate_from_modifiers("Overhead, Mirror"), 1.0);
+        assert_eq!(music_rate_from_modifiers("1.5xMusic"), 1.5);
+        assert_eq!(
+            music_rate_from_modifiers("Overhead, 2.0xMusic, Mirror"),
+            2.0
+        );
+        assert_eq!(music_rate_from_modifiers("0.8xmusic"), 0.8);
+        // Malformed / non-positive rate falls back to 1.0.
+        assert_eq!(music_rate_from_modifiers("xMusic"), 1.0);
+        assert_eq!(music_rate_from_modifiers("0xMusic"), 1.0);
+    }
+
+    #[test]
+    fn applies_music_rate_to_entry() {
+        let hs = ImportedHighScore {
+            grade: "Grade_Tier03".into(),
+            modifiers: "1.5xMusic, Reverse".into(),
+            ..Default::default()
+        };
+        let e = local_score_from_itg(&hs).expect("entry");
+        assert_eq!(e.music_rate, 1.5);
     }
 }

--- a/docs/itgmania-import-mapping.md
+++ b/docs/itgmania-import-mapping.md
@@ -178,6 +178,8 @@ rejects unknown vocabularies (unknown → default preserved).
 | `ErrorBarTrim` | `error_bar_trim` | `Off`, `Fantastic`, `Excellent`, `Great` |
 | `MiniIndicator` | `mini_indicator` | `None`, `SubtractiveScoring`, `PredictiveScoring`, `PaceScoring`, `RivalScoring`, `Pacemaker`, `StreamProg` |
 | `DataVisualizations` | `step_statistics` | `None`/`Target Score Graph` → empty; `Step Statistics` → all widgets |
+| `StepStatsExtra` | `step_stats_extra` | `None`, `ErrorStats`, and the GIF widgets (`AmongUs`, `CatJAM`, `Nyan Cat`, `Sonic`, …) |
+| `TargetScore` | `target_score` | only `Machine best` / `Personal best` (SL's `SpecifiedValue`+number and `Ghost Data` have no equivalent → default) |
 
 ### 4.4 SelectMultiple flag groups → bitmasks
 
@@ -335,10 +337,15 @@ audit notes in the session history for rationale:
   per-score `MaxCombo`, `Name`, `RadarValues`, `Disqualified`.
 - **Simply Love extras:** `SL-Scores/*.json`, and favorites
   **section/playlist names** (the songs are imported; the grouping is not).
-- **Player options judged risky:** numeric/`Ghost Data` `TargetScore`,
-  `MiniIndicatorColor` (color-name vocabulary), scorebox sub-options
-  (`SBITGScore`/`SBExScore`/`SBEvents`), and SL-only aesthetic effects with no
-  DeadSync equivalent.
+- **Player options with no clean mapping:** `MiniIndicatorColor` (color-name
+  vocabulary vs DeadSync's `Default`/`Detailed`/`Combo`), `PackBanner`/`StepInfo`
+  (interact with `DataVisualizations`), scorebox sub-options
+  (`SBITGScore`/`SBExScore`/`SBEvents`), and SL-only aesthetic/joke effects with
+  no DeadSync equivalent (`TimerMode`, `JudgmentAnimation`, `RailBalance`,
+  `GhostFault`, `BreakUI`, `GrowCombo`, `SpinCombo`, `WildCombo`,
+  `RainbowComboOptions`, `TiltOptions`, `Waterfall`, `FadeFantastic`, `NoBar`,
+  `TrackRecalc`, `TrackFoot`). The numeric/`Ghost Data` parts of `TargetScore`
+  are also dropped (the `Machine best`/`Personal best` values **are** imported).
 
 ## Source-of-truth code
 

--- a/docs/itgmania-import-mapping.md
+++ b/docs/itgmania-import-mapping.md
@@ -57,6 +57,13 @@ Source: `Editable.ini` `[Editable]`. Writer: `src/game/profile.rs`
 | `WeightPounds` | weight (lbs) | parsed `u32`, `0` if absent |
 | `BirthYear` | birth year | parsed `u32`, `0` if absent |
 | `LastUsedHighScoreName` | player initials | sanitised; falls back to initials derived from the display name |
+| `IgnoreStepCountCalories` | `ignore_step_count_calories` | disables step-count calorie estimation; parsed as bool |
+
+The `Stats.xml` `GeneralData/CurrentCombo` is imported into the profile's
+`current_combo` (the streak carried between songs) via `ProfileStats`. Known
+packs are **not** imported — DeadSync marks all currently-scanned packs as known
+on a new profile's first load, which is the desired behavior (importing only the
+ITGmania-played subset would wrongly flag the rest as "new").
 
 ## 2. Online service keys
 
@@ -319,10 +326,11 @@ and looks it up in DeadSync's scanned song library to recover the GrooveStats
 Present in an ITGmania profile but currently left to DeadSync defaults — see the
 audit notes in the session history for rationale:
 
-- **Profile/stats:** `IgnoreStepCountCalories`, `CharacterID`, `Voomax`,
-  `IsMale`, `CurrentCombo`, lifetime totals (`TotalDancePoints`,
-  `TotalSessions`, step/jump/hold totals), play-count histograms, last
-  song/difficulty, calorie history.
+- **Profile/stats:** `CharacterID`, `Voomax`, `IsMale`, lifetime totals
+  (`TotalDancePoints`, `TotalSessions`, step/jump/hold totals), play-count
+  histograms, last song/difficulty, calorie history. (`IgnoreStepCountCalories`
+  and `CurrentCombo` **are** imported; `known_pack_names` is intentionally left
+  to DeadSync's first-load default.)
 - **Per-chart:** `HighScoreList/NumTimesPlayed`, `LastPlayed`, `HighGrade`;
   per-score `MaxCombo`, `Name`, `RadarValues`, `Disqualified`.
 - **Simply Love extras:** `SL-Scores/*.json`, and favorites

--- a/docs/itgmania-import-mapping.md
+++ b/docs/itgmania-import-mapping.md
@@ -20,6 +20,7 @@ An ITGmania `LocalProfiles/<id>/` directory contains:
 | `Simply Love UserPrefs.ini` | `[Simply Love]` section → player options |
 | `Avatar.png` (or `.jpg`/`.jpeg`) | Profile avatar image |
 | `favorites.txt` | Favorited songs (resolved to chart hashes) |
+| `ITL2026.json` | ITL event progress (scores, points, unlocks) |
 | `Stats.xml` (or `Stats.xml.gz`) | Per-chart high scores |
 
 Reader code: `src/game/import/itg.rs`. Each reader degrades gracefully — a
@@ -100,6 +101,20 @@ grouped under `---Section` headers (custom playlists). DeadSync stores favorites
 
 Section/playlist grouping is **not** preserved (DeadSync has no favorites
 sections); songs not in the library are reported as skipped in the summary.
+
+## 3b. ITL event data
+
+Source: `ITL2026.json` (Simply Love ITL event file). Reader: `read_itl_json` in
+`src/game/import/itg.rs`; import in `src/game/scores/itl.rs`
+(`import_itl_json`).
+
+DeadSync's ITL support uses the **same `ITL2026.json` schema** Simply Love
+writes — `pathMap` (song dir → hash), `hashMap` (hash → per-song event metadata:
+EX, points, clear type, judgments, ranks…), and `unlockFolders`. The importer
+parses the Simply Love file through DeadSync's own `ItlFileData` and writes it
+into the new profile, so your ITL event progress (scores, points, unlocks)
+carries over directly. Song ranks are recomputed when the profile's ITL cache
+next loads. A missing, empty, or unparseable file imports nothing.
 
 ## 4. Player options (Simply Love)
 
@@ -310,7 +325,7 @@ audit notes in the session history for rationale:
   song/difficulty, calorie history.
 - **Per-chart:** `HighScoreList/NumTimesPlayed`, `LastPlayed`, `HighGrade`;
   per-score `MaxCombo`, `Name`, `RadarValues`, `Disqualified`.
-- **Simply Love extras:** `ITL2026.json`, `SL-Scores/*.json`, and favorites
+- **Simply Love extras:** `SL-Scores/*.json`, and favorites
   **section/playlist names** (the songs are imported; the grouping is not).
 - **Player options judged risky:** numeric/`Ghost Data` `TargetScore`,
   `MiniIndicatorColor` (color-name vocabulary), scorebox sub-options

--- a/docs/itgmania-import-mapping.md
+++ b/docs/itgmania-import-mapping.md
@@ -1,0 +1,310 @@
+# ITGmania / Simply Love → DeadSync import mapping
+
+This is the authoritative field-by-field reference for what DeadSync's profile
+importer (**Options → Manage Local Profiles → Import from ITGmania**) reads from
+an ITGmania + Simply Love local profile and where each value lands in DeadSync.
+
+For the end-user walkthrough see
+[migrating-from-itgmania.md](./migrating-from-itgmania.md); this document is for
+contributors maintaining the importer.
+
+## Source files in an ITGmania profile
+
+An ITGmania `LocalProfiles/<id>/` directory contains:
+
+| File | What the importer reads from it |
+| --- | --- |
+| `Editable.ini` | Display name, weight, birth year, player initials |
+| `GrooveStats.ini` | GrooveStats API key, username, pad-player flag |
+| `ArrowCloud.ini` | ArrowCloud API key |
+| `Simply Love UserPrefs.ini` | `[Simply Love]` section → player options |
+| `Avatar.png` (or `.jpg`/`.jpeg`) | Profile avatar image |
+| `Stats.xml` (or `Stats.xml.gz`) | Per-chart high scores |
+
+Reader code: `src/game/import/itg.rs`. Each reader degrades gracefully — a
+missing file or key yields an empty/default value rather than failing the whole
+import.
+
+## Pipeline overview
+
+```
+Editable.ini ─┐
+GrooveStats ──┤
+ArrowCloud  ──┼─► itg.rs (readers) ─► ItgSource ─► run.rs (orchestration)
+UserPrefs.ini ┤                                        │
+Avatar.png  ──┤                          options.rs ◄──┤ player options
+Stats.xml ────┘                          resolver.rs ◄─┤ chart → GS hash
+                                         import.rs   ◄──┘ score → LocalScoreEntry
+```
+
+- **`options.rs`** translates Simply Love mods → `PlayerOptionsData`.
+- **`resolver.rs`** matches a `Stats.xml` chart (song dir + steps type +
+  difficulty + description) to a chart in DeadSync's scanned library, recovering
+  the GrooveStats `short_hash`.
+- **`deadsync-score/src/import.rs`** maps one `<HighScore>` → `LocalScoreEntry`.
+- **`run.rs`** writes the new profile and imported scores.
+
+## 1. Profile metadata
+
+Source: `Editable.ini` `[Editable]`. Writer: `src/game/profile.rs`
+(`ImportProfileData`).
+
+| ITGmania key | DeadSync field | Notes |
+| --- | --- | --- |
+| `DisplayName` | display name | |
+| `WeightPounds` | weight (lbs) | parsed `u32`, `0` if absent |
+| `BirthYear` | birth year | parsed `u32`, `0` if absent |
+| `LastUsedHighScoreName` | player initials | sanitised; falls back to initials derived from the display name |
+
+## 2. Online service keys
+
+Sources: `GrooveStats.ini` `[GrooveStats]`, `ArrowCloud.ini` `[ArrowCloud]`.
+Written into the new profile's lowercase `groovestats.ini` / `arrowcloud.ini`.
+
+| ITGmania source | DeadSync target |
+| --- | --- |
+| `GrooveStats.ApiKey` | `groovestats.ini` ApiKey |
+| `GrooveStats.Username` | `groovestats.ini` Username |
+| `GrooveStats.IsPadPlayer` | `groovestats.ini` IsPadPlayer |
+| `ArrowCloud.ApiKey` | `arrowcloud.ini` ApiKey |
+
+The importer copies **credentials only**; it does not enable the services. The
+machine-level toggles (`enable_groovestats`, `enable_arrowcloud`,
+`enable_boogiestats`) live in global config and must still be turned on under
+**Options → Online Scoring**. BoogieStats has no separate credential — it reuses
+the GrooveStats key (`is_boogiestats_active()` is just
+`enable_groovestats && enable_boogiestats`), so importing the GrooveStats key is
+all that's needed for it.
+
+## 3. Avatar
+
+`Avatar.png` / `avatar.png` / `Avatar.jpg` / `Avatar.jpeg` (first match,
+case-insensitive) is copied into the new profile directory as `profile.png`.
+
+## 4. Player options (Simply Love)
+
+Source: `Simply Love UserPrefs.ini` `[Simply Love]`. Translator:
+`src/game/import/options.rs` (`translate_player_options`).
+
+**Design rule:** only settings that map with high confidence are translated.
+Anything DeadSync doesn't recognise — including custom theme graphics/fonts it
+doesn't ship — is left at the DeadSync default rather than guessed. Simply Love
+serialises with Lua `tostring`, so booleans are `true`/`false`.
+
+### 4.1 Scalar / parsed values
+
+| Simply Love key | Value format | DeadSync field | Translation |
+| --- | --- | --- | --- |
+| `SpeedModType` + `SpeedMod` | `X`/`C`/`M` + number | `scroll_speed` | → `ScrollSpeedSetting::{XMod,CMod,MMod}`; ignored if rate ≤ 0 |
+| `Mini` | `"50%"` | `mini_percent` | leading signed int |
+| `Spacing` | `"-25%"` | `spacing_percent` | leading signed int |
+| `NoteFieldOffsetX` | int | `note_field_offset_x` | leading signed int |
+| `NoteFieldOffsetY` | int | `note_field_offset_y` | leading signed int |
+| `VisualDelay` | `"12ms"` | `visual_delay_ms` | leading signed int |
+| `TiltMultiplier` | float | `tilt_multiplier` | parsed `f32` |
+| `MeasureCounterLookahead` | int | `measure_counter_lookahead` | clamped `0..=255` |
+| `NoteSkin` | name | `noteskin` | `NoteSkin::new` (passthrough) |
+
+### 4.2 Theme graphics & font
+
+Simply Love stores the **full sprite filename** for the graphics and the **font
+directory name** for the combo font. These resolve through DeadSync's stock
+alias tables via a *stock-only* parse (`from_stock_name`): a name DeadSync
+doesn't ship resolves to `None` and the base default is kept (so the profile
+never points at a missing texture).
+
+| Simply Love key | Example value | DeadSync field |
+| --- | --- | --- |
+| `JudgmentGraphic` | `Love 2x7 (doubleres).png` | `judgment_graphic` |
+| `HeldGraphic` | `Love (doubleres).png` | `held_miss_graphic` |
+| `HoldJudgment` | `ITG2 1x2 (doubleres).png` | `hold_judgment_graphic` |
+| `ComboFont` | `Wendy`, `Bebas Neue` | `combo_font` (`FromStr`; unknown → default) |
+
+### 4.3 Enum-valued settings
+
+Translated via DeadSync's `FromStr`, which normalises case/punctuation and
+rejects unknown vocabularies (unknown → default preserved).
+
+| Simply Love key | DeadSync field | Accepted values |
+| --- | --- | --- |
+| `BackgroundFilter` | `background_filter` | `0`–`100` (or `Off`/`Dark`/`Darker`/`Darkest`) |
+| `ComboColors` | `combo_colors` | `Glow`, `Solid`, `Rainbow`, `RainbowScroll`, `None` |
+| `ComboMode` | `combo_mode` | `FullCombo`, `CurrentCombo` |
+| `LifeMeterType` | `lifemeter_type` | `Standard`, `Surround`, `Vertical` |
+| `MeasureCounter` | `measure_counter` | `None`, `8th`, `12th`, `16th`, `24th`, `32nd` |
+| `MeasureLines` | `measure_lines` | `Off`, `Measure`, `Quarter`, `Eighth` |
+| `ErrorBarTrim` | `error_bar_trim` | `Off`, `Fantastic`, `Excellent`, `Great` |
+| `MiniIndicator` | `mini_indicator` | `None`, `SubtractiveScoring`, `PredictiveScoring`, `PaceScoring`, `RivalScoring`, `Pacemaker`, `StreamProg` |
+| `DataVisualizations` | `step_statistics` | `None`/`Target Score Graph` → empty; `Step Statistics` → all widgets |
+
+### 4.4 SelectMultiple flag groups → bitmasks
+
+Applied only when at least one flag of the group is present (otherwise the
+DeadSync default is kept).
+
+**Error-bar style** → `error_bar_active_mask` (then `error_bar` and
+`error_bar_text` are derived from the mask):
+
+| Simply Love flag | `ErrorBarMask` bit |
+| --- | --- |
+| `Colorful` | `COLORFUL` |
+| `Monochrome` | `MONOCHROME` |
+| `Text` | `TEXT` |
+| `Highlight` | `HIGHLIGHT` |
+| `Average` | `AVERAGE` |
+
+**Judgment flash** → `column_flash_mask`:
+
+| Simply Love flag | `ColumnFlashMask` bit |
+| --- | --- |
+| `FlashMiss` | `MISS` |
+| `FlashWayOff` | `WAY_OFF` |
+| `FlashDecent` | `DECENT` |
+| `FlashGreat` | `GREAT` |
+| `FlashExcellent` | `EXCELLENT` |
+| `FlashFantastic` | `BLUE_FANTASTIC` **and** `WHITE_FANTASTIC` |
+
+> Simply Love has a single "Fantastic" flash; DeadSync splits fantastic into
+> blue (W0/FA+) and white (W1) columns, so a single `FlashFantastic` enables
+> both bits.
+
+### 4.5 Engine modifier string
+
+`PlayerOptionsString` (comma-separated engine mods, e.g.
+`"1.5x, Reverse, Mirror"`) contributes:
+
+| Token(s) | DeadSync field |
+| --- | --- |
+| `reverse` | `scroll_option |= Reverse`, `reverse_scroll = true` |
+| `split` / `alternate` / `cross` / `centered` | corresponding `ScrollOption` bit |
+| a parseable `TurnOption` (e.g. `mirror`, `left`, `right`, `shuffle`) | `turn_option` |
+
+### 4.6 Boolean toggles (1:1)
+
+These Simply Love booleans map directly to the same-meaning DeadSync field:
+
+| Simply Love key | DeadSync field |
+| --- | --- |
+| `HideTargets` | `hide_targets` |
+| `HideSongBG` | `hide_song_bg` |
+| `HideCombo` | `hide_combo` |
+| `HideLifebar` | `hide_lifebar` |
+| `HideScore` | `hide_score` |
+| `HideDanger` | `hide_danger` |
+| `HideComboExplosions` | `hide_combo_explosions` |
+| `MeasureCounterLeft` | `measure_counter_left` |
+| `MeasureCounterUp` | `measure_counter_up` |
+| `MeasureCounterVert` | `measure_counter_vert` |
+| `BrokenRun` | `broken_run` |
+| `RunTimer` | `run_timer` |
+| `RainbowMax` | `rainbow_max` |
+| `ResponsiveColors` | `responsive_colors` |
+| `ShowLifePercent` | `show_life_percent` |
+| `ColumnFlashOnMiss` | `column_flash_on_miss` |
+| `SubtractiveScoring` | `subtractive_scoring` |
+| `Pacemaker` | `pacemaker` |
+| `TrackEarlyJudgments` | `track_early_judgments` |
+| `ScaleGraph` | `scale_scatterplot` |
+| `NPSGraphAtTop` | `nps_graph_at_top` |
+| `JudgmentTilt` | `judgment_tilt` |
+| `ColumnCues` | `column_cues` |
+| `ColumnCountdown` | `column_countdown` |
+| `ErrorBarUp` | `error_bar_up` |
+| `ErrorBarMultiTick` | `error_bar_multi_tick` |
+| `ShowFaPlusWindow` | `show_fa_plus_window` |
+| `ShowExScore` | `show_ex_score` |
+| `ShowFaPlusPane` | `show_fa_plus_pane` |
+| `SmallerWhite` | `fa_plus_10ms_blue_window` |
+| `SplitWhites` | `split_15_10ms` |
+| `HideEarlyDecentWayOffJudgments` | `hide_early_dw_judgments` |
+| `HideEarlyDecentWayOffFlash` | `hide_early_dw_flash` |
+| `DisplayScorebox` | `display_scorebox` |
+| `JudgmentBack` | `judgment_back` |
+| `ErrorMSDisplay` | `error_ms_display` |
+
+## 5. Offline scores
+
+Source: `Stats.xml`
+`SongScores/Song[@Dir]/Steps[@StepsType,@Difficulty,@Description]/HighScoreList/HighScore`.
+Mapper: `deadsync-score/src/import.rs` (`local_score_from_itg`).
+
+### Chart resolution (`resolver.rs`)
+
+`Stats.xml` keys a chart by song folder + steps type + difficulty (+ optional
+edit description), **not** by hash. The resolver normalises the song directory
+and looks it up in DeadSync's scanned song library to recover the GrooveStats
+`short_hash`. Outcomes:
+
+- **Found** → the score is mapped and attached to that chart.
+- **SongNotFound** / **ChartNotFound** → counted in the import summary and
+  skipped. Scan your packs (and add your ITGmania `Songs` folder) before
+  importing so more scores match.
+
+### `<HighScore>` → `LocalScoreEntry`
+
+| ITGmania element | DeadSync field | Notes |
+| --- | --- | --- |
+| `Grade` (`Tier01`…`Failed`, with or without a `Grade_` prefix) | `grade_code` | via `grade_from_itg`; unrecognised grade → score skipped |
+| `PercentDP` (0.0–1.0) | `score_percent` | clamped `0.0..=1.0` |
+| `DateTime` (`YYYY-MM-DD HH:MM:SS`, local) | `played_at_ms` | epoch ms; `0` if unparseable |
+| `Modifiers` (`"1.5xMusic, …"`) | `music_rate` | parsed `xMusic` token; default `1.0` |
+| `TapNoteScores/{W1,W2,W3,W4,W5,Miss}` | `judgment_counts` | `[W1, W2, W3, W4, W5, Miss]` |
+| `TapNoteScores/AvoidMine` | `mines_avoided` | |
+| `TapNoteScores/HitMine` + `AvoidMine` | `mines_total` | |
+| `HoldNoteScores/Held` | `holds_held` | |
+| `HoldNoteScores/{Held,LetGo,MissedHold}` | `holds_total` | summed |
+| `SurviveSeconds` | `fail_time` | only for `Grade_Failed` |
+| (recomputed from judgments) | `lamp_index`, `lamp_judge_count` | `compute_local_lamp` |
+
+**Always defaulted (not recoverable from `Stats.xml`):**
+
+| DeadSync field | Value | Why |
+| --- | --- | --- |
+| `ex_score_percent` | `0.0` | ITGmania stores no FA+ (W0) split |
+| `hard_ex_score_percent` | `0.0` | same |
+| `rolls_held`, `rolls_total` | `0` | `Stats.xml` folds holds and rolls together |
+| `hands_achieved` | `0` | not stored per high score |
+| `beat0_time_ns` | `0` | no replay data |
+| `replay` | empty | no per-tap offset data in `Stats.xml` |
+
+## Known limitations
+
+- **Scores only attach to charts present in DeadSync's library** (hash recovered
+  via the resolver); unmatched charts are reported and skipped.
+- **EX / Hard-EX can't be reconstructed** — ITGmania records only bucketed
+  judgments (no W0 split, no per-tap timing), so EX starts at 0.
+- **Holds vs rolls aren't distinguished**, and mine tallies are partial.
+- **Auto-detection** covers the per-user save dirs only
+  (`%APPDATA%\ITGmania\Save\LocalProfiles`, `~/.itgmania/...`,
+  `~/Library/Application Support/ITGmania/...`); portable installs aren't found
+  automatically.
+
+## Deliberately not (yet) imported
+
+Present in an ITGmania profile but currently left to DeadSync defaults — see the
+audit notes in the session history for rationale:
+
+- **Profile/stats:** `IgnoreStepCountCalories`, `CharacterID`, `Voomax`,
+  `IsMale`, `CurrentCombo`, lifetime totals (`TotalDancePoints`,
+  `TotalSessions`, step/jump/hold totals), play-count histograms, last
+  song/difficulty, calorie history.
+- **Per-chart:** `HighScoreList/NumTimesPlayed`, `LastPlayed`, `HighGrade`;
+  per-score `MaxCombo`, `Name`, `RadarValues`, `Disqualified`.
+- **Simply Love extras:** `favorites.txt`, `ITL2026.json`, `SL-Scores/*.json`.
+- **Player options judged risky:** numeric/`Ghost Data` `TargetScore`,
+  `MiniIndicatorColor` (color-name vocabulary), scorebox sub-options
+  (`SBITGScore`/`SBExScore`/`SBEvents`), and SL-only aesthetic effects with no
+  DeadSync equivalent.
+
+## Source-of-truth code
+
+| Concern | File |
+| --- | --- |
+| ITGmania file readers | `src/game/import/itg.rs` |
+| `Stats.xml` parser | `src/game/import/xml.rs` |
+| Player-options translation | `src/game/import/options.rs` |
+| Chart resolver | `src/game/import/resolver.rs` |
+| Score mapping | `crates/deadsync-score/src/import.rs` |
+| Orchestration / profile writer | `src/game/import/run.rs`, `src/game/profile.rs` |
+| Auto-detection | `src/game/import/detect.rs` |
+| In-game UI | `src/screens/manage_local_profiles.rs` |

--- a/docs/itgmania-import-mapping.md
+++ b/docs/itgmania-import-mapping.md
@@ -19,6 +19,7 @@ An ITGmania `LocalProfiles/<id>/` directory contains:
 | `ArrowCloud.ini` | ArrowCloud API key |
 | `Simply Love UserPrefs.ini` | `[Simply Love]` section → player options |
 | `Avatar.png` (or `.jpg`/`.jpeg`) | Profile avatar image |
+| `favorites.txt` | Favorited songs (resolved to chart hashes) |
 | `Stats.xml` (or `Stats.xml.gz`) | Per-chart high scores |
 
 Reader code: `src/game/import/itg.rs`. Each reader degrades gracefully — a
@@ -80,6 +81,25 @@ all that's needed for it.
 
 `Avatar.png` / `avatar.png` / `Avatar.jpg` / `Avatar.jpeg` (first match,
 case-insensitive) is copied into the new profile directory as `profile.png`.
+
+## 3a. Favorites
+
+Source: `favorites.txt` (Simply Love). Reader: `read_favorites` /
+`parse_favorites_text` in `src/game/import/itg.rs`; resolution + write in
+`src/game/import/run.rs` and `src/game/profile.rs`.
+
+Simply Love stores favorites **per song** as `Pack/SongFolder` lines, optionally
+grouped under `---Section` headers (custom playlists). DeadSync stores favorites
+**per chart** (`short_hash`). The importer therefore:
+
+1. Reads each favorited song key, skipping `---` section headers and blanks.
+2. Resolves the song against the scanned library (same `Pack/SongFolder`
+   matching as scores).
+3. Favorites **all of that song's charts'** hashes, so the song shows as
+   favorited regardless of which difficulty is viewed.
+
+Section/playlist grouping is **not** preserved (DeadSync has no favorites
+sections); songs not in the library are reported as skipped in the summary.
 
 ## 4. Player options (Simply Love)
 
@@ -290,7 +310,8 @@ audit notes in the session history for rationale:
   song/difficulty, calorie history.
 - **Per-chart:** `HighScoreList/NumTimesPlayed`, `LastPlayed`, `HighGrade`;
   per-score `MaxCombo`, `Name`, `RadarValues`, `Disqualified`.
-- **Simply Love extras:** `favorites.txt`, `ITL2026.json`, `SL-Scores/*.json`.
+- **Simply Love extras:** `ITL2026.json`, `SL-Scores/*.json`, and favorites
+  **section/playlist names** (the songs are imported; the grouping is not).
 - **Player options judged risky:** numeric/`Ghost Data` `TargetScore`,
   `MiniIndicatorColor` (color-name vocabulary), scorebox sub-options
   (`SBITGScore`/`SBExScore`/`SBEvents`), and SL-only aesthetic effects with no

--- a/docs/itgmania-import-mapping.md
+++ b/docs/itgmania-import-mapping.md
@@ -323,29 +323,62 @@ and looks it up in DeadSync's scanned song library to recover the GrooveStats
   `~/Library/Application Support/ITGmania/...`); portable installs aren't found
   automatically.
 
-## Deliberately not (yet) imported
+## Deliberately not imported
 
-Present in an ITGmania profile but currently left to DeadSync defaults — see the
-audit notes in the session history for rationale:
+Everything below is present in an ITGmania / Simply Love profile but **intentionally
+left to DeadSync's defaults**. This is the definitive list; each row records *why*
+it is excluded so the decision is auditable. Items that **are** imported (even
+partially) are noted inline and are not repeated here.
 
-- **Profile/stats:** `CharacterID`, `Voomax`, `IsMale`, lifetime totals
-  (`TotalDancePoints`, `TotalSessions`, step/jump/hold totals), play-count
-  histograms, last song/difficulty, calorie history. (`IgnoreStepCountCalories`
-  and `CurrentCombo` **are** imported; `known_pack_names` is intentionally left
-  to DeadSync's first-load default.)
-- **Per-chart:** `HighScoreList/NumTimesPlayed`, `LastPlayed`, `HighGrade`;
-  per-score `MaxCombo`, `Name`, `RadarValues`, `Disqualified`.
-- **Simply Love extras:** `SL-Scores/*.json`, and favorites
-  **section/playlist names** (the songs are imported; the grouping is not).
-- **Player options with no clean mapping:** `MiniIndicatorColor` (color-name
-  vocabulary vs DeadSync's `Default`/`Detailed`/`Combo`), `PackBanner`/`StepInfo`
-  (interact with `DataVisualizations`), scorebox sub-options
-  (`SBITGScore`/`SBExScore`/`SBEvents`), and SL-only aesthetic/joke effects with
-  no DeadSync equivalent (`TimerMode`, `JudgmentAnimation`, `RailBalance`,
-  `GhostFault`, `BreakUI`, `GrowCombo`, `SpinCombo`, `WildCombo`,
-  `RainbowComboOptions`, `TiltOptions`, `Waterfall`, `FadeFantastic`, `NoBar`,
-  `TrackRecalc`, `TrackFoot`). The numeric/`Ghost Data` parts of `TargetScore`
-  are also dropped (the `Machine best`/`Personal best` values **are** imported).
+**Reason codes**
+
+| Code | Meaning |
+| --- | --- |
+| `NO-TARGET` | DeadSync has no field/feature for this — importing would require a new schema field (and usually UI) with nothing to read it yet. |
+| `NO-MAP` | A target exists but the value vocabularies/semantics don't correspond, so any mapping would be a lossy guess. The translator deliberately never guesses. |
+| `COUNTERPRODUCTIVE` | A faithful import would produce *worse* behavior than DeadSync's default. |
+| `REDUNDANT` | Off by default and/or already covered by a source we do import. |
+| `NOT-MODELED` | DeadSync doesn't implement the underlying feature (courses, characters, unlock system, …). |
+
+### Player options (`Simply Love UserPrefs.ini`)
+
+| Setting(s) | Reason | Detail |
+| --- | --- | --- |
+| `MiniIndicatorColor` | `NO-MAP` | SL is a **fixed-color** picker (`Default`, `Red`, `Blue`, `Yellow`, `Green`, `Magenta`, `White`). DeadSync's enum is a **coloring strategy** (`Default`/`Detailed` = score gradient, `Combo` = match combo color). Only `Default`↔`Default` lines up — a no-op — and every actual color choice has no representation. |
+| `TargetScore` = `SpecifiedValue` (+ `TargetScoreNumber`), `Ghost Data`; `ActionOnMissedTarget` | `NO-MAP` | DeadSync's `target_score` is a grade (`C-`…`S+`) or `Machine/Personal best`; it has no numeric-percent or ghost-data target. **`Machine best` / `Personal best` *are* imported.** |
+| `PackBanner`, `StepInfo` | `NO-MAP` | These would set individual `step_statistics` bits (`PACK_BANNER` / `SONG_INFO`), but they collide with the all-or-nothing `DataVisualizations` → `step_statistics` mapping we already apply. |
+| `SBITGScore`, `SBExScore`, `SBEvents` | `NO-TARGET` | Scorebox sub-toggles with no matching DeadSync field. |
+| `TrackRecalc`, `TrackFoot` | `NO-TARGET` | No corresponding DeadSync option. |
+| `TimerMode`, `JudgmentAnimation`, `RailBalance`, `GhostFault`, `BreakUI`, `GrowCombo`, `SpinCombo`, `WildCombo`, `RainbowComboOptions`, `TiltOptions`, `Waterfall`, `FadeFantastic`, `NoBar` | `NO-TARGET` | SL-only aesthetic / novelty effects DeadSync doesn't implement. |
+
+### Profile metadata & `GeneralData`
+
+| Field(s) | Reason | Detail |
+| --- | --- | --- |
+| `known_pack_names` (derived) | `COUNTERPRODUCTIVE` | DeadSync marks **all** currently-scanned packs as known on a new profile's first load. Importing only the ITGmania-played subset would wrongly flag every other pack as "new". |
+| `CharacterID` | `NOT-MODELED` | DeadSync has no character system. |
+| `Voomax`, `IsMale` | `NO-TARGET` | Calorie-model inputs DeadSync doesn't model (weight + birth year **are** imported, as is `IgnoreStepCountCalories`). |
+| Lifetime totals: `TotalDancePoints`, `TotalSessions`, `TotalSessionSeconds`, `TotalGameplaySeconds`, `TotalTapsAndHolds`, `TotalJumps`, `TotalHolds`, `TotalRolls`, `TotalMines`, `TotalHands`, `TotalLifts`, `NumToasties`, `NumExtraStagesPassed/Failed` | `NO-TARGET` | No lifetime-stats store or display in DeadSync. |
+| Play-count histograms: `NumSongsPlayedBy{PlayMode,Style,Difficulty,Meter}`, `NumTotalSongsPlayed`, `NumStagesPassedBy{PlayMode,Grade}` | `NO-TARGET` | No aggregate play-count store. |
+| `LastDifficulty`, `LastStepsType`, `Song`, `Course`, `LastPlayedDate` | `NO-TARGET` | DeadSync tracks last-played by chart hash internally; ITGmania's last-selection isn't portable. |
+| Calorie history: `CalorieData/CaloriesBurned[@Date]`, `TotalCaloriesBurned`, `GoalType`/`GoalCalories`/`GoalSeconds` | `NO-TARGET` | Only *today's* calories are tracked; cross-machine daily history isn't meaningful. (`CurrentCombo` **is** imported.) |
+| `Unlocks/UnlockEntry` | `NOT-MODELED` | Different unlock system. (ITL unlock folders **are** imported via `ITL2026.json`.) |
+
+### Scores (`Stats.xml`)
+
+| Field(s) | Reason | Detail |
+| --- | --- | --- |
+| Per-chart `HighScoreList/NumTimesPlayed`, `LastPlayed`, `HighGrade` | `NO-TARGET` | DeadSync stores the best score per chart, not play counts / last-played per chart. |
+| Per-score `MaxCombo`, `Name`, `RadarValues`, `Disqualified`, `StageAward`, `PeakComboAward`, checkpoint counts | `NO-TARGET` | Not fields on `LocalScoreEntry`; would need a score-schema change. (Judgments, holds, mines, percent, grade, date, and music rate **are** imported.) |
+| `CourseScores`, `CategoryScores` | `NOT-MODELED` | DeadSync has no course / ranking-category score store. |
+| `ScreenshotData` | `NOT-MODELED` | No screenshot metadata store. |
+
+### Simply Love extras
+
+| Source | Reason | Detail |
+| --- | --- | --- |
+| `SL-Scores/*.json` | `REDUNDANT` | Per-play archive, **off by default** (`WriteCustomScores` theme pref). Richer than `Stats.xml` (rolls-vs-holds split, `MaxCombo`) but would duplicate the best-score data we already import and require play-level dedup. |
+| `favorites.txt` section / playlist names (the `---Section` headers) | `NOT-MODELED` | DeadSync favorites have no section grouping. **The favorited songs themselves are imported.** |
 
 ## Source-of-truth code
 

--- a/docs/migrating-from-itgmania.md
+++ b/docs/migrating-from-itgmania.md
@@ -75,6 +75,8 @@ new DeadSync profile from it in one step.
   are left at their default rather than guessed.
 - **Offline scores** — every high score in `Stats.xml` becomes a DeadSync local
   play, matched to the chart in your library.
+- **Favorites** — your favorited songs from `favorites.txt` (those present in
+  your DeadSync library). Custom favorites-section names aren't carried over.
 
 ### Where it looks
 

--- a/docs/migrating-from-itgmania.md
+++ b/docs/migrating-from-itgmania.md
@@ -102,6 +102,10 @@ never merges, so a manual top-up afterwards is safe).
 - **Holds and rolls aren't distinguished** in `Stats.xml`; all hold-type
   judgments are folded together, and mine tallies are partial.
 
+Rate-modded plays keep their music rate (DeadSync reads the `xMusic` modifier
+from each score), and your judgment counts, grade, combo lamp, and play date all
+carry across.
+
 ## Manual migration
 
 If you prefer to move pieces by hand, the sections below cover each item

--- a/docs/migrating-from-itgmania.md
+++ b/docs/migrating-from-itgmania.md
@@ -67,9 +67,11 @@ new DeadSync profile from it in one step.
   **Options → Online Scoring → Score Import**.
 - **Player options** — your Simply Love per-profile mods from
   `Simply Love UserPrefs.ini`: scroll speed and type, mini, spacing, noteskin,
-  note-field offsets, visual delay, tilt, life-meter type, measure counter and
-  lines, combo mode/colors, mini-indicator, error-bar trim, data-visualization
-  mode, and the many on/off display toggles. Settings DeadSync doesn't recognise
+  judgment / held / hold-judgment graphics, combo font, note-field offsets,
+  visual delay, tilt, life-meter type, measure counter and lines, combo
+  mode/colors, mini-indicator, error-bar style and trim, column-flash, data-
+  visualization mode, and the many on/off display toggles. Settings DeadSync
+  doesn't recognise — including custom theme graphics/fonts it doesn't ship —
   are left at their default rather than guessed.
 - **Offline scores** — every high score in `Stats.xml` becomes a DeadSync local
   play, matched to the chart in your library.

--- a/docs/migrating-from-itgmania.md
+++ b/docs/migrating-from-itgmania.md
@@ -65,9 +65,12 @@ new DeadSync profile from it in one step.
   ArrowCloud, written into the new profile's `groovestats.ini` /
   `arrowcloud.ini`. Your online history can then be pulled via
   **Options → Online Scoring → Score Import**.
-- **Player options** — your Simply Love per-profile mods (scroll speed and type,
-  mini, noteskin, note-field offsets, turn/reverse and other toggles) from
-  `Simply Love UserPrefs.ini`.
+- **Player options** — your Simply Love per-profile mods from
+  `Simply Love UserPrefs.ini`: scroll speed and type, mini, spacing, noteskin,
+  note-field offsets, visual delay, tilt, life-meter type, measure counter and
+  lines, combo mode/colors, mini-indicator, error-bar trim, data-visualization
+  mode, and the many on/off display toggles. Settings DeadSync doesn't recognise
+  are left at their default rather than guessed.
 - **Offline scores** — every high score in `Stats.xml` becomes a DeadSync local
   play, matched to the chart in your library.
 

--- a/docs/migrating-from-itgmania.md
+++ b/docs/migrating-from-itgmania.md
@@ -1,9 +1,13 @@
 # Migrating from ITGmania to DeadSync
 
-There is no automatic ITGmania → DeadSync profile import. The two games use
-different on-disk formats, and DeadSync does not read ITGmania's `Stats.xml`.
-This guide explains what carries over by hand, what doesn't, and exactly which
-files to copy or edit.
+DeadSync can **automatically import** an ITGmania + Simply Love local profile —
+including your player options and offline scores — from inside the game. This is
+the recommended path; see [Automatic import](#automatic-import-recommended)
+below.
+
+If you'd rather move individual pieces by hand (or the automatic importer can't
+find your ITGmania install), the rest of this guide explains what carries over
+manually, what doesn't, and exactly which files to copy or edit.
 
 Throughout this doc:
 
@@ -40,7 +44,65 @@ Throughout this doc:
 You can jump straight to DeadSync's profile root from inside the game via
 **Options → Folders → Profiles → Open**.
 
-## What you can actually migrate
+## Automatic import (recommended)
+
+DeadSync can read an ITGmania `LocalProfiles/<id>/` folder and create a brand
+new DeadSync profile from it in one step.
+
+1. In DeadSync, go to **Options → Manage Local Profiles**.
+2. Select **Import from ITGmania** and press **Start**.
+3. DeadSync scans for ITGmania profiles and lists the ones it finds. Pick the
+   profile you want and press **Start**.
+4. The import runs in the background; when it finishes, a summary shows how many
+   scores were imported and how many were skipped. The new profile is selected
+   in the list.
+
+### What it brings across
+
+- **Profile** — display name, weight, birth year, player initials, and your
+  avatar (`Avatar.png`).
+- **Online keys** — GrooveStats (API key, username, pad-player flag) and
+  ArrowCloud, written into the new profile's `groovestats.ini` /
+  `arrowcloud.ini`. Your online history can then be pulled via
+  **Options → Online Scoring → Score Import**.
+- **Player options** — your Simply Love per-profile mods (scroll speed and type,
+  mini, noteskin, note-field offsets, turn/reverse and other toggles) from
+  `Simply Love UserPrefs.ini`.
+- **Offline scores** — every high score in `Stats.xml` becomes a DeadSync local
+  play, matched to the chart in your library.
+
+### Where it looks
+
+The importer auto-detects ITGmania's per-user save directory:
+
+| OS      | Scanned location                                              |
+| ------- | ------------------------------------------------------------ |
+| Windows | `%APPDATA%\ITGmania\Save\LocalProfiles\`                      |
+| Linux   | `~/.itgmania/Save/LocalProfiles/`                            |
+| macOS   | `~/Library/Application Support/ITGmania/Save/LocalProfiles/`  |
+
+If your ITGmania uses a portable/custom save location that isn't found, fall
+back to the manual steps below (the importer always creates a *new* profile and
+never merges, so a manual top-up afterwards is safe).
+
+### Limitations
+
+- **Scores only attach to charts that exist in DeadSync's library.** ITGmania's
+  `Stats.xml` keys a chart by its song folder + steps type + difficulty, not by
+  hash, so DeadSync looks the chart up in your scanned songs to recover the
+  GrooveStats hash. Scan your packs *before* importing, and add your ITGmania
+  `Songs` folder (see [Songs folder](#7-songs-folder)) so more scores match.
+  Charts that aren't found are counted as skipped in the summary, not imported.
+- **EX / Hard-EX scores can't be recovered.** ITGmania doesn't store the FA+
+  (W0) split, so imported plays show the ITG percent and grade but start with an
+  EX score of 0.
+- **Holds and rolls aren't distinguished** in `Stats.xml`; all hold-type
+  judgments are folded together, and mine tallies are partial.
+
+## Manual migration
+
+If you prefer to move pieces by hand, the sections below cover each item
+individually.
 
 ### 1. Create a fresh DeadSync profile
 
@@ -136,8 +198,11 @@ Three ways to populate it:
   dropping the API key into the matching `.ini` (above) reconnects you to your
   existing online account. After that, **Options → Online Scoring →
   Score Import** can download your history.
-- **Offline scores** from ITGmania's `Stats.xml` have **no migration path**.
-  DeadSync does not read `Stats.xml`. Those scores stay in ITGmania.
+- **Offline scores** from ITGmania's `Stats.xml` are brought across by the
+  [automatic importer](#automatic-import-recommended) — there's no manual
+  equivalent, because each play has to be matched to a chart in your library to
+  recover its hash. If you migrate by hand, run the importer afterwards to pull
+  in your offline history (remember it creates a separate new profile).
 
 ### 7. Songs folder
 
@@ -166,6 +231,19 @@ Save and relaunch. DeadSync will scan those roots in addition to its default
 `songs/` folder.
 
 ## Quick checklist
+
+**Fastest path**
+
+- [ ] Scan your packs first — add your ITGmania `Songs` folder via
+      `AdditionalSongFoldersReadOnly` in `deadsync.ini`, or move packs into
+      `<data dir>/songs/`, so imported scores match.
+- [ ] **Options → Manage Local Profiles → Import from ITGmania**, pick your
+      profile, and let it copy the profile, options, avatar, online keys and
+      offline scores.
+- [ ] Run **Options → Online Scoring → Score Import** to pull down your online
+      history.
+
+**Manual path (if the importer can't find your install)**
 
 - [ ] Create a profile via **Options → Manage Local Profiles → Create**.
 - [ ] Drop ITGmania's `Avatar.png` into the new profile folder (rename to

--- a/docs/migrating-from-itgmania.md
+++ b/docs/migrating-from-itgmania.md
@@ -108,6 +108,10 @@ Rate-modded plays keep their music rate (DeadSync reads the `xMusic` modifier
 from each score), and your judgment counts, grade, combo lamp, and play date all
 carry across.
 
+For the exact field-by-field mapping (every Simply Love setting and `Stats.xml`
+element and where it lands in DeadSync), see
+[itgmania-import-mapping.md](./itgmania-import-mapping.md).
+
 ## Manual migration
 
 If you prefer to move pieces by hand, the sections below cover each item

--- a/docs/migrating-from-itgmania.md
+++ b/docs/migrating-from-itgmania.md
@@ -77,6 +77,8 @@ new DeadSync profile from it in one step.
   play, matched to the chart in your library.
 - **Favorites** — your favorited songs from `favorites.txt` (those present in
   your DeadSync library). Custom favorites-section names aren't carried over.
+- **ITL event progress** — your `ITL2026.json` (ITL Online scores, points, and
+  unlocked folders), which DeadSync reads in the same format.
 
 ### Where it looks
 

--- a/src/game/import/detect.rs
+++ b/src/game/import/detect.rs
@@ -18,6 +18,9 @@ pub struct ItgProfileCandidate {
     pub dir: PathBuf,
     /// `DisplayName` from `Editable.ini`, falling back to the folder name.
     pub display_name: String,
+    /// ITGmania `Stats.xml` `Guid`, when present. Used to detect a profile that
+    /// has already been imported. `None` when the profile has no `Stats.xml`.
+    pub source_guid: Option<String>,
 }
 
 /// Scans the known ITGmania save locations and returns every local profile
@@ -55,7 +58,12 @@ fn collect_from_root(root: &Path, out: &mut Vec<ItgProfileCandidate>, seen: &mut
                 .map(|s| s.to_string_lossy().into_owned())
                 .unwrap_or_default()
         });
-        out.push(ItgProfileCandidate { dir, display_name });
+        let source_guid = itg::read_source_guid(&dir);
+        out.push(ItgProfileCandidate {
+            dir,
+            display_name,
+            source_guid,
+        });
     }
 }
 

--- a/src/game/import/detect.rs
+++ b/src/game/import/detect.rs
@@ -1,0 +1,92 @@
+//! Auto-discovery of ITGmania local profiles.
+//!
+//! ITGmania stores per-machine save data in a platform-specific directory, with
+//! local profiles under `<Save>/LocalProfiles/<id>/`. This module scans the
+//! likely save roots and returns every directory that looks like an ITGmania
+//! profile so the import UI can present a picker without asking the user to
+//! browse the filesystem manually.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use super::itg;
+
+/// One ITGmania local profile found on disk.
+#[derive(Debug, Clone)]
+pub struct ItgProfileCandidate {
+    /// Absolute path to the `LocalProfiles/<id>/` directory.
+    pub dir: PathBuf,
+    /// `DisplayName` from `Editable.ini`, falling back to the folder name.
+    pub display_name: String,
+}
+
+/// Scans the known ITGmania save locations and returns every local profile
+/// found, sorted by display name. Returns an empty list when ITGmania isn't
+/// installed or has no profiles.
+pub fn detect_itg_local_profiles() -> Vec<ItgProfileCandidate> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for root in local_profiles_roots() {
+        collect_from_root(&root, &mut out, &mut seen);
+    }
+    out.sort_by(|a, b| {
+        a.display_name
+            .to_lowercase()
+            .cmp(&b.display_name.to_lowercase())
+    });
+    out
+}
+
+fn collect_from_root(root: &Path, out: &mut Vec<ItgProfileCandidate>, seen: &mut HashSet<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        if !dir.is_dir() || !itg::is_itg_profile_dir(&dir) {
+            continue;
+        }
+        let key = std::fs::canonicalize(&dir).unwrap_or_else(|_| dir.clone());
+        if !seen.insert(key) {
+            continue;
+        }
+        let display_name = itg::read_display_name(&dir).unwrap_or_else(|| {
+            dir.file_name()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        });
+        out.push(ItgProfileCandidate { dir, display_name });
+    }
+}
+
+/// Candidate `LocalProfiles` directories across platforms. Most won't exist on
+/// any given machine; non-existent roots are silently skipped during scanning.
+fn local_profiles_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+
+    // Windows: %APPDATA%\ITGmania\Save\LocalProfiles
+    if let Some(appdata) = std::env::var_os("APPDATA") {
+        roots.push(
+            PathBuf::from(&appdata)
+                .join("ITGmania")
+                .join("Save")
+                .join("LocalProfiles"),
+        );
+    }
+
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        // Linux: ~/.itgmania/Save/LocalProfiles
+        roots.push(home.join(".itgmania").join("Save").join("LocalProfiles"));
+        // macOS: ~/Library/Application Support/ITGmania/Save/LocalProfiles
+        roots.push(
+            home.join("Library")
+                .join("Application Support")
+                .join("ITGmania")
+                .join("Save")
+                .join("LocalProfiles"),
+        );
+    }
+
+    roots
+}

--- a/src/game/import/itg.rs
+++ b/src/game/import/itg.rs
@@ -64,6 +64,8 @@ pub struct ItgSource {
     /// Favorited song keys (`Pack/SongFolder`) from `favorites.txt`, with any
     /// Simply Love section headers stripped.
     pub favorites: Vec<String>,
+    /// Raw contents of `ITL2026.json` (Simply Love ITL event data), if present.
+    pub itl_json: Option<String>,
 }
 
 impl ItgSource {
@@ -139,6 +141,7 @@ pub fn read_profile_dir(dir: &Path) -> Result<ItgSource, ItgReadError> {
     let simply_love = read_simply_love(dir);
     let songs = read_stats(dir)?;
     let favorites = read_favorites(dir);
+    let itl_json = read_itl_json(dir);
 
     Ok(ItgSource {
         source_dir: dir.to_path_buf(),
@@ -148,6 +151,7 @@ pub fn read_profile_dir(dir: &Path) -> Result<ItgSource, ItgReadError> {
         simply_love,
         songs,
         favorites,
+        itl_json,
     })
 }
 
@@ -250,6 +254,15 @@ fn read_favorites(dir: &Path) -> Vec<String> {
         Ok(text) => parse_favorites_text(&text),
         Err(_) => Vec::new(),
     }
+}
+
+/// Reads the raw `ITL2026.json` (Simply Love ITL event data) from a profile
+/// directory, if present. The contents are parsed downstream by DeadSync's ITL
+/// module, which uses the same schema. Returns `None` when the file is missing
+/// or unreadable.
+fn read_itl_json(dir: &Path) -> Option<String> {
+    let path = find_case_insensitive(dir, "ITL2026.json")?;
+    fs::read_to_string(&path).ok()
 }
 
 /// Finds an avatar image in the profile dir. ITGmania uses `Avatar.png`; some

--- a/src/game/import/itg.rs
+++ b/src/game/import/itg.rs
@@ -61,6 +61,9 @@ pub struct ItgSource {
     /// Raw `[Simply Love]` settings from `Simply Love UserPrefs.ini`, if present.
     pub simply_love: HashMap<String, String>,
     pub songs: Vec<ItgSongScores>,
+    /// Favorited song keys (`Pack/SongFolder`) from `favorites.txt`, with any
+    /// Simply Love section headers stripped.
+    pub favorites: Vec<String>,
 }
 
 impl ItgSource {
@@ -135,6 +138,7 @@ pub fn read_profile_dir(dir: &Path) -> Result<ItgSource, ItgReadError> {
     let avatar_path = find_avatar(dir);
     let simply_love = read_simply_love(dir);
     let songs = read_stats(dir)?;
+    let favorites = read_favorites(dir);
 
     Ok(ItgSource {
         source_dir: dir.to_path_buf(),
@@ -143,6 +147,7 @@ pub fn read_profile_dir(dir: &Path) -> Result<ItgSource, ItgReadError> {
         avatar_path,
         simply_love,
         songs,
+        favorites,
     })
 }
 
@@ -214,6 +219,37 @@ fn read_simply_love(dir: &Path) -> HashMap<String, String> {
         }
     }
     HashMap::new()
+}
+
+/// Parses Simply Love `favorites.txt` content into a list of `Pack/SongFolder`
+/// song keys. Section header lines (which begin with `---`, e.g.
+/// `---My Stamina Playlist`) and blank lines are skipped; remaining lines are
+/// the favorited song paths. Order is preserved and duplicates are removed.
+pub fn parse_favorites_text(text: &str) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with("---") {
+            continue;
+        }
+        if seen.insert(trimmed.to_ascii_lowercase()) {
+            out.push(trimmed.to_string());
+        }
+    }
+    out
+}
+
+/// Reads `favorites.txt` from a profile directory. Returns an empty list when
+/// the file is missing (a profile that never favorited anything).
+fn read_favorites(dir: &Path) -> Vec<String> {
+    let Some(path) = find_case_insensitive(dir, "favorites.txt") else {
+        return Vec::new();
+    };
+    match fs::read_to_string(&path) {
+        Ok(text) => parse_favorites_text(&text),
+        Err(_) => Vec::new(),
+    }
 }
 
 /// Finds an avatar image in the profile dir. ITGmania uses `Avatar.png`; some
@@ -453,5 +489,19 @@ mod tests {
         assert_eq!(entry.judgment_counts, [480, 12, 0, 0, 0, 0]);
         assert_eq!(entry.holds_total, 20);
         assert_eq!(entry.mines_avoided, 4);
+    }
+
+    #[test]
+    fn parses_favorites_skipping_headers_and_dupes() {
+        let text = "---My Stamina Playlist\nPack A/Song One\n\nPack B/Song Two\n---Another Section\nPack A/Song One\n  Pack C/Song Three  \n";
+        let favs = parse_favorites_text(text);
+        assert_eq!(
+            favs,
+            vec![
+                "Pack A/Song One".to_string(),
+                "Pack B/Song Two".to_string(),
+                "Pack C/Song Three".to_string(),
+            ]
+        );
     }
 }

--- a/src/game/import/itg.rs
+++ b/src/game/import/itg.rs
@@ -111,6 +111,20 @@ pub fn is_itg_profile_dir(dir: &Path) -> bool {
     find_case_insensitive(dir, "Editable.ini").is_some()
 }
 
+/// Cheaply reads just the `DisplayName` from a profile's `Editable.ini`,
+/// without parsing the (potentially large) `Stats.xml`. Used to label profiles
+/// in the import picker. Returns `None` when the file is missing or the name is
+/// blank.
+pub fn read_display_name(dir: &Path) -> Option<String> {
+    let path = find_case_insensitive(dir, "Editable.ini")?;
+    let name = read_editable(&path).display_name;
+    if name.trim().is_empty() {
+        None
+    } else {
+        Some(name)
+    }
+}
+
 /// Reads an entire ITGmania local profile directory into an [`ItgSource`].
 pub fn read_profile_dir(dir: &Path) -> Result<ItgSource, ItgReadError> {
     let editable_path = find_case_insensitive(dir, "Editable.ini")

--- a/src/game/import/itg.rs
+++ b/src/game/import/itg.rs
@@ -22,6 +22,8 @@ pub struct ItgEditable {
     pub weight_pounds: u32,
     pub birth_year: u32,
     pub last_used_high_score_name: String,
+    /// `IgnoreStepCountCalories` — disables step-count calorie estimation.
+    pub ignore_step_count_calories: bool,
 }
 
 /// GrooveStats + ArrowCloud online keys.
@@ -66,6 +68,14 @@ pub struct ItgSource {
     pub favorites: Vec<String>,
     /// Raw contents of `ITL2026.json` (Simply Love ITL event data), if present.
     pub itl_json: Option<String>,
+    /// `Stats.xml` `GeneralData/CurrentCombo` — the running combo carried between
+    /// songs. `0` when absent.
+    pub current_combo: u32,
+    /// `Stats.xml` `GeneralData/Guid` — ITGmania's stable per-profile identifier.
+    /// Used to derive the imported DeadSync profile's GUID so re-importing the
+    /// same profile yields the same identity. Empty when the `Stats.xml` is
+    /// missing or has no `Guid`.
+    pub guid: String,
 }
 
 impl ItgSource {
@@ -139,7 +149,7 @@ pub fn read_profile_dir(dir: &Path) -> Result<ItgSource, ItgReadError> {
     let online = read_online_keys(dir);
     let avatar_path = find_avatar(dir);
     let simply_love = read_simply_love(dir);
-    let songs = read_stats(dir)?;
+    let stats = read_stats(dir)?;
     let favorites = read_favorites(dir);
     let itl_json = read_itl_json(dir);
 
@@ -149,9 +159,11 @@ pub fn read_profile_dir(dir: &Path) -> Result<ItgSource, ItgReadError> {
         online,
         avatar_path,
         simply_love,
-        songs,
+        songs: stats.songs,
         favorites,
         itl_json,
+        current_combo: stats.current_combo,
+        guid: stats.guid,
     })
 }
 
@@ -170,6 +182,9 @@ fn read_editable(path: &Path) -> ItgEditable {
             .and_then(|s| s.parse::<u32>().ok())
             .unwrap_or(0),
         last_used_high_score_name: get("LastUsedHighScoreName").unwrap_or_default(),
+        ignore_step_count_calories: get("IgnoreStepCountCalories")
+            .map(|s| parse_bool(&s))
+            .unwrap_or(false),
     }
 }
 
@@ -277,19 +292,51 @@ fn find_avatar(dir: &Path) -> Option<PathBuf> {
     None
 }
 
-/// Reads `Stats.xml` (or `Stats.xml.gz`) and returns the parsed song scores.
-/// A missing Stats file is not an error — it yields an empty list.
-fn read_stats(dir: &Path) -> Result<Vec<ItgSongScores>, ItgReadError> {
+/// Parsed contents of `Stats.xml` beyond the per-chart song scores.
+#[derive(Debug, Clone, Default)]
+pub struct ItgStatsData {
+    pub songs: Vec<ItgSongScores>,
+    /// `GeneralData/CurrentCombo`.
+    pub current_combo: u32,
+    /// `GeneralData/Guid` — empty when absent.
+    pub guid: String,
+}
+
+/// Reads `Stats.xml` (or `Stats.xml.gz`) and returns the parsed song scores plus
+/// selected `GeneralData`. A missing Stats file is not an error — it yields an
+/// empty result.
+fn read_stats(dir: &Path) -> Result<ItgStatsData, ItgReadError> {
     let content = if let Some(path) = find_case_insensitive(dir, "Stats.xml") {
         fs::read_to_string(&path)?
     } else if let Some(path) = find_case_insensitive(dir, "Stats.xml.gz") {
         read_gz_to_string(&path)?
     } else {
-        return Ok(Vec::new());
+        return Ok(ItgStatsData::default());
     };
 
     let root = xml::parse(&content).map_err(ItgReadError::Xml)?;
-    Ok(parse_song_scores(&root))
+    let (current_combo, guid) = parse_general_data(&root);
+    Ok(ItgStatsData {
+        songs: parse_song_scores(&root),
+        current_combo,
+        guid,
+    })
+}
+
+/// Extracts `(CurrentCombo, Guid)` from a parsed `Stats.xml` root's
+/// `GeneralData`. Returns `(0, "")` when the node is absent.
+fn parse_general_data(root: &XmlNode) -> (u32, String) {
+    let general = if root.tag == "GeneralData" {
+        root
+    } else {
+        match root.child("GeneralData") {
+            Some(g) => g,
+            None => return (0, String::new()),
+        }
+    };
+    let combo = general.child_parse::<u32>("CurrentCombo").unwrap_or(0);
+    let guid = general.child_text("Guid").trim().to_string();
+    (combo, guid)
 }
 
 fn read_gz_to_string(path: &Path) -> Result<String, std::io::Error> {
@@ -516,5 +563,26 @@ mod tests {
                 "Pack C/Song Three".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn parses_general_data_current_combo() {
+        let xml_text = r#"<Stats>
+  <GeneralData>
+    <DisplayName>Test</DisplayName>
+    <CurrentCombo>137</CurrentCombo>
+    <Guid>99f55b745304ebcf</Guid>
+  </GeneralData>
+  <SongScores></SongScores>
+</Stats>"#;
+        let root = xml::parse(xml_text).expect("xml");
+        assert_eq!(
+            parse_general_data(&root),
+            (137, "99f55b745304ebcf".to_string())
+        );
+
+        // Absent GeneralData / CurrentCombo / Guid → (0, "").
+        let root2 = xml::parse(SAMPLE_STATS).expect("xml");
+        assert_eq!(parse_general_data(&root2), (0, String::new()));
     }
 }

--- a/src/game/import/itg.rs
+++ b/src/game/import/itg.rs
@@ -327,6 +327,7 @@ fn parse_high_score(node: &XmlNode) -> ImportedHighScore {
         let_go: hold_count("LetGo"),
         missed_hold: hold_count("MissedHold"),
         survive_seconds: node.child_parse::<f32>("SurviveSeconds").unwrap_or(0.0),
+        modifiers: node.child_text("Modifiers").to_string(),
     }
 }
 

--- a/src/game/import/itg.rs
+++ b/src/game/import/itg.rs
@@ -140,6 +140,55 @@ pub fn read_display_name(dir: &Path) -> Option<String> {
     }
 }
 
+/// Cheaply reads the ITGmania profile `Guid` from `Stats.xml` (or `Stats.xml.gz`)
+/// without a full XML parse. The `Guid` lives in `GeneralData` at the very top of
+/// the file, so we only scan the head (bounded) instead of the whole — possibly
+/// many-megabyte — score database. Used by the import picker to flag profiles
+/// that have already been imported. Returns `None` when absent or unreadable.
+pub fn read_source_guid(dir: &Path) -> Option<String> {
+    // GeneralData (and thus Guid) sits before SongScores, well within this cap.
+    const HEAD_CAP: u64 = 256 * 1024;
+    let head = if let Some(path) = find_case_insensitive(dir, "Stats.xml") {
+        read_head(&path, HEAD_CAP)?
+    } else if let Some(path) = find_case_insensitive(dir, "Stats.xml.gz") {
+        read_gz_head(&path, HEAD_CAP)?
+    } else {
+        return None;
+    };
+    extract_guid(&head)
+}
+
+/// Extracts the text inside the first `<Guid>…</Guid>` element. Returns `None`
+/// when the element is absent or empty.
+fn extract_guid(s: &str) -> Option<String> {
+    let start = s.find("<Guid>")? + "<Guid>".len();
+    let rest = &s[start..];
+    let end = rest.find("</Guid>")?;
+    let guid = rest[..end].trim();
+    if guid.is_empty() {
+        None
+    } else {
+        Some(guid.to_string())
+    }
+}
+
+/// Reads up to `cap` bytes from the head of `path` as lossy UTF-8.
+fn read_head(path: &Path, cap: u64) -> Option<String> {
+    let file = fs::File::open(path).ok()?;
+    let mut buf = Vec::new();
+    file.take(cap).read_to_end(&mut buf).ok()?;
+    Some(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Decompresses up to `cap` bytes from the head of a gzip file as lossy UTF-8.
+fn read_gz_head(path: &Path, cap: u64) -> Option<String> {
+    let bytes = fs::read(path).ok()?;
+    let decoder = flate2::read::GzDecoder::new(&bytes[..]);
+    let mut buf = Vec::new();
+    decoder.take(cap).read_to_end(&mut buf).ok()?;
+    Some(String::from_utf8_lossy(&buf).into_owned())
+}
+
 /// Reads an entire ITGmania local profile directory into an [`ItgSource`].
 pub fn read_profile_dir(dir: &Path) -> Result<ItgSource, ItgReadError> {
     let editable_path = find_case_insensitive(dir, "Editable.ini")
@@ -584,5 +633,19 @@ mod tests {
         // Absent GeneralData / CurrentCombo / Guid → (0, "").
         let root2 = xml::parse(SAMPLE_STATS).expect("xml");
         assert_eq!(parse_general_data(&root2), (0, String::new()));
+    }
+
+    #[test]
+    fn extracts_guid_from_stats_head() {
+        let head = r#"<Stats><GeneralData>
+            <DisplayName>adstep</DisplayName>
+            <Guid>99f55b745304ebcf</Guid>
+            <CurrentCombo>3</CurrentCombo>
+        </GeneralData>"#;
+        assert_eq!(extract_guid(head).as_deref(), Some("99f55b745304ebcf"));
+        // Missing or empty Guid → None.
+        assert_eq!(extract_guid("<GeneralData></GeneralData>"), None);
+        assert_eq!(extract_guid("<Guid></Guid>"), None);
+        assert_eq!(extract_guid("<Guid>   </Guid>"), None);
     }
 }

--- a/src/game/import/mod.rs
+++ b/src/game/import/mod.rs
@@ -7,7 +7,9 @@
 //! Submodules:
 //! * [`xml`] — a tiny dependency-free XML reader for `Stats.xml`.
 //! * [`itg`] — readers that turn the ITGmania files into plain structs.
+//! * [`detect`] — auto-discovery of ITGmania local profiles on disk.
 
+pub mod detect;
 pub mod itg;
 pub mod options;
 pub mod resolver;

--- a/src/game/import/mod.rs
+++ b/src/game/import/mod.rs
@@ -15,3 +15,6 @@ pub mod options;
 pub mod resolver;
 pub mod run;
 pub mod xml;
+
+#[cfg(test)]
+mod pipeline_tests;

--- a/src/game/import/options.rs
+++ b/src/game/import/options.rs
@@ -13,6 +13,9 @@
 //! * `SpeedModType` + `SpeedMod` -> [`ScrollSpeedSetting`]
 //! * `Mini` -> `mini_percent`, `Spacing` -> `spacing_percent`
 //! * `NoteSkin` -> `noteskin`
+//! * `JudgmentGraphic` / `HeldGraphic` / `HoldJudgment` -> the matching graphic
+//!   (stock graphics only; custom theme graphics fall back to the default) and
+//!   `ComboFont` -> `combo_font`
 //! * `NoteFieldOffsetX` / `NoteFieldOffsetY` -> note-field offsets
 //! * `VisualDelay` -> `visual_delay_ms`
 //! * `TiltMultiplier`, `MeasureCounterLookahead`
@@ -32,10 +35,10 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use deadsync_profile::{
-    BackgroundFilter, ColumnFlashMask, ComboColors, ComboMode, ErrorBarMask, ErrorBarTrim,
-    LifeMeterType, MeasureCounter, MeasureLines, MiniIndicator, NoteSkin, PlayerOptionsData,
-    ScrollOption, StepStatisticsMask, TurnOption, error_bar_style_from_mask,
-    error_bar_text_from_mask,
+    BackgroundFilter, ColumnFlashMask, ComboColors, ComboFont, ComboMode, ErrorBarMask,
+    ErrorBarTrim, HeldMissGraphic, HoldJudgmentGraphic, JudgmentGraphic, LifeMeterType,
+    MeasureCounter, MeasureLines, MiniIndicator, NoteSkin, PlayerOptionsData, ScrollOption,
+    StepStatisticsMask, TurnOption, error_bar_style_from_mask, error_bar_text_from_mask,
 };
 use deadsync_rules::scroll::ScrollSpeedSetting;
 
@@ -163,6 +166,23 @@ pub fn translate_player_options(map: &SlSettings, base: &PlayerOptionsData) -> P
     }
     if let Some(skin) = sl_str(map, "NoteSkin") {
         out.noteskin = NoteSkin::new(skin);
+    }
+    // Theme graphic / font names. These resolve only to graphics DeadSync ships
+    // (via the stock-only parse); a Simply Love profile referencing a custom
+    // theme graphic is left at the default rather than pointing at a missing
+    // texture. Simply Love stores the full sprite filename for the three
+    // graphics and the font directory name for ComboFont.
+    if let Some(g) = sl_str(map, "JudgmentGraphic").and_then(JudgmentGraphic::from_stock_name) {
+        out.judgment_graphic = g;
+    }
+    if let Some(g) = sl_str(map, "HeldGraphic").and_then(HeldMissGraphic::from_stock_name) {
+        out.held_miss_graphic = g;
+    }
+    if let Some(g) = sl_str(map, "HoldJudgment").and_then(HoldJudgmentGraphic::from_stock_name) {
+        out.hold_judgment_graphic = g;
+    }
+    if let Some(font) = sl_enum::<ComboFont>(map, "ComboFont") {
+        out.combo_font = font;
     }
     if let Some(x) = sl_str(map, "NoteFieldOffsetX").and_then(leading_i32) {
         out.note_field_offset_x = x;
@@ -439,6 +459,46 @@ mod tests {
             translate_player_options(&sl(&[("Spacing", "-25%"), ("VisualDelay", "12ms")]), &base);
         assert_eq!(out.spacing_percent, -25);
         assert_eq!(out.visual_delay_ms, 12);
+    }
+
+    #[test]
+    fn translates_stock_graphics_and_font() {
+        let base = PlayerOptionsData::default();
+        let out = translate_player_options(
+            &sl(&[
+                ("JudgmentGraphic", "Wendy 2x7 (doubleres).png"),
+                ("HoldJudgment", "ITG2 1x2 (doubleres).png"),
+                ("HeldGraphic", "None"),
+                ("ComboFont", "Bebas Neue"),
+            ]),
+            &base,
+        );
+        assert_eq!(
+            out.judgment_graphic.as_str(),
+            "judgements/Wendy 2x7 (doubleres).png"
+        );
+        assert_eq!(
+            out.hold_judgment_graphic.as_str(),
+            "hold_judgements/ITG2 1x2 (doubleres).png"
+        );
+        assert!(out.held_miss_graphic.is_none());
+        assert_eq!(out.combo_font, ComboFont::BebasNeue);
+    }
+
+    #[test]
+    fn ignores_unknown_custom_graphics() {
+        let mut base = PlayerOptionsData::default();
+        base.judgment_graphic = JudgmentGraphic::new("Wendy");
+        let out = translate_player_options(
+            &sl(&[
+                ("JudgmentGraphic", "MyCustomTheme 2x7 (doubleres).png"),
+                ("ComboFont", "SomeCustomFont"),
+            ]),
+            &base,
+        );
+        // Unknown graphic/font must not fabricate a path — keep the base value.
+        assert_eq!(out.judgment_graphic, base.judgment_graphic);
+        assert_eq!(out.combo_font, base.combo_font);
     }
 
     #[test]

--- a/src/game/import/options.rs
+++ b/src/game/import/options.rs
@@ -22,7 +22,8 @@
 //! * enum-valued settings whose value vocabulary matches a DeadSync `FromStr`:
 //!   `BackgroundFilter`, `ComboColors`, `ComboMode`, `LifeMeterType`,
 //!   `MeasureCounter`, `MeasureLines`, `ErrorBarTrim`, `MiniIndicator`,
-//!   `DataVisualizations` -> `step_statistics`
+//!   `StepStatsExtra`, `DataVisualizations` -> `step_statistics`,
+//!   `TargetScore` -> `target_score` (Machine/Personal best only)
 //! * `PlayerOptionsString` -> turn + scroll (reverse) modifiers
 //! * SelectMultiple flag groups: `Colorful`/`Monochrome`/`Text`/`Highlight`/
 //!   `Average` -> `error_bar_active_mask`; `Flash*` -> `column_flash_mask`
@@ -38,7 +39,8 @@ use deadsync_profile::{
     BackgroundFilter, ColumnFlashMask, ComboColors, ComboFont, ComboMode, ErrorBarMask,
     ErrorBarTrim, HeldMissGraphic, HoldJudgmentGraphic, JudgmentGraphic, LifeMeterType,
     MeasureCounter, MeasureLines, MiniIndicator, NoteSkin, PlayerOptionsData, ScrollOption,
-    StepStatisticsMask, TurnOption, error_bar_style_from_mask, error_bar_text_from_mask,
+    StepStatisticsMask, StepStatsExtra, TargetScoreSetting, TurnOption, error_bar_style_from_mask,
+    error_bar_text_from_mask,
 };
 use deadsync_rules::scroll::ScrollSpeedSetting;
 
@@ -228,6 +230,15 @@ pub fn translate_player_options(map: &SlSettings, base: &PlayerOptionsData) -> P
     }
     if let Some(v) = sl_enum::<StepStatisticsMask>(map, "DataVisualizations") {
         out.step_statistics = v;
+    }
+    if let Some(v) = sl_enum::<StepStatsExtra>(map, "StepStatsExtra") {
+        out.step_stats_extra = v;
+    }
+    // Simply Love's `TargetScore` is one of SpecifiedValue / Machine best /
+    // Personal best / Ghost Data. Only the latter two have a DeadSync equivalent;
+    // the numeric and ghost-data variants are rejected by `FromStr` and ignored.
+    if let Some(v) = sl_enum::<TargetScoreSetting>(map, "TargetScore") {
+        out.target_score = v;
     }
 
     apply_bool_toggles(&mut out, map);
@@ -541,6 +552,36 @@ mod tests {
         );
         assert_eq!(out.combo_colors, base.combo_colors);
         assert_eq!(out.measure_counter, base.measure_counter);
+    }
+
+    #[test]
+    fn translates_step_stats_extra_and_target_score() {
+        let base = PlayerOptionsData::default();
+
+        let out = translate_player_options(
+            &sl(&[
+                ("StepStatsExtra", "ErrorStats"),
+                ("TargetScore", "Machine best"),
+            ]),
+            &base,
+        );
+        assert_eq!(out.step_stats_extra, StepStatsExtra::ErrorStats);
+        assert_eq!(out.target_score, TargetScoreSetting::MachineBest);
+
+        let pb = translate_player_options(&sl(&[("TargetScore", "Personal best")]), &base);
+        assert_eq!(pb.target_score, TargetScoreSetting::PersonalBest);
+
+        // SL's numeric / ghost-data targets have no DeadSync equivalent → default.
+        let specified = translate_player_options(
+            &sl(&[
+                ("TargetScore", "SpecifiedValue"),
+                ("TargetScoreNumber", "95"),
+            ]),
+            &base,
+        );
+        assert_eq!(specified.target_score, base.target_score);
+        let ghost = translate_player_options(&sl(&[("TargetScore", "Ghost Data")]), &base);
+        assert_eq!(ghost.target_score, base.target_score);
     }
 
     #[test]

--- a/src/game/import/options.rs
+++ b/src/game/import/options.rs
@@ -21,6 +21,8 @@
 //!   `MeasureCounter`, `MeasureLines`, `ErrorBarTrim`, `MiniIndicator`,
 //!   `DataVisualizations` -> `step_statistics`
 //! * `PlayerOptionsString` -> turn + scroll (reverse) modifiers
+//! * SelectMultiple flag groups: `Colorful`/`Monochrome`/`Text`/`Highlight`/
+//!   `Average` -> `error_bar_active_mask`; `Flash*` -> `column_flash_mask`
 //! * a set of boolean toggles whose name and meaning match 1:1
 //!
 //! Everything is pure (no disk / engine state) so it can be unit-tested with a
@@ -30,9 +32,10 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use deadsync_profile::{
-    BackgroundFilter, ComboColors, ComboMode, ErrorBarTrim, LifeMeterType, MeasureCounter,
-    MeasureLines, MiniIndicator, NoteSkin, PlayerOptionsData, ScrollOption, StepStatisticsMask,
-    TurnOption,
+    BackgroundFilter, ColumnFlashMask, ComboColors, ComboMode, ErrorBarMask, ErrorBarTrim,
+    LifeMeterType, MeasureCounter, MeasureLines, MiniIndicator, NoteSkin, PlayerOptionsData,
+    ScrollOption, StepStatisticsMask, TurnOption, error_bar_style_from_mask,
+    error_bar_text_from_mask,
 };
 use deadsync_rules::scroll::ScrollSpeedSetting;
 
@@ -208,12 +211,83 @@ pub fn translate_player_options(map: &SlSettings, base: &PlayerOptionsData) -> P
     }
 
     apply_bool_toggles(&mut out, map);
+    apply_error_bar_flags(&mut out, map);
+    apply_column_flash_flags(&mut out, map);
 
     if let Some(pos) = sl_str(map, "PlayerOptionsString") {
         apply_player_options_string(&mut out, pos);
     }
 
     out
+}
+
+/// Translate Simply Love's `JudgmentFlash` SelectMultiple booleans
+/// (`FlashMiss`/`FlashWayOff`/…/`FlashFantastic`) into a [`ColumnFlashMask`].
+/// Only applied when at least one flag is present so an absent group keeps the
+/// DeadSync default.
+fn apply_column_flash_flags(out: &mut PlayerOptionsData, map: &SlSettings) {
+    let single_bits = [
+        ("FlashMiss", ColumnFlashMask::MISS),
+        ("FlashWayOff", ColumnFlashMask::WAY_OFF),
+        ("FlashDecent", ColumnFlashMask::DECENT),
+        ("FlashGreat", ColumnFlashMask::GREAT),
+        ("FlashExcellent", ColumnFlashMask::EXCELLENT),
+    ];
+
+    let mut mask = ColumnFlashMask::empty();
+    let mut seen = false;
+    for (key, bit) in single_bits {
+        if let Some(v) = sl_bool(map, key) {
+            seen = true;
+            if v {
+                mask |= bit;
+            }
+        }
+    }
+    // Simply Love exposes a single "Fantastic" flash; DeadSync splits fantastic
+    // into blue (W0/FA+) and white (W1) columns, so enable both.
+    if let Some(v) = sl_bool(map, "FlashFantastic") {
+        seen = true;
+        if v {
+            mask |= ColumnFlashMask::BLUE_FANTASTIC | ColumnFlashMask::WHITE_FANTASTIC;
+        }
+    }
+
+    if seen {
+        out.column_flash_mask = mask;
+    }
+}
+
+/// Translate Simply Love's error-bar style SelectMultiple booleans
+/// (`Colorful`/`Monochrome`/`Text`/`Highlight`/`Average`) into the
+/// [`ErrorBarMask`], deriving the legacy `error_bar` / `error_bar_text` fields
+/// from the resulting mask (mirroring the DeadSync profile loader). Only applied
+/// when at least one flag is present.
+fn apply_error_bar_flags(out: &mut PlayerOptionsData, map: &SlSettings) {
+    let flags = [
+        ("Colorful", ErrorBarMask::COLORFUL),
+        ("Monochrome", ErrorBarMask::MONOCHROME),
+        ("Text", ErrorBarMask::TEXT),
+        ("Highlight", ErrorBarMask::HIGHLIGHT),
+        ("Average", ErrorBarMask::AVERAGE),
+    ];
+
+    let mut mask = ErrorBarMask::empty();
+    let mut seen = false;
+    for (key, bit) in flags {
+        if let Some(v) = sl_bool(map, key) {
+            seen = true;
+            if v {
+                mask |= bit;
+            }
+        }
+    }
+
+    if seen {
+        out.error_bar_active_mask = mask;
+        out.error_bar = error_bar_style_from_mask(mask);
+        out.error_bar_text = error_bar_text_from_mask(mask);
+    }
 }
 
 /// Boolean toggles whose Simply Love key and meaning match a DeadSync field 1:1.
@@ -420,6 +494,62 @@ mod tests {
         let none =
             translate_player_options(&sl(&[("DataVisualizations", "Target Score Graph")]), &base);
         assert_eq!(none.step_statistics, StepStatisticsMask::empty());
+    }
+
+    #[test]
+    fn translates_error_bar_flags() {
+        let base = PlayerOptionsData::default();
+        let out = translate_player_options(
+            &sl(&[
+                ("Colorful", "true"),
+                ("Monochrome", "false"),
+                ("Text", "true"),
+                ("Highlight", "false"),
+                ("Average", "false"),
+            ]),
+            &base,
+        );
+        assert!(
+            out.error_bar_active_mask
+                .contains(ErrorBarMask::COLORFUL | ErrorBarMask::TEXT)
+        );
+        assert!(!out.error_bar_active_mask.contains(ErrorBarMask::MONOCHROME));
+        assert_eq!(
+            out.error_bar,
+            error_bar_style_from_mask(out.error_bar_active_mask)
+        );
+        assert!(out.error_bar_text);
+    }
+
+    #[test]
+    fn translates_column_flash_flags_splitting_fantastic() {
+        let base = PlayerOptionsData::default();
+        let out = translate_player_options(
+            &sl(&[
+                ("FlashMiss", "true"),
+                ("FlashWayOff", "false"),
+                ("FlashDecent", "false"),
+                ("FlashGreat", "false"),
+                ("FlashExcellent", "true"),
+                ("FlashFantastic", "true"),
+            ]),
+            &base,
+        );
+        assert!(out.column_flash_mask.contains(ColumnFlashMask::MISS));
+        assert!(out.column_flash_mask.contains(ColumnFlashMask::EXCELLENT));
+        assert!(
+            out.column_flash_mask
+                .contains(ColumnFlashMask::BLUE_FANTASTIC | ColumnFlashMask::WHITE_FANTASTIC)
+        );
+        assert!(!out.column_flash_mask.contains(ColumnFlashMask::WAY_OFF));
+    }
+
+    #[test]
+    fn flag_groups_absent_keep_default() {
+        let base = PlayerOptionsData::default();
+        let out = translate_player_options(&sl(&[("SpeedMod", "300")]), &base);
+        assert_eq!(out.column_flash_mask, base.column_flash_mask);
+        assert_eq!(out.error_bar_active_mask, base.error_bar_active_mask);
     }
 
     #[test]

--- a/src/game/import/options.rs
+++ b/src/game/import/options.rs
@@ -11,10 +11,15 @@
 //! DeadSync default:
 //!
 //! * `SpeedModType` + `SpeedMod` -> [`ScrollSpeedSetting`]
-//! * `Mini` -> `mini_percent`
+//! * `Mini` -> `mini_percent`, `Spacing` -> `spacing_percent`
 //! * `NoteSkin` -> `noteskin`
 //! * `NoteFieldOffsetX` / `NoteFieldOffsetY` -> note-field offsets
+//! * `VisualDelay` -> `visual_delay_ms`
 //! * `TiltMultiplier`, `MeasureCounterLookahead`
+//! * enum-valued settings whose value vocabulary matches a DeadSync `FromStr`:
+//!   `BackgroundFilter`, `ComboColors`, `ComboMode`, `LifeMeterType`,
+//!   `MeasureCounter`, `MeasureLines`, `ErrorBarTrim`, `MiniIndicator`,
+//!   `DataVisualizations` -> `step_statistics`
 //! * `PlayerOptionsString` -> turn + scroll (reverse) modifiers
 //! * a set of boolean toggles whose name and meaning match 1:1
 //!
@@ -22,8 +27,13 @@
 //! plain map of strings.
 
 use std::collections::HashMap;
+use std::str::FromStr;
 
-use deadsync_profile::{NoteSkin, PlayerOptionsData, ScrollOption, TurnOption};
+use deadsync_profile::{
+    BackgroundFilter, ComboColors, ComboMode, ErrorBarTrim, LifeMeterType, MeasureCounter,
+    MeasureLines, MiniIndicator, NoteSkin, PlayerOptionsData, ScrollOption, StepStatisticsMask,
+    TurnOption,
+};
 use deadsync_rules::scroll::ScrollSpeedSetting;
 
 /// Settings read from a `[Simply Love]` INI section.
@@ -46,6 +56,14 @@ fn sl_str<'a>(map: &'a SlSettings, key: &str) -> Option<&'a str> {
 
 fn sl_f32(map: &SlSettings, key: &str) -> Option<f32> {
     sl_str(map, key)?.parse::<f32>().ok()
+}
+
+/// Parse a Simply Love value into a DeadSync enum via its [`FromStr`]. Returns
+/// `None` (leaving the caller's default in place) when the key is absent or the
+/// value isn't one DeadSync recognises — the DeadSync `FromStr` impls normalise
+/// case/punctuation and reject unknown vocabularies, so this never guesses.
+fn sl_enum<T: FromStr>(map: &SlSettings, key: &str) -> Option<T> {
+    sl_str(map, key)?.parse::<T>().ok()
 }
 
 /// Parse a signed integer out of a value that may carry trailing units, e.g.
@@ -137,6 +155,9 @@ pub fn translate_player_options(map: &SlSettings, base: &PlayerOptionsData) -> P
     if let Some(mini) = sl_str(map, "Mini").and_then(leading_i32) {
         out.mini_percent = mini;
     }
+    if let Some(spacing) = sl_str(map, "Spacing").and_then(leading_i32) {
+        out.spacing_percent = spacing;
+    }
     if let Some(skin) = sl_str(map, "NoteSkin") {
         out.noteskin = NoteSkin::new(skin);
     }
@@ -146,11 +167,44 @@ pub fn translate_player_options(map: &SlSettings, base: &PlayerOptionsData) -> P
     if let Some(y) = sl_str(map, "NoteFieldOffsetY").and_then(leading_i32) {
         out.note_field_offset_y = y;
     }
+    if let Some(delay) = sl_str(map, "VisualDelay").and_then(leading_i32) {
+        out.visual_delay_ms = delay;
+    }
     if let Some(mult) = sl_f32(map, "TiltMultiplier") {
         out.tilt_multiplier = mult;
     }
     if let Some(look) = sl_str(map, "MeasureCounterLookahead").and_then(leading_i32) {
         out.measure_counter_lookahead = look.clamp(0, i32::from(u8::MAX)) as u8;
+    }
+
+    // Enum-valued settings whose Simply Love vocabulary matches DeadSync's
+    // `FromStr`. Unknown values are ignored (default preserved).
+    if let Some(v) = sl_enum::<BackgroundFilter>(map, "BackgroundFilter") {
+        out.background_filter = v;
+    }
+    if let Some(v) = sl_enum::<ComboColors>(map, "ComboColors") {
+        out.combo_colors = v;
+    }
+    if let Some(v) = sl_enum::<ComboMode>(map, "ComboMode") {
+        out.combo_mode = v;
+    }
+    if let Some(v) = sl_enum::<LifeMeterType>(map, "LifeMeterType") {
+        out.lifemeter_type = v;
+    }
+    if let Some(v) = sl_enum::<MeasureCounter>(map, "MeasureCounter") {
+        out.measure_counter = v;
+    }
+    if let Some(v) = sl_enum::<MeasureLines>(map, "MeasureLines") {
+        out.measure_lines = v;
+    }
+    if let Some(v) = sl_enum::<ErrorBarTrim>(map, "ErrorBarTrim") {
+        out.error_bar_trim = v;
+    }
+    if let Some(v) = sl_enum::<MiniIndicator>(map, "MiniIndicator") {
+        out.mini_indicator = v;
+    }
+    if let Some(v) = sl_enum::<StepStatisticsMask>(map, "DataVisualizations") {
+        out.step_statistics = v;
     }
 
     apply_bool_toggles(&mut out, map);
@@ -191,6 +245,7 @@ fn apply_bool_toggles(out: &mut PlayerOptionsData, map: &SlSettings) {
     set_bool!("SubtractiveScoring" => subtractive_scoring);
     set_bool!("Pacemaker" => pacemaker);
     set_bool!("TrackEarlyJudgments" => track_early_judgments);
+    set_bool!("ScaleGraph" => scale_scatterplot);
     set_bool!("NPSGraphAtTop" => nps_graph_at_top);
     set_bool!("JudgmentTilt" => judgment_tilt);
     set_bool!("ColumnCues" => column_cues);
@@ -301,6 +356,70 @@ mod tests {
         assert_eq!(out.turn_option, TurnOption::Mirror);
         assert!(out.reverse_scroll);
         assert!(out.scroll_option.contains(ScrollOption::Reverse));
+    }
+
+    #[test]
+    fn parses_spacing_and_visual_delay() {
+        let base = PlayerOptionsData::default();
+        let out =
+            translate_player_options(&sl(&[("Spacing", "-25%"), ("VisualDelay", "12ms")]), &base);
+        assert_eq!(out.spacing_percent, -25);
+        assert_eq!(out.visual_delay_ms, 12);
+    }
+
+    #[test]
+    fn translates_enum_settings() {
+        let base = PlayerOptionsData::default();
+        let out = translate_player_options(
+            &sl(&[
+                ("BackgroundFilter", "50"),
+                ("ComboColors", "RainbowScroll"),
+                ("ComboMode", "CurrentCombo"),
+                ("LifeMeterType", "Surround"),
+                ("MeasureCounter", "16th"),
+                ("MeasureLines", "Quarter"),
+                ("ErrorBarTrim", "Great"),
+                ("MiniIndicator", "Pacemaker"),
+                ("ScaleGraph", "true"),
+            ]),
+            &base,
+        );
+        assert_eq!(
+            out.background_filter,
+            BackgroundFilter::from_str("50").unwrap()
+        );
+        assert_eq!(out.combo_colors, ComboColors::RainbowScroll);
+        assert_eq!(out.combo_mode, ComboMode::CurrentCombo);
+        assert_eq!(out.lifemeter_type, LifeMeterType::Surround);
+        assert_eq!(out.measure_counter, MeasureCounter::Sixteenth);
+        assert_eq!(out.measure_lines, MeasureLines::Quarter);
+        assert_eq!(out.error_bar_trim, ErrorBarTrim::Great);
+        assert_eq!(out.mini_indicator, MiniIndicator::Pacemaker);
+        assert!(out.scale_scatterplot);
+    }
+
+    #[test]
+    fn ignores_unknown_enum_values() {
+        let base = PlayerOptionsData::default();
+        let out = translate_player_options(
+            &sl(&[("ComboColors", "NotARealValue"), ("MeasureCounter", "99th")]),
+            &base,
+        );
+        assert_eq!(out.combo_colors, base.combo_colors);
+        assert_eq!(out.measure_counter, base.measure_counter);
+    }
+
+    #[test]
+    fn translates_data_visualizations_legacy_values() {
+        let base = PlayerOptionsData::default();
+
+        let stats =
+            translate_player_options(&sl(&[("DataVisualizations", "Step Statistics")]), &base);
+        assert_eq!(stats.step_statistics, StepStatisticsMask::all_widgets());
+
+        let none =
+            translate_player_options(&sl(&[("DataVisualizations", "Target Score Graph")]), &base);
+        assert_eq!(none.step_statistics, StepStatisticsMask::empty());
     }
 
     #[test]

--- a/src/game/import/pipeline_tests.rs
+++ b/src/game/import/pipeline_tests.rs
@@ -22,6 +22,7 @@ const STATS_XML: &str = r#"<Stats>
             <Grade>Tier03</Grade>
             <PercentDP>0.9421</PercentDP>
             <DateTime>2023-04-15 21:07:33</DateTime>
+            <Modifiers>Overhead, 1.5xMusic, Reverse</Modifiers>
             <TapNoteScores>
               <W1>410</W1><W2>52</W2><W3>11</W3><W4>3</W4><W5>1</W5>
               <Miss>4</Miss><HitMine>2</HitMine><AvoidMine>7</AvoidMine>
@@ -193,6 +194,7 @@ fn imports_stats_xml_against_library_end_to_end() {
         "EX not recoverable from Stats.xml"
     );
     assert_ne!(entry.played_at_ms, 0, "DateTime parsed");
+    assert_eq!(entry.music_rate, 1.5, "music rate recovered from Modifiers");
 
     // The mapped entry must survive the on-disk bincode round-trip used by the
     // local-score writer.

--- a/src/game/import/pipeline_tests.rs
+++ b/src/game/import/pipeline_tests.rs
@@ -202,3 +202,21 @@ fn imports_stats_xml_against_library_end_to_end() {
     let decoded = decode_local_score_entry(&bytes).expect("decode");
     assert_eq!(&decoded, entry);
 }
+
+#[test]
+fn resolves_favorite_song_to_chart_hashes() {
+    let packs = library();
+    let resolver = ChartResolver::build(&packs);
+
+    // Simply Love favorites.txt stores "Pack/SongFolder" keys.
+    let song = resolver
+        .resolve_song("My Pack/Cool Song")
+        .expect("favorite song resolves");
+    let hashes: Vec<&str> = song.charts.iter().map(|c| c.short_hash.as_str()).collect();
+    assert_eq!(hashes, vec!["abc123def456"]);
+
+    assert!(
+        resolver.resolve_song("Ghost Pack/Ghost Song").is_none(),
+        "unknown favorite song does not resolve"
+    );
+}

--- a/src/game/import/pipeline_tests.rs
+++ b/src/game/import/pipeline_tests.rs
@@ -1,0 +1,202 @@
+//! End-to-end integration test for the import pipeline: a fixture `Stats.xml`
+//! string is parsed, resolved against an in-memory song library, and mapped into
+//! [`LocalScoreEntry`] records — the same sequence [`super::run`] performs, but
+//! without touching any global engine state or the filesystem.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use deadsync_chart::{ChartData, SongData, SongPack};
+use deadsync_score::{decode_local_score_entry, encode_local_score_entry, local_score_from_itg};
+
+use super::itg::parse_song_scores;
+use super::resolver::{ChartResolver, Resolution};
+use super::xml;
+
+const STATS_XML: &str = r#"<Stats>
+  <SongScores>
+    <Song Dir="Songs/My Pack/Cool Song/">
+      <Steps StepsType="dance-single" Difficulty="Hard">
+        <HighScoreList>
+          <HighScore>
+            <Grade>Tier03</Grade>
+            <PercentDP>0.9421</PercentDP>
+            <DateTime>2023-04-15 21:07:33</DateTime>
+            <TapNoteScores>
+              <W1>410</W1><W2>52</W2><W3>11</W3><W4>3</W4><W5>1</W5>
+              <Miss>4</Miss><HitMine>2</HitMine><AvoidMine>7</AvoidMine>
+            </TapNoteScores>
+            <HoldNoteScores>
+              <Held>18</Held><LetGo>2</LetGo><MissedHold>1</MissedHold>
+            </HoldNoteScores>
+          </HighScore>
+        </HighScoreList>
+      </Steps>
+    </Song>
+    <Song Dir="Songs/Missing Pack/Ghost Song/">
+      <Steps StepsType="dance-single" Difficulty="Expert">
+        <HighScoreList>
+          <HighScore>
+            <Grade>Tier01</Grade>
+            <PercentDP>0.99</PercentDP>
+            <DateTime>2023-04-16 10:00:00</DateTime>
+          </HighScore>
+        </HighScoreList>
+      </Steps>
+    </Song>
+  </SongScores>
+</Stats>"#;
+
+fn chart(difficulty: &str, hash: &str) -> ChartData {
+    ChartData {
+        chart_type: "dance-single".into(),
+        difficulty: difficulty.into(),
+        description: String::new(),
+        chart_name: String::new(),
+        meter: 10,
+        step_artist: String::new(),
+        music_path: None,
+        short_hash: hash.into(),
+        stats: Default::default(),
+        tech_counts: Default::default(),
+        mines_nonfake: 0,
+        stamina_counts: Default::default(),
+        total_streams: 0,
+        matrix_rating: 0.0,
+        max_nps: 0.0,
+        sn_detailed_breakdown: String::new(),
+        sn_partial_breakdown: String::new(),
+        sn_simple_breakdown: String::new(),
+        detailed_breakdown: String::new(),
+        partial_breakdown: String::new(),
+        simple_breakdown: String::new(),
+        total_measures: 0,
+        measure_nps_vec: Vec::new(),
+        measure_seconds_vec: Vec::new(),
+        first_second: 0.0,
+        has_note_data: true,
+        has_chart_attacks: false,
+        possible_grade_points: 0,
+        holds_total: 0,
+        rolls_total: 0,
+        mines_total: 0,
+        display_bpm: None,
+        min_bpm: 150.0,
+        max_bpm: 150.0,
+    }
+}
+
+fn song(simfile_path: &str, charts: Vec<ChartData>) -> SongData {
+    SongData {
+        simfile_path: PathBuf::from(simfile_path),
+        title: "Cool Song".into(),
+        subtitle: String::new(),
+        translit_title: String::new(),
+        translit_subtitle: String::new(),
+        artist: String::new(),
+        genre: String::new(),
+        banner_path: None,
+        background_path: None,
+        background_changes: Vec::new(),
+        background_layer2_changes: Vec::new(),
+        foreground_changes: Vec::new(),
+        background_lua_changes: Vec::new(),
+        foreground_lua_changes: Vec::new(),
+        has_lua: false,
+        cdtitle_path: None,
+        music_path: None,
+        display_bpm: String::new(),
+        offset: 0.0,
+        sample_start: None,
+        sample_length: None,
+        min_bpm: 150.0,
+        max_bpm: 150.0,
+        normalized_bpms: String::new(),
+        music_length_seconds: 0.0,
+        first_second: 0.0,
+        total_length_seconds: 0,
+        precise_last_second_seconds: 0.0,
+        charts,
+    }
+}
+
+fn library() -> Vec<SongPack> {
+    vec![SongPack {
+        group_name: "My Pack".into(),
+        name: "My Pack".into(),
+        sort_title: String::new(),
+        translit_title: String::new(),
+        series: String::new(),
+        year: 0,
+        sync_pref: deadsync_chart::SyncPref::Default,
+        directory: PathBuf::from("Songs/My Pack"),
+        banner_path: None,
+        songs: vec![Arc::new(song(
+            "Songs/My Pack/Cool Song/cool.ssc",
+            vec![chart("Hard", "abc123def456")],
+        ))],
+    }]
+}
+
+#[test]
+fn imports_stats_xml_against_library_end_to_end() {
+    let root = xml::parse(STATS_XML).expect("parse Stats.xml");
+    let songs = parse_song_scores(&root);
+    assert_eq!(songs.len(), 2, "both <Song> blocks parsed");
+
+    let packs = library();
+    let resolver = ChartResolver::build(&packs);
+
+    let mut imported: Vec<(String, deadsync_score::LocalScoreEntry)> = Vec::new();
+    let mut song_not_found = 0usize;
+    let mut chart_not_found = 0usize;
+    let mut total = 0usize;
+
+    for s in &songs {
+        for steps in &s.steps {
+            for hs in &steps.high_scores {
+                total += 1;
+                match resolver.resolve(
+                    &s.dir,
+                    &steps.steps_type,
+                    &steps.difficulty,
+                    &steps.description,
+                ) {
+                    Resolution::Found(hash) => {
+                        let entry = local_score_from_itg(hs).expect("map high score");
+                        imported.push((hash.to_string(), entry));
+                    }
+                    Resolution::SongNotFound => song_not_found += 1,
+                    Resolution::ChartNotFound => chart_not_found += 1,
+                }
+            }
+        }
+    }
+
+    assert_eq!(total, 2);
+    assert_eq!(song_not_found, 1, "Ghost Song isn't in the library");
+    assert_eq!(chart_not_found, 0);
+    assert_eq!(imported.len(), 1, "Cool Song/Hard resolved and mapped");
+
+    let (hash, entry) = &imported[0];
+    assert_eq!(hash, "abc123def456");
+    assert_eq!(entry.judgment_counts, [410, 52, 11, 3, 1, 4]);
+    // Holds fold all hold-type tallies together: 18 + 2 + 1.
+    assert_eq!(entry.holds_held, 18);
+    assert_eq!(entry.holds_total, 21);
+    // Mines: hit + avoided.
+    assert_eq!(entry.mines_avoided, 7);
+    assert_eq!(entry.mines_total, 9);
+    assert!((entry.score_percent - 0.9421).abs() < 1e-6);
+    assert_eq!(
+        entry.ex_score_percent, 0.0,
+        "EX not recoverable from Stats.xml"
+    );
+    assert_ne!(entry.played_at_ms, 0, "DateTime parsed");
+
+    // The mapped entry must survive the on-disk bincode round-trip used by the
+    // local-score writer.
+    let bytes = encode_local_score_entry(entry).expect("encode");
+    let decoded = decode_local_score_entry(&bytes).expect("decode");
+    assert_eq!(&decoded, entry);
+}

--- a/src/game/import/resolver.rs
+++ b/src/game/import/resolver.rs
@@ -50,6 +50,14 @@ impl<'a> ChartResolver<'a> {
         Self { by_song }
     }
 
+    /// Resolves an ITGmania song directory key (e.g. `"Pack/Song"` from
+    /// `favorites.txt`, or a `Stats.xml` `Dir`) to the matching library song.
+    /// Returns `None` when the song isn't in DeadSync's scanned library.
+    pub fn resolve_song(&self, song_dir: &str) -> Option<&'a SongData> {
+        let (pack, folder) = normalize_song_dir(song_dir)?;
+        self.by_song.get(&(pack, folder)).copied()
+    }
+
     /// Resolves a score key to a chart `short_hash`.
     pub fn resolve(
         &self,

--- a/src/game/import/run.rs
+++ b/src/game/import/run.rs
@@ -2,6 +2,7 @@
 //! new DeadSync local profile (metadata, online keys, avatar, Simply Love player
 //! options) plus its offline high-score history.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use deadsync_profile::{initials_from_name, sanitize_player_initials};
@@ -9,6 +10,7 @@ use deadsync_score::{LocalScoreEntry, local_score_from_itg};
 
 use crate::game::profile::{
     ImportProfileData, create_local_profile_from_import, default_local_profile_options,
+    write_imported_favorites,
 };
 use crate::game::scores::import_local_scores;
 use crate::game::song::get_song_cache;
@@ -33,6 +35,12 @@ pub struct ImportSummary {
     pub charts_chart_not_found: usize,
     /// Records whose grade/percent couldn't be mapped to a DeadSync play.
     pub scores_unmapped: usize,
+    /// Total favorited songs found in `favorites.txt`.
+    pub favorites_total: usize,
+    /// Favorited songs matched to a library song and imported.
+    pub favorites_imported: usize,
+    /// Favorited songs skipped because the song wasn't in DeadSync's library.
+    pub favorites_song_not_found: usize,
 }
 
 /// Read an ITGmania profile directory and import it into a new local profile.
@@ -89,6 +97,7 @@ pub fn import_from_source<F: FnMut(usize, usize, &str)>(
     };
 
     let mut entries: Vec<(String, LocalScoreEntry)> = Vec::new();
+    let mut favorite_hashes: HashSet<String> = HashSet::new();
     {
         let packs = get_song_cache();
         let resolver = ChartResolver::build(&packs);
@@ -116,9 +125,25 @@ pub fn import_from_source<F: FnMut(usize, usize, &str)>(
         }
         // Final tick so the bar reads 100% once every song is processed.
         on_progress(total_songs, total_songs, "");
+
+        // Favorites are per-song in Simply Love but per-chart in DeadSync, so a
+        // resolved song favorites all of its charts' hashes.
+        for fav in &source.favorites {
+            summary.favorites_total += 1;
+            match resolver.resolve_song(fav) {
+                Some(song) => {
+                    summary.favorites_imported += 1;
+                    for chart in &song.charts {
+                        favorite_hashes.insert(chart.short_hash.to_string());
+                    }
+                }
+                None => summary.favorites_song_not_found += 1,
+            }
+        }
     }
 
     summary.scores_imported = import_local_scores(&profile_id, &initials, &mut entries);
+    write_imported_favorites(&profile_id, &favorite_hashes);
     Ok(summary)
 }
 

--- a/src/game/import/run.rs
+++ b/src/game/import/run.rs
@@ -12,7 +12,7 @@ use crate::game::profile::{
     ImportProfileData, create_local_profile_from_import, default_local_profile_options,
     write_imported_favorites,
 };
-use crate::game::scores::import_local_scores;
+use crate::game::scores::{import_itl_json, import_local_scores};
 use crate::game::song::get_song_cache;
 
 use super::itg::{self, ItgReadError, ItgSource};
@@ -41,6 +41,8 @@ pub struct ImportSummary {
     pub favorites_imported: usize,
     /// Favorited songs skipped because the song wasn't in DeadSync's library.
     pub favorites_song_not_found: usize,
+    /// ITL `hashMap` entries imported from `ITL2026.json` (0 if absent).
+    pub itl_entries_imported: usize,
 }
 
 /// Read an ITGmania profile directory and import it into a new local profile.
@@ -144,6 +146,9 @@ pub fn import_from_source<F: FnMut(usize, usize, &str)>(
 
     summary.scores_imported = import_local_scores(&profile_id, &initials, &mut entries);
     write_imported_favorites(&profile_id, &favorite_hashes);
+    if let Some(itl_json) = &source.itl_json {
+        summary.itl_entries_imported = import_itl_json(&profile_id, itl_json);
+    }
     Ok(summary)
 }
 

--- a/src/game/import/run.rs
+++ b/src/game/import/run.rs
@@ -45,27 +45,68 @@ pub struct ImportSummary {
     pub favorites_song_not_found: usize,
     /// ITL `hashMap` entries imported from `ITL2026.json` (0 if absent).
     pub itl_entries_imported: usize,
+    /// Whether the source had `ITL2026.json` event data at all.
+    pub itl_present: bool,
+    /// Whether Simply Love player-options preferences were found and translated
+    /// (vs. falling back to DeadSync defaults for a profile that never ran it).
+    pub simply_love_options_imported: bool,
+    /// Whether a GrooveStats API key was carried across.
+    pub groovestats_imported: bool,
+    /// Whether an ArrowCloud API key was carried across.
+    pub arrowcloud_imported: bool,
+    /// Whether an avatar image was copied into the new profile.
+    pub avatar_imported: bool,
+    /// Whether the user canceled mid-import. When set, the partially-created
+    /// profile was deleted (clean abort) and the count fields are not meaningful.
+    pub canceled: bool,
+    /// Set to the existing profile's display name when the import was refused
+    /// because this ITGmania profile (matched by its derived GUID) was already
+    /// imported. When set, no new profile was created.
+    pub already_imported_as: Option<String>,
+}
+
+impl ImportSummary {
+    /// Whether GrooveStats and/or ArrowCloud credentials were carried across (so
+    /// the user can pull online scores via Score Import).
+    pub fn online_keys_imported(&self) -> bool {
+        self.groovestats_imported || self.arrowcloud_imported
+    }
 }
 
 /// Read an ITGmania profile directory and import it into a new local profile.
 ///
-/// `on_progress(done, total, label)` is invoked once per song as the offline
-/// scores are processed, so a caller can drive a progress bar. Pass a no-op
-/// closure when progress isn't needed.
-pub fn import_itg_profile_dir<F: FnMut(usize, usize, &str)>(
+/// `on_progress(done, total, label)` is invoked as imported scores are written to
+/// disk (the phase that dominates import time), so a caller can drive a progress
+/// bar. `label` is currently empty. Pass a no-op closure when progress isn't
+/// needed.
+///
+/// `should_cancel()` is polled before each score write; when it returns `true`
+/// the import is cleanly aborted: the partially-created profile is deleted and a
+/// summary with `canceled = true` is returned.
+pub fn import_itg_profile_dir<F, C>(
     dir: &Path,
     on_progress: F,
-) -> Result<ImportSummary, ItgReadError> {
+    should_cancel: C,
+) -> Result<ImportSummary, ItgReadError>
+where
+    F: FnMut(usize, usize, &str),
+    C: Fn() -> bool,
+{
     let source = itg::read_profile_dir(dir)?;
-    import_from_source(&source, on_progress)
+    import_from_source(&source, on_progress, should_cancel)
 }
 
 /// Import an already-read [`ItgSource`] into a new local profile. See
-/// [`import_itg_profile_dir`] for the `on_progress` contract.
-pub fn import_from_source<F: FnMut(usize, usize, &str)>(
+/// [`import_itg_profile_dir`] for the `on_progress` / `should_cancel` contract.
+pub fn import_from_source<F, C>(
     source: &ItgSource,
     mut on_progress: F,
-) -> Result<ImportSummary, ItgReadError> {
+    should_cancel: C,
+) -> Result<ImportSummary, ItgReadError>
+where
+    F: FnMut(usize, usize, &str),
+    C: Fn() -> bool,
+{
     let (base_singles, base_doubles) = default_local_profile_options();
     let options_singles = translate_player_options(&source.simply_love, &base_singles);
     let options_doubles = translate_player_options(&source.simply_love, &base_doubles);
@@ -75,6 +116,21 @@ pub fn import_from_source<F: FnMut(usize, usize, &str)>(
     // GUID (handled by `create_local_profile_from_import`) when the source has no
     // `Stats.xml`/`Guid`.
     let profile_guid = profile_guid_from_itgmania_guid(&source.guid).unwrap_or_default();
+
+    // Refuse to import a profile we've already imported: if the derived GUID
+    // already identifies a local profile, report it instead of creating a
+    // duplicate (which would corrupt GUID-keyed lookups).
+    if !profile_guid.is_empty()
+        && let Some(existing) = crate::game::profile::scan_local_profiles()
+            .into_iter()
+            .find(|p| p.id == profile_guid)
+    {
+        return Ok(ImportSummary {
+            display_name: source.editable.display_name.clone(),
+            already_imported_as: Some(existing.display_name),
+            ..Default::default()
+        });
+    }
 
     let data = ImportProfileData {
         display_name: &source.editable.display_name,
@@ -105,6 +161,11 @@ pub fn import_from_source<F: FnMut(usize, usize, &str)>(
     let mut summary = ImportSummary {
         profile_id: profile_id.clone(),
         display_name: source.editable.display_name.clone(),
+        simply_love_options_imported: !source.simply_love.is_empty(),
+        groovestats_imported: !source.online.groovestats_api_key.trim().is_empty(),
+        arrowcloud_imported: !source.online.arrowcloud_api_key.trim().is_empty(),
+        avatar_imported: source.avatar_path.is_some(),
+        itl_present: source.itl_json.is_some(),
         ..Default::default()
     };
 
@@ -113,9 +174,7 @@ pub fn import_from_source<F: FnMut(usize, usize, &str)>(
     {
         let packs = get_song_cache();
         let resolver = ChartResolver::build(&packs);
-        let total_songs = source.songs.len();
-        for (song_idx, song) in source.songs.iter().enumerate() {
-            on_progress(song_idx, total_songs, song_label(&song.dir));
+        for song in &source.songs {
             for steps in &song.steps {
                 for hs in &steps.high_scores {
                     summary.scores_total += 1;
@@ -135,8 +194,6 @@ pub fn import_from_source<F: FnMut(usize, usize, &str)>(
                 }
             }
         }
-        // Final tick so the bar reads 100% once every song is processed.
-        on_progress(total_songs, total_songs, "");
 
         // Favorites are per-song in Simply Love but per-chart in DeadSync, so a
         // resolved song favorites all of its charts' hashes.
@@ -154,41 +211,30 @@ pub fn import_from_source<F: FnMut(usize, usize, &str)>(
         }
     }
 
-    summary.scores_imported = import_local_scores(&profile_id, &initials, &mut entries);
+    // Resolution above is in-memory and quick; the disk writes below dominate the
+    // import time, so the progress bar tracks the per-score save phase and the
+    // cancel check is polled here.
+    let (written, canceled) = import_local_scores(
+        &profile_id,
+        &initials,
+        &mut entries,
+        |done, total| on_progress(done, total, ""),
+        &should_cancel,
+    );
+    if canceled {
+        // Clean abort: remove the partially-created profile so canceling leaves
+        // no trace. Best-effort — a failed delete still reports as canceled.
+        if let Err(e) = crate::game::profile::delete_local_profile(&profile_id) {
+            log::warn!("Failed to delete canceled import profile {profile_id}: {e}");
+        }
+        summary.canceled = true;
+        return Ok(summary);
+    }
+    summary.scores_imported = written;
     write_imported_favorites(&profile_id, &favorite_hashes);
     write_imported_profile_stats(&profile_id, source.current_combo);
     if let Some(itl_json) = &source.itl_json {
         summary.itl_entries_imported = import_itl_json(&profile_id, itl_json);
     }
     Ok(summary)
-}
-
-/// Derives a short, human-readable label for a song from its ITGmania `Dir`
-/// attribute (e.g. `"Songs/My Pack/Cool Song/"` → `"My Pack/Cool Song"`), for
-/// display in the import progress bar.
-fn song_label(dir: &str) -> &str {
-    let trimmed = dir.trim().trim_matches(['/', '\\']);
-    // Strip a leading song-root component so the label is pack/song.
-    let after_root = trimmed
-        .strip_prefix("Songs/")
-        .or_else(|| trimmed.strip_prefix("AdditionalSongs/"))
-        .unwrap_or(trimmed);
-    if after_root.is_empty() {
-        trimmed
-    } else {
-        after_root
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn song_label_strips_root_and_slashes() {
-        assert_eq!(song_label("Songs/My Pack/Cool Song/"), "My Pack/Cool Song");
-        assert_eq!(song_label("AdditionalSongs/Pack/Song"), "Pack/Song");
-        assert_eq!(song_label("Pack/Song/"), "Pack/Song");
-        assert_eq!(song_label(""), "");
-    }
 }

--- a/src/game/import/run.rs
+++ b/src/game/import/run.rs
@@ -5,12 +5,14 @@
 use std::collections::HashSet;
 use std::path::Path;
 
-use deadsync_profile::{initials_from_name, sanitize_player_initials};
+use deadsync_profile::{
+    initials_from_name, profile_guid_from_itgmania_guid, sanitize_player_initials,
+};
 use deadsync_score::{LocalScoreEntry, local_score_from_itg};
 
 use crate::game::profile::{
     ImportProfileData, create_local_profile_from_import, default_local_profile_options,
-    write_imported_favorites,
+    write_imported_favorites, write_imported_profile_stats,
 };
 use crate::game::scores::{import_itl_json, import_local_scores};
 use crate::game::song::get_song_cache;
@@ -68,6 +70,12 @@ pub fn import_from_source<F: FnMut(usize, usize, &str)>(
     let options_singles = translate_player_options(&source.simply_love, &base_singles);
     let options_doubles = translate_player_options(&source.simply_love, &base_doubles);
 
+    // Derive a stable DeadSync identity from the ITGmania profile GUID so
+    // re-importing the same profile maps to the same GUID. Falls back to a fresh
+    // GUID (handled by `create_local_profile_from_import`) when the source has no
+    // `Stats.xml`/`Guid`.
+    let profile_guid = profile_guid_from_itgmania_guid(&source.guid).unwrap_or_default();
+
     let data = ImportProfileData {
         display_name: &source.editable.display_name,
         weight_pounds: source.editable.weight_pounds,
@@ -77,9 +85,11 @@ pub fn import_from_source<F: FnMut(usize, usize, &str)>(
         groovestats_username: &source.online.groovestats_username,
         groovestats_is_pad_player: source.online.groovestats_is_pad_player,
         arrowcloud_api_key: &source.online.arrowcloud_api_key,
+        ignore_step_count_calories: source.editable.ignore_step_count_calories,
         avatar_src: source.avatar_path.as_deref(),
         options_singles: &options_singles,
         options_doubles: &options_doubles,
+        guid: &profile_guid,
     };
     let profile_id = create_local_profile_from_import(&data).map_err(ItgReadError::Io)?;
 
@@ -146,6 +156,7 @@ pub fn import_from_source<F: FnMut(usize, usize, &str)>(
 
     summary.scores_imported = import_local_scores(&profile_id, &initials, &mut entries);
     write_imported_favorites(&profile_id, &favorite_hashes);
+    write_imported_profile_stats(&profile_id, source.current_combo);
     if let Some(itl_json) = &source.itl_json {
         summary.itl_entries_imported = import_itl_json(&profile_id, itl_json);
     }

--- a/src/game/profile.rs
+++ b/src/game/profile.rs
@@ -1809,6 +1809,18 @@ fn save_favorites(profile_id: &str, favorites: &HashSet<String>) {
     }
 }
 
+/// Writes imported favorites (chart `short_hash`es) into a freshly-created
+/// profile's `favorites.txt`, merging with anything already present. Used by the
+/// ITGmania importer, which resolves Simply Love song favorites to chart hashes.
+pub fn write_imported_favorites(profile_id: &str, hashes: &HashSet<String>) {
+    if hashes.is_empty() {
+        return;
+    }
+    let mut merged = load_favorites(profile_id);
+    merged.extend(hashes.iter().cloned());
+    save_favorites(profile_id, &merged);
+}
+
 /// Toggle a song's favorite status for the given player side.
 /// Returns `true` if the song is now a favorite, `false` if removed.
 pub fn toggle_favorite(side: PlayerSide, chart_hash: &str) -> bool {

--- a/src/game/profile.rs
+++ b/src/game/profile.rs
@@ -910,13 +910,17 @@ fn save_profile_stats_for_side(side: PlayerSide) {
     let Some((profile_id, payload)) = maybe_payload else {
         return;
     };
-    let Some(buf) = encode_profile_stats(&payload) else {
+    write_profile_stats(&profile_id, &payload);
+}
+
+fn write_profile_stats(profile_id: &str, payload: &ProfileStats) {
+    let Some(buf) = encode_profile_stats(payload) else {
         warn!("Failed to encode profile stats for '{}'.", profile_id);
         return;
     };
 
-    let path = profile_stats_path(&profile_id);
-    let tmp_path = profile_stats_tmp_path(&profile_id);
+    let path = profile_stats_path(profile_id);
+    let tmp_path = profile_stats_tmp_path(profile_id);
     if let Some(parent) = path.parent()
         && let Err(e) = fs::create_dir_all(parent)
     {
@@ -935,6 +939,23 @@ fn save_profile_stats_for_side(side: PlayerSide) {
         warn!("Failed to save {}: {}", path.display(), e);
         let _ = fs::remove_file(&tmp_path);
     }
+}
+
+/// Writes [`ProfileStats`] for a freshly-imported profile that isn't loaded into
+/// a player side (used by the ITGmania importer). `known_pack_names` is left
+/// empty so the normal first-load reconciliation still marks the current packs
+/// as known. Does nothing when there's no stat worth persisting.
+pub fn write_imported_profile_stats(profile_id: &str, current_combo: u32) {
+    if current_combo == 0 {
+        return;
+    }
+    write_profile_stats(
+        profile_id,
+        &ProfileStats {
+            current_combo,
+            known_pack_names: HashSet::new(),
+        },
+    );
 }
 
 fn save_groovestats_ini_for_side(side: PlayerSide) {
@@ -2092,10 +2113,17 @@ pub struct ImportProfileData<'a> {
     pub groovestats_username: &'a str,
     pub groovestats_is_pad_player: bool,
     pub arrowcloud_api_key: &'a str,
+    /// Whether step-count calorie estimation is disabled (ITGmania
+    /// `IgnoreStepCountCalories`).
+    pub ignore_step_count_calories: bool,
     /// Source avatar image to copy in as `profile.png`, if any.
     pub avatar_src: Option<&'a Path>,
     pub options_singles: &'a PlayerOptionsData,
     pub options_doubles: &'a PlayerOptionsData,
+    /// Desired profile GUID (canonical identity). For ITGmania imports this is
+    /// derived deterministically from the source profile's `Guid`. When empty or
+    /// not a valid GUID, a fresh one is generated.
+    pub guid: &'a str,
 }
 
 /// Create a new local profile from imported data, writing `profile.ini`,
@@ -2113,7 +2141,11 @@ pub fn create_local_profile_from_import(
         ));
     }
 
-    let id = generate_profile_guid();
+    let id = if is_valid_profile_guid(data.guid.trim()) {
+        data.guid.trim().to_string()
+    } else {
+        generate_profile_guid()
+    };
     let folder = folder_name_for_display(name, &id, &existing_profile_folder_names());
     let dir = profile_dir_by_folder(&folder);
     fs::create_dir_all(&dir)?;
@@ -2148,7 +2180,10 @@ pub fn create_local_profile_from_import(
     content.push_str("[Editable]\n");
     content.push_str(&format!("WeightPounds={weight}\n"));
     content.push_str(&format!("BirthYear={}\n", data.birth_year));
-    content.push_str("IgnoreStepCountCalories=0\n");
+    content.push_str(&format!(
+        "IgnoreStepCountCalories={}\n",
+        i32::from(data.ignore_step_count_calories)
+    ));
     content.push('\n');
 
     let today = Local::now().date_naive().to_string();

--- a/src/game/scores.rs
+++ b/src/game/scores.rs
@@ -1296,23 +1296,41 @@ fn append_local_score_on_disk(
 }
 
 /// Write a batch of imported local scores for `profile_id`. Each tuple is the
-/// DeadSync chart `short_hash` and the play to record. Returns the number of
-/// plays successfully written to disk.
+/// DeadSync chart `short_hash` and the play to record. Returns `(written,
+/// canceled)`: the number of plays successfully written to disk, and whether the
+/// loop stopped early because `should_cancel` returned `true`.
 ///
 /// This reuses the same per-play write path as live gameplay, so the per-profile
 /// best index and any loaded in-memory caches stay correct.
-pub fn import_local_scores(
+///
+/// `on_progress(done, total)` is invoked after each play is processed (whether or
+/// not it was written), so a caller can drive a progress bar over the disk-write
+/// phase, which dominates import time for large histories. `should_cancel()` is
+/// polled before each write so a long import can be aborted promptly. Pass no-op
+/// closures when progress / cancellation aren't needed.
+pub fn import_local_scores<F, C>(
     profile_id: &str,
     profile_initials: &str,
     scores: &mut [(String, LocalScoreEntry)],
-) -> usize {
+    mut on_progress: F,
+    should_cancel: C,
+) -> (usize, bool)
+where
+    F: FnMut(usize, usize),
+    C: Fn() -> bool,
+{
+    let total = scores.len();
     let mut written = 0usize;
-    for (chart_hash, entry) in scores.iter_mut() {
+    for (idx, (chart_hash, entry)) in scores.iter_mut().enumerate() {
+        if should_cancel() {
+            return (written, true);
+        }
         if append_local_score_on_disk(profile_id, profile_initials, chart_hash, entry) {
             written += 1;
         }
+        on_progress(idx + 1, total);
     }
-    written
+    (written, false)
 }
 
 fn judgment_counts_arr(p: &gameplay::PlayerRuntime) -> [u32; 6] {

--- a/src/game/scores.rs
+++ b/src/game/scores.rs
@@ -66,9 +66,10 @@ pub use itl::{
     ensure_itl_wheel_caches_loaded, get_cached_itl_score_for_side, get_cached_itl_score_for_song,
     get_cached_itl_self_score_for_side, get_cached_itl_tournament_overall_ranks_for_side,
     get_cached_itl_tournament_rank_for_side, get_or_fetch_itl_self_score_for_side,
-    get_or_fetch_itl_tournament_rank_for_side, is_itl_song_folder_unlocked_for_side,
-    is_itl_song_folder_unlocked_with_profile, is_itl_unlocks_pack, itl_eval_state_from_gameplay,
-    itl_points_for_chart, save_itl_data_from_gameplay, seed_session_itl_unlock_folders,
+    get_or_fetch_itl_tournament_rank_for_side, import_itl_json,
+    is_itl_song_folder_unlocked_for_side, is_itl_song_folder_unlocked_with_profile,
+    is_itl_unlocks_pack, itl_eval_state_from_gameplay, itl_points_for_chart,
+    save_itl_data_from_gameplay, seed_session_itl_unlock_folders,
     seed_session_online_itl_self_rank, seed_session_online_itl_self_score,
     should_warn_cmod_for_itl_chart,
 };

--- a/src/game/scores/itl.rs
+++ b/src/game/scores/itl.rs
@@ -1152,6 +1152,38 @@ fn write_itl_file(profile_id: &str, data: &ItlFileData) {
     }
 }
 
+/// Parses an external `ITL2026.json` (e.g. from an ITGmania/Simply Love profile)
+/// into [`ItlFileData`]. Returns `None` when the text is unparseable or carries
+/// no ITL data. DeadSync's ITL file uses the same schema Simply Love writes
+/// (`pathMap` / `hashMap` / `unlockFolders`), so the data maps directly.
+fn itl_data_from_json(json_text: &str) -> Option<ItlFileData> {
+    let data: ItlFileData = match serde_json::from_str(json_text) {
+        Ok(data) => data,
+        Err(error) => {
+            warn!("Failed to parse imported ITL data: {error}");
+            return None;
+        }
+    };
+    if data.path_map.is_empty() && data.hash_map.is_empty() && data.unlock_folders.is_empty() {
+        return None;
+    }
+    Some(data)
+}
+
+/// Imports an ITGmania/Simply Love `ITL2026.json` (raw text) into a
+/// freshly-created DeadSync profile, writing it to the profile's ITL file.
+/// Returns the number of `hashMap` entries imported (`0` when the file is
+/// missing, empty, or unparseable). Song ranks are recomputed lazily the next
+/// time the profile's ITL cache is loaded.
+pub fn import_itl_json(profile_id: &str, json_text: &str) -> usize {
+    let Some(data) = itl_data_from_json(json_text) else {
+        return 0;
+    };
+    let count = data.hash_map.len();
+    write_itl_file(profile_id, &data);
+    count
+}
+
 fn update_unlock_folders(profile_id: &str, folders: &[String]) {
     if folders.is_empty() {
         return;
@@ -2161,6 +2193,29 @@ mod tests {
 
         assert_eq!(sl.hash_map["sl"].ex, 9437);
         assert_eq!(legacy.hash_map["legacy"].ex, 9437);
+    }
+
+    #[test]
+    fn itl_data_from_json_parses_and_guards() {
+        // A Simply Love ITL2026.json with pathMap, hashMap and unlockFolders.
+        let text = serde_json::to_string(&json!({
+            "pathMap": { "/Songs/ITL Online 2026/Example": "deadbeefcafebabe" },
+            "hashMap": {
+                "deadbeefcafebabe": { "ex": 94.37, "points": 4200, "clearType": 5 }
+            },
+            "unlockFolders": { "/Songs/ITL Online 2026/Example": true }
+        }))
+        .unwrap();
+        let data = itl_data_from_json(&text).expect("parses");
+        assert_eq!(data.hash_map.len(), 1);
+        assert_eq!(data.hash_map["deadbeefcafebabe"].ex, 9437);
+        assert_eq!(data.path_map.len(), 1);
+        assert!(data.unlock_folders["/Songs/ITL Online 2026/Example"]);
+
+        // Empty and malformed inputs yield None (nothing to import).
+        assert!(itl_data_from_json("{}").is_none());
+        assert!(itl_data_from_json("not json").is_none());
+        assert!(itl_data_from_json(r#"{"hashMap":{}}"#).is_none());
     }
 
     #[test]

--- a/src/screens/manage_local_profiles.rs
+++ b/src/screens/manage_local_profiles.rs
@@ -2,7 +2,10 @@ use crate::act;
 use crate::assets::AssetManager;
 use crate::assets::i18n::{tr, tr_fmt};
 use crate::assets::visual_styles;
+use crate::game::import::detect::{ItgProfileCandidate, detect_itg_local_profiles};
+use crate::game::import::run::{ImportSummary, import_itg_profile_dir};
 use crate::game::profile;
+use crate::screens::components::shared::loading_bar;
 use crate::screens::components::shared::screen_bar::{
     self, ScreenBarPosition, ScreenBarTitlePlacement,
 };
@@ -18,6 +21,8 @@ use deadsync_input::RawKeyboardEvent;
 use deadsync_input::{InputEvent, VirtualAction};
 use deadsync_profile as profile_data;
 use std::sync::Arc;
+use std::sync::mpsc::{Receiver, TryRecvError};
+use std::thread;
 use std::time::{Duration, Instant};
 use winit::keyboard::KeyCode;
 
@@ -68,6 +73,7 @@ const PROFILE_MENU_BORDER: f32 = 3.0;
 #[derive(Clone, Debug)]
 enum RowKind {
     CreateNew,
+    ImportItg,
     Profile { id: String, display_name: String },
     Exit,
 }
@@ -147,6 +153,45 @@ struct DeleteConfirmState {
     error: Option<Arc<str>>,
 }
 
+/// Modal listing ITGmania profiles found on disk, for the user to pick one to
+/// import.
+struct ImportPickerState {
+    candidates: Vec<ItgProfileCandidate>,
+    selected: usize,
+}
+
+/// A running import on a worker thread. The screen polls `rx` each frame and
+/// keeps the latest per-song progress snapshot for the progress bar.
+struct ImportJob {
+    rx: Receiver<ImportMsg>,
+    /// Latest `(done, total, song label)` reported by the worker, if any.
+    progress: Option<(usize, usize, Arc<str>)>,
+}
+
+/// Messages sent from the import worker thread to the screen.
+enum ImportMsg {
+    /// Per-song progress: `done` of `total` songs processed, current song label.
+    Progress {
+        done: usize,
+        total: usize,
+        label: String,
+    },
+    /// The import finished (success or failure).
+    Done(ImportOutcome),
+}
+
+enum ImportOutcome {
+    Ok(Box<ImportSummary>),
+    Err(String),
+}
+
+/// A simple centered message modal: an import summary, "none found", or an
+/// error. Dismissed with Start/Back.
+struct ImportMessageState {
+    title: Arc<str>,
+    lines: Vec<String>,
+}
+
 pub struct State {
     pub selected: usize,
     prev_selected: usize,
@@ -159,6 +204,9 @@ pub struct State {
     name_entry: Option<NameEntryState>,
     profile_menu: Option<ProfileMenuState>,
     delete_confirm: Option<DeleteConfirmState>,
+    import_picker: Option<ImportPickerState>,
+    import_job: Option<ImportJob>,
+    import_message: Option<ImportMessageState>,
     menu_lr_chord: screen_input::MenuLrChordTracker,
     menu_lr_undo: i8,
 }
@@ -177,6 +225,9 @@ pub fn init() -> State {
         name_entry: None,
         profile_menu: None,
         delete_confirm: None,
+        import_picker: None,
+        import_job: None,
+        import_message: None,
         menu_lr_chord: screen_input::MenuLrChordTracker::default(),
         menu_lr_undo: 0,
     }
@@ -187,6 +238,9 @@ fn build_rows() -> Vec<Row> {
     let mut out = Vec::with_capacity(profiles.len() + 2);
     out.push(Row {
         kind: RowKind::CreateNew,
+    });
+    out.push(Row {
+        kind: RowKind::ImportItg,
     });
     for p in profiles {
         out.push(Row {
@@ -313,6 +367,7 @@ fn update_name_entry_blink(state: &mut State, dt: f32) {
 pub fn update(state: &mut State, dt: f32) -> Option<ScreenAction> {
     update_hold_scroll(state);
     update_name_entry_blink(state, dt);
+    poll_import_job(state);
     None
 }
 
@@ -579,6 +634,210 @@ fn cancel_delete_confirm(state: &mut State) {
     reset_nav_hold(state);
 }
 
+/* ----------------------------- ITGmania import ---------------------------- */
+
+fn begin_import_picker(state: &mut State) {
+    reset_nav_hold(state);
+    audio::play_sfx("assets/sounds/start.ogg");
+    let candidates = detect_itg_local_profiles();
+    if candidates.is_empty() {
+        state.import_message = Some(ImportMessageState {
+            title: tr("Profiles", "ImportNoneFoundTitle"),
+            lines: vec![tr("Profiles", "ImportNoneFoundBody").to_string()],
+        });
+        return;
+    }
+    state.import_picker = Some(ImportPickerState {
+        candidates,
+        selected: 0,
+    });
+}
+
+fn cancel_import_picker(state: &mut State) {
+    state.import_picker = None;
+    reset_nav_hold(state);
+}
+
+fn move_import_picker_selected(state: &mut State, dir: NavDirection) {
+    let Some(picker) = state.import_picker.as_mut() else {
+        return;
+    };
+    let len = picker.candidates.len();
+    if len == 0 {
+        picker.selected = 0;
+        return;
+    }
+    picker.selected = match dir {
+        NavDirection::Up => {
+            if picker.selected == 0 {
+                len - 1
+            } else {
+                picker.selected - 1
+            }
+        }
+        NavDirection::Down => (picker.selected + 1) % len,
+    };
+}
+
+fn confirm_import_picker(state: &mut State) {
+    let Some(picker) = state.import_picker.take() else {
+        return;
+    };
+    let Some(candidate) = picker.candidates.get(picker.selected) else {
+        return;
+    };
+    let dir = candidate.dir.clone();
+    audio::play_sfx("assets/sounds/start.ogg");
+    reset_nav_hold(state);
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let progress_tx = tx.clone();
+    thread::spawn(move || {
+        let result = import_itg_profile_dir(&dir, |done, total, label| {
+            let _ = progress_tx.send(ImportMsg::Progress {
+                done,
+                total,
+                label: label.to_string(),
+            });
+        });
+        let outcome = match result {
+            Ok(summary) => ImportOutcome::Ok(Box::new(summary)),
+            Err(e) => ImportOutcome::Err(e.to_string()),
+        };
+        let _ = tx.send(ImportMsg::Done(outcome));
+    });
+    state.import_job = Some(ImportJob { rx, progress: None });
+}
+
+fn poll_import_job(state: &mut State) {
+    let Some(job) = state.import_job.as_mut() else {
+        return;
+    };
+    // Drain all pending messages this frame: update the progress snapshot, and
+    // finalize when the Done message arrives.
+    let mut outcome: Option<ImportOutcome> = None;
+    loop {
+        match job.rx.try_recv() {
+            Ok(ImportMsg::Progress { done, total, label }) => {
+                job.progress = Some((done, total, Arc::from(label.as_str())));
+            }
+            Ok(ImportMsg::Done(o)) => {
+                outcome = Some(o);
+                break;
+            }
+            Err(TryRecvError::Empty) => return,
+            Err(TryRecvError::Disconnected) => {
+                state.import_job = None;
+                state.import_message = Some(ImportMessageState {
+                    title: tr("Profiles", "ImportFailedTitle"),
+                    lines: vec![tr("Profiles", "ImportFailedBody").to_string()],
+                });
+                return;
+            }
+        }
+    }
+    let Some(outcome) = outcome else {
+        return;
+    };
+    state.import_job = None;
+    match outcome {
+        ImportOutcome::Ok(summary) => {
+            audio::play_sfx("assets/sounds/start.ogg");
+            refresh_rows(state);
+            select_profile_row(state, &summary.profile_id);
+            state.import_message = Some(import_summary_message(&summary));
+        }
+        ImportOutcome::Err(e) => {
+            state.import_message = Some(ImportMessageState {
+                title: tr("Profiles", "ImportFailedTitle"),
+                lines: vec![e],
+            });
+        }
+    }
+}
+
+fn select_profile_row(state: &mut State, profile_id: &str) {
+    if let Some(pos) = state
+        .rows
+        .iter()
+        .position(|r| matches!(&r.kind, RowKind::Profile { id, .. } if id == profile_id))
+    {
+        state.selected = pos;
+        state.prev_selected = pos;
+    }
+}
+
+fn import_summary_message(summary: &ImportSummary) -> ImportMessageState {
+    let mut lines = Vec::new();
+    lines.push(
+        tr_fmt(
+            "Profiles",
+            "ImportSummaryName",
+            &[("name", &summary.display_name)],
+        )
+        .to_string(),
+    );
+    lines.push(
+        tr_fmt(
+            "Profiles",
+            "ImportSummaryScores",
+            &[
+                ("imported", &summary.scores_imported.to_string()),
+                ("total", &summary.scores_total.to_string()),
+            ],
+        )
+        .to_string(),
+    );
+    let skipped =
+        summary.charts_song_not_found + summary.charts_chart_not_found + summary.scores_unmapped;
+    if skipped > 0 {
+        lines.push(
+            tr_fmt(
+                "Profiles",
+                "ImportSummarySkipped",
+                &[("skipped", &skipped.to_string())],
+            )
+            .to_string(),
+        );
+    }
+    lines.push(tr("Profiles", "ImportSummaryExNote").to_string());
+    ImportMessageState {
+        title: tr("Profiles", "ImportSummaryTitle"),
+        lines,
+    }
+}
+
+fn dismiss_import_message(state: &mut State) {
+    state.import_message = None;
+    reset_nav_hold(state);
+    audio::play_sfx("assets/sounds/start.ogg");
+}
+
+fn handle_import_picker_input(state: &mut State, ev: &InputEvent) {
+    if !ev.pressed {
+        return;
+    }
+    match ev.action {
+        VirtualAction::p1_back | VirtualAction::p2_back => cancel_import_picker(state),
+        VirtualAction::p1_up
+        | VirtualAction::p1_menu_up
+        | VirtualAction::p2_up
+        | VirtualAction::p2_menu_up => {
+            move_import_picker_selected(state, NavDirection::Up);
+            audio::play_sfx("assets/sounds/change.ogg");
+        }
+        VirtualAction::p1_down
+        | VirtualAction::p1_menu_down
+        | VirtualAction::p2_down
+        | VirtualAction::p2_menu_down => {
+            move_import_picker_selected(state, NavDirection::Down);
+            audio::play_sfx("assets/sounds/change.ogg");
+        }
+        VirtualAction::p1_start | VirtualAction::p2_start => confirm_import_picker(state),
+        _ => {}
+    }
+}
+
 #[inline(always)]
 fn activate_selected_row(state: &mut State) -> ScreenAction {
     let total = state.rows.len();
@@ -590,6 +849,10 @@ fn activate_selected_row(state: &mut State) -> ScreenAction {
     match start_row {
         RowKind::CreateNew => {
             begin_name_entry_create(state);
+            ScreenAction::None
+        }
+        RowKind::ImportItg => {
+            begin_import_picker(state);
             ScreenAction::None
         }
         RowKind::Exit => {
@@ -623,6 +886,24 @@ fn undo_profile_menu_move(state: &mut State, undo: i8) {
 }
 
 pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
+    if state.import_job.is_some() {
+        return ScreenAction::None;
+    }
+    if state.import_message.is_some() {
+        if ev.pressed
+            && matches!(
+                ev.action,
+                VirtualAction::p1_start
+                    | VirtualAction::p2_start
+                    | VirtualAction::p1_back
+                    | VirtualAction::p2_back
+            )
+        {
+            dismiss_import_message(state);
+        }
+        return ScreenAction::None;
+    }
+
     let three_key_action = screen_input::three_key_menu_action(&mut state.menu_lr_chord, ev);
     if screen_input::dedicated_three_key_nav_enabled() {
         match ev.action {
@@ -649,6 +930,21 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
             _ => {}
         }
         if let Some((_, nav)) = three_key_action {
+            if state.import_picker.is_some() {
+                match nav {
+                    screen_input::ThreeKeyMenuAction::Prev => {
+                        move_import_picker_selected(state, NavDirection::Up);
+                        audio::play_sfx("assets/sounds/change.ogg");
+                    }
+                    screen_input::ThreeKeyMenuAction::Next => {
+                        move_import_picker_selected(state, NavDirection::Down);
+                        audio::play_sfx("assets/sounds/change.ogg");
+                    }
+                    screen_input::ThreeKeyMenuAction::Confirm => confirm_import_picker(state),
+                    screen_input::ThreeKeyMenuAction::Cancel => cancel_import_picker(state),
+                }
+                return ScreenAction::None;
+            }
             if state.name_entry.is_some() {
                 match nav {
                     screen_input::ThreeKeyMenuAction::Confirm => confirm_name_entry(state),
@@ -721,6 +1017,10 @@ pub fn handle_input(state: &mut State, ev: &InputEvent) -> ScreenAction {
                 }
             };
         }
+    }
+    if state.import_picker.is_some() {
+        handle_import_picker_input(state, ev);
+        return ScreenAction::None;
     }
     if state.name_entry.is_some() {
         match ev.action {
@@ -925,6 +1225,13 @@ fn help_for_selected(state: &State, p1_id: Option<&str>, p2_id: Option<&str>) ->
             (title.to_string(), bullets)
         }
         RowKind::Exit => (tr("Profiles", "ReturnToOptions").to_string(), String::new()),
+        RowKind::ImportItg => {
+            let title = tr("Profiles", "ImportItgTitle");
+            let b1 = tr("Profiles", "ImportItgHelp1");
+            let b2 = tr("Profiles", "ImportItgHelp2");
+            let bullets = make_bullets(&[&b1, &b2]);
+            (title.to_string(), bullets)
+        }
         RowKind::Profile { id, display_name } => {
             let title =
                 tr_fmt("Profiles", "LocalProfileFormat", &[("name", display_name)]).to_string();
@@ -1189,6 +1496,230 @@ fn push_overlay_error(
     ));
 }
 
+const IMPORT_PICK_MAX_VISIBLE: usize = 8;
+
+fn push_import_picker_overlay(ui: &mut Vec<Actor>, state: &State) {
+    let Some(picker) = &state.import_picker else {
+        return;
+    };
+
+    let w = screen_width();
+    let h = screen_height();
+    let box_w = 760.0_f32.min(w * 0.92);
+    let header_h = 56.0_f32;
+    let item_h = 34.0_f32;
+    let footer_h = 44.0_f32;
+    let total = picker.candidates.len();
+    let visible = total.min(IMPORT_PICK_MAX_VISIBLE);
+    let box_h = header_h + (visible as f32) * item_h + footer_h;
+    let cx = w * 0.5;
+    let cy = h * 0.5;
+    let top = cy - box_h * 0.5;
+
+    push_overlay_backdrop(ui, w, h);
+    push_overlay_box(ui, cx, cy, box_w, box_h);
+
+    let title = tr("Profiles", "ImportPickTitle");
+    ui.push(act!(text:
+        align(0.5, 0.0):
+        xy(cx, top + 14.0):
+        font("miso"):
+        zoom(1.05):
+        maxwidth(box_w - 40.0):
+        settext(title):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        z(1002):
+        horizalign(center)
+    ));
+
+    let offset = if total <= IMPORT_PICK_MAX_VISIBLE {
+        0
+    } else {
+        picker
+            .selected
+            .saturating_sub(IMPORT_PICK_MAX_VISIBLE - 1)
+            .min(total - IMPORT_PICK_MAX_VISIBLE)
+    };
+    let accent = color::simply_love_rgba(state.active_color_index);
+    let list_left = cx - box_w * 0.5 + 24.0;
+    let list_w = box_w - 48.0;
+
+    for i in 0..visible {
+        let idx = offset + i;
+        let Some(cand) = picker.candidates.get(idx) else {
+            break;
+        };
+        let row_y = (i as f32).mul_add(item_h, top + header_h);
+        let selected = idx == picker.selected;
+        if selected {
+            ui.push(act!(quad:
+                align(0.0, 0.0):
+                xy(list_left - 8.0, row_y):
+                zoomto(list_w + 16.0, item_h):
+                diffuse(0.17, 0.23, 0.28, 0.95):
+                z(1002)
+            ));
+        }
+        let text_col = if selected {
+            [accent[0], accent[1], accent[2], 1.0]
+        } else {
+            [1.0, 1.0, 1.0, 1.0]
+        };
+        ui.push(act!(text:
+            align(0.0, 0.5):
+            xy(list_left, row_y + item_h * 0.5):
+            font("miso"):
+            zoom(0.95):
+            maxwidth(list_w):
+            settext(cand.display_name.clone()):
+            diffuse(text_col[0], text_col[1], text_col[2], text_col[3]):
+            z(1003):
+            horizalign(left)
+        ));
+    }
+
+    let prompt = tr("Profiles", "ImportPickPrompt");
+    ui.push(act!(text:
+        align(0.5, 1.0):
+        xy(cx, cy + box_h * 0.5 - 12.0):
+        font("miso"):
+        zoom(0.85):
+        maxwidth(box_w - 40.0):
+        settext(prompt):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        z(1003):
+        horizalign(center)
+    ));
+}
+
+fn push_import_progress_overlay(ui: &mut Vec<Actor>, state: &State) {
+    let Some(job) = state.import_job.as_ref() else {
+        return;
+    };
+    let w = screen_width();
+    let h = screen_height();
+    let box_w = 560.0_f32.min(w * 0.92);
+    let box_h = 150.0_f32;
+    let cx = w * 0.5;
+    let cy = h * 0.5;
+    let top = cy - box_h * 0.5;
+
+    push_overlay_backdrop(ui, w, h);
+    push_overlay_box(ui, cx, cy, box_w, box_h);
+
+    // Heading.
+    ui.push(act!(text:
+        align(0.5, 0.0):
+        xy(cx, top + 16.0):
+        font("miso"):
+        zoom(1.05):
+        maxwidth(box_w - 40.0):
+        settext(tr("Profiles", "ImportInProgress")):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        z(1002):
+        horizalign(center)
+    ));
+
+    // Until the first song is reported (file read + resolver build), there's no
+    // determinate progress yet — leave just the heading. Once songs start
+    // processing, show the progress bar + current song label.
+    if let Some((done, total, label)) = &job.progress {
+        let progress = if *total > 0 {
+            (*done as f32 / *total as f32).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        let accent = color::simply_love_rgba(state.active_color_index);
+        let bar_w = (box_w - 64.0).max(0.0);
+        ui.push(loading_bar::build(loading_bar::LoadingBarParams {
+            align: [0.5, 0.5],
+            offset: [cx, cy],
+            width: bar_w,
+            height: 22.0,
+            progress,
+            label: crate::screens::progress_count_text(*done, *total).into(),
+            fill_rgba: [accent[0], accent[1], accent[2], 1.0],
+            bg_rgba: [0.0, 0.0, 0.0, 1.0],
+            border_rgba: [1.0, 1.0, 1.0, 1.0],
+            text_rgba: [1.0, 1.0, 1.0, 1.0],
+            text_zoom: 0.8,
+            z: 1002,
+        }));
+
+        if !label.is_empty() {
+            ui.push(act!(text:
+                align(0.5, 0.5):
+                xy(cx, cy + 34.0):
+                font("miso"):
+                zoom(0.78):
+                maxwidth(box_w - 40.0):
+                settext(label.to_string()):
+                diffuse(0.8, 0.8, 0.8, 1.0):
+                z(1003):
+                horizalign(center)
+            ));
+        }
+    }
+}
+
+fn push_import_message_overlay(ui: &mut Vec<Actor>, state: &State) {
+    let Some(message) = &state.import_message else {
+        return;
+    };
+
+    let w = screen_width();
+    let h = screen_height();
+    let box_w = 760.0_f32.min(w * 0.92);
+    let line_h = 28.0_f32;
+    let header_h = 52.0_f32;
+    let footer_h = 44.0_f32;
+    let box_h = header_h + (message.lines.len().max(1) as f32) * line_h + footer_h;
+    let cx = w * 0.5;
+    let cy = h * 0.5;
+    let top = cy - box_h * 0.5;
+
+    push_overlay_backdrop(ui, w, h);
+    push_overlay_box(ui, cx, cy, box_w, box_h);
+
+    ui.push(act!(text:
+        align(0.5, 0.0):
+        xy(cx, top + 14.0):
+        font("miso"):
+        zoom(1.05):
+        maxwidth(box_w - 40.0):
+        settext(message.title.clone()):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        z(1002):
+        horizalign(center)
+    ));
+
+    for (i, line) in message.lines.iter().enumerate() {
+        let line_y = (i as f32).mul_add(line_h, top + header_h);
+        ui.push(act!(text:
+            align(0.5, 0.0):
+            xy(cx, line_y):
+            font("miso"):
+            zoom(0.9):
+            maxwidth(box_w - 48.0):
+            settext(line.clone()):
+            diffuse(1.0, 1.0, 1.0, 1.0):
+            z(1002):
+            horizalign(center)
+        ));
+    }
+
+    ui.push(act!(text:
+        align(0.5, 1.0):
+        xy(cx, cy + box_h * 0.5 - 12.0):
+        font("miso"):
+        zoom(0.85):
+        settext(tr("Profiles", "ImportMessageDismiss")):
+        diffuse(1.0, 1.0, 1.0, 1.0):
+        z(1002):
+        horizalign(center)
+    ));
+}
+
 fn push_list_chrome(
     ui: &mut Vec<Actor>,
     col_active_bg: [f32; 4],
@@ -1228,6 +1759,7 @@ struct RowColors {
 fn row_label(kind: &RowKind) -> Arc<str> {
     match kind {
         RowKind::CreateNew => tr("Profiles", "CreateProfileButton"),
+        RowKind::ImportItg => tr("Profiles", "ImportItgButton"),
         RowKind::Exit => tr("Common", "Exit"),
         RowKind::Profile { display_name, .. } => Arc::from(display_name.as_str()),
     }
@@ -1549,6 +2081,9 @@ pub fn push_actors(
     push_profile_menu_overlay(actors, state, s, list_x, list_y);
     push_name_entry_overlay(actors, state);
     push_delete_confirm_overlay(actors, state);
+    push_import_picker_overlay(actors, state);
+    push_import_progress_overlay(actors, state);
+    push_import_message_overlay(actors, state);
 
     for actor in &mut actors[ui_start..] {
         actor.mul_alpha(alpha_multiplier);

--- a/src/screens/manage_local_profiles.rs
+++ b/src/screens/manage_local_profiles.rs
@@ -800,6 +800,19 @@ fn import_summary_message(summary: &ImportSummary) -> ImportMessageState {
             .to_string(),
         );
     }
+    if summary.favorites_total > 0 {
+        lines.push(
+            tr_fmt(
+                "Profiles",
+                "ImportSummaryFavorites",
+                &[
+                    ("imported", &summary.favorites_imported.to_string()),
+                    ("total", &summary.favorites_total.to_string()),
+                ],
+            )
+            .to_string(),
+        );
+    }
     lines.push(tr("Profiles", "ImportSummaryExNote").to_string());
     ImportMessageState {
         title: tr("Profiles", "ImportSummaryTitle"),

--- a/src/screens/manage_local_profiles.rs
+++ b/src/screens/manage_local_profiles.rs
@@ -813,6 +813,16 @@ fn import_summary_message(summary: &ImportSummary) -> ImportMessageState {
             .to_string(),
         );
     }
+    if summary.itl_entries_imported > 0 {
+        lines.push(
+            tr_fmt(
+                "Profiles",
+                "ImportSummaryItl",
+                &[("count", &summary.itl_entries_imported.to_string())],
+            )
+            .to_string(),
+        );
+    }
     lines.push(tr("Profiles", "ImportSummaryExNote").to_string());
     ImportMessageState {
         title: tr("Profiles", "ImportSummaryTitle"),

--- a/src/screens/manage_local_profiles.rs
+++ b/src/screens/manage_local_profiles.rs
@@ -693,13 +693,17 @@ fn confirm_import_picker(state: &mut State) {
     let (tx, rx) = std::sync::mpsc::channel();
     let progress_tx = tx.clone();
     thread::spawn(move || {
-        let result = import_itg_profile_dir(&dir, |done, total, label| {
-            let _ = progress_tx.send(ImportMsg::Progress {
-                done,
-                total,
-                label: label.to_string(),
-            });
-        });
+        let result = import_itg_profile_dir(
+            &dir,
+            |done, total, label| {
+                let _ = progress_tx.send(ImportMsg::Progress {
+                    done,
+                    total,
+                    label: label.to_string(),
+                });
+            },
+            || false,
+        );
         let outcome = match result {
             Ok(summary) => ImportOutcome::Ok(Box::new(summary)),
             Err(e) => ImportOutcome::Err(e.to_string()),


### PR DESCRIPTION
Broadens what data the ITGmania importer brings across beyond scores and player options, and adds per-section result tracking plus a duplicate-import guard.

> [!NOTE]
> **Stacked on #572.**

### What''s here
- **Simply Love favorites** (`src/game/import/itg.rs`, `run.rs`): read favorites from the source profile, write them to the new profile, and surface the matched count.
- **ITL2026.json event data** (`src/game/scores/itl.rs`): parse ITL2026.json and import the event data into the new profile''s score store.
- **Calorie pref and current-combo stats** (`src/game/import/itg.rs`, `profile.rs`): carry the calorie-tracking preference and current-combo profile stats (adds `chrono` for date handling).
- **StepStatsExtra and TargetScore options** (`src/game/import/options.rs`): translate those Simply Love player options.
- **Per-section summary and exclusions** (`src/game/import/run.rs`): track per-section import results (scores, favorites, player options, online keys, avatar, ITL) and whether the run was canceled, and hard-block re-importing a profile whose GUID already exists locally. Documents the definitive imported-vs-excluded table.