### PR TITLE
Show decimal BPMs to 3 places instead of rounding to nearest tenth

### DIFF
--- a/src/screens/gameplay.rs
+++ b/src/screens/gameplay.rs
@@ -2179,15 +2179,21 @@ fn cached_bpm_text(bpm: f64, show_decimal: bool) -> Arc<str> {
             format!("{rounded:.0}")
         });
     }
-    let rounded_tenth = (bpm * 10.0).round() / 10.0;
-    let rounded_tenth = rounded_tenth.max(0.0);
-    let key = (rounded_tenth.to_bits(), true);
+    let rounded = ((bpm * 1000.0).round() / 1000.0).max(0.0);
+    let key = (rounded.to_bits(), true);
     cached_text(&BPM_TEXT_CACHE, key, TEXT_CACHE_LIMIT, || {
-        let nearest_int = rounded_tenth.round();
-        if (rounded_tenth - nearest_int).abs() <= 0.001 {
+        let nearest_int = rounded.round();
+        if (rounded - nearest_int).abs() <= 0.0005 {
             format!("{nearest_int:.0}")
         } else {
-            format!("{rounded_tenth:.1}")
+            let mut s = format!("{rounded:.3}");
+            while s.ends_with('0') {
+                s.pop();
+            }
+            if s.ends_with('.') {
+                s.pop();
+            }
+            s
         }
     })
 }


### PR DESCRIPTION
## Why

With "Show Decimal in BPM" enabled, BPMs were still rounded to the nearest tenth, so a chart authored at 100.001 BPM displayed as "100". Official DDR files frequently specify BPMs to 3 decimal places, and players want to see them accurately.

## What changed

`cached_bpm_text` (in `src/screens/gameplay.rs`) now rounds the decimal display to thousandths instead of tenths, and trims trailing zeros so precision only shows when it matters:

- `100.001` -> `100.001`
- `133.33` -> `133.33`
- `100.000` / `150` -> `100` / `150` (clean integers still render with no decimal)

This goes a bit further than the reference themes: ITGMania's BPMDisplay always rounds to an integer, and Simply Love shows at most one decimal. Anything finer than a thousandth still rounds, matching DDR's actual precision.