### PR TITLE
gameplay: fix crossover cue fade timing and crossfade behavior

### DIFF
--- a/crates/deadsync-gameplay/src/cues.rs
+++ b/crates/deadsync-gameplay/src/cues.rs
@@ -53,6 +53,23 @@ pub fn active_column_cue(cues: &[ColumnCue], current_time: f32) -> Option<&Colum
     idx.checked_sub(1).and_then(|i| cues.get(i))
 }
 
+// Returns every cue whose [start_time, start_time + duration] window contains
+// `current_time`, as a contiguous slice in chronological order.
+#[inline]
+pub fn active_column_cues(cues: &[ColumnCue], current_time: f32) -> &[ColumnCue] {
+    let end = cues.partition_point(|cue| cue.start_time <= current_time);
+    let mut begin = end;
+    while begin > 0 {
+        let cue = &cues[begin - 1];
+        if current_time < cue.start_time + cue.duration {
+            begin -= 1;
+        } else {
+            break;
+        }
+    }
+    &cues[begin..end]
+}
+
 // Lead-in/out fade applied to every crossover cue.
 pub const CROSSOVER_CUE_FADE_SECONDS: f32 = 0.075;
 

--- a/crates/deadsync-gameplay/src/cues.rs
+++ b/crates/deadsync-gameplay/src/cues.rs
@@ -53,10 +53,12 @@ pub fn active_column_cue(cues: &[ColumnCue], current_time: f32) -> Option<&Colum
     idx.checked_sub(1).and_then(|i| cues.get(i))
 }
 
-// Returns every cue whose [start_time, start_time + duration] window contains
-// `current_time`, as a contiguous slice in chronological order.
+// Returns the half-open index range of cues whose [start_time, start_time +
+// duration] window contains `current_time`, in chronological order. Consecutive
+// crossover cues are built to overlap by the fade time, so up to two cues can be
+// active at once.
 #[inline]
-pub fn active_column_cues(cues: &[ColumnCue], current_time: f32) -> &[ColumnCue] {
+pub fn active_column_cue_range(cues: &[ColumnCue], current_time: f32) -> core::ops::Range<usize> {
     let end = cues.partition_point(|cue| cue.start_time <= current_time);
     let mut begin = end;
     while begin > 0 {
@@ -67,11 +69,29 @@ pub fn active_column_cues(cues: &[ColumnCue], current_time: f32) -> &[ColumnCue]
             break;
         }
     }
-    &cues[begin..end]
+    begin..end
+}
+
+// Returns every cue whose [start_time, start_time + duration] window contains
+// `current_time`, as a contiguous slice in chronological order. Rendering all of
+// them lets the outgoing cue's fade-out crossfade with the incoming cue's
+// fade-in, matching the 8ms theme where each cue animates on its own independent
+// column actor.
+#[inline]
+pub fn active_column_cues(cues: &[ColumnCue], current_time: f32) -> &[ColumnCue] {
+    &cues[active_column_cue_range(cues, current_time)]
 }
 
 // Lead-in/out fade applied to every crossover cue.
 pub const CROSSOVER_CUE_FADE_SECONDS: f32 = 0.075;
