### PR TITLE
feat(gameplay): add Ctrl+Shift+R to reload chart from disk

### DIFF
--- a/crates/deadsync-gameplay/src/controls.rs
+++ b/crates/deadsync-gameplay/src/controls.rs
@@ -81,6 +81,8 @@ pub const fn offset_adjust_target(
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum GameplayRawKeyPlan {
     Restart,
+    /// Re-read the simfile from disk (refresh the chart cache) and restart.
+    Reload,
     SetAutosyncMode(AutosyncMode),
     SetTimingTickMode(GameplayTimingTickMode),
     SetAutoplayEnabled(bool),
@@ -98,6 +100,8 @@ pub enum RawKeyAction {
     #[default]
     None,
     Restart,
+    /// Refresh the chart cache from disk, then restart.
+    Reload,
 }
 
 #[inline(always)]

--- a/crates/deadsync-gameplay/src/runtime_config.rs
+++ b/crates/deadsync-gameplay/src/runtime_config.rs
@@ -80,6 +80,7 @@ pub const fn gameplay_raw_key_plan(
         return GameplayRawKeyPlan::None;
     }
     match input {
+        GameplayRawKeyInput::Restart if ctrl_held && shift_held => GameplayRawKeyPlan::Reload,
         GameplayRawKeyInput::Restart if ctrl_held => GameplayRawKeyPlan::Restart,
         GameplayRawKeyInput::Autosync => {
             GameplayRawKeyPlan::SetAutosyncMode(next_autosync_mode(autosync_mode, course_active))
@@ -100,6 +101,7 @@ pub const fn gameplay_raw_key_plan(
 pub const fn gameplay_raw_key_action_for_plan(plan: GameplayRawKeyPlan) -> RawKeyAction {
     match plan {
         GameplayRawKeyPlan::Restart => RawKeyAction::Restart,
+        GameplayRawKeyPlan::Reload => RawKeyAction::Reload,
         _ => RawKeyAction::None,
     }
 }

--- a/crates/deadsync-gameplay/src/runtime_update.rs
+++ b/crates/deadsync-gameplay/src/runtime_update.rs
@@ -2774,7 +2774,7 @@ where
     ) -> RawKeyAction {
         let action = gameplay_raw_key_action_for_plan(plan);
         match plan {
-            GameplayRawKeyPlan::Restart => return action,
+            GameplayRawKeyPlan::Restart | GameplayRawKeyPlan::Reload => return action,
             GameplayRawKeyPlan::SetAutosyncMode(mode) => self.set_autosync_mode(mode),
             GameplayRawKeyPlan::SetTimingTickMode(mode) => {
                 self.apply_timing_tick_mode_command(mode, now_music_time)

--- a/crates/deadsync-gameplay/src/tests.rs
+++ b/crates/deadsync-gameplay/src/tests.rs
@@ -8614,6 +8614,20 @@ mod tests {
         );
         assert_eq!(
             gameplay_raw_key_plan(
+                GameplayRawKeyInput::Restart,
+                true,
+                true,
+                true,
+                true,
+                AutosyncMode::Off,
+                false,
+                GameplayTimingTickMode::Off,
+                false,
+            ),
+            GameplayRawKeyPlan::Reload
+        );
+        assert_eq!(
+            gameplay_raw_key_plan(
                 GameplayRawKeyInput::Autosync,
                 true,
                 true,
@@ -8661,6 +8675,10 @@ mod tests {
         assert_eq!(
             gameplay_raw_key_action_for_plan(GameplayRawKeyPlan::Restart),
             RawKeyAction::Restart
+        );
+        assert_eq!(
+            gameplay_raw_key_action_for_plan(GameplayRawKeyPlan::Reload),
+            RawKeyAction::Reload
         );
         assert_eq!(
             gameplay_raw_key_action_for_plan(GameplayRawKeyPlan::SetAutoplayEnabled(true)),

--- a/src/app/input_routing.rs
+++ b/src/app/input_routing.rs
@@ -180,11 +180,16 @@ impl App {
             allow_commands,
         );
         crate::screens::gameplay::drain_audio_commands(gs);
-        if matches!(action, RawKeyAction::Restart)
-            && config::get().keyboard_features
-            && self.state.session.course_run.is_none()
-        {
-            self.try_gameplay_restart(event_loop, "Ctrl+R");
+        let keyboard_features = config::get().keyboard_features;
+        let non_course = self.state.session.course_run.is_none();
+        match action {
+            RawKeyAction::Restart if keyboard_features && non_course => {
+                self.try_gameplay_restart(event_loop, "Ctrl+R");
+            }
+            RawKeyAction::Reload if keyboard_features && non_course => {
+                self.try_gameplay_reload(event_loop, "Ctrl+Shift+R");
+            }
+            _ => {}
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8653,10 +8653,12 @@ impl App {
             }
         } else if self.state.screens.current_screen == CurrentScreen::SelectMusic {
             // Route screen-specific raw key handling (e.g., F7 fetch) to the screen
-            let action = crate::screens::select_music::handle_raw_key_event(
+            let action = crate::screens::select_music::handle_raw_key_event_with_modifiers(
                 &mut self.state.screens.select_music_state,
                 Some(&raw_key),
                 None,
+                self.state.shell.ctrl_held,
+                self.state.shell.shift_held,
             );
             if !matches!(action, ScreenAction::None) {
                 if let Err(e) = self.handle_action(action, event_loop) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6491,6 +6491,93 @@ impl App {
         true
     }
 
+    fn try_practice_reload(&mut self, event_loop: &ActiveEventLoop, label: &str) -> bool {
+        if self.state.screens.current_screen != CurrentScreen::Practice {
+            return false;
+        }
+        let Some((
+            simfile_path,
+            old_song,
+            music_rate,
+            scroll_speed,
+            active_color_index,
+            old_hashes,
+            old_difficulties,
+        )) = self.state.screens.practice_state.as_ref().map(|ps| {
+            let gs = &ps.gameplay;
+            (
+                gs.song().simfile_path.clone(),
+                gs.song_arc(),
+                gs.music_rate(),
+                [
+                    gs.scroll_speed_for_player(0),
+                    gs.scroll_speed_for_player(1),
+                ],
+                gs.active_color_index(),
+                [
+                    gs.charts()[0].short_hash.clone(),
+                    gs.charts()[1].short_hash.clone(),
+                ],
+                [
+                    gs.charts()[0].difficulty.clone(),
+                    gs.charts()[1].difficulty.clone(),
+                ],
+            )
+        }) else {
+            log::warn!("Ignored {label} reload: no practice stage state.");
+            return false;
+        };
+
+        let updated_song = match song_loading::reload_song_in_cache(simfile_path.as_path()) {
+            Ok(song) => song,
+            Err(e) => {
+                log::warn!(
+                    "Ignored {label} reload for '{}': {e}",
+                    simfile_path.display()
+                );
+                return false;
+            }
+        };
+        select_music::refresh_from_song_cache(&mut self.state.screens.select_music_state);
+
+        // Editing notes changes a chart's hash, so the old hash will not exist
+        // in the reloaded song. Resolve each slot by its stable difficulty steps
+        // index (derived from the pre-reload chart) and take the reloaded chart's
+        // new hash so the restart selects the same difficulty.
+        let target_chart_type = profile::get_session_play_style().chart_type();
+        let new_hashes: [String; MAX_PLAYERS] = std::array::from_fn(|slot| {
+            let steps_index = old_song
+                .steps_index_for_chart_hash(target_chart_type, &old_hashes[slot])
+                .or_else(|| {
+                    deadsync_chart::song::standard_difficulty_index(&old_difficulties[slot])
+                })
+                .unwrap_or(0);
+            updated_song
+                .chart_for_steps_index(target_chart_type, steps_index)
+                .map(|chart| chart.short_hash.clone())
+                .unwrap_or_default()
+        });
+
+        if !self.prepare_restart_player_options(
+            updated_song,
+            [new_hashes[0].as_str(), new_hashes[1].as_str()],
+            music_rate,
+            scroll_speed,
+            active_color_index,
+            CurrentScreen::Practice,
+        ) {
+            log::warn!("Ignored {label} reload: could not rebuild practice options.");
+            return false;
+        }
+        if let Err(e) =
+            self.handle_action(ScreenAction::Navigate(CurrentScreen::Practice), event_loop)
+        {
+            log::error!("Failed to reload Practice with {label}: {e}");
+            return false;
+        }
+        true
+    }
+
     fn should_chain_course_to_next_stage(&self) -> bool {
         self.state.screens.current_screen == CurrentScreen::Gameplay
             && !self.current_gameplay_stage_failed()
@@ -8667,6 +8754,16 @@ impl App {
                 return true;
             }
         } else if self.state.screens.current_screen == CurrentScreen::Practice {
+            if raw_key.pressed
+                && !raw_key.repeat
+                && raw_key.code == KeyCode::KeyR
+                && self.state.shell.ctrl_held
+                && self.state.shell.shift_held
+                && config::get().keyboard_features
+            {
+                self.try_practice_reload(event_loop, "Ctrl+Shift+R");
+                return true;
+            }
             if let Some(ps) = self.state.screens.practice_state.as_mut() {
                 let (consumed, action) =
                     crate::screens::practice::handle_raw_key_event(ps, &raw_key);
@@ -9464,8 +9561,12 @@ impl App {
         if target == CurrentScreen::Practice {
             deadsync_audio_stream::stop_music();
             if let Some(mut po_state) = self.state.screens.player_options_state.take() {
-                let edit_snapshot = (prev == CurrentScreen::PlayerOptions
+                // Preserve the editor cursor/selection across a returning
+                // PlayerOptions->Practice trip and across an in-place Practice
+                // chart reload (Ctrl+Shift+R re-enters Practice from Practice).
+                let edit_snapshot = ((prev == CurrentScreen::PlayerOptions
                     && po_state.return_screen == CurrentScreen::Practice)
+                    || prev == CurrentScreen::Practice)
                     .then(|| {
                         self.state
                             .screens

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6433,6 +6433,42 @@ impl App {
         true
     }
 
+    fn try_gameplay_reload(&mut self, event_loop: &ActiveEventLoop, label: &str) -> bool {
+        let simfile_path = if let Some(gs) = self.state.screens.gameplay_state.as_ref() {
+            Some(gs.song().simfile_path.clone())
+        } else if self.state.screens.current_screen == CurrentScreen::Evaluation {
+            restart_payload_from_eval(&self.state.screens.evaluation_state.score_info)
+                .map(|(song, ..)| song.simfile_path.clone())
+        } else {
+            None
+        };
+        let Some(simfile_path) = simfile_path else {
+            log::warn!("Ignored {label} reload: no restartable stage state.");
+            return false;
+        };
+
+        let updated_song = match song_loading::reload_song_in_cache(simfile_path.as_path()) {
+            Ok(song) => song,
+            Err(e) => {
+                log::warn!(
+                    "Ignored {label} reload for '{}': {e}",
+                    simfile_path.display()
+                );
+                return false;
+            }
+        };
+        select_music::refresh_from_song_cache(&mut self.state.screens.select_music_state);
+
+        if !self.try_gameplay_restart(event_loop, label) {
+            return false;
+        }
+
+        if let Some(po_state) = self.state.screens.player_options_state.as_mut() {
+            let _ = replace_song_arc_if_same_simfile(&mut po_state.song, &updated_song);
+        }
+        true
+    }
+
     /// SL-zmod parity (`BGAnimations/ScreenEvaluation common/Shared/RestartHandler.lua`):
     /// Ctrl+P on the Evaluation screen re-enters the just-played chart in
     /// Practice mode. Mirrors `try_gameplay_restart`, but routes to
@@ -8655,7 +8691,11 @@ impl App {
                 && config::get().keyboard_features
                 && self.state.session.course_run.is_none()
             {
-                self.try_gameplay_restart(event_loop, "Ctrl+R");
+                if self.state.shell.shift_held {
+                    self.try_gameplay_reload(event_loop, "Ctrl+Shift+R");
+                } else {
+                    self.try_gameplay_restart(event_loop, "Ctrl+R");
+                }
                 return true;
             }
             if raw_key.pressed

--- a/src/screens/select_music.rs
+++ b/src/screens/select_music.rs
@@ -1448,6 +1448,28 @@ fn selected_song_arc(state: &State) -> Option<Arc<SongData>> {
     }
 }
 
+fn reload_selected_song(state: &mut State) -> bool {
+    let Some(song) = selected_song_arc(state) else {
+        return false;
+    };
+    let simfile_path = song.simfile_path.clone();
+    match song_loading::reload_song_in_cache(&simfile_path) {
+        Ok(_) => {
+            refresh_from_song_cache(state);
+            audio::play_sfx("assets/sounds/change.ogg");
+            debug!("Force-reloaded song from disk: {}", simfile_path.display());
+            true
+        }
+        Err(e) => {
+            warn!(
+                "Force reload failed for '{}': {e}",
+                simfile_path.display()
+            );
+            false
+        }
+    }
+}
+
 fn song_entry_index(entries: &[MusicWheelEntry], target_song: &Arc<SongData>) -> Option<usize> {
     entries
         .iter()
@@ -9360,6 +9382,26 @@ pub fn handle_raw_key_event(
     key: Option<&RawKeyboardEvent>,
     text: Option<&str>,
 ) -> ScreenAction {
+    handle_raw_key_event_impl(state, key, text, false, false)
+}
+
+pub fn handle_raw_key_event_with_modifiers(
+    state: &mut State,
+    key: Option<&RawKeyboardEvent>,
+    text: Option<&str>,
+    ctrl_held: bool,
+    shift_held: bool,
+) -> ScreenAction {
+    handle_raw_key_event_impl(state, key, text, ctrl_held, shift_held)
+}
+
+fn handle_raw_key_event_impl(
+    state: &mut State,
+    key: Option<&RawKeyboardEvent>,
+    text: Option<&str>,
+    ctrl_held: bool,
+    shift_held: bool,
+) -> ScreenAction {
     if state.reload_ui.is_some() {
         return ScreenAction::None;
     }
@@ -9565,6 +9607,18 @@ pub fn handle_raw_key_event(
             state.song_search_ignore_next_text = true;
         }
         return action;
+    }
+    if let Some(key) = key
+        && ctrl_held
+        && shift_held
+        && key.code == KeyCode::KeyR
+        && key.pressed
+        && !key.repeat
+        && config::get().keyboard_features
+        && !key_bound_to_player_input(key)
+        && reload_selected_song(state)
+    {
+        return ScreenAction::ConsumeInput;
     }
     if let Some(key) = key
         && key.code == KeyCode::F7


### PR DESCRIPTION
## Why

When drafting a chart in an external editor, there is currently no way to audition your edits on the keyboard without leaving to Select Music and re-entering the song. Ctrl+R restarts the stage, but it replays the chart already cached in memory, so freshly written notes and timing never take effect.

## What

Adds **Ctrl+Shift+R** as a force chart reload, available across the whole chart-authoring loop:

**Gameplay / Evaluation** - reload from disk and restart:
- Re-parses the simfile from disk, rebuilding both the in-memory and on-disk chart cache via the existing `reload_song_in_cache`.
- Refreshes the Select Music cache, then restarts the stage so the new notes/timing apply on the immediate replay.
- Swaps the freshly reloaded song into the restart player-options so song-level metadata (offset, timing) matches the reloaded chart.

**Select Music** - reload the highlighted song in place:
- Re-reads the highlighted song's simfile from disk and rebuilds the wheel from the refreshed cache, so edited notes, timing, and newly added difficulties appear without a full pack rescan.
- The cursor stays on the same song.

**Practice** - reload the practiced chart in place:
- Re-reads the simfile from disk and re-enters Practice with the refreshed chart.
- The editor cursor, selection, snap, and scroll speed are preserved across the reload.

Plain **Ctrl+R** behavior is unchanged (fast in-place restart using the cached chart).
