### PR TITLE
Force XMod on XMod-tagged charts

### DIFF
--- a/crates/deadsync-chart/src/song.rs
+++ b/crates/deadsync-chart/src/song.rs
@@ -311,6 +311,12 @@ impl SongData {
             .contains("no cmod")
     }
 
+    pub fn is_xmod(&self) -> bool {
+        self.display_full_title(false)
+            .to_ascii_lowercase()
+            .contains("xmod")
+    }
+
     pub fn has_standard_difficulty(&self, chart_type: &str, difficulty_index: usize) -> bool {
         let Some(target) = STANDARD_DIFFICULTY_NAMES.get(difficulty_index) else {
             return false;
@@ -718,6 +724,19 @@ mod tests {
         song.subtitle = "Mix".to_string();
         song.title = "Hard Song [No CMod]".to_string();
         assert!(song.is_no_cmod());
+    }
+
+    #[test]
+    fn is_xmod_matches_title_or_subtitle_case_insensitively() {
+        let mut song = song_data();
+        assert!(!song.is_xmod());
+
+        song.subtitle = "(XMOD)".to_string();
+        assert!(song.is_xmod());
+
+        song.subtitle = "Mix".to_string();
+        song.title = "Hard Song (xmod only)".to_string();
+        assert!(song.is_xmod());
     }
 
     #[test]

--- a/src/screens/player_options/profile.rs
+++ b/src/screens/player_options/profile.rs
@@ -164,20 +164,50 @@ pub(super) fn effective_scroll_speed_with_alt(
     }
 }
 
+/// Resolve the scroll speed a single player will actually use for a chart,
+/// applying both the XMod-tag force and the no-cmod alternative.
+///
+/// XMod-tagged charts demand XMod: any non-XMod `base` (CMod or MMod) is converted
+/// to the equivalent XMod, preserving on-screen scroll speed. This is unconditional
+/// (it ignores the `NoCmodAlternative` preference) and takes precedence over the
+/// no-cmod substitution. When the chart is not XMod-tagged, this defers to
+/// [`effective_scroll_speed_with_alt`].
+pub(super) fn effective_scroll_speed_for_chart(
+    base: &SpeedMod,
+    alt: deadsync_profile::NoCmodAlternative,
+    is_no_cmod: bool,
+    is_xmod: bool,
+    reference_bpm: f32,
+    rate: f32,
+) -> ScrollSpeedSetting {
+    if is_xmod && base.mod_type != SpeedModType::X {
+        return scroll_speed_for_mod(&convert_speed_mod_to_type(
+            base,
+            SpeedModType::X,
+            reference_bpm,
+            rate,
+        ));
+    }
+    effective_scroll_speed_with_alt(base, alt, is_no_cmod, reference_bpm, rate)
+}
+
 /// Resolve the scroll speed each player will actually use for the upcoming
 /// play, applying the "No CMod alternative" substitution for charts tagged
-/// "no cmod".
+/// "no cmod" and forcing XMod for charts tagged "xmod".
 ///
 /// For any player who is on CMod, is about to play a no-cmod chart, and has a
 /// non-`None` alternative configured, their CMod speed is converted (preserving
-/// on-screen speed) to the chosen X/M type. The substitution is written into
+/// on-screen speed) to the chosen X/M type. For charts tagged "xmod", any player
+/// not already on XMod is converted to the equivalent XMod regardless of their
+/// alternative preference. The substitution is written into
 /// the (non-persisted) `player_profiles[..].scroll_speed` snapshot as well as
 /// returned, so both the arrow-scroll path (which reads the returned array) and
 /// the score-validity path (which reads `player_profiles`) observe the same
 /// effective speed. The persisted profile is never touched, so returning to
-/// song select restores CMod automatically.
+/// song select restores the player's real mod automatically.
 pub fn apply_no_cmod_alternative(state: &mut State) -> [ScrollSpeedSetting; PLAYER_SLOTS] {
     let is_no_cmod = state.song.is_no_cmod();
+    let is_xmod = state.song.is_xmod();
     let reference_bpm = reference_bpm_for_song(
         &state.song,
         resolve_p1_chart(&state.song, &state.chart_steps_index),
@@ -188,10 +218,11 @@ pub fn apply_no_cmod_alternative(state: &mut State) -> [ScrollSpeedSetting; PLAY
         1.0
     };
     std::array::from_fn(|player_idx| {
-        let effective = effective_scroll_speed_with_alt(
+        let effective = effective_scroll_speed_for_chart(
             &state.speed_mod[player_idx],
             state.player_profiles[player_idx].no_cmod_alternative,
             is_no_cmod,
+            is_xmod,
             reference_bpm,
             rate,
         );

--- a/src/screens/player_options/tests.rs
+++ b/src/screens/player_options/tests.rs
@@ -9,12 +9,12 @@ pub(super) mod tests {
         HUD_OFFSET_MAX, HUD_OFFSET_MIN, HUD_OFFSET_ZERO_INDEX, HideMask, NAV_INITIAL_HOLD_DELAY,
         NavDirection, NumericBinding, NumericInit, P1, P2, PlayerOptionMasks, Row, RowBehavior,
         RowId, RowMap, ScrollMask, SpeedMod, SpeedModType, compute_row_window, count_visible_rows,
-        effective_scroll_speed_with_alt, handle_arcade_start_event, handle_nav_event,
-        handle_start_event, hud_offset_choices, init_cycle_row_from_binding,
-        init_numeric_row_from_binding, is_row_visible, judgment_tilt_options_visible,
-        on_start_press, player_option_column_x, repeat_held_arcade_start, row_f_pos_for_index,
-        row_visibility, session_active_players, sync_profile_scroll_speed, sync_speed_mod_type_row,
-        update,
+        effective_scroll_speed_for_chart, effective_scroll_speed_with_alt,
+        handle_arcade_start_event, handle_nav_event, handle_start_event, hud_offset_choices,
+        init_cycle_row_from_binding, init_numeric_row_from_binding, is_row_visible,
+        judgment_tilt_options_visible, on_start_press, player_option_column_x,
+        repeat_held_arcade_start, row_f_pos_for_index, row_visibility, session_active_players,
+        sync_profile_scroll_speed, sync_speed_mod_type_row, update,
     };
     use crate::assets::AssetManager;
     use crate::assets::i18n::{LookupKey, lookup_key};
@@ -215,6 +215,75 @@ pub(super) mod tests {
                 rate
             ),
             ScrollSpeedSetting::XMod(2.0)
+        );
+    }
+
+    #[test]
+    fn xmod_tagged_chart_forces_xmod_preserving_on_screen_speed() {
+        let (reference_bpm, rate) = (150.0, 1.0);
+
+        // CMod on an xmod chart → equivalent XMod (C600 == X4.0 at 150 BPM).
+        let cmod = SpeedMod {
+            mod_type: SpeedModType::C,
+            value: 600.0,
+        };
+        assert_eq!(
+            effective_scroll_speed_for_chart(
+                &cmod,
+                NoCmodAlternative::None,
+                false,
+                true,
+                reference_bpm,
+                rate
+            ),
+            ScrollSpeedSetting::XMod(4.0)
+        );
+
+        // MMod on an xmod chart → equivalent XMod (M600 == X4.0 at 150 BPM).
+        let mmod = SpeedMod {
+            mod_type: SpeedModType::M,
+            value: 600.0,
+        };
+        assert_eq!(
+            effective_scroll_speed_for_chart(
+                &mmod,
+                NoCmodAlternative::None,
+                false,
+                true,
+                reference_bpm,
+                rate
+            ),
+            ScrollSpeedSetting::XMod(4.0)
+        );
+
+        // Already on XMod → unchanged.
+        let xmod = SpeedMod {
+            mod_type: SpeedModType::X,
+            value: 2.0,
+        };
+        assert_eq!(
+            effective_scroll_speed_for_chart(
+                &xmod,
+                NoCmodAlternative::None,
+                false,
+                true,
+                reference_bpm,
+                rate
+            ),
+            ScrollSpeedSetting::XMod(2.0)
+        );
+
+        // Not an xmod chart → defers to the no-cmod logic (here: unchanged CMod).
+        assert_eq!(
+            effective_scroll_speed_for_chart(
+                &cmod,
+                NoCmodAlternative::None,
+                false,
+                false,
+                reference_bpm,
+                rate
+            ),
+            ScrollSpeedSetting::CMod(600.0)
         );
     }
 


### PR DESCRIPTION
## Why

Some packs (for example Maxx Simz 3) tag charts with `(XMOD ...)` in the title or subtitle to signal that they are meant to be played on XMod. Only the `no cmod` tag was recognized, so these charts did nothing special and a player on CMod or MMod would play them with the wrong scroll mod.

## What

- Add `SongData::is_xmod()` (`crates/deadsync-chart/src/song.rs`), which matches `"xmod"` anywhere in the combined title + subtitle, case-insensitively. `is_no_cmod()` is left unchanged.
- In `apply_no_cmod_alternative` (`src/screens/player_options/profile.rs`), force XMod on XMod-tagged charts: any non-XMod speed (CMod or MMod) is converted to the equivalent XMod, preserving on-screen scroll speed via the same conversion the manual Type-of-Speed-Mod row uses.