+
+// When the playhead first crosses a cue's start, the cue is only shown if it was
+// reached within this window. During normal play a cue is always caught a frame
+// or two after its start (well under the fade time). After a practice-mode seek
+// that lands past this window, the cue is suppressed instead of popping in at
+// partial/full alpha. Using the fade time guarantees a caught cue is still
+// inside its fade-in, so it always fades in from a low alpha.
+pub const CROSSOVER_CUE_SEEK_GUARD_SECONDS: f32 = CROSSOVER_CUE_FADE_SECONDS;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct CrossoverRow {

--- a/crates/deadsync-gameplay/src/runtime_state.rs
+++ b/crates/deadsync-gameplay/src/runtime_state.rs
@@ -303,6 +303,15 @@ pub struct GameplayCueRuntimeState {
     measure_counter_segments: [Vec<StreamSegment>; MAX_PLAYERS],
     column_cues: [Vec<ColumnCue>; MAX_PLAYERS],
     crossover_cues: [Vec<ColumnCue>; MAX_PLAYERS],
+    // Per crossover cue: None = not yet reached (or rewound before its start),
+    // Some(t) = the fade-in anchor time. During normal play this is the cue's own
+    // start; when the playhead seeks into the middle of a cue it is the landing
+    // time, so the cue fades in from there instead of popping in at full alpha.
+    crossover_cue_entry: [Vec<Option<f32>>; MAX_PLAYERS],
+    // Number of leading crossover cues whose start has been crossed (and thus
+    // anchored) at the last evaluated time. Lets the gate anchor/rewind only the
+    // cues that changed since the previous frame.
+    crossover_cue_cursor: [usize; MAX_PLAYERS],
 }
 
 impl Default for GameplayCueRuntimeState {
@@ -311,6 +320,8 @@ impl Default for GameplayCueRuntimeState {
             measure_counter_segments: std::array::from_fn(|_| Vec::new()),
             column_cues: std::array::from_fn(|_| Vec::new()),
             crossover_cues: std::array::from_fn(|_| Vec::new()),
+            crossover_cue_entry: std::array::from_fn(|_| Vec::new()),
+            crossover_cue_cursor: [0; MAX_PLAYERS],
         }
     }
 }
@@ -325,6 +336,8 @@ impl GameplayCueRuntimeState {
             measure_counter_segments,
             column_cues,
             crossover_cues,
+            crossover_cue_entry: std::array::from_fn(|_| Vec::new()),
+            crossover_cue_cursor: [0; MAX_PLAYERS],
         }
     }
 
@@ -345,6 +358,58 @@ impl GameplayCueRuntimeState {
         self.crossover_cues.get(player).map_or(&[], Vec::as_slice)
     }
 
+    // Advances the per-player crossover cue fade-in anchors to `current_time`
+    // (visible music seconds). The first frame the playhead crosses a cue's
+    // start, anchor it to the cue's start if it was reached within
+    // CROSSOVER_CUE_SEEK_GUARD_SECONDS (normal play -> natural fade-in) or to
+    // `current_time` if the start was jumped over (seek -> fade in from the
+    // landing point). Anchors are cleared for cues the playhead has rewound
+    // before, so a replayed section fades in naturally. Call once per player per
+    // frame.
+    pub fn update_crossover_cue_anchors(&mut self, player: usize, current_time: f32) {
+        let Some(cues) = self.crossover_cues.get(player) else {
+            return;
+        };
+        let Some(entry) = self.crossover_cue_entry.get_mut(player) else {
+            return;
+        };
+        if entry.len() != cues.len() {
+            entry.clear();
+            entry.resize(cues.len(), None);
+            self.crossover_cue_cursor[player] = 0;
+        }
+        if cues.is_empty() {
+            return;
+        }
+        let cursor = self.crossover_cue_cursor[player];
+        let target = cues.partition_point(|cue| cue.start_time <= current_time);
+        if target > cursor {
+            for i in cursor..target {
+                let start = cues[i].start_time;
+                entry[i] = Some(if current_time - start < CROSSOVER_CUE_SEEK_GUARD_SECONDS {
+                    start
+                } else {
+                    current_time
+                });
+            }
+        } else if target < cursor {
+            for slot in &mut entry[target..cursor] {
+                *slot = None;
+            }
+        }
+        self.crossover_cue_cursor[player] = target;
+    }
+
+    // The fade-in anchor time for the crossover cue at `index`, or None when the
+    // cue has not been reached yet or is outside a tracked gate (callers fall
+    // back to the cue's own start, i.e. the natural fade-in).
+    #[inline(always)]
+    pub fn crossover_cue_entry_time(&self, player: usize, index: usize) -> Option<f32> {
+        self.crossover_cue_entry
+            .get(player)
+            .and_then(|entry| entry.get(index).copied().flatten())
+    }
+
     #[inline(always)]
     pub fn set_column_cues_for_benchmark(&mut self, player: usize, cues: Vec<ColumnCue>) {
         if let Some(slot) = self.column_cues.get_mut(player) {
@@ -363,6 +428,10 @@ impl GameplayCueRuntimeState {
         for cues in &mut self.crossover_cues {
             cues.clear();
         }
+        for entry in &mut self.crossover_cue_entry {
+            entry.clear();
+        }
+        self.crossover_cue_cursor = [0; MAX_PLAYERS];
     }
 }
 

--- a/crates/deadsync-gameplay/src/runtime_update.rs
+++ b/crates/deadsync-gameplay/src/runtime_update.rs
@@ -1262,6 +1262,13 @@ where
     }
 
     #[inline(always)]
