### PR TITLE
Suppress ffmpeg console window on Windows to prevent focus loss

### DIFF
--- a/crates/deadlib-video/src/lib.rs
+++ b/crates/deadlib-video/src/lib.rs
@@ -448,21 +448,34 @@ fn tool_is_available(name: &str) -> bool {
     if resolve_tool_path(name).is_some() {
         return true;
     }
-    Command::new(name)
-        .arg("-version")
+    let mut cmd = Command::new(name);
+    cmd.arg("-version")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
+        .stderr(Stdio::null());
+    suppress_console(&mut cmd);
+    cmd.status()
         .map(|status| status.success())
         .unwrap_or(false)
 }
 
 fn tool_command(name: &str) -> Command {
-    resolve_tool_path(name)
+    let mut cmd = resolve_tool_path(name)
         .map(Command::new)
-        .unwrap_or_else(|| Command::new(name))
+        .unwrap_or_else(|| Command::new(name));
+    suppress_console(&mut cmd);
+    cmd
 }
+
+#[cfg(windows)]
+fn suppress_console(cmd: &mut Command) {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    cmd.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(not(windows))]
+fn suppress_console(_cmd: &mut Command) {}
 
 fn resolve_tool_path(name: &str) -> Option<PathBuf> {
     let runtime_bin = std::env::current_dir().ok().map(|dir| dir.join("bin"));


### PR DESCRIPTION
## Why

Players reported DeadSync intermittently losing focus: pads/buttons stop responding and FPS drops to ~15, mostly on the song-select wheel and the evaluation screen. Alt-tabbing back to DeadSync restores normal behavior. The only clue was a black window with "ffmpeg" in its title showing up in the alt-tab switcher, and the problem started right after using the new in-app ffmpeg downloader in the options menu.

## Root cause

Release builds run as a GUI-subsystem app (`#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]`), so the process has no console. When a no-console Windows process spawns a console subprocess (ffmpeg/ffprobe), Windows allocates a brand-new console window for the child. That window momentarily becomes the foreground window and steals focus from the game, which kills input and drops FPS until the user alt-tabs back.

In `crates/deadlib-video/src/lib.rs`, every ffmpeg/ffprobe spawn went through `Command` without the `CREATE_NO_WINDOW` creation flag. Video decode runs continuously while preview videos play on the song wheel and background videos play on the evaluation screen, so each newly started decode popped the offending window. Before ffmpeg was installed none of these spawns ran, which is why it only began after the in-app download.

## Approach

Add a `#[cfg(windows)]` `suppress_console` helper that sets `CREATE_NO_WINDOW` via `CommandExt::creation_flags` (a no-op on macOS/Linux).