### PR TITLE
fix(smx): gif pack option display and CanBeEmpty fallback semantics

### DIFF
--- a/crates/deadsync-shell/src/app/mod.rs
+++ b/crates/deadsync-shell/src/app/mod.rs
@@ -1747,35 +1747,54 @@ impl App {
                 // the global pack (selected -> basic), then the global `default`
                 // role. `_25` is the baseline both pad layouts render; 16-LED pads
                 // show its outer ring. Each tier picks the BPM-best variant.
+                // Scoped (song/pack folder) gifs are authored by the song and sit
+                // above pack policy, so the selected pack's `CanBeEmpty` does not
+                // affect them.
                 let scoped = song_dir
                     .as_deref()
                     .and_then(|dir| self.resolve_scoped_smx_background(dir, role, song_bpm));
                 scoped.or_else(|| {
-                    let registry = self.smx_gif_registry();
+                    let registry = self.smx_gif_registry().clone();
                     let size = deadsync_smx::gifs::PadSize::Leds25;
-                    let try_role =
-                        |role_str: &str| registry.background(pack_str, role_str, size, song_bpm);
-                    // On results screens, try grade- and difficulty-specific roles
-                    // before the plain role; `results_role_candidates` documents and
-                    // tests the exact order.
-                    let grade_anim = if role == "results" {
-                        eval_grade.and_then(|grade| {
-                            deadsync_smx::panel_fx::results_role_candidates(grade, eval_difficulty)
-                                .iter()
-                                .find_map(|r| try_role(r))
-                        })
+                    // Global-registry role candidates, most specific first: on
+                    // results screens the grade- and difficulty-specific roles
+                    // (`results_role_candidates` documents and tests the exact
+                    // order), then the screen role, then the global `default`
+                    // role. A candidate the selected pack declares under
+                    // `CanBeEmpty` (and doesn't supply) ends the chain with no
+                    // animation at all: the pack opted that name out, so a later
+                    // candidate must not resurrect one.
+                    let mut candidates: Vec<String> = if role == "results" {
+                        eval_grade
+                            .map(|grade| {
+                                deadsync_smx::panel_fx::results_role_candidates(
+                                    grade,
+                                    eval_difficulty,
+                                )
+                            })
+                            .unwrap_or_default()
                     } else {
-                        None
+                        Vec::new()
                     };
-                    let resolved = grade_anim
-                        .or_else(|| registry.background(pack_str, role, size, song_bpm))
-                        .or_else(|| registry.background(pack_str, "default", size, song_bpm));
-                    // Only pack-resolved gifs get tinted; a per-song/pack scoped gif
-                    // (the `scoped` branch above, handled outside this closure) is
-                    // fully authored by the song and left as-is.
-                    resolved.map(|anim| {
-                        self.maybe_tint_smx_background(pack_str, role, eval_difficulty, anim)
-                    })
+                    candidates.push(role.to_owned());
+                    candidates.push("default".to_owned());
+                    for name in &candidates {
+                        if registry.background_declared_empty(pack_str, name, size) {
+                            return None;
+                        }
+                        if let Some(anim) = registry.background(pack_str, name, size, song_bpm) {
+                            // Only pack-resolved gifs get tinted; a per-song/pack
+                            // scoped gif (the `scoped` branch above) is fully
+                            // authored by the song and left as-is.
+                            return Some(self.maybe_tint_smx_background(
+                                pack_str,
+                                role,
+                                eval_difficulty,
+                                anim,
+                            ));
+                        }
+                    }
+                    None
                 })
             });
             let background = anim.map(|anim| {

--- a/crates/deadsync-smx/src/gifs.rs
+++ b/crates/deadsync-smx/src/gifs.rs
@@ -751,6 +751,25 @@ impl GifRegistry {
             .is_some_and(|m| m.match_color_to_difficulty.contains(role))
     }
 
+    /// Whether `pack` declares `name` under `CanBeEmpty` in its background
+    /// `gifpack.ini` and supplies no gif for it (either size): the pack has
+    /// explicitly resolved `name` to nothing. Callers walking a role-level
+    /// fallback chain (e.g. screen role, then the `default` role) must stop at
+    /// such a name rather than resurrect an animation from a later candidate;
+    /// `background()` itself already returns `None` for it. A supplied gif
+    /// always wins over the declaration, and `None` or the default pack has no
+    /// declarations.
+    pub fn background_declared_empty(&self, pack: Option<&str>, name: &str, size: PadSize) -> bool {
+        let Some(p) = pack.filter(|p| *p != DEFAULT_PACK) else {
+            return false;
+        };
+        self.background_pack_meta
+            .get(p)
+            .is_some_and(|m| m.can_be_empty.contains(name))
+            && !self.backgrounds.contains_key(&key(p, name, size))
+            && !self.backgrounds.contains_key(&key(p, name, size.other()))
+    }
+
     pub fn is_empty(&self) -> bool {
         self.backgrounds.is_empty() && self.judgements.is_empty()
     }
@@ -1584,6 +1603,45 @@ mod tests {
         );
         // "ok" is not listed: still gets the automatic default-pack fallback.
         assert!(reg.judgement(Some("foo"), "ok", PadSize::Leds25).is_some());
+    }
+
+    #[test]
+    fn background_declared_empty_flags_only_declared_and_unsupplied_names() {
+        let mut reg = GifRegistry::default();
+        reg.backgrounds.insert(
+            key(DEFAULT_PACK, "gameplay", PadSize::Leds25),
+            dummy_variants(),
+        );
+        reg.backgrounds
+            .insert(key("foo", "default", PadSize::Leds25), dummy_variants());
+        reg.background_pack_meta.insert(
+            "foo".to_owned(),
+            PackMeta {
+                fallback: PackFallback::Auto,
+                can_be_empty: ["gameplay".to_owned(), "default".to_owned()]
+                    .into_iter()
+                    .collect(),
+                match_color_to_difficulty: Default::default(),
+                merge_common_bpm_variants: Default::default(),
+                merge_fallback_bpm_variants: Default::default(),
+            },
+        );
+
+        // Declared and unsupplied: explicitly empty, and background() agrees.
+        assert!(reg.background_declared_empty(Some("foo"), "gameplay", PadSize::Leds25));
+        assert!(
+            reg.background(Some("foo"), "gameplay", PadSize::Leds25, None)
+                .is_none()
+        );
+        // Declared but supplied (either size): the pack's own gif wins.
+        assert!(!reg.background_declared_empty(Some("foo"), "default", PadSize::Leds16));
+        // Not declared: missing names still use the regular fallbacks.
+        assert!(!reg.background_declared_empty(Some("foo"), "song_select", PadSize::Leds25));
+        // No pack (or the default pack) has no declarations.
+        assert!(!reg.background_declared_empty(None, "gameplay", PadSize::Leds25));
+        assert!(!reg.background_declared_empty(Some(DEFAULT_PACK), "gameplay", PadSize::Leds25));
+        // A pack without a gifpack.ini has none either.
+        assert!(!reg.background_declared_empty(Some("bar"), "gameplay", PadSize::Leds25));
     }
 
     #[test]

--- a/crates/deadsync-theme-simply-love/src/screens/options/state.rs
+++ b/crates/deadsync-theme-simply-love/src/screens/options/state.rs
@@ -564,7 +564,11 @@ pub fn init(
         SubRowId::SmxDefaultPadConfig,
         cfg.smx_default_pad_config.index(),
     );
-    // Bg/judge pack selections: index 0 = default, 1..N = user packs.
+    // Bg/judge pack selections: index 0 = default, 1..N = user packs. These rows'
+    // real choice lists are provided dynamically by the layout (the static row
+    // definition holds a single placeholder), so write the index directly like the
+    // noteskin and software-thread rows do; `set_choice_by_id` would clamp it to
+    // the placeholder length and always show "Default".
     let bg_pack_idx = if cfg.smx_pad_gifs_pack.is_empty() {
         0
     } else {
@@ -575,12 +579,13 @@ pub fn init(
             .map(|i| i + 1)
             .unwrap_or(0)
     };
-    set_choice_by_id(
+    if let Some(slot) = get_choice_by_id_mut(
         &mut state.sub[SubmenuKind::SmxConfig].choice_indices,
         SMX_CONFIG_OPTIONS_ROWS,
         SubRowId::SmxBgPack,
-        bg_pack_idx,
-    );
+    ) {
+        *slot = bg_pack_idx;
+    }
     let judge_pack_idx = if cfg.smx_judge_gifs_pack.is_empty() {
         0
     } else {
@@ -591,12 +596,13 @@ pub fn init(
             .map(|i| i + 1)
             .unwrap_or(0)
     };
-    set_choice_by_id(
+    if let Some(slot) = get_choice_by_id_mut(
         &mut state.sub[SubmenuKind::SmxConfig].choice_indices,
         SMX_CONFIG_OPTIONS_ROWS,
         SubRowId::SmxJudgePack,
-        judge_pack_idx,
-    );
+    ) {
+        *slot = judge_pack_idx;
+    }
     // Single-pad P1/P2 picker: reflect the slot the SDK currently has the lone pad
     // in (slot 1 = P2, index 1; slot 0 = P1, index 0). The slot already accounts for
     // both the saved serial assignment and the hardware jumper, so reading it covers

--- a/docs/stepmaniax.md
+++ b/docs/stepmaniax.md
@@ -760,11 +760,16 @@ collapse to `common` directly.
 Every pack automatically falls back to `common` for any role it doesn't
 supply (steps 5 and 8) — a pack only has to author what it wants to
 customize. A pack can opt individual roles, or itself entirely, out of this
-via `gifpack.ini` (see §11e); an opted-out missing role shows **solid black**
-on the pad. This is not the same as the pad's own auto-lights: when Panel
-Lights is on the game holds ownership of the LEDs at all times and the
-firmware's built-in animations are suppressed. Auto-lights only resume when
-Panel Lights is turned off.
+via `gifpack.ini` (see §11e). A role the selected pack lists under
+`CanBeEmpty` (and doesn't supply) ends the chain at its step outright: no
+`Fallback` pack, no `common`, and no `default`-role fallback (steps 6-8 are
+skipped) — that role shows no animation at all.
+
+What "no animation" looks like depends on the screen. During gameplay the
+game still owns the pad LEDs (judgement effects may fire), so the background
+is solid black. On every other screen a pad with nothing to show is handed
+back to the firmware, which resumes the pad's own built-in lighting (its
+stored idle and step animations) until the game next takes the LEDs.
 
 The table below lists **role names** (the internal key used for lookup). The
 corresponding filename is `{role}_{size}.gif` — for grade-tagged roles like
@@ -823,6 +828,12 @@ results@F      -->  results  -->  default
 
 So authoring `results_25@A.gif` covers A+, A, and A- automatically unless you
 also provide the `+`/`-` variants.
+
+These grade chains are walked with the same `CanBeEmpty` rule as the main
+resolution chain: a candidate the selected pack lists under `CanBeEmpty` (and
+doesn't supply) stops the walk right there, so e.g. `CanBeEmpty = "results"`
+shows nothing for any grade you didn't author a grade-specific gif for,
+instead of falling through to `default`.
 
 **Difficulty tagging:** any `results@<grade>` role above can also be
 qualified with the difficulty of the chart that earned the grade:
@@ -924,7 +935,7 @@ are ignored).
 | Key | Values | Effect |
 | --- | --- | --- |
 | `Fallback` | any pack name, or `"none"` | Try the named pack (both LED sizes) before falling back to `common`. `"none"` opts the *whole pack* out of the automatic `common` fallback -- every role/judgement this pack doesn't supply shows nothing rather than pulling from `common`. Omitting the key is the default: no extra pack to try, but the automatic `common` fallback still applies. |
-| `CanBeEmpty` | comma-separated list of role or judgement names | These specific names never fall back to anything (not `Fallback`, not `common`) when this pack doesn't supply them -- they show nothing for that name specifically, while every other name still falls back normally. |
+| `CanBeEmpty` | comma-separated list of role or judgement names | These specific names never fall back to anything when this pack doesn't supply them -- not `Fallback`, not `common`, and for background roles not the `default`-role fallback either (the resolution chain stops dead at the listed name). They show nothing for that name specifically, while every other name still falls back normally. |
 | `MatchColorToDifficulty` | comma-separated list of base role names (background packs only, e.g. `"results"`) | Whatever gif actually resolves for that role gets recolored to match the played chart's difficulty color. See "Difficulty color matching" below. |
 | `MergeCommonBPMVariants` | comma-separated list of base role names (background packs only, e.g. `"song_select"`) | Pool this pack's own BPM-tagged variants for that role with `common`'s, instead of using only this pack's own variants. See "Merging BPM variants across packs" below. |
 | `MergeFallbackBPMVariants` | comma-separated list of base role names (background packs only) | Same as `MergeCommonBPMVariants`, but pools with the declared `Fallback` pack's variants instead. No-op if this pack has no `Fallback` declared. |
@@ -983,7 +994,10 @@ for the gameplay role and every other role from `cool-pack` (or `common` if
 events to show no gif at all rather than borrowing `common`'s (or a
 `Fallback` pack's) version -- for example a minimalist judgement pack that
 only lights up misses and mines, and wants everything else to stay dark
-instead of showing `common`'s style for the rest.
+instead of showing `common`'s style for the rest. For background packs the
+opt-out is total: a pack that supplies its own `default` but declares
+`CanBeEmpty = "gameplay"` gets no background during gameplay at all -- the
+`gameplay` role does not slide over to the pack's `default` gif.
 
 **Combining GIFs from more than two packs** is not directly supported beyond
 the automatic `common` step: `Fallback` is a single value pointing to one


### PR DESCRIPTION
> Rebased onto current `main`. #617 is stacked on this branch, so this one lands first.

Two fixes for the gif-pack bug reports against v0.4.2004.

## 1. Selected gif pack shows as Default when re-entering the options screen

Selecting a pad or judgement gif pack on the StepManiaX options page appears not to stick: re-entering the options screen always shows **Default** checked, regardless of what was selected.

The saved value is actually fine the whole time: the config, the ini round-trip, and the pad lighting all keep the chosen pack. Only the displayed row selection resets.

**Cause:** the `SmxBgPack` / `SmxJudgePack` rows are defined with a single static placeholder choice; their real choice list (`Default` plus the discovered packs) is provided dynamically by the options layout. The screen-init sync used `set_choice_by_id`, which clamps the incoming index against the *static* row definition's choice list:

```rust
// src/screens/options/row.rs
let max_idx = rows[pos].choices.len().saturating_sub(1); // placeholder len = 1 -> max_idx = 0
*slot = idx.min(max_idx);                                // always clamped to 0 = "Default"
```

**Fix:** write the index directly via `get_choice_by_id_mut`, the same pattern already used by the other dynamically-populated rows (`DefaultNoteSkin`, `SoftwareRendererThreads`). The remaining dynamic rows (display mode/resolution/refresh rate, sound device) already use direct writes; the per-player pack rows in Player Options bake their full choice list into the row and are not affected.

## 2. `CanBeEmpty` roles still slid over to the pack's `default` gif

A pack that supplies all of its own gifs except `gameplay` and declares `CanBeEmpty = "gameplay"` expects no background during gameplay. The registry honored the declaration for the pack-level chain (no `Fallback` pack, no `common`), but the app's screen resolution then fell back to the `default` **role**, so the pack's own `default` gif showed during gameplay anyway.

**Fix:** the role-candidate walk (grade-specific results roles, then the screen role, then `default`) now stops dead at any candidate the selected pack declares under `CanBeEmpty` without supplying: that event shows no animation at all. `CanBeEmpty` now means what it says: this name never has an animation, no matter which fallback would have provided one.

Details:
- A gif the pack supplies still wins over its own declaration (unchanged).
- Per-song / per-pack scoped gifs sit above pack policy and are unaffected (they are an override, not a fallback).
- New registry API `GifRegistry::background_declared_empty` exposes the declared-empty state (the existing `background()` lookup cannot distinguish "empty by declaration" from "missing, keep falling back"), with a unit test.
- docs/stepmaniax.md updated: the resolution chain, the grade-chain section, the `CanBeEmpty` table row, and the "when to use" example now describe the stop-dead semantics. Also corrected the section that claimed an opted-out role shows solid black with the game holding LED ownership at all times: actual behavior is solid black during gameplay (the game still owns the LEDs for judgement effects), and outside gameplay an empty pad is handed back to the pad firmware's built-in lighting.

## Testing

- `cargo test -p deadsync-smx`: 76 passed (includes the new `background_declared_empty` test).
- `cargo build` clean.
- Manual (options display fix): select a pack on the SMX options page, leave the screen, re-enter; the row now shows the selected pack instead of Default.