+    pub fn crossover_cue_entry_time(&self, player: usize, index: usize) -> Option<f32> {
+        self.display
+            .cue_runtime
+            .crossover_cue_entry_time(player, index)
+    }
+
+    #[inline(always)]
     pub fn set_column_cues(&mut self, player: usize, cues: Vec<ColumnCue>) {
         self.display
             .cue_runtime
@@ -2874,12 +2881,16 @@ where
         for player in 0..self.setup.num_players {
             let delay = self.clock.visible_timing.visual_delay_seconds(player);
             let visible_time_ns = visible_notefield_time_ns(music_time_ns, delay);
+            let visible_time_seconds = song_time_ns_to_seconds(visible_time_ns);
             self.clock.visible_timing.set_player_time(
                 player,
                 visible_time_ns,
-                song_time_ns_to_seconds(visible_time_ns),
+                visible_time_seconds,
                 self.timing_runtime.timing_players[player].get_beat_for_time_ns(visible_time_ns),
             );
+            self.display
+                .cue_runtime
+                .update_crossover_cue_anchors(player, visible_time_seconds);
         }
     }
 

--- a/crates/deadsync-gameplay/src/tests.rs
+++ b/crates/deadsync-gameplay/src/tests.rs
@@ -12019,6 +12019,44 @@ mod tests {
         assert_eq!(active_column_cue(&cues, 9.0).unwrap().start_time, 3.0);
     }
 
