### PR TITLE
fix(gameplay): crossover cue reflash, fade timing, and crossfade behavior

### DIFF
--- a/crates/deadsync-gameplay/src/cues.rs
+++ b/crates/deadsync-gameplay/src/cues.rs
@@ -300,13 +300,38 @@ fn build_crossover_cues_core(
                 is_mine: true,
             });
         }
-        if let Some(last) = cues.last() {
+        let overlap = cues.last().map(|last| {
             let prev_end = last.start_time + last.duration;
-            if start_time < prev_end {
-                let duration_difference = prev_end - start_time;
-                start_time = prev_end - fade;
-                cue_duration = cue_duration - duration_difference + fade;
+            // Only one cue is active at a time and each cue drives all of its
+            // columns with a single fade envelope, so a column shared by two
+            // overlapping cues would fade out and back in (a visible reflash).
+            let shares_column = last
+                .columns
+                .iter()
+                .any(|prev_col| columns.iter().any(|c| c.column == prev_col.column));
+            (prev_end, shares_column)
+        });
+        if let Some((prev_end, shares_column)) = overlap
+            && start_time < prev_end
+        {
+            if shares_column {
+                // Merge into the previous cue so the shared column stays lit
+                // continuously across the overlap instead of reflashing.
+                let merged_end = (start_time + cue_duration).max(prev_end);
+                let last = cues
+                    .last_mut()
+                    .expect("cues is non-empty when overlap is Some");
+                last.duration = merged_end - last.start_time;
+                for col in columns {
+                    if !last.columns.iter().any(|c| c.column == col.column) {
+                        last.columns.push(col);
+                    }
+                }
+                continue;
             }
+            let duration_difference = prev_end - start_time;
+            start_time = prev_end - fade;
+            cue_duration = cue_duration - duration_difference + fade;
         }
         cues.push(ColumnCue {
             start_time,

--- a/crates/deadsync-gameplay/src/cues.rs
+++ b/crates/deadsync-gameplay/src/cues.rs
@@ -53,6 +53,34 @@ pub fn active_column_cue(cues: &[ColumnCue], current_time: f32) -> Option<&Colum
     idx.checked_sub(1).and_then(|i| cues.get(i))
 }
 
+// Returns the half-open index range of cues whose `[start_time, start_time +
+// duration]` window contains `current_time`, in chronological order.
+// Consecutive crossover cues are built to overlap by the fade time, so up to
+// two cues can be active at once; rendering both lets the outgoing cue's
+// fade-out crossfade with the incoming cue's fade-in.
+#[inline]
+pub fn active_column_cue_range(cues: &[ColumnCue], current_time: f32) -> core::ops::Range<usize> {
+    let end = cues.partition_point(|cue| cue.start_time <= current_time);
+    let mut begin = end;
+    while begin > 0 {
+        let cue = &cues[begin - 1];
+        if current_time < cue.start_time + cue.duration {
+            begin -= 1;
+        } else {
+            break;
+        }
+    }
+    begin..end
+}
+
+// Returns every cue whose `[start_time, start_time + duration]` window contains
+// `current_time`, as a contiguous slice in chronological order. See
+// `active_column_cue_range`.
+#[inline]
+pub fn active_column_cues(cues: &[ColumnCue], current_time: f32) -> &[ColumnCue] {
+    &cues[active_column_cue_range(cues, current_time)]
+}
+
 // Lead-in/out fade applied to every crossover cue.
 pub const CROSSOVER_CUE_FADE_SECONDS: f32 = 0.075;
 

--- a/crates/deadsync-gameplay/src/cues.rs
+++ b/crates/deadsync-gameplay/src/cues.rs
@@ -84,6 +84,13 @@ pub fn active_column_cues(cues: &[ColumnCue], current_time: f32) -> &[ColumnCue]
 // Lead-in/out fade applied to every crossover cue.
 pub const CROSSOVER_CUE_FADE_SECONDS: f32 = 0.075;
 
+// When the playhead first crosses a cue's start, the cue's fade-in anchors to
+// its own start only if it was reached within this window; otherwise (a
+// practice-mode seek that lands past it) the cue fades in from the landing
+// point instead of popping in at partial/full alpha. Using the fade time
+// guarantees a cue caught during normal play is still inside its fade-in.
+pub const CROSSOVER_CUE_SEEK_GUARD_SECONDS: f32 = CROSSOVER_CUE_FADE_SECONDS;
+
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct CrossoverRow {
     pub beat: f32,

--- a/crates/deadsync-gameplay/src/runtime_state.rs
+++ b/crates/deadsync-gameplay/src/runtime_state.rs
@@ -307,6 +307,15 @@ pub struct GameplayCueRuntimeState {
     measure_counter_segments: [Vec<StreamSegment>; MAX_PLAYERS],
     column_cues: [Vec<ColumnCue>; MAX_PLAYERS],
     crossover_cues: [Vec<ColumnCue>; MAX_PLAYERS],
+    // Per crossover cue: None = not yet reached (or rewound before its start),
+    // Some(t) = the fade-in anchor time. During normal play this is the cue's own
+    // start; when the playhead seeks into the middle of a cue it is the landing
+    // time, so the cue fades in from there instead of popping in at full alpha.
+    crossover_cue_entry: [Vec<Option<f32>>; MAX_PLAYERS],
+    // Number of leading crossover cues whose start has been crossed (and thus
+    // anchored) at the last evaluated time. Lets the gate anchor/rewind only the
+    // cues that changed since the previous frame.
+    crossover_cue_cursor: [usize; MAX_PLAYERS],
 }
 
 impl Default for GameplayCueRuntimeState {
@@ -315,6 +324,8 @@ impl Default for GameplayCueRuntimeState {
             measure_counter_segments: std::array::from_fn(|_| Vec::new()),
             column_cues: std::array::from_fn(|_| Vec::new()),
             crossover_cues: std::array::from_fn(|_| Vec::new()),
+            crossover_cue_entry: std::array::from_fn(|_| Vec::new()),
+            crossover_cue_cursor: [0; MAX_PLAYERS],
         }
     }
 }
@@ -329,6 +340,8 @@ impl GameplayCueRuntimeState {
             measure_counter_segments,
             column_cues,
             crossover_cues,
+            crossover_cue_entry: std::array::from_fn(|_| Vec::new()),
+            crossover_cue_cursor: [0; MAX_PLAYERS],
         }
     }
 
@@ -349,6 +362,68 @@ impl GameplayCueRuntimeState {
         self.crossover_cues.get(player).map_or(&[], Vec::as_slice)
     }
 
+    // Per-cue fade-in anchor times for a player's crossover cues, parallel to
+    // `crossover_cues(player)`. Entries are None until the playhead reaches each
+    // cue; callers fall back to the cue's own start (natural fade-in).
+    #[inline(always)]
+    pub fn crossover_cue_entries(&self, player: usize) -> &[Option<f32>] {
+        self.crossover_cue_entry
+            .get(player)
+            .map_or(&[], Vec::as_slice)
+    }
+
+    // The fade-in anchor time for the crossover cue at `index`, or None when the
+    // cue has not been reached yet (callers fall back to the cue's own start,
+    // i.e. the natural fade-in).
+    #[inline(always)]
+    pub fn crossover_cue_entry_time(&self, player: usize, index: usize) -> Option<f32> {
+        self.crossover_cue_entry
+            .get(player)
+            .and_then(|entry| entry.get(index).copied().flatten())
+    }
+
+    // Advances the per-player crossover cue fade-in anchors to `current_time`
+    // (visible music seconds). The first frame the playhead crosses a cue's
+    // start, anchor it to the cue's start if it was reached within
+    // CROSSOVER_CUE_SEEK_GUARD_SECONDS (normal play -> natural fade-in) or to
+    // `current_time` if the start was jumped over (seek -> fade in from the
+    // landing point). Anchors are cleared for cues the playhead has rewound
+    // before, so a replayed section fades in naturally. Call once per player per
+    // frame.
+    pub fn update_crossover_cue_anchors(&mut self, player: usize, current_time: f32) {
+        let Some(cues) = self.crossover_cues.get(player) else {
+            return;
+        };
+        let Some(entry) = self.crossover_cue_entry.get_mut(player) else {
+            return;
+        };
+        if entry.len() != cues.len() {
+            entry.clear();
+            entry.resize(cues.len(), None);
+            self.crossover_cue_cursor[player] = 0;
+        }
+        if cues.is_empty() {
+            return;
+        }
+        let cursor = self.crossover_cue_cursor[player];
+        let target = cues.partition_point(|cue| cue.start_time <= current_time);
+        if target > cursor {
+            for i in cursor..target {
+                let start = cues[i].start_time;
+                entry[i] = Some(if current_time - start < CROSSOVER_CUE_SEEK_GUARD_SECONDS {
+                    start
+                } else {
+                    current_time
+                });
+            }
+        } else if target < cursor {
+            for slot in &mut entry[target..cursor] {
+                *slot = None;
+            }
+        }
+        self.crossover_cue_cursor[player] = target;
+    }
+
     #[inline(always)]
     pub fn set_column_cues_for_benchmark(&mut self, player: usize, cues: Vec<ColumnCue>) {
         if let Some(slot) = self.column_cues.get_mut(player) {
@@ -367,6 +442,10 @@ impl GameplayCueRuntimeState {
         for cues in &mut self.crossover_cues {
             cues.clear();
         }
+        for entry in &mut self.crossover_cue_entry {
+            entry.clear();
+        }
+        self.crossover_cue_cursor = [0; MAX_PLAYERS];
     }
 }
 

--- a/crates/deadsync-gameplay/src/runtime_update.rs
+++ b/crates/deadsync-gameplay/src/runtime_update.rs
@@ -1288,6 +1288,11 @@ where
     }
 
     #[inline(always)]
+    pub fn crossover_cue_entries(&self, player: usize) -> &[Option<f32>] {
+        self.display.cue_runtime.crossover_cue_entries(player)
+    }
+
+    #[inline(always)]
     pub fn set_column_cues(&mut self, player: usize, cues: Vec<ColumnCue>) {
         self.display
             .cue_runtime
@@ -2899,16 +2904,20 @@ where
         for player in 0..self.setup.num_players {
             let delay = self.clock.visible_timing.visual_delay_seconds(player);
             let visible_time_ns = visible_notefield_time_ns(music_time_ns, delay);
+            let visible_time_seconds = song_time_ns_to_seconds(visible_time_ns);
             self.clock.visible_timing.set_player_time(
                 player,
                 visible_time_ns,
-                song_time_ns_to_seconds(visible_time_ns),
+                visible_time_seconds,
                 self.timing_runtime.time_to_beat_caches.visible_beat(
                     player,
                     &self.timing_runtime.timing_players[player],
                     visible_time_ns,
                 ),
             );
+            self.display
+                .cue_runtime
+                .update_crossover_cue_anchors(player, visible_time_seconds);
         }
     }
 

--- a/crates/deadsync-gameplay/src/tests.rs
+++ b/crates/deadsync-gameplay/src/tests.rs
@@ -12300,6 +12300,25 @@ mod tests {
     }
 
     #[test]
+    fn crossover_cue_builder_merges_overlapping_same_column_cues() {
+        // Two crossover cues that overlap in time and share column 1. Merging
+        // keeps that column lit continuously instead of reflashing it.
+        let shared = [
+            xover_anno(0.0, 1, 0b0010, false),
+            xover_anno(0.5, 1, 0b0001, true),
+            xover_anno(0.6, 1, 0b0010, false),
+            xover_anno(0.7, 1, 0b1000, true),
+        ];
+        let cues = build_crossover_cues_core(&shared, xover_time, 0, 500, 8, false, 0.0);
+        assert_eq!(cues.len(), 1);
+        assert_near(cues[0].start_time, -0.5);
+        assert_near(cues[0].duration, 0.875);
+        let mut merged_cols: Vec<usize> = cues[0].columns.iter().map(|c| c.column).collect();
+        merged_cols.sort_unstable();
+        assert_eq!(merged_cols, vec![0, 1, 3]);
+    }
+
+    #[test]
     fn crossover_cue_builder_offsets_columns_and_respects_brackets() {
         let shifted = [
             xover_anno(0.0, 1, 0b0010, false),

--- a/crates/deadsync-gameplay/src/tests.rs
+++ b/crates/deadsync-gameplay/src/tests.rs
@@ -12112,6 +12112,44 @@ mod tests {
         assert_eq!(active_column_cue(&cues, 9.0).unwrap().start_time, 3.0);
     }
 
+    #[test]
+    fn active_column_cues_returns_overlapping_window() {
+        // Two consecutive cues overlapping by the fade time, as the crossover
+        // builder emits them (cue2.start == cue1.end - fade).
+        let fade = CROSSOVER_CUE_FADE_SECONDS;
+        let cues = [
+            ColumnCue {
+                start_time: 1.0,
+                duration: 0.5,
+                columns: Vec::new(),
+            },
+            ColumnCue {
+                start_time: 1.5 - fade,
+                duration: 0.5,
+                columns: Vec::new(),
+            },
+        ];
+
+        // Before anything starts: empty.
+        assert!(active_column_cues(&cues, 0.99).is_empty());
+        // Only the first cue is active well inside its window.
+        let only_first = active_column_cues(&cues, 1.2);
+        assert_eq!(only_first.len(), 1);
+        assert_eq!(only_first[0].start_time, 1.0);
+        // Inside the overlap region both cues render simultaneously.
+        let overlap = active_column_cues(&cues, 1.5 - fade + 0.01);
+        assert_eq!(overlap.len(), 2);
+        assert_eq!(overlap[0].start_time, 1.0);
+        assert_eq!(overlap[1].start_time, 1.5 - fade);
+        // After the first cue ends, only the second remains.
+        let only_second = active_column_cues(&cues, 1.6);
+        assert_eq!(only_second.len(), 1);
+        assert_eq!(only_second[0].start_time, 1.5 - fade);
+        // After both end, and for empty input: empty.
+        assert!(active_column_cues(&cues, 9.0).is_empty());
+        assert!(active_column_cues(&[], 2.0).is_empty());
+    }
+
     fn xover_anno(beat: f32, note_count: u8, column_mask: u8, is_crossover: bool) -> CrossoverRow {
         debug_assert_eq!(
             u32::from(note_count),

--- a/crates/deadsync-gameplay/src/tests.rs
+++ b/crates/deadsync-gameplay/src/tests.rs
@@ -13489,6 +13489,55 @@ mod tests {
     }
 
     #[test]
+    fn crossover_cue_anchor_tracks_entry_time() {
+        let new_state = || {
+            let measure_counter_segments: [Vec<StreamSegment>; MAX_PLAYERS] =
+                std::array::from_fn(|_| Vec::new());
+            let column_cues: [Vec<ColumnCue>; MAX_PLAYERS] = std::array::from_fn(|_| Vec::new());
+            let mut crossover_cues: [Vec<ColumnCue>; MAX_PLAYERS] =
+                std::array::from_fn(|_| Vec::new());
+            // Two well-separated cues so seeking lands clearly inside one.
+            crossover_cues[0].push(ColumnCue {
+                start_time: 1.0,
+                duration: 1.0,
+                columns: Vec::new(),
+            });
+            crossover_cues[0].push(ColumnCue {
+                start_time: 5.0,
+                duration: 1.0,
+                columns: Vec::new(),
+            });
+            GameplayCueRuntimeState::new(measure_counter_segments, column_cues, crossover_cues)
+        };
+
+        // Normal forward play: each cue is caught near its start, so it anchors
+        // to its own start (natural fade-in).
+        let mut state = new_state();
+        state.update_crossover_cue_anchors(0, 0.5);
+        state.update_crossover_cue_anchors(0, 1.0 + 0.01);
+        assert_eq!(state.crossover_cue_entry_time(0, 0), Some(1.0));
+
+        // Seek straight into the middle of cue 1: it anchors to the landing time,
+        // so the renderer fades it in from there instead of popping it in.
+        state.update_crossover_cue_anchors(0, 5.5);
+        assert_eq!(state.crossover_cue_entry_time(0, 1), Some(5.5));
+        // Cue 0 keeps its earlier natural anchor.
+        assert_eq!(state.crossover_cue_entry_time(0, 0), Some(1.0));
+
+        // Rewind before cue 1's start, then catch it from the start: it
+        // re-anchors to its own start.
+        state.update_crossover_cue_anchors(0, 4.0);
+        assert_eq!(state.crossover_cue_entry_time(0, 1), None);
+        state.update_crossover_cue_anchors(0, 5.0 + 0.01);
+        assert_eq!(state.crossover_cue_entry_time(0, 1), Some(5.0));
+
+        // Out-of-range / untracked players have no anchor (callers fall back to
+        // the cue's own start).
+        assert_eq!(state.crossover_cue_entry_time(0, 99), None);
+        assert_eq!(state.crossover_cue_entry_time(1, 0), None);
+    }
+
+    #[test]
     fn hold_feedback_state_returns_slices_and_clears() {
         let mut state = GameplayHoldFeedbackState::default();
         state.hold_judgments[1] = Some(HoldJudgmentRenderInfo {

--- a/crates/deadsync-notefield/src/feedback.rs
+++ b/crates/deadsync-notefield/src/feedback.rs
@@ -2,7 +2,7 @@ use crate::*;
 use deadlib_present::actors::Actor;
 use deadlib_present::dsl::{SpriteBuilder, TextBuilder};
 use deadsync_gameplay::{
-    ActiveColumnFlash, ColumnCue, active_column_cue, active_column_cues, column_flash_duration,
+    ActiveColumnFlash, ColumnCue, active_column_cue_range, column_flash_duration,
 };
 use deadsync_rules::judgment::{JudgeGrade, TimingWindow};
 use deadsync_rules::scroll::ScrollSpeedSetting;
@@ -171,13 +171,31 @@ pub(crate) fn column_cue_alpha(elapsed_real: f32, duration_real: f32) -> f32 {
 
 // Alpha envelope for a column cue that fades in/out over `fade_time` seconds.
 // Regular column cues and crossover cues use different fade windows (0.15 vs
-// 0.075), so the fade time is passed in rather than hardcoded.
+// 0.075), so the fade time is passed in rather than hardcoded. The fade-in is
+// anchored to the cue's own start (the natural, unseeked case).
 pub(crate) fn column_cue_alpha_with_fade(
     elapsed_real: f32,
     duration_real: f32,
     fade_time: f32,
 ) -> f32 {
-    if !elapsed_real.is_finite() || !duration_real.is_finite() {
+    column_cue_alpha_anchored(elapsed_real, elapsed_real, duration_real, fade_time)
+}
+
+// Alpha envelope for a column cue whose fade-in is anchored to an arbitrary
+// entry point. `since_entry_real` is the time since the cue first became visible
+// (its natural start during normal play, or the seek-landing time when the
+// playhead jumped into the middle of it); it drives the fade-in. `elapsed_real`
+// is the time since the cue's real start; it drives the fade-out and bounds the
+// cue's lifetime. When `since_entry_real == elapsed_real` this is identical to
+// the natural fade. Anchoring the fade-in lets a seeked-into cue ramp up from 0
+// instead of popping in at full alpha.
+pub(crate) fn column_cue_alpha_anchored(
+    since_entry_real: f32,
+    elapsed_real: f32,
+    duration_real: f32,
+    fade_time: f32,
+) -> f32 {
+    if !since_entry_real.is_finite() || !elapsed_real.is_finite() || !duration_real.is_finite() {
         return 0.0;
     }
     if elapsed_real < 0.0 || elapsed_real > duration_real {
@@ -186,15 +204,19 @@ pub(crate) fn column_cue_alpha_with_fade(
     if duration_real <= fade_time * 2.0 {
         return 0.0;
     }
-    if elapsed_real < fade_time {
-        let t = (elapsed_real / fade_time).clamp(0.0, 1.0);
-        return 1.0 - (1.0 - t) * (1.0 - t);
-    }
-    if elapsed_real > duration_real - fade_time {
+    let fade_in = if since_entry_real < fade_time {
+        let t = (since_entry_real / fade_time).clamp(0.0, 1.0);
+        1.0 - (1.0 - t) * (1.0 - t)
+    } else {
+        1.0
+    };
+    let fade_out = if elapsed_real > duration_real - fade_time {
         let t = ((elapsed_real - (duration_real - fade_time)) / fade_time).clamp(0.0, 1.0);
-        return 1.0 - t * t;
-    }
-    1.0
+        1.0 - t * t
+    } else {
+        1.0
+    };
+    fade_in.min(fade_out)
 }
 
 #[derive(Clone, Copy)]
@@ -202,6 +224,9 @@ pub(crate) struct ColumnFeedbackRequest<'a> {
     pub style: NotefieldStyle,
     pub column_cues: Option<&'a [ColumnCue]>,
     pub crossover_cues: Option<&'a [ColumnCue]>,
+    // Per-cue fade-in anchor times parallel to `crossover_cues`; None entries (or
+    // a missing slice) fall back to each cue's own start (natural fade-in).
+    pub crossover_cue_entries: Option<&'a [Option<f32>]>,
     pub column_flashes: Option<&'a [Option<ActiveColumnFlash>]>,
     pub regular_countdown: bool,
     pub crossover_countdown: bool,
@@ -275,14 +300,19 @@ fn compose_column_cue(
     // rendering both lets the outgoing cue's fade-out crossfade with the
     // incoming cue's fade-in, matching Simply Love's independent per-column
     // actors.
-    let active: &[ColumnCue] = match kind {
-        ColumnCueKind::Regular => match active_column_cue(cues, request.current_music_time) {
-            Some(cue) => std::slice::from_ref(cue),
-            None => return,
-        },
-        ColumnCueKind::Crossover => active_column_cues(cues, request.current_music_time),
+    let active_range = match kind {
+        ColumnCueKind::Regular => {
+            let end = cues.partition_point(|cue| cue.start_time <= request.current_music_time);
+            match end.checked_sub(1) {
+                Some(begin) => begin..end,
+                None => return,
+            }
+        }
+        ColumnCueKind::Crossover => {
+            active_column_cue_range(cues, request.current_music_time)
+        }
     };
-    if active.is_empty() {
+    if active_range.is_empty() {
         return;
     }
 
@@ -302,13 +332,26 @@ fn compose_column_cue(
         .min(request.column_xs.len())
         .min(request.column_dirs.len());
 
-    for cue in active {
+    for cue_idx in active_range {
+        let cue = &cues[cue_idx];
         let duration_real = cue.duration / rate;
         let elapsed_real = (request.current_music_time - cue.start_time) / rate;
         let alpha_mul = match kind {
             ColumnCueKind::Regular => column_cue_alpha(elapsed_real, duration_real),
             ColumnCueKind::Crossover => {
-                column_cue_alpha_with_fade(elapsed_real, duration_real, CROSSOVER_CUE_FADE_TIME)
+                // Anchor the fade-in to where the cue first became visible so a
+                // cue you seek into ramps up instead of popping in at full alpha.
+                let entry_time = request
+                    .crossover_cue_entries
+                    .and_then(|entries| entries.get(cue_idx).copied().flatten())
+                    .unwrap_or(cue.start_time);
+                let since_entry_real = (request.current_music_time - entry_time) / rate;
+                column_cue_alpha_anchored(
+                    since_entry_real,
+                    elapsed_real,
+                    duration_real,
+                    CROSSOVER_CUE_FADE_TIME,
+                )
             }
         };
         if alpha_mul <= 0.0 {
@@ -821,6 +864,7 @@ mod tests {
             style: style(),
             column_cues,
             crossover_cues,
+            crossover_cue_entries: None,
             column_flashes,
             regular_countdown: true,
             crossover_countdown: false,

--- a/crates/deadsync-notefield/src/feedback.rs
+++ b/crates/deadsync-notefield/src/feedback.rs
@@ -7,7 +7,15 @@ use deadsync_rules::scroll::ScrollSpeedSetting;
 use deadsync_theme::{ColumnCueStyle, ColumnFlashLayoutStyle, ColumnFlashStyle, NotefieldStyle};
 use std::sync::Arc;
 
+// Regular column cues fade in/out over this window, matching Simply Love's
+// `ColumnCues.lua` (`fadeTime = 0.15`).
 const COLUMN_CUE_FADE_TIME: f32 = 0.15;
+
+// Crossover cues fade over half that, matching Simply Love's
+// `CrossoverCues.lua` (`fadeTime = 0.075`). This also equals the amount the cue
+// builder overlaps consecutive crossover cues (`CROSSOVER_CUE_FADE_SECONDS`),
+// so a cue's fade-out lines up exactly with the next cue's fade-in.
+const CROSSOVER_CUE_FADE_TIME: f32 = 0.075;
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct JudgmentTiltParams {
@@ -156,22 +164,32 @@ pub(crate) fn column_cue_reverse_top_y(
 }
 
 pub(crate) fn column_cue_alpha(elapsed_real: f32, duration_real: f32) -> f32 {
+    column_cue_alpha_with_fade(elapsed_real, duration_real, COLUMN_CUE_FADE_TIME)
+}
+
+// Alpha envelope for a column cue that fades in/out over `fade_time` seconds.
+// Regular column cues and crossover cues use different fade windows (0.15 vs
+// 0.075), so the fade time is passed in rather than hardcoded.
+pub(crate) fn column_cue_alpha_with_fade(
+    elapsed_real: f32,
+    duration_real: f32,
+    fade_time: f32,
+) -> f32 {
     if !elapsed_real.is_finite() || !duration_real.is_finite() {
         return 0.0;
     }
     if elapsed_real < 0.0 || elapsed_real > duration_real {
         return 0.0;
     }
-    if duration_real <= COLUMN_CUE_FADE_TIME * 2.0 {
+    if duration_real <= fade_time * 2.0 {
         return 0.0;
     }
-    if elapsed_real < COLUMN_CUE_FADE_TIME {
-        let t = (elapsed_real / COLUMN_CUE_FADE_TIME).clamp(0.0, 1.0);
+    if elapsed_real < fade_time {
+        let t = (elapsed_real / fade_time).clamp(0.0, 1.0);
         return 1.0 - (1.0 - t) * (1.0 - t);
     }
-    if elapsed_real > duration_real - COLUMN_CUE_FADE_TIME {
-        let t = ((elapsed_real - (duration_real - COLUMN_CUE_FADE_TIME)) / COLUMN_CUE_FADE_TIME)
-            .clamp(0.0, 1.0);
+    if elapsed_real > duration_real - fade_time {
+        let t = ((elapsed_real - (duration_real - fade_time)) / fade_time).clamp(0.0, 1.0);
         return 1.0 - t * t;
     }
     1.0
@@ -260,7 +278,11 @@ fn compose_column_cue(
     };
     let duration_real = cue.duration / rate;
     let elapsed_real = (request.current_music_time - cue.start_time) / rate;
-    let alpha_mul = column_cue_alpha(elapsed_real, duration_real);
+    let fade_time = match kind {
+        ColumnCueKind::Regular => COLUMN_CUE_FADE_TIME,
+        ColumnCueKind::Crossover => CROSSOVER_CUE_FADE_TIME,
+    };
+    let alpha_mul = column_cue_alpha_with_fade(elapsed_real, duration_real, fade_time);
     if alpha_mul <= 0.0 {
         return;
     }

--- a/crates/deadsync-notefield/src/feedback.rs
+++ b/crates/deadsync-notefield/src/feedback.rs
@@ -1,7 +1,9 @@
 use crate::*;
 use deadlib_present::actors::Actor;
 use deadlib_present::dsl::{SpriteBuilder, TextBuilder};
-use deadsync_gameplay::{ActiveColumnFlash, ColumnCue, active_column_cue, column_flash_duration};
+use deadsync_gameplay::{
+    ActiveColumnFlash, ColumnCue, active_column_cue, active_column_cues, column_flash_duration,
+};
 use deadsync_rules::judgment::{JudgeGrade, TimingWindow};
 use deadsync_rules::scroll::ScrollSpeedSetting;
 use deadsync_theme::{ColumnCueStyle, ColumnFlashLayoutStyle, ColumnFlashStyle, NotefieldStyle};
@@ -268,25 +270,27 @@ fn compose_column_cue(
     kind: ColumnCueKind,
     show_countdown: bool,
 ) {
-    let Some(cue) = active_column_cue(cues, request.current_music_time) else {
-        return;
+    // Regular cues never overlap, so at most one is active. Crossover cues are
+    // built to overlap by the fade time, so up to two can be active at once;
+    // rendering both lets the outgoing cue's fade-out crossfade with the
+    // incoming cue's fade-in, matching Simply Love's independent per-column
+    // actors.
+    let active: &[ColumnCue] = match kind {
+        ColumnCueKind::Regular => match active_column_cue(cues, request.current_music_time) {
+            Some(cue) => std::slice::from_ref(cue),
+            None => return,
+        },
+        ColumnCueKind::Crossover => active_column_cues(cues, request.current_music_time),
     };
+    if active.is_empty() {
+        return;
+    }
+
     let rate = if request.music_rate.is_finite() && request.music_rate > 0.0 {
         request.music_rate
     } else {
         1.0
     };
-    let duration_real = cue.duration / rate;
-    let elapsed_real = (request.current_music_time - cue.start_time) / rate;
-    let fade_time = match kind {
-        ColumnCueKind::Regular => COLUMN_CUE_FADE_TIME,
-        ColumnCueKind::Crossover => CROSSOVER_CUE_FADE_TIME,
-    };
-    let alpha_mul = column_cue_alpha_with_fade(elapsed_real, duration_real, fade_time);
-    if alpha_mul <= 0.0 {
-        return;
-    }
-
     let style = request.style.column_cue;
     let lane_width = ScrollSpeedSetting::ARROW_SPACING * request.field_zoom;
     let cue_height = match kind {
@@ -298,80 +302,94 @@ fn compose_column_cue(
         .min(request.column_xs.len())
         .min(request.column_dirs.len());
 
-    for col_cue in &cue.columns {
-        let local_col = col_cue.column.saturating_sub(request.col_start);
+    for cue in active {
+        let duration_real = cue.duration / rate;
+        let elapsed_real = (request.current_music_time - cue.start_time) / rate;
+        let alpha_mul = match kind {
+            ColumnCueKind::Regular => column_cue_alpha(elapsed_real, duration_real),
+            ColumnCueKind::Crossover => {
+                column_cue_alpha_with_fade(elapsed_real, duration_real, CROSSOVER_CUE_FADE_TIME)
+            }
+        };
+        if alpha_mul <= 0.0 {
+            continue;
+        }
+
+        for col_cue in &cue.columns {
+            let local_col = col_cue.column.saturating_sub(request.col_start);
+            if local_col >= num_cols {
+                continue;
+            }
+            let x = request.playfield_center_x
+                + request.column_xs[local_col] * request.spacing_multiplier * request.field_zoom;
+            let alpha = style.base_alpha * alpha_mul;
+            let rgb = if col_cue.is_mine {
+                style.mine_color
+            } else {
+                style.normal_color
+            };
+            let reverse = request.column_dirs[local_col] < 0.0;
+            let y = if reverse {
+                column_cue_reverse_top_y(
+                    style,
+                    lane_width,
+                    cue_height,
+                    request.field_center_y,
+                    request.style.receptor_reverse_y,
+                )
+            } else {
+                style.top_y + request.field_center_y
+            };
+            append_column_quad(
+                actors,
+                x,
+                y,
+                lane_width,
+                cue_height,
+                reverse,
+                style.body_fade,
+                [rgb[0], rgb[1], rgb[2], alpha],
+                style.body_z,
+            );
+        }
+
+        if !show_countdown || duration_real < 5.0 {
+            continue;
+        }
+        let remaining = duration_real - elapsed_real;
+        if remaining <= 0.5 {
+            continue;
+        }
+        let Some(last_col) = cue.columns.last() else {
+            continue;
+        };
+        let local_col = last_col.column.saturating_sub(request.col_start);
         if local_col >= num_cols {
             continue;
         }
         let x = request.playfield_center_x
             + request.column_xs[local_col] * request.spacing_multiplier * request.field_zoom;
-        let alpha = style.base_alpha * alpha_mul;
-        let rgb = if col_cue.is_mine {
-            style.mine_color
-        } else {
-            style.normal_color
-        };
-        let reverse = request.column_dirs[local_col] < 0.0;
-        let y = if reverse {
-            column_cue_reverse_top_y(
-                style,
-                lane_width,
-                cue_height,
-                request.field_center_y,
-                request.style.receptor_reverse_y,
-            )
-        } else {
-            style.top_y + request.field_center_y
-        };
-        append_column_quad(
-            actors,
-            x,
-            y,
-            lane_width,
-            cue_height,
-            reverse,
-            style.body_fade,
-            [rgb[0], rgb[1], rgb[2], alpha],
-            style.body_z,
-        );
+        let y = request.field_center_y
+            + if request.column_dirs[local_col] < 0.0 {
+                style.countdown_reverse_y
+            } else {
+                style.countdown_normal_y
+            };
+        let mut text = TextBuilder::new();
+        text.font(request.countdown_font);
+        text.settext((request.countdown_text)(remaining.round() as i32).into());
+        text.align(0.5, 0.5);
+        text.xy(x, y);
+        text.zoom(style.countdown_zoom);
+        text.z(style.countdown_z);
+        text.diffuse([
+            style.countdown_color[0],
+            style.countdown_color[1],
+            style.countdown_color[2],
+            alpha_mul,
+        ]);
+        hud_actors.push(text.build(0));
     }
-
-    if !show_countdown || duration_real < 5.0 {
-        return;
-    }
-    let remaining = duration_real - elapsed_real;
-    if remaining <= 0.5 {
-        return;
-    }
-    let Some(last_col) = cue.columns.last() else {
-        return;
-    };
-    let local_col = last_col.column.saturating_sub(request.col_start);
-    if local_col >= num_cols {
-        return;
-    }
-    let x = request.playfield_center_x
-        + request.column_xs[local_col] * request.spacing_multiplier * request.field_zoom;
-    let y = request.field_center_y
-        + if request.column_dirs[local_col] < 0.0 {
-            style.countdown_reverse_y
-        } else {
-            style.countdown_normal_y
-        };
-    let mut text = TextBuilder::new();
-    text.font(request.countdown_font);
-    text.settext((request.countdown_text)(remaining.round() as i32).into());
-    text.align(0.5, 0.5);
-    text.xy(x, y);
-    text.zoom(style.countdown_zoom);
-    text.z(style.countdown_z);
-    text.diffuse([
-        style.countdown_color[0],
-        style.countdown_color[1],
-        style.countdown_color[2],
-        alpha_mul,
-    ]);
-    hud_actors.push(text.build(0));
 }
 
 fn compose_column_flashes(

--- a/crates/deadsync-notefield/src/frame_feedback.rs
+++ b/crates/deadsync-notefield/src/frame_feedback.rs
@@ -33,6 +33,8 @@ pub struct NotefieldFeedbackFrameView<'a> {
     pub column_cues: Option<&'a [ColumnCue]>,
     /// Crossover cue columns use chart-global column indices.
     pub crossover_cues: Option<&'a [ColumnCue]>,
+    /// Per-cue fade-in anchor times parallel to `crossover_cues`.
+    pub crossover_cue_entries: Option<&'a [Option<f32>]>,
     /// Column flashes are ordered by local lane within the prepared player span.
     pub column_flashes: Option<&'a [Option<ActiveColumnFlash>]>,
     /// Tap explosions are ordered by local lane within the prepared player span.
@@ -81,6 +83,7 @@ pub(crate) fn compose_notefield_feedback<S, F>(
             style: request.style,
             column_cues: frame.column_cues,
             crossover_cues: frame.crossover_cues,
+            crossover_cue_entries: frame.crossover_cue_entries,
             column_flashes: frame.column_flashes,
             // The regular cue countdown is independent of the crossover-only
             // profile toggle.
@@ -912,6 +915,7 @@ mod tests {
         let frame = NotefieldFeedbackFrameView {
             column_cues: None,
             crossover_cues: None,
+            crossover_cue_entries: None,
             column_flashes: Some(&flashes),
             tap_explosions: &taps,
             mine_explosions: &mines,
@@ -997,6 +1001,7 @@ mod tests {
         let frame = NotefieldFeedbackFrameView {
             column_cues: Some(&cues),
             crossover_cues: None,
+            crossover_cue_entries: None,
             column_flashes: None,
             tap_explosions: &taps,
             mine_explosions: &mines,

--- a/crates/deadsync-notefield/src/lib.rs
+++ b/crates/deadsync-notefield/src/lib.rs
@@ -141,7 +141,8 @@ use error_bar::{
 };
 #[cfg(test)]
 use feedback::{
-    JudgmentTiltParams, TapJudgmentRowsParams, column_cue_alpha, column_cue_alpha_with_fade,
+    JudgmentTiltParams, TapJudgmentRowsParams, column_cue_alpha, column_cue_alpha_anchored,
+    column_cue_alpha_with_fade,
     column_cue_height,
     column_cue_reverse_top_y, column_flash_alpha, column_flash_alpha_at, column_flash_color,
     column_flash_height, column_flash_layout, column_flash_reverse_top_y, crossover_cue_height,
@@ -203,7 +204,8 @@ mod tests {
         append_mini_part, append_perspective_parts, append_turn_parts, apply_accel_y,
         apply_accel_y_with_peak, average_error_bar_mini_scale, beat_factor, beat_scroll_travel,
         beat_x_extra, bottom_cap_uv_window, bumpy_angle, clamp_rounded_i16,
-        clipped_hold_body_bounds, column_cue_alpha, column_cue_alpha_with_fade, column_cue_height,
+        clipped_hold_body_bounds, column_cue_alpha, column_cue_alpha_anchored,
+        column_cue_alpha_with_fade, column_cue_height,
         column_cue_reverse_top_y,
         column_flash_alpha, column_flash_alpha_at, column_flash_color, column_flash_height,
         column_flash_layout, column_flash_reverse_top_y, combo_actor_zoom,
@@ -1908,6 +1910,27 @@ mod tests {
         assert!((column_cue_alpha_with_fade(1.0, 1.0, fade) - 0.0).abs() <= 1e-6);
         // The 2-arg regular helper is unchanged (0.15 fade).
         assert!((column_cue_alpha(0.075, 1.0) - 0.75).abs() <= 1e-6);
+    }
+
+    #[test]
+    fn column_cue_alpha_anchored_matches_natural_when_entry_is_start() {
+        for &elapsed in &[0.0_f32, 0.0375, 0.075, 0.5, 0.925, 0.95, 1.0] {
+            let natural = column_cue_alpha(elapsed, 1.0);
+            let anchored = column_cue_alpha_anchored(elapsed, elapsed, 1.0, 0.15);
+            assert!((natural - anchored).abs() <= 1e-6);
+        }
+    }
+
+    #[test]
+    fn column_cue_alpha_anchored_fades_in_from_entry_without_pop() {
+        // Seeked into the middle of a cue: at the entry instant alpha is 0 (no
+        // pop), then it ramps up over the fade time, using the crossover fade.
+        let fade = 0.075;
+        assert!((column_cue_alpha_anchored(0.0, 0.5, 1.0, fade) - 0.0).abs() <= 1e-6);
+        assert!((column_cue_alpha_anchored(0.0375, 0.5, 1.0, fade) - 0.75).abs() <= 1e-6);
+        assert!((column_cue_alpha_anchored(0.075, 0.5, 1.0, fade) - 1.0).abs() <= 1e-6);
+        // The cue's real fade-out still applies near its end regardless of entry.
+        assert!((column_cue_alpha_anchored(0.5, 0.9625, 1.0, fade) - 0.75).abs() <= 1e-6);
     }
 
     #[test]

--- a/crates/deadsync-notefield/src/lib.rs
+++ b/crates/deadsync-notefield/src/lib.rs
@@ -141,7 +141,8 @@ use error_bar::{
 };
 #[cfg(test)]
 use feedback::{
-    JudgmentTiltParams, TapJudgmentRowsParams, column_cue_alpha, column_cue_height,
+    JudgmentTiltParams, TapJudgmentRowsParams, column_cue_alpha, column_cue_alpha_with_fade,
+    column_cue_height,
     column_cue_reverse_top_y, column_flash_alpha, column_flash_alpha_at, column_flash_color,
     column_flash_height, column_flash_layout, column_flash_reverse_top_y, crossover_cue_height,
     hold_glow_color, judgment_actor_zoom, judgment_tilt_rotation_deg, tap_judgment_rows,
@@ -202,7 +203,8 @@ mod tests {
         append_mini_part, append_perspective_parts, append_turn_parts, apply_accel_y,
         apply_accel_y_with_peak, average_error_bar_mini_scale, beat_factor, beat_scroll_travel,
         beat_x_extra, bottom_cap_uv_window, bumpy_angle, clamp_rounded_i16,
-        clipped_hold_body_bounds, column_cue_alpha, column_cue_height, column_cue_reverse_top_y,
+        clipped_hold_body_bounds, column_cue_alpha, column_cue_alpha_with_fade, column_cue_height,
+        column_cue_reverse_top_y,
         column_flash_alpha, column_flash_alpha_at, column_flash_color, column_flash_height,
         column_flash_layout, column_flash_reverse_top_y, combo_actor_zoom,
         compute_invert_distances, compute_tornado_bounds, crossover_cue_height, default_column_x,
@@ -1889,6 +1891,23 @@ mod tests {
         assert_eq!(column_cue_alpha(0.1, 0.3), 0.0);
         assert_eq!(column_cue_alpha(f32::NAN, 1.0), 0.0);
         assert_eq!(column_cue_alpha(0.1, f32::INFINITY), 0.0);
+    }
+
+    #[test]
+    fn crossover_cue_alpha_uses_half_fade_time() {
+        // Crossover cues fade over 0.075s (CrossoverCues.lua), half the regular
+        // ColumnCues fade, so a cue reaches full alpha twice as fast and its
+        // fade-out lines up with the next cue's fade-in.
+        let fade = 0.075;
+        assert!((column_cue_alpha_with_fade(0.0, 1.0, fade) - 0.0).abs() <= 1e-6);
+        assert!((column_cue_alpha_with_fade(0.0375, 1.0, fade) - 0.75).abs() <= 1e-6);
+        assert!((column_cue_alpha_with_fade(0.075, 1.0, fade) - 1.0).abs() <= 1e-6);
+        assert!((column_cue_alpha_with_fade(0.5, 1.0, fade) - 1.0).abs() <= 1e-6);
+        assert!((column_cue_alpha_with_fade(0.925, 1.0, fade) - 1.0).abs() <= 1e-6);
+        assert!((column_cue_alpha_with_fade(0.9625, 1.0, fade) - 0.75).abs() <= 1e-6);
+        assert!((column_cue_alpha_with_fade(1.0, 1.0, fade) - 0.0).abs() <= 1e-6);
+        // The 2-arg regular helper is unchanged (0.15 fade).
+        assert!((column_cue_alpha(0.075, 1.0) - 0.75).abs() <= 1e-6);
     }
 
     #[test]

--- a/crates/deadsync-theme-simply-love/src/screens/components/gameplay/notefield/mod.rs
+++ b/crates/deadsync-theme-simply-love/src/screens/components/gameplay/notefield/mod.rs
@@ -457,6 +457,10 @@ pub(crate) fn compose_frame(
             .frame_features
             .crossover_cues
             .then(|| state.crossover_cues(player_idx)),
+        crossover_cue_entries: options
+            .frame_features
+            .crossover_cues
+            .then(|| state.crossover_cue_entries(player_idx)),
         column_flashes: options
             .frame_features
             .column_flash


### PR DESCRIPTION
## Why

Crossover cues were ported from Simply Love's crossover theme, but several differences from the reference (the `chris4life` Simply Love fork) made consecutive cues look wrong: a shared column reflashed on overlap, back-to-back cues did not crossfade, and seeking into a cue popped it in at full alpha. This PR brings the deadsync behavior in line with the reference.

Reference: `Simply-Love-SM5/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/{CrossoverCues,ColumnCues}.lua`, where each column is an independent actor with `stoptweening():decelerate(fade):diffuse(clr):sleep(...):accelerate(fade):diffuse(0)`, and the two cue types use different fade times (`CrossoverCues.lua` = 0.075s, `ColumnCues.lua` = 0.15s).

## What changed

Four focused commits:

1. **Merge overlapping same-column crossover cues.** deadsync renders one active cue at a time with a single shared fade envelope, so two cues overlapping on the same column made that column fade out and back in (a reflash). When a new cue overlaps and shares a column with the previous one, it now merges (extends duration + unions columns) so the shared column stays lit continuously. Overlaps on different columns keep the existing clamp.

2. **Use a shorter fade for crossover cues.** The builder overlaps consecutive crossover cues by `CROSSOVER_CUE_FADE_SECONDS` (0.075s), but the renderer faded every column cue over a single shared 0.15s -- twice the overlap -- so crossover cues never crossfaded. Simply Love uses two separate constants (ColumnCues 0.15s, CrossoverCues 0.075s); `column_cue_alpha` now takes an explicit fade time and crossover cues use 0.075s while regular column cues stay 0.15s.

3. **Render every active crossover cue so consecutive cues crossfade.** The render path used `active_column_cue`, which returns only the latest-started cue, so the moment the next cue began the previous cue's fade-out was dropped. It now draws every cue whose `[start, start+duration]` window contains the playhead (at most two by construction), so the outgoing fade-out and incoming fade-in draw simultaneously -- matching the reference's independent per-column actors. Regular column cues never overlap and keep the single-cue path.

4. **Fade seeked-into cues from the landing point.** deadsync's cue rendering is time-based, so unlike Simply Love's fire-and-forget tweens it can show a cue's true state at any playhead position. Instead of suppressing a cue whose start you seek past, each cue's fade-in is anchored to where it first becomes visible: its own start during normal play, or the seek-landing time when you jump into its middle. The cue ramps up from 0 instead of popping in. Normal play is byte-for-byte unchanged (anchor == start), and anchors clear when the playhead rewinds before a cue's start so replays fade in naturally.