### PR TITLE
Fix exclusive fullscreen trapping focus on Windows Alt+Tab

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -10637,6 +10637,17 @@ impl ApplicationHandler<UserEvent> for App {
                 }
             }
             WindowEvent::Focused(focused) => {
+                #[cfg(target_os = "windows")]
+                if matches!(
+                    self.state.shell.display_mode,
+                    DisplayMode::Fullscreen(config::FullscreenType::Exclusive)
+                ) {
+                    if !focused {
+                        window.set_minimized(true);
+                    } else if window.is_minimized().unwrap_or(false) {
+                        window.set_minimized(false);
+                    }
+                }
                 self.apply_window_focus_change(focused, Instant::now(), Some(&window));
             }
             WindowEvent::Occluded(occluded) => {


### PR DESCRIPTION
## Why

On Windows 11 in **exclusive fullscreen** (winit `Fullscreen::Exclusive`, wgpu/Vulkan renderer), Alt+Tab does not work: the switcher appears but no other application can come to the foreground. DeadSync registers the focus loss (pad/panel input goes dead, FPS throttles to ~15) yet stays fullscreen, leaving the desktop unusable until the game is closed.

## Root cause

winit on Windows does not auto-minimize a `Fullscreen::Exclusive` window when it loses focus (unlike classic DirectX exclusive mode). Because the window keeps owning the exclusive display mode, the compositor cannot bring another window forward. The existing focus handler updated input/throttle state but never touched the window's minimized state.

## Fix

In the `WindowEvent::Focused` handler, for **exclusive fullscreen on Windows only**:
- on focus loss, `set_minimized(true)` so Windows releases the exclusive mode and other apps can surface;
- on focus gain, `set_minimized(false)` to restore the fullscreen window.

This mirrors SDL's default `MINIMIZE_ON_FOCUS_LOSS` behavior and how mainstream games handle exclusive mode. It is gated with `#[cfg(target_os = "windows")]` and the exclusive check, so borderless/windowed modes and other platforms are unaffected. The change is additive: the existing input/throttle bookkeeping in `apply_window_focus_change` is unchanged.