+    #[test]
+    fn active_column_cues_returns_overlapping_window() {
+        // Two consecutive cues overlapping by the fade time, as the builder emits
+        // them: cue2.start == cue1.end - fade.
+        let fade = CROSSOVER_CUE_FADE_SECONDS;
+        let cues = [
+            ColumnCue {
+                start_time: 1.0,
+                duration: 0.5,
+                columns: Vec::new(),
+            },
+            ColumnCue {
+                start_time: 1.5 - fade,
+                duration: 0.5,
+                columns: Vec::new(),
+            },
+        ];
+
+        // Before anything starts: empty.
+        assert!(active_column_cues(&cues, 0.99).is_empty());
+        // Only the first cue is active well inside its window.
+        let only_first = active_column_cues(&cues, 1.2);
+        assert_eq!(only_first.len(), 1);
+        assert_eq!(only_first[0].start_time, 1.0);
+        // Inside the overlap region both cues render simultaneously.
+        let overlap = active_column_cues(&cues, 1.5 - fade + 0.01);
+        assert_eq!(overlap.len(), 2);
+        assert_eq!(overlap[0].start_time, 1.0);
+        assert_eq!(overlap[1].start_time, 1.5 - fade);
+        // After the first cue ends, only the second remains.
+        let only_second = active_column_cues(&cues, 1.6);
+        assert_eq!(only_second.len(), 1);
+        assert_eq!(only_second[0].start_time, 1.5 - fade);
+        // After both end: empty.
+        assert!(active_column_cues(&cues, 9.0).is_empty());
+        assert!(active_column_cues(&[], 2.0).is_empty());
+    }
+
     fn xover_anno(beat: f32, note_count: u8, column_mask: u8, is_crossover: bool) -> CrossoverRow {
         debug_assert_eq!(
             u32::from(note_count),

--- a/crates/deadsync-gameplay/src/tests.rs
+++ b/crates/deadsync-gameplay/src/tests.rs
@@ -13227,6 +13227,55 @@ mod tests {
     }
 
     #[test]
+    fn crossover_cue_anchor_tracks_entry_time() {
+        let new_state = || {
+            let measure_counter_segments: [Vec<StreamSegment>; MAX_PLAYERS] =
+                std::array::from_fn(|_| Vec::new());
+            let column_cues: [Vec<ColumnCue>; MAX_PLAYERS] = std::array::from_fn(|_| Vec::new());
+            let mut crossover_cues: [Vec<ColumnCue>; MAX_PLAYERS] =
+                std::array::from_fn(|_| Vec::new());
+            // Two well-separated cues so seeking lands clearly inside one.
+            crossover_cues[0].push(ColumnCue {
+                start_time: 1.0,
+                duration: 1.0,
+                columns: Vec::new(),
+            });
+            crossover_cues[0].push(ColumnCue {
+                start_time: 5.0,
+                duration: 1.0,
+                columns: Vec::new(),
+            });
+            GameplayCueRuntimeState::new(measure_counter_segments, column_cues, crossover_cues)
+        };
+
+        // Normal forward play: each cue is caught near its start, so it anchors
+        // to its own start (natural fade-in).
+        let mut state = new_state();
+        state.update_crossover_cue_anchors(0, 0.5);
+        state.update_crossover_cue_anchors(0, 1.0 + 0.01);
+        assert_eq!(state.crossover_cue_entry_time(0, 0), Some(1.0));
+
+        // Seek straight into the middle of cue 1: it anchors to the landing time,
+        // so the renderer fades it in from there instead of popping it in.
+        state.update_crossover_cue_anchors(0, 5.5);
+        assert_eq!(state.crossover_cue_entry_time(0, 1), Some(5.5));
+        // Cue 0 keeps its earlier natural anchor.
+        assert_eq!(state.crossover_cue_entry_time(0, 0), Some(1.0));
+
+        // Rewind before cue 1's start, then catch it from the start: it re-anchors
+        // to its own start.
+        state.update_crossover_cue_anchors(0, 4.0);
+        assert_eq!(state.crossover_cue_entry_time(0, 1), None);
+        state.update_crossover_cue_anchors(0, 5.0 + 0.01);
+        assert_eq!(state.crossover_cue_entry_time(0, 1), Some(5.0));
+
+        // Out-of-range / untracked players have no anchor (callers fall back to
+        // the cue's own start).
+        assert_eq!(state.crossover_cue_entry_time(0, 99), None);
+        assert_eq!(state.crossover_cue_entry_time(1, 0), None);
+    }
+
+    #[test]
     fn hold_feedback_state_returns_slices_and_clears() {
         let mut state = GameplayHoldFeedbackState::default();
         state.hold_judgments[1] = Some(HoldJudgmentRenderInfo {

--- a/crates/deadsync-notefield/src/feedback.rs
+++ b/crates/deadsync-notefield/src/feedback.rs
@@ -2,7 +2,7 @@ use crate::style::*;
 use crate::*;
 use deadsync_rules::judgment::{JudgeGrade, TimingWindow};
 
-const COLUMN_CUE_FADE_TIME: f32 = 0.15;
+const COLUMN_CUE_FADE_TIME: f32 = 0.075;
 
 #[derive(Clone, Copy, Debug)]
 pub struct JudgmentTiltParams {

--- a/crates/deadsync-notefield/src/feedback.rs
+++ b/crates/deadsync-notefield/src/feedback.rs
@@ -183,7 +183,25 @@ pub fn column_cue_reverse_top_y(
 }
 
 pub fn column_cue_alpha(elapsed_real: f32, duration_real: f32) -> f32 {
-    if !elapsed_real.is_finite() || !duration_real.is_finite() {
+    // The natural envelope is the anchored envelope with the fade-in anchored to
+    // the cue's own start (i.e. since_entry == elapsed).
+    column_cue_alpha_anchored(elapsed_real, elapsed_real, duration_real)
+}
+
+// Alpha envelope for a column cue whose fade-in is anchored to an arbitrary
+// entry point. `since_entry_real` is the time since the cue first became visible
+// (its natural start during normal play, or the seek-landing time when the
+// playhead jumped into the middle of it); it drives the fade-in. `elapsed_real`
+// is the time since the cue's real start; it drives the fade-out and bounds the
+// cue's lifetime. When since_entry_real == elapsed_real this is identical to the
+// natural fade. Anchoring the fade-in lets a seeked-into cue ramp up from 0
+// instead of popping in at full alpha.
+pub fn column_cue_alpha_anchored(
+    since_entry_real: f32,
+    elapsed_real: f32,
+    duration_real: f32,
+) -> f32 {
+    if !since_entry_real.is_finite() || !elapsed_real.is_finite() || !duration_real.is_finite() {
         return 0.0;
     }
     if elapsed_real < 0.0 || elapsed_real > duration_real {
@@ -192,16 +210,20 @@ pub fn column_cue_alpha(elapsed_real: f32, duration_real: f32) -> f32 {
     if duration_real <= COLUMN_CUE_FADE_TIME * 2.0 {
         return 0.0;
     }
-    if elapsed_real < COLUMN_CUE_FADE_TIME {
-        let t = (elapsed_real / COLUMN_CUE_FADE_TIME).clamp(0.0, 1.0);
-        return 1.0 - (1.0 - t) * (1.0 - t);
-    }
-    if elapsed_real > duration_real - COLUMN_CUE_FADE_TIME {
+    let fade_in = if since_entry_real < COLUMN_CUE_FADE_TIME {
+        let t = (since_entry_real / COLUMN_CUE_FADE_TIME).clamp(0.0, 1.0);
+        1.0 - (1.0 - t) * (1.0 - t)
+    } else {
+        1.0
+    };
+    let fade_out = if elapsed_real > duration_real - COLUMN_CUE_FADE_TIME {
         let t = ((elapsed_real - (duration_real - COLUMN_CUE_FADE_TIME)) / COLUMN_CUE_FADE_TIME)
             .clamp(0.0, 1.0);
-        return 1.0 - t * t;
-    }
-    1.0
+        1.0 - t * t
+    } else {
+        1.0
+    };
+    fade_in.min(fade_out)
 }
 
 pub fn judgment_tilt_rotation_deg(params: JudgmentTiltParams) -> f32 {

--- a/crates/deadsync-notefield/src/lib.rs
+++ b/crates/deadsync-notefield/src/lib.rs
@@ -1590,12 +1590,12 @@ mod tests {
     #[test]
     fn column_cue_alpha_fades_in_and_out() {
         assert!((column_cue_alpha(0.0, 1.0) - 0.0).abs() <= 1e-6);
-        assert!((column_cue_alpha(0.0375, 1.0) - 0.4375).abs() <= 1e-6);
-        assert!((column_cue_alpha(0.075, 1.0) - 0.75).abs() <= 1e-6);
+        assert!((column_cue_alpha(0.0375, 1.0) - 0.75).abs() <= 1e-6);
+        assert!((column_cue_alpha(0.075, 1.0) - 1.0).abs() <= 1e-6);
         assert!((column_cue_alpha(0.15, 1.0) - 1.0).abs() <= 1e-6);
         assert!((column_cue_alpha(0.5, 1.0) - 1.0).abs() <= 1e-6);
-        assert!((column_cue_alpha(0.925, 1.0) - 0.75).abs() <= 1e-6);
-        assert!((column_cue_alpha(0.95, 1.0) - 0.5555556).abs() <= 1e-6);
+        assert!((column_cue_alpha(0.925, 1.0) - 1.0).abs() <= 1e-6);
+        assert!((column_cue_alpha(0.95, 1.0) - 0.8888889).abs() <= 1e-6);
         assert!((column_cue_alpha(1.0, 1.0) - 0.0).abs() <= 1e-6);
     }
 
@@ -1603,7 +1603,7 @@ mod tests {
     fn column_cue_alpha_rejects_invalid_ranges() {
         assert_eq!(column_cue_alpha(-0.1, 1.0), 0.0);
         assert_eq!(column_cue_alpha(1.1, 1.0), 0.0);
-        assert_eq!(column_cue_alpha(0.1, 0.3), 0.0);
+        assert_eq!(column_cue_alpha(0.05, 0.1), 0.0);
         assert_eq!(column_cue_alpha(f32::NAN, 1.0), 0.0);
         assert_eq!(column_cue_alpha(0.1, f32::INFINITY), 0.0);
     }

--- a/crates/deadsync-notefield/src/lib.rs
+++ b/crates/deadsync-notefield/src/lib.rs
@@ -57,9 +57,9 @@ mod tests {
         append_mini_part, append_perspective_parts, append_turn_parts, apply_accel_y,
         apply_accel_y_with_peak, average_error_bar_mini_scale, beat_factor, beat_scroll_travel,
         beat_x_extra, bottom_cap_uv_window, bumpy_angle, clamp_rounded_i16,
-        clipped_hold_body_bounds, column_cue_alpha, column_cue_height, column_cue_reverse_top_y,
-        column_flash_alpha, column_flash_alpha_at, column_flash_color, column_flash_height,
-        column_flash_layout, column_flash_reverse_top_y, combo_actor_zoom,
+        clipped_hold_body_bounds, column_cue_alpha, column_cue_alpha_anchored, column_cue_height,
+        column_cue_reverse_top_y, column_flash_alpha, column_flash_alpha_at, column_flash_color,
+        column_flash_height, column_flash_layout, column_flash_reverse_top_y, combo_actor_zoom,
         compute_invert_distances, compute_tornado_bounds, crossover_cue_height, default_column_x,
         disabled_timing_windows_name, drunk_x_extra, edit_bar_candidate_step_rows,
         edit_bar_scroll_speed, edit_beat_bar_info_for_row, edit_beat_scroll_travel,
@@ -1606,6 +1606,26 @@ mod tests {
         assert_eq!(column_cue_alpha(0.05, 0.1), 0.0);
         assert_eq!(column_cue_alpha(f32::NAN, 1.0), 0.0);
         assert_eq!(column_cue_alpha(0.1, f32::INFINITY), 0.0);
+    }
+
+    #[test]
+    fn column_cue_alpha_anchored_matches_natural_when_entry_is_start() {
+        for &elapsed in &[0.0_f32, 0.0375, 0.075, 0.5, 0.925, 0.95, 1.0] {
+            let natural = column_cue_alpha(elapsed, 1.0);
+            let anchored = column_cue_alpha_anchored(elapsed, elapsed, 1.0);
+            assert!((natural - anchored).abs() <= 1e-6);
+        }
+    }
+
+    #[test]
+    fn column_cue_alpha_anchored_fades_in_from_entry_without_pop() {
+        // Seeked into the middle of the hold: at the entry instant alpha is 0
+        // (no pop), then it ramps up over the fade time.
+        assert!((column_cue_alpha_anchored(0.0, 0.5, 1.0) - 0.0).abs() <= 1e-6);
+        assert!((column_cue_alpha_anchored(0.0375, 0.5, 1.0) - 0.75).abs() <= 1e-6);
+        assert!((column_cue_alpha_anchored(0.075, 0.5, 1.0) - 1.0).abs() <= 1e-6);
+        // The cue's real fade-out still applies near its end regardless of entry.
+        assert!((column_cue_alpha_anchored(0.5, 0.95, 1.0) - 0.8888889).abs() <= 1e-6);
     }
 
     #[test]

--- a/src/screens/components/gameplay/notefield/mod.rs
+++ b/src/screens/components/gameplay/notefield/mod.rs
@@ -19,8 +19,8 @@ use deadsync_gameplay::{
     COMBO_THOUSAND_MILESTONE_DURATION, ComboMilestoneKind, FantasticWindowOptions,
     GameplayErrorBarTrim, HELD_MISS_TOTAL_DURATION, HOLD_JUDGMENT_TOTAL_DURATION,
     RECEPTOR_Y_OFFSET_FROM_CENTER, RECEPTOR_Y_OFFSET_FROM_CENTER_REVERSE, TapExplosionOptions,
-    VisualEffects, active_column_cue, blue_fantastic_window_ms, column_flash_duration,
-    gameplay_error_bar_trim_max_window_ix, hold_explosion_active,
+    VisualEffects, active_column_cue, active_column_cues, blue_fantastic_window_ms,
+    column_flash_duration, gameplay_error_bar_trim_max_window_ix, hold_explosion_active,
     hold_explosion_enabled_for_options, hold_head_render_flags, let_go_head_beat,
     scroll_receptor_y, song_lua_column_y_offset, song_lua_note_hidden,
 };
@@ -1763,13 +1763,18 @@ pub(crate) fn build_bundles(
             } else {
                 1.0
             };
-            if let Some(cue) = active_column_cue(state.crossover_cues(player_idx), current_time) {
-                let duration_real = cue.duration / rate;
-                let elapsed_real = (current_time - cue.start_time) / rate;
-                let alpha_mul = column_cue_alpha(elapsed_real, duration_real);
-                if alpha_mul > 0.0 {
-                    let lane_width = ScrollSpeedSetting::ARROW_SPACING * field_zoom;
-                    let cue_height = crossover_cue_height(screen_height());
+            let active_cues = active_column_cues(state.crossover_cues(player_idx), current_time);
+            if !active_cues.is_empty() {
+                let lane_width = ScrollSpeedSetting::ARROW_SPACING * field_zoom;
+                let cue_height = crossover_cue_height(screen_height());
+
+                for cue in active_cues {
+                    let duration_real = cue.duration / rate;
+                    let elapsed_real = (current_time - cue.start_time) / rate;
+                    let alpha_mul = column_cue_alpha(elapsed_real, duration_real);
+                    if alpha_mul <= 0.0 {
+                        continue;
+                    }
                     let mut countdown_text: Option<(f32, f32, i32)> = None;
 
                     if profile.column_countdown && duration_real >= 5.0 {

--- a/src/screens/components/gameplay/notefield/mod.rs
+++ b/src/screens/components/gameplay/notefield/mod.rs
@@ -19,7 +19,7 @@ use deadsync_gameplay::{
     COMBO_THOUSAND_MILESTONE_DURATION, ComboMilestoneKind, FantasticWindowOptions,
     GameplayErrorBarTrim, HELD_MISS_TOTAL_DURATION, HOLD_JUDGMENT_TOTAL_DURATION,
     RECEPTOR_Y_OFFSET_FROM_CENTER, RECEPTOR_Y_OFFSET_FROM_CENTER_REVERSE, TapExplosionOptions,
-    VisualEffects, active_column_cue, active_column_cues, blue_fantastic_window_ms,
+    VisualEffects, active_column_cue, active_column_cue_range, blue_fantastic_window_ms,
     column_flash_duration, gameplay_error_bar_trim_max_window_ix, hold_explosion_active,
     hold_explosion_enabled_for_options, hold_head_render_flags, let_go_head_beat,
     scroll_receptor_y, song_lua_column_y_offset, song_lua_note_hidden,
@@ -32,9 +32,10 @@ use deadsync_notefield::{
     appearance_note_glow, append_beat_bar, append_cue_bar, append_edit_measure_number,
     apply_accel_y as crate_apply_accel_y, apply_accel_y_with_peak as crate_apply_accel_y_with_peak,
     average_error_bar_mini_scale, beat_factor, beat_scroll_travel, bottom_cap_uv_window,
-    clipped_hold_body_bounds, column_cue_alpha, column_cue_height, column_cue_reverse_top_y,
-    column_flash_alpha, column_flash_color, column_flash_height, column_flash_layout,
-    column_flash_reverse_top_y, combo_actor_zoom, compute_invert_distances, compute_tornado_bounds,
+    clipped_hold_body_bounds, column_cue_alpha, column_cue_alpha_anchored, column_cue_height,
+    column_cue_reverse_top_y, column_flash_alpha, column_flash_color, column_flash_height,
+    column_flash_layout, column_flash_reverse_top_y, combo_actor_zoom, compute_invert_distances,
+    compute_tornado_bounds,
     crossover_cue_height, edit_bar_candidate_step_rows, edit_bar_scroll_speed,
     edit_beat_bar_info_for_row, edit_beat_scroll_travel,
     effective_mini_value as crate_effective_mini_value, error_bar_boundaries_s,
@@ -1763,15 +1764,22 @@ pub(crate) fn build_bundles(
             } else {
                 1.0
             };
-            let active_cues = active_column_cues(state.crossover_cues(player_idx), current_time);
-            if !active_cues.is_empty() {
+            let crossover_cues = state.crossover_cues(player_idx);
+            let active_range = active_column_cue_range(crossover_cues, current_time);
+            if !active_range.is_empty() {
                 let lane_width = ScrollSpeedSetting::ARROW_SPACING * field_zoom;
                 let cue_height = crossover_cue_height(screen_height());
 
-                for cue in active_cues {
+                for cue_idx in active_range {
+                    let cue = &crossover_cues[cue_idx];
+                    let entry_time = state
+                        .crossover_cue_entry_time(player_idx, cue_idx)
+                        .unwrap_or(cue.start_time);
                     let duration_real = cue.duration / rate;
                     let elapsed_real = (current_time - cue.start_time) / rate;
-                    let alpha_mul = column_cue_alpha(elapsed_real, duration_real);
+                    let since_entry_real = (current_time - entry_time) / rate;
+                    let alpha_mul =
+                        column_cue_alpha_anchored(since_entry_real, elapsed_real, duration_real);
                     if alpha_mul <= 0.0 {
                         continue;
                     }


### PR DESCRIPTION
## Why

Crossover cues were recently ported from the custom Simply Love 8ms theme, and a user reported that the fade-out of one cue and the fade-in of the next did not overlap enough. Digging in showed the port split a single fade constant into two mismatched ones and changed the rendering model in ways that quietly broke the intended crossfade.

## What changed

Three focused fixes to how crossover cues display (in `deadsync-gameplay` and `deadsync-notefield`):

1. **Match the 8ms fade time.** The cue builder overlaps consecutive cues by `CROSSOVER_CUE_FADE_SECONDS` (0.075s), but the renderer faded each cue in/out over 0.15s, twice the overlap. Set the render fade to 0.075s so a cue's fade-out fully crossfades with the next cue's fade-in.

2. **Render every active cue.** The render path used `active_column_cue`, which returns only the single most-recently-started cue, so the moment the next cue began the previous cue's fade-out was dropped. It now draws every cue whose `[start, start+duration]` window contains the playhead (at most two by construction), producing a true crossfade that matches the 8ms theme's independent per-column actors.

3. **Fade seeked-into cues from the landing point.** Instead of popping a cue in at full alpha when you seek into its middle in practice mode, each cue's fade-in is anchored to the point it first becomes visible: its own start during normal play, or the seek-landing time when you jump into it. Normal play is byte-for-byte unchanged.