### PR TITLE
Fix half-second delay before animated banners start

### DIFF
--- a/src/app/dynamic_media.rs
+++ b/src/app/dynamic_media.rs
@@ -18,7 +18,7 @@ use std::{
 
 struct DynamicVideoState {
     player: video::Player,
-    started_at: Instant,
+    started_at: Option<Instant>,
     path: PathBuf,
 }
 
@@ -956,8 +956,11 @@ impl DynamicMedia {
             if assets.has_pending_texture_upload(key) {
                 continue;
             }
-            let play_time = video.started_at.elapsed().as_secs_f32();
+            let play_time = video
+                .started_at
+                .map_or(0.0, |start| start.elapsed().as_secs_f32());
             if let Some(frame) = video.player.take_due_frame(play_time) {
+                video.started_at.get_or_insert_with(Instant::now);
                 assets.queue_texture_upload(key.clone(), frame);
             }
         }
@@ -1113,7 +1116,7 @@ impl DynamicMedia {
                         prepared.key,
                         DynamicVideoState {
                             player: prepared.player,
-                            started_at: Instant::now(),
+                            started_at: None,
                             path: prepared.path,
                         },
                     ) {
@@ -1151,7 +1154,7 @@ impl DynamicMedia {
                         prepared.key,
                         DynamicVideoState {
                             player: prepared.player,
-                            started_at: Instant::now(),
+                            started_at: None,
                             path: prepared.path,
                         },
                     ) {


### PR DESCRIPTION
## Why

Animated (video) banners ran smoothly and FPS-performant, but started about half a second late. Anyone authoring banners timed to the music ended up out of sync because the animation never began at frame 0.

## Cause

Each banner video's playback clock (`started_at`) was set to `Instant::now()` the moment its async prep finished draining. ffmpeg spawn plus first-frame decode takes roughly 0.5s, so the clock kept ticking while only the static poster was visible. By the time real frames arrived, `play_time` was already ~0.5s, and `take_due_frame` skipped the opening frames -- effectively starting the animation half a second in.

## Fix

`DynamicVideoState.started_at` is now `Option<Instant>`, initialized to `None`. The clock anchors on the first frame that actually appears (`get_or_insert_with`), so playback always begins at frame 0 with no leading skip and stays in sync with the music.

Scope is limited to `src/app/dynamic_media.rs`.