### PR TITLE
perf(select-music): downscale oversized banner art to fix wheel scroll lag

### DIFF
--- a/src/app/dynamic_media.rs
+++ b/src/app/dynamic_media.rs
@@ -306,7 +306,7 @@ impl DynamicMedia {
                 self.release_texture_key(assets, backend, old_key);
             }
 
-            let rgba = match media_cache::load_banner_source_rgba(&path) {
+            let rgba = match media_cache::load_banner_art_rgba(&path) {
                 Ok(rgba) => rgba,
                 Err(e) => {
                     warn!(
@@ -348,7 +348,7 @@ impl DynamicMedia {
         for path in paths {
             let key = path.to_string_lossy().into_owned();
             if desired.insert(key) {
-                media_cache::ensure_banner_texture(assets, backend, &path);
+                media_cache::ensure_banner_art_texture(assets, backend, &path);
             }
         }
 
@@ -381,7 +381,7 @@ impl DynamicMedia {
                 return current.key.clone();
             }
             self.destroy_current_dynamic_banner(assets, backend);
-            let rgba = match media_cache::load_banner_source_rgba(&path) {
+            let rgba = match media_cache::load_banner_art_rgba(&path) {
                 Ok(rgba) => rgba,
                 Err(e) => {
                     warn!(
@@ -1257,7 +1257,7 @@ fn prepare_banner_video(key: String, path: PathBuf) -> BannerVideoPrepResult {
         };
     }
 
-    let poster = match media_cache::load_banner_source_rgba(&path) {
+    let poster = match media_cache::load_banner_art_rgba(&path) {
         Ok(rgba) => rgba,
         Err(msg) => {
             return BannerVideoPrepResult::Failed { path, msg };

--- a/src/app/media_cache.rs
+++ b/src/app/media_cache.rs
@@ -11,10 +11,25 @@ use std::{
     time::Instant,
 };
 
+/// Maximum length (in pixels) of the longest side of a cached banner image.
+/// Banner art is drawn at roughly 320 virtual px wide, which is at most ~1440
+/// device px on a 4K display, so 1536 keeps it crisp everywhere while preventing
+/// oversized source art from slowing things down.
+const BANNER_MAX_DIMENSION: u32 = 1536;
+
 #[inline(always)]
 pub(crate) fn banner_cache_options() -> dynamic::BannerCacheOptions {
     dynamic::BannerCacheOptions {
         enabled: crate::config::get().banner_cache,
+        max_dim: None,
+    }
+}
+
+#[inline(always)]
+pub(crate) fn banner_art_cache_options() -> dynamic::BannerCacheOptions {
+    dynamic::BannerCacheOptions {
+        enabled: crate::config::get().banner_cache,
+        max_dim: Some(BANNER_MAX_DIMENSION),
     }
 }
 
@@ -22,25 +37,46 @@ pub(crate) fn banner_cache_options() -> dynamic::BannerCacheOptions {
 pub(crate) fn cdtitle_cache_options() -> dynamic::BannerCacheOptions {
     dynamic::BannerCacheOptions {
         enabled: crate::config::get().cdtitle_cache,
+        max_dim: None,
     }
 }
 
-pub(crate) fn load_banner_source_rgba(path: &Path) -> Result<RgbaImage, String> {
-    let opts = banner_cache_options();
+fn load_dynamic_image_rgba(
+    path: &Path,
+    opts: dynamic::BannerCacheOptions,
+    cache_dir: &Path,
+) -> Result<RgbaImage, String> {
     if opts.enabled {
-        return dynamic::load_or_build_cached_dynamic_image(
-            path,
-            opts,
-            &dirs::app_dirs().banner_cache_dir(),
-        )
-        .map_err(|e| e.to_string());
+        return dynamic::load_or_build_cached_dynamic_image(path, opts, cache_dir)
+            .map_err(|e| e.to_string());
     }
-    if dynamic::is_dynamic_video_path(path) {
-        return video::load_poster(path);
-    }
-    open_image_fallback(path)
-        .map(|img| img.to_rgba8())
-        .map_err(|e| e.to_string())
+    let rgba = if dynamic::is_dynamic_video_path(path) {
+        video::load_poster(path)?
+    } else {
+        open_image_fallback(path)
+            .map(|img| img.to_rgba8())
+            .map_err(|e| e.to_string())?
+    };
+    Ok(dynamic::downscale_to_max_dim(rgba, opts.max_dim))
+}
+
+/// Loads an image at full resolution.
+pub(crate) fn load_banner_source_rgba(path: &Path) -> Result<RgbaImage, String> {
+    load_dynamic_image_rgba(
+        path,
+        banner_cache_options(),
+        &dirs::app_dirs().banner_cache_dir(),
+    )
+}
+
+/// Loads banner art, downscaling oversized source images to keep wheel scrolling
+/// smooth.
+pub(crate) fn load_banner_art_rgba(path: &Path) -> Result<RgbaImage, String> {
+    load_dynamic_image_rgba(
+        path,
+        banner_art_cache_options(),
+        &dirs::app_dirs().banner_cache_dir(),
+    )
 }
 
 pub(crate) fn load_cdtitle_source_rgba(path: &Path) -> Result<RgbaImage, String> {
@@ -74,6 +110,31 @@ pub(crate) fn ensure_banner_texture(assets: &mut AssetManager, backend: &mut Bac
 
     if let Err(e) = assets.update_texture_for_key(backend, &key, &rgba) {
         warn!("Failed to create GPU texture for image {path:?}: {e}. Skipping.");
+    }
+}
+
+/// Like [`ensure_banner_texture`], but downscales oversized banner art so that
+/// uploading it does not stall the frame (see [`load_banner_art_rgba`]).
+pub(crate) fn ensure_banner_art_texture(
+    assets: &mut AssetManager,
+    backend: &mut Backend,
+    path: &Path,
+) {
+    let key = path.to_string_lossy().into_owned();
+    if assets.has_texture_key(&key) {
+        return;
+    }
+
+    let rgba = match load_banner_art_rgba(path) {
+        Ok(rgba) => rgba,
+        Err(e) => {
+            warn!("Failed to load banner art {path:?}: {e}. Skipping.");
+            return;
+        }
+    };
+
+    if let Err(e) = assets.update_texture_for_key(backend, &key, &rgba) {
+        warn!("Failed to create GPU texture for banner art {path:?}: {e}. Skipping.");
     }
 }
 
@@ -317,7 +378,7 @@ fn prewarm_dynamic_image_jobs_with_progress<F>(
 }
 
 pub(crate) fn artwork_cache_jobs(banner_paths: &[PathBuf], cdtitle_paths: &[PathBuf]) -> usize {
-    let banner_opts = banner_cache_options();
+    let banner_opts = banner_art_cache_options();
     let cdtitle_opts = cdtitle_cache_options();
     let total_paths = banner_paths.len().saturating_add(cdtitle_paths.len());
     let mut unique = HashSet::<String>::with_capacity(total_paths);
@@ -347,7 +408,7 @@ pub(crate) fn prewarm_artwork_cache_with_progress<F>(
 ) where
     F: FnMut(usize, usize, Option<&Path>),
 {
-    let banner_opts = banner_cache_options();
+    let banner_opts = banner_art_cache_options();
     let cdtitle_opts = cdtitle_cache_options();
     let total_paths = banner_paths.len().saturating_add(cdtitle_paths.len());
     let mut unique = HashSet::<String>::with_capacity(total_paths);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9526,7 +9526,11 @@ impl App {
                         &overlay_video_paths,
                     );
                     if let Some(path) = gs.song().banner_path.as_ref() {
-                        media_cache::ensure_banner_texture(&mut self.asset_manager, backend, path);
+                        media_cache::ensure_banner_art_texture(
+                            &mut self.asset_manager,
+                            backend,
+                            path,
+                        );
                     }
                 }
                 let asset_prewarm_ms = asset_prewarm_started.elapsed().as_secs_f64() * 1000.0;
@@ -9954,7 +9958,11 @@ impl App {
                         &overlay_video_paths,
                     );
                     if let Some(path) = gs.song().banner_path.as_ref() {
-                        media_cache::ensure_banner_texture(&mut self.asset_manager, backend, path);
+                        media_cache::ensure_banner_art_texture(
+                            &mut self.asset_manager,
+                            backend,
+                            path,
+                        );
                     }
                 }
                 let asset_prewarm_ms = asset_prewarm_started.elapsed().as_secs_f64() * 1000.0;
@@ -10034,7 +10042,7 @@ impl App {
             if let (Some(backend), Some(gs)) = (self.backend.as_mut(), gameplay_results.as_ref())
                 && let Some(path) = gs.song().banner_path.as_ref()
             {
-                media_cache::ensure_banner_texture(&mut self.asset_manager, backend, path);
+                media_cache::ensure_banner_art_texture(&mut self.asset_manager, backend, path);
             }
             let color_idx = gameplay_results.as_ref().map_or(
                 self.state.screens.evaluation_state.active_color_index,
@@ -10087,7 +10095,11 @@ impl App {
             if let Some(backend) = self.backend.as_mut() {
                 for stage in display_stages.iter() {
                     if let Some(path) = stage.song.banner_path.as_ref() {
-                        media_cache::ensure_banner_texture(&mut self.asset_manager, backend, path);
+                        media_cache::ensure_banner_art_texture(
+                            &mut self.asset_manager,
+                            backend,
+                            path,
+                        );
                     }
                 }
             }
@@ -10118,7 +10130,11 @@ impl App {
             if let Some(backend) = self.backend.as_mut() {
                 for stage in display_stages.iter() {
                     if let Some(path) = stage.song.banner_path.as_ref() {
-                        media_cache::ensure_banner_texture(&mut self.asset_manager, backend, path);
+                        media_cache::ensure_banner_art_texture(
+                            &mut self.asset_manager,
+                            backend,
+                            path,
+                        );
                     }
                 }
             }

--- a/src/assets/dynamic.rs
+++ b/src/assets/dynamic.rs
@@ -16,13 +16,35 @@ static BANNER_CACHE_TMP_COUNTER: AtomicU64 = AtomicU64::new(1);
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct BannerCacheOptions {
     pub(crate) enabled: bool,
+    /// When set, the longest side of the decoded image is clamped to this many
+    /// pixels (preserving aspect ratio) before it is cached or uploaded.
+    pub(crate) max_dim: Option<u32>,
 }
 
 fn banner_cache_opthash(opts: BannerCacheOptions) -> u64 {
     let mut hasher = XxHash64::with_seed(0);
-    hasher.write_u8(1);
+    hasher.write_u8(2);
     hasher.write_u8(u8::from(opts.enabled));
+    hasher.write_u32(opts.max_dim.unwrap_or(0));
     hasher.finish()
+}
+
+/// Downscale `img` so its longest side is at most `max_dim` pixels, preserving
+/// aspect ratio. Images already within the limit (or when no limit is given)
+/// are returned untouched.
+pub(crate) fn downscale_to_max_dim(img: RgbaImage, max_dim: Option<u32>) -> RgbaImage {
+    let Some(max_dim) = max_dim.filter(|d| *d > 0) else {
+        return img;
+    };
+    let (w, h) = img.dimensions();
+    let longest = w.max(h);
+    if longest <= max_dim {
+        return img;
+    }
+    let scale = f64::from(max_dim) / f64::from(longest);
+    let new_w = ((f64::from(w) * scale).round() as u32).max(1);
+    let new_h = ((f64::from(h) * scale).round() as u32).max(1);
+    image::imageops::resize(&img, new_w, new_h, image::imageops::FilterType::Lanczos3)
 }
 
 const BANNER_CACHE_MAGIC: [u8; 8] = *b"DSBNR02\0";
@@ -272,13 +294,15 @@ pub(crate) fn ensure_cached_dynamic_image_on_disk(
 
 fn build_cached_banner_rgba(
     path: &Path,
-    _opts: BannerCacheOptions,
+    opts: BannerCacheOptions,
 ) -> image::ImageResult<RgbaImage> {
-    if is_dynamic_video_path(path) {
-        return video::load_poster(path)
-            .map_err(|e| image::ImageError::IoError(std::io::Error::other(e)));
-    }
-    Ok(open_image_fallback_quiet(path)?.to_rgba8())
+    let rgba = if is_dynamic_video_path(path) {
+        video::load_poster(path)
+            .map_err(|e| image::ImageError::IoError(std::io::Error::other(e)))?
+    } else {
+        open_image_fallback_quiet(path)?.to_rgba8()
+    };
+    Ok(downscale_to_max_dim(rgba, opts.max_dim))
 }
 
 pub(crate) fn dedupe_dynamic_keys(keys: Vec<String>) -> Vec<String> {
@@ -290,4 +314,46 @@ pub(crate) fn dedupe_dynamic_keys(keys: Vec<String>) -> Vec<String> {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BannerCacheOptions, banner_cache_opthash, downscale_to_max_dim};
+    use image::RgbaImage;
+
+    #[test]
+    fn downscale_clamps_longest_side_and_keeps_aspect() {
+        let img = RgbaImage::new(3483, 1368);
+        let out = downscale_to_max_dim(img, Some(1536));
+        assert_eq!(out.width(), 1536);
+        // 1368 * 1536 / 3483 ≈ 603, aspect ratio preserved.
+        assert_eq!(out.height(), 603);
+    }
+
+    #[test]
+    fn downscale_leaves_small_images_untouched() {
+        let img = RgbaImage::new(418, 164);
+        let out = downscale_to_max_dim(img, Some(1536));
+        assert_eq!(out.dimensions(), (418, 164));
+    }
+
+    #[test]
+    fn downscale_noop_without_limit() {
+        let img = RgbaImage::new(4000, 4000);
+        let out = downscale_to_max_dim(img, None);
+        assert_eq!(out.dimensions(), (4000, 4000));
+    }
+
+    #[test]
+    fn max_dim_changes_cache_opthash() {
+        let without = banner_cache_opthash(BannerCacheOptions {
+            enabled: true,
+            max_dim: None,
+        });
+        let with = banner_cache_opthash(BannerCacheOptions {
+            enabled: true,
+            max_dim: Some(1536),
+        });
+        assert_ne!(without, with);
+    }
 }

--- a/src/assets/mod.rs
+++ b/src/assets/mod.rs
@@ -1050,7 +1050,10 @@ mod tests {
         let dir = TempDir::new("cache-hit-no-prune");
         let src = dir.path().join("banner.png");
         let cache_dir = dir.path().join("cache");
-        let opts = BannerCacheOptions { enabled: true };
+        let opts = BannerCacheOptions {
+            enabled: true,
+            max_dim: None,
+        };
         let expected = test_rgba([1, 2, 3, 4]);
 
         write_test_png(&src, [1, 2, 3, 4]);
@@ -1077,7 +1080,10 @@ mod tests {
         let dir = TempDir::new("cache-write-prune");
         let src = dir.path().join("banner.png");
         let cache_dir = dir.path().join("cache");
-        let opts = BannerCacheOptions { enabled: true };
+        let opts = BannerCacheOptions {
+            enabled: true,
+            max_dim: None,
+        };
         let current = test_rgba([4, 3, 2, 1]);
 
         write_test_png(&src, [4, 3, 2, 1]);


### PR DESCRIPTION
## Why

Fast-scrolling (tab) through the song wheel stuttered noticeably when passing certain folders, most reproducibly The Starter Pack of Stamina 2. That pack's banner is 3483x1368, which is ~18 MB of raw RGBA versus ~0.27 MB for a normal 418x164 banner.

The banner for the current selection is destroyed and recreated on every selection change, and each load decodes plus GPU-uploads the image synchronously on the main thread. Re-uploading an 18 MB texture on every step (and again for the wheel-row backgrounds as you scroll back and forth) stalled the frame, which is exactly the lag the user hit.

## Approach

Cap the longest side of cached banner art at 1536 px, preserving aspect ratio, before it is cached or uploaded. Banners are only ever drawn a few hundred virtual px wide (at most ~1440 device px on a 4K display), so 1536 keeps them crisp everywhere while making decode and upload cheap. The cap is computed once and stored in the on-disk banner cache.

- `BannerCacheOptions` gains a `max_dim` field, and a `downscale_to_max_dim` helper (Lanczos3) runs when building the cache entry.
- `media_cache` splits banner loading into a downscaled "art" path (`load_banner_art_rgba` / `ensure_banner_art_texture`) used by everything that draws a banner, and the existing full-resolution path.
- The cap is folded into the cache opthash so any previously cached full-size banners rebuild automatically.