### PR TITLE
fix(build): repair the macOS build

### DIFF
--- a/crates/deadlib-renderer/src/window_size.rs
+++ b/crates/deadlib-renderer/src/window_size.rs
@@ -5,12 +5,14 @@ use winit::{
 };
 
 #[cfg(target_os = "macos")]
-use winit::{dpi::LogicalSize, platform::macos::WindowAttributesExtMacOS};
+use winit::dpi::LogicalSize;
 
 #[cfg(target_os = "macos")]
 #[inline(always)]
 const fn macos_opengl_low_dpi(backend_type: BackendType, high_dpi: bool) -> bool {
-    backend_type == BackendType::OpenGL && !high_dpi
+    // `matches!` rather than `==`: `PartialEq::eq` is not callable in a `const fn`
+    // on stable, but pattern matching is.
+    matches!(backend_type, BackendType::OpenGL) && !high_dpi
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/crates/deadsync-shell/src/window.rs
+++ b/crates/deadsync-shell/src/window.rs
@@ -9,6 +9,8 @@ use deadlib_renderer::{render_size_for_window, request_window_size, with_request
 use deadsync_config::app_config::DisplayMode;
 use winit::dpi::{PhysicalPosition, PhysicalSize};
 use winit::event_loop::ActiveEventLoop;
+#[cfg(target_os = "macos")]
+use winit::platform::macos::WindowAttributesExtMacOS;
 use winit::window::{Icon, Window};
 
 const WINDOW_ICON_PATHS: [&str; 2] = [


### PR DESCRIPTION
## Summary

`main` does not compile on macOS with stable Rust. Both faults sit inside `#[cfg(target_os = "macos")]` blocks, which is why CI on the other targets stays green.

Reproduced on a clean worktree at `146d8241`, stable `rustc 1.96.0`, `aarch64-apple-darwin`. No behaviour change on any target.

## 1. `const fn` calling `PartialEq` (`crates/deadlib-renderer/src/window_size.rs`)

```rust
const fn macos_opengl_low_dpi(backend_type: BackendType, high_dpi: bool) -> bool {
    backend_type == BackendType::OpenGL && !high_dpi
}
```

```
error[E0015]: cannot call non-const operator in constant functions
```

`==` goes through `PartialEq::eq`, which is not callable in a `const fn` on stable (it needs `const_trait_impl`). Introduced by `de4a1c5b`.

Fixed with `matches!`, which pattern-matches instead of calling a trait method, so the function stays `const`:

```rust
matches!(backend_type, BackendType::OpenGL) && !high_dpi
```

## 2. Missing trait import (`crates/deadsync-shell/src/window.rs`)

```rust
attributes = attributes.with_disallow_hidpi(!config.high_dpi);
```

```
error[E0599]: no method named `with_disallow_hidpi` found for struct `WindowAttributes`
```

The method exists in winit 0.30.13, but its trait `WindowAttributesExtMacOS` is not in scope here. The call moved into `window.rs` during `146d8241` without its import; `window_size.rs`, where it used to live, still imports the trait. Fixed by importing it, `cfg`-gated to match the call site.

## 3. Unused import (`crates/deadlib-renderer/src/window_size.rs`)

Following from 2, `window_size.rs` no longer uses `WindowAttributesExtMacOS`, so on macOS it was an unused import. Dropped.

## Testing

`cargo check` and `cargo clippy` are clean on macOS with this branch; both fail on `main` without it. `cargo fmt --check` clean. The only remaining `cargo check` warnings are the pre-existing ones in `deadsync-audio` and `deadsync-config`.

Noticed while rebasing #616 / #617; those PRs are unaffected by this and do not depend on it.
