### PR TITLE
Add NeverCacheList preference to skip caching WIP packs

### DIFF
--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -100,6 +100,7 @@ fn publish_keymap(conf: &SimpleIni) {
 fn load_defaults_after_error() {
     *MACHINE_DEFAULT_NOTESKIN.lock().unwrap() = DEFAULT_MACHINE_NOTESKIN.to_string();
     ADDITIONAL_SONG_FOLDERS.lock().unwrap().clear();
+    NEVER_CACHE_LIST.lock().unwrap().clear();
     *SMX_P1_SERIAL.lock().unwrap() = None;
     *SMX_P2_SERIAL.lock().unwrap() = None;
     *DEFAULT_PROFILE_P1.lock().unwrap() = None;
@@ -116,6 +117,7 @@ fn load_runtime_state(conf: &SimpleIni) {
         .unwrap_or_else(|| DEFAULT_MACHINE_NOTESKIN.to_string());
     *MACHINE_DEFAULT_NOTESKIN.lock().unwrap() = noteskin;
     *ADDITIONAL_SONG_FOLDERS.lock().unwrap() = load_additional_song_folders(conf);
+    *NEVER_CACHE_LIST.lock().unwrap() = load_never_cache_list(conf);
     // SMX pad assignment serials: missing/blank means "no assignment" (jumper).
     let serial = |key| {
         conf.get("Options", key)
@@ -177,6 +179,16 @@ fn push_additional_song_folders(raw: &str, writable: bool, out: &mut Vec<Additio
                 writable,
             }),
     );
+}
+
+fn load_never_cache_list(conf: &SimpleIni) -> Vec<String> {
+    conf.get("Options", "NeverCacheList")
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 fn load_additional_song_folders(conf: &SimpleIni) -> Vec<AdditionalSongFolder> {
@@ -267,5 +279,21 @@ AdditionalSongFoldersReadOnly= , G:\\ro , \n");
                 folder("D:\\b", true),
             ]
         );
+    }
+
+    #[test]
+    fn never_cache_list_parses_and_trims_entries() {
+        let conf = ini("[Options]\nNeverCacheList= WIP Pack , ,Another \n");
+
+        assert_eq!(
+            load_never_cache_list(&conf),
+            vec!["WIP Pack".to_string(), "Another".to_string()]
+        );
+    }
+
+    #[test]
+    fn never_cache_list_empty_when_missing_or_blank() {
+        assert!(load_never_cache_list(&ini("[Options]\n")).is_empty());
+        assert!(load_never_cache_list(&ini("[Options]\nNeverCacheList=\n")).is_empty());
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,7 +29,8 @@ pub use self::null_or_die_cfg::null_or_die_bias_cfg;
 pub use self::pad_order::pad_index_for_uuid;
 pub use self::runtime::{
     additional_song_folder_roots, audio_mix_levels, default_profiles, flush_pending_saves, get,
-    machine_default_noteskin, smx_pad_assignment, song_path_is_writable,
+    group_is_never_cached, machine_default_noteskin, never_cache_list, smx_pad_assignment,
+    song_path_is_writable,
 };
 pub use self::theme::{
     AUTO_SS_CLEARS, AUTO_SS_FAILS, AUTO_SS_FLAG_NAMES, AUTO_SS_NUM_FLAGS, AUTO_SS_PBS,
@@ -55,7 +56,8 @@ use self::null_or_die_cfg::{
 };
 use self::runtime::{
     ADDITIONAL_SONG_FOLDERS, DEFAULT_PROFILE_P1, DEFAULT_PROFILE_P2, MACHINE_DEFAULT_NOTESKIN,
-    SMX_P1_SERIAL, SMX_P2_SERIAL, lock_config, queue_save_write, sync_audio_mix_levels_from_config,
+    NEVER_CACHE_LIST, SMX_P1_SERIAL, SMX_P2_SERIAL, lock_config, queue_save_write,
+    sync_audio_mix_levels_from_config,
 };
 use self::store::{normalize_machine_default_noteskin, save_without_keymaps};
 use deadlib_platform::logging;

--- a/src/config/runtime.rs
+++ b/src/config/runtime.rs
@@ -14,6 +14,12 @@ pub(super) static MACHINE_DEFAULT_NOTESKIN: std::sync::LazyLock<Mutex<String>> =
     std::sync::LazyLock::new(|| Mutex::new(DEFAULT_MACHINE_NOTESKIN.to_string()));
 pub(super) static ADDITIONAL_SONG_FOLDERS: std::sync::LazyLock<Mutex<Vec<AdditionalSongFolder>>> =
     std::sync::LazyLock::new(|| Mutex::new(Vec::new()));
+/// Pack group (song-folder) names that must never be cached to disk. Stored
+/// outside the `Copy` `Config` because the entries are owned strings. Mirrors
+/// ITGMania's `NeverCacheList` preference — useful for WIP packs whose files
+/// change frequently and would otherwise serve stale cached data.
+pub(super) static NEVER_CACHE_LIST: std::sync::LazyLock<Mutex<Vec<String>>> =
+    std::sync::LazyLock::new(|| Mutex::new(Vec::new()));
 /// SMX pad → player serial assignment (slot 0 = P1, slot 1 = P2). Stored outside
 /// the `Copy` `Config` because serials are owned strings. `None` = follow jumper.
 pub(super) static SMX_P1_SERIAL: std::sync::LazyLock<Mutex<Option<String>>> =
@@ -236,6 +242,27 @@ pub fn default_profiles() -> (Option<String>, Option<String>) {
 
 pub fn additional_song_folder_roots() -> Vec<AdditionalSongFolder> {
     ADDITIONAL_SONG_FOLDERS.lock().unwrap().clone()
+}
+
+/// The configured `NeverCacheList` pack group names.
+pub fn never_cache_list() -> Vec<String> {
+    NEVER_CACHE_LIST.lock().unwrap().clone()
+}
+
+/// Returns true when the given pack group (song-folder) name is listed in
+/// `NeverCacheList` and therefore must skip the on-disk song cache entirely
+/// (both reads and writes). Matching is case-insensitive and ignores
+/// surrounding whitespace.
+pub fn group_is_never_cached(group: &str) -> bool {
+    let group = group.trim();
+    if group.is_empty() {
+        return false;
+    }
+    NEVER_CACHE_LIST
+        .lock()
+        .unwrap()
+        .iter()
+        .any(|entry| entry.eq_ignore_ascii_case(group))
 }
 
 pub fn song_path_is_writable(path: &Path) -> bool {

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -60,6 +60,7 @@ pub(super) fn current_save_content() -> String {
     let keymap = deadsync_input::get_keymap();
     let machine_default_noteskin = MACHINE_DEFAULT_NOTESKIN.lock().unwrap().clone();
     let additional_song_folders = ADDITIONAL_SONG_FOLDERS.lock().unwrap().clone();
+    let never_cache_list = NEVER_CACHE_LIST.lock().unwrap().clone();
     let smx_p1_serial = SMX_P1_SERIAL.lock().unwrap().clone().unwrap_or_default();
     let smx_p2_serial = SMX_P2_SERIAL.lock().unwrap().clone().unwrap_or_default();
     let default_profile_p1 = DEFAULT_PROFILE_P1
@@ -77,6 +78,7 @@ pub(super) fn current_save_content() -> String {
         &keymap,
         &machine_default_noteskin,
         additional_song_folders.as_slice(),
+        never_cache_list.as_slice(),
         &smx_p1_serial,
         &smx_p2_serial,
         &default_profile_p1,

--- a/src/config/store/defaults.rs
+++ b/src/config/store/defaults.rs
@@ -40,6 +40,7 @@ fn push_default_options(content: &mut String, default: &Config) {
     );
     push_bool(content, "BannerCache", default.banner_cache);
     push_bool(content, "CacheSongs", default.cachesongs);
+    push_line(content, "NeverCacheList", "");
     push_bool(content, "CDTitleCache", default.cdtitle_cache);
     push_bool(content, "Center1Player", default.center_1player_notefield);
     push_line(

--- a/src/config/store/save.rs
+++ b/src/config/store/save.rs
@@ -6,6 +6,7 @@ pub(super) fn build_content(
     keymap: &Keymap,
     machine_default_noteskin: &str,
     additional_song_folders: &[AdditionalSongFolder],
+    never_cache_list: &[String],
     smx_p1_serial: &str,
     smx_p2_serial: &str,
     default_profile_p1: &str,
@@ -17,6 +18,7 @@ pub(super) fn build_content(
         cfg,
         machine_default_noteskin,
         additional_song_folders,
+        never_cache_list,
         smx_p1_serial,
         smx_p2_serial,
         default_profile_p1,
@@ -32,6 +34,7 @@ fn push_saved_options(
     cfg: &Config,
     machine_default_noteskin: &str,
     additional_song_folders: &[AdditionalSongFolder],
+    never_cache_list: &[String],
     smx_p1_serial: &str,
     smx_p2_serial: &str,
     default_profile_p1: &str,
@@ -74,6 +77,7 @@ fn push_saved_options(
     push_line(content, "GameplayBgColor", cfg.gameplay_bg_color.to_hex());
     push_bool(content, "BannerCache", cfg.banner_cache);
     push_bool(content, "CacheSongs", cfg.cachesongs);
+    push_line(content, "NeverCacheList", never_cache_list.join(","));
     push_bool(content, "CDTitleCache", cfg.cdtitle_cache);
     push_bool(content, "Center1Player", cfg.center_1player_notefield);
     push_line(

--- a/src/game/parsing/simfile.rs
+++ b/src/game/parsing/simfile.rs
@@ -22,6 +22,20 @@ mod scan;
 pub(crate) use scan::collect_song_scan_roots;
 pub use scan::{reload_song_dirs_with_progress_counts, scan_and_load_songs_with_progress_counts};
 
+/// Returns true when the pack (song-folder group) that owns this simfile is
+/// listed in `NeverCacheList` and so must skip the on-disk cache entirely.
+///
+/// The group folder is the simfile's pack directory, i.e. the parent of the
+/// song directory: `.../Songs/<Group>/<Song>/file.sm`.
+fn song_group_is_never_cached(simfile_path: &Path) -> bool {
+    simfile_path
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .is_some_and(config::group_is_never_cached)
+}
+
 pub(super) fn compute_song_cache_path(path: &Path) -> Option<PathBuf> {
     let cache_dir = dirs::app_dirs().song_cache_dir();
     match song_cache_path(&cache_dir, path) {
@@ -91,7 +105,7 @@ fn load_gameplay_charts_from_cache(
 pub fn reload_song_in_cache(simfile_path: &Path) -> Result<Arc<SongData>, String> {
     let config = config::get();
     let global_offset_seconds = config.global_offset_seconds;
-    let cachesongs = config.cachesongs;
+    let cachesongs = config.cachesongs && !song_group_is_never_cached(simfile_path);
     let cache_path = cachesongs
         .then(|| compute_song_cache_path(simfile_path))
         .flatten();
@@ -162,8 +176,9 @@ pub fn load_gameplay_charts(
 ) -> Result<Vec<GameplayChartData>, String> {
     let started = Instant::now();
     let config = config::get();
-    let allow_cache_read = config.fastload || config.cachesongs;
-    let allow_cache_write = config.cachesongs;
+    let never_cache = song_group_is_never_cached(&song.simfile_path);
+    let allow_cache_read = (config.fastload || config.cachesongs) && !never_cache;
+    let allow_cache_write = config.cachesongs && !never_cache;
     let verify_cache_freshness = !config.fastload;
     let load_started = Instant::now();
     if allow_cache_read
@@ -221,7 +236,8 @@ pub fn load_sync_analysis_chart(
     chart_ix: usize,
 ) -> Result<GameplayChartData, String> {
     let config = config::get();
-    let allow_cache_read = config.fastload || config.cachesongs;
+    let allow_cache_read = (config.fastload || config.cachesongs)
+        && !song_group_is_never_cached(&song.simfile_path);
     let verify_cache_freshness = !config.fastload;
     if allow_cache_read
         && let Some(mut charts) =

--- a/src/game/parsing/simfile/scan.rs
+++ b/src/game/parsing/simfile/scan.rs
@@ -234,6 +234,16 @@ where
         let pack_idx = loaded_packs.len();
         loaded_packs.push(current_pack);
 
+        // Honor NeverCacheList: WIP packs listed here always re-parse from disk
+        // and never read or write the on-disk song cache.
+        let pack_never_cache = crate::config::group_is_never_cached(&pack.group_name)
+            || crate::config::group_is_never_cached(&pack_display);
+        if pack_never_cache {
+            debug!("Skipping song cache for pack '{pack_display}' (NeverCacheList).");
+        }
+        let pack_fastload = fastload && !pack_never_cache;
+        let pack_cachesongs = cachesongs && !pack_never_cache;
+
         for song in pack.songs {
             let simfile_path = song.simfile;
             let song_display = song_progress_name(&simfile_path);
@@ -266,8 +276,8 @@ where
                 let Some(tx) = tx_opt.as_ref() else {
                     match process_song(
                         simfile_path.clone(),
-                        fastload,
-                        cachesongs,
+                        pack_fastload,
+                        pack_cachesongs,
                         global_offset_seconds,
                     ) {
                         Ok((song_data, is_hit)) => {
@@ -300,8 +310,8 @@ where
                     let out = catch_unwind(AssertUnwindSafe(|| {
                         process_song(
                             simfile_path_owned.clone(),
-                            fastload,
-                            cachesongs,
+                            pack_fastload,
+                            pack_cachesongs,
                             global_offset_seconds,
                         )
                         .map(|(data, is_hit)| (Arc::new(data), is_hit))
@@ -313,8 +323,8 @@ where
             } else {
                 match process_song(
                     simfile_path.clone(),
-                    fastload,
-                    cachesongs,
+                    pack_fastload,
+                    pack_cachesongs,
                     global_offset_seconds,
                 ) {
                     Ok((song_data, is_hit)) => {


### PR DESCRIPTION
## Why

ITGMania has a `NeverCacheList` preference that lets you exclude specific song groups from the on-disk cache. It is handy for work-in-progress packs whose files change often, where a stale cache would otherwise hide your edits. DeadSync only had the global `CacheSongs` / `FastLoad` toggles, so there was no way to keep one WIP pack always fresh without disabling caching for the whole library.

This ports `NeverCacheList` to DeadSync.

## What

Add a comma-separated `NeverCacheList` key under `[Options]` in `deadsync.ini`:

```ini
[Options]
NeverCacheList=My WIP Pack,Another WIP
```

Packs listed here always re-parse from disk and never read or write the on-disk song cache, even when `FastLoad=1`. Matching is case-insensitive and accepts either the logical group name or the on-disk folder name.