### PR TITLE
Add lobby code to online lobbies hud

### DIFF
--- a/src/screens/components/shared/lobby_hud.rs
+++ b/src/screens/components/shared/lobby_hud.rs
@@ -70,13 +70,14 @@ fn build_body_lines(
 ) -> Vec<String> {
     let mut lines = Vec::new();
 
+    lines.push(format!("Lobby Code: {}", joined.code));
+    lines.push(String::new());
+
     if let Some(status_text) = status_text {
         for line in status_text.lines() {
             lines.push(truncate_text(line, 44));
         }
-        if !lines.is_empty() {
-            lines.push(String::new());
-        }
+        lines.push(String::new());
     }
 
     let ordered_players = ordered_players(joined);


### PR DESCRIPTION
### Fix
Added Lobby Code to the online lobbies panel. This appears in music select and in game, and at the top of the lines of data for visibility.

### Reasoning
This has been requested a few times, either in the DeadSync dev channel or on streams. I have watched streamers have to go back into the online lobbies screen to tell the other player what the lobby code is, when it would be more convenient for it to be visible on all screens.