### PR TITLE
Make `cargo run` work on macOS without manual library paths

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,22 @@
+# Make `cargo build`/`cargo run` work on macOS without manually exporting
+# LIBRARY_PATH / RUSTFLAGS / DYLD_FALLBACK_LIBRARY_PATH for the Homebrew Vulkan
+# loader (see the macOS section of README.md).
+#
+# The link-search flags are scoped to macOS so they don't affect Linux/Windows
+# builds. Both the Apple Silicon (/opt/homebrew) and Intel (/usr/local) Homebrew
+# prefixes are listed; non-existent search paths are simply ignored by the
+# linker, so this works on either machine.
+
+[target.'cfg(target_os = "macos")']
+rustflags = [
+    "-L", "native=/opt/homebrew/lib",
+    "-L", "native=/opt/homebrew/opt/vulkan-loader/lib",
+    "-L", "native=/usr/local/lib",
+    "-L", "native=/usr/local/opt/vulkan-loader/lib",
+]
+
+# Runtime dylib search path so the freshly built binary can find libvulkan at
+# launch. Cargo only applies these when the variable isn't already set in the
+# environment, so an existing export still wins.
+[env]
+DYLD_FALLBACK_LIBRARY_PATH = "/opt/homebrew/lib:/opt/homebrew/opt/vulkan-loader/lib:/usr/local/lib:/usr/local/opt/vulkan-loader/lib"

--- a/README.md
+++ b/README.md
@@ -29,12 +29,39 @@ sudo apt install --no-install-recommends build-essential cmake pkg-config libude
 ```
 
 ### macOS build dependencies (Homebrew)
+
+Install the toolchain and native libraries:
 ```bash
-xcode-select --install
-brew install vulkan-loader molten-vk
+xcode-select --install          # C/C++ toolchain, Git, Python (needed by shaderc-sys)
+brew install cmake vulkan-loader molten-vk
 ```
 
-If linking fails with `library 'vulkan' not found`, export the Homebrew library paths:
+- **CMake** — required to build `shaderc-sys` (the shader compiler) from source.
+- **vulkan-loader** — the `libvulkan` the engine links against and loads at runtime.
+- **molten-vk** — the Vulkan-to-Metal driver that makes Vulkan actually run on Apple GPUs.
+- The **Xcode Command Line Tools** provide the compiler/linker plus the Git and
+  Python that `shaderc-sys` invokes during its build.
+
+You do **not** need the LunarG Vulkan SDK for a normal build/run on macOS — the
+Homebrew loader + MoltenVK are enough. Install the SDK only if you want the
+Vulkan **validation layers** for debugging (`GfxDebug` in `deadsync.ini`).
+
+#### Building and running
+
+The repo ships a `.cargo/config.toml` that adds the Homebrew Vulkan loader to
+the link and runtime search paths for macOS, so no manual environment variables
+are required on either Apple Silicon (`/opt/homebrew`) or Intel (`/usr/local`):
+```bash
+cargo run                       # fast dev build
+cargo run --profile local       # optimized, but faster to link than full release
+cargo build --release           # fully optimized (LTO) build for benchmarking/play
+```
+Before the first run, grant **Input Monitoring** to your terminal (see the
+macOS run note under [Getting Started](#getting-started)) or the game won't
+receive keystrokes.
+
+If you use a non-standard Homebrew prefix and linking still fails with
+`library 'vulkan' not found`, export the paths for your prefix:
 ```bash
 brew_prefix="$(brew --prefix)"
 export LIBRARY_PATH="$brew_prefix/lib:$brew_prefix/opt/vulkan-loader/lib:${LIBRARY_PATH:-}"


### PR DESCRIPTION
## Why

On macOS you currently have to `export LIBRARY_PATH`, `RUSTFLAGS`, and `DYLD_FALLBACK_LIBRARY_PATH` before every build so the linker and runtime can find the Homebrew Vulkan loader. That is easy to forget and makes a plain `cargo run` fail with `library 'vulkan' not found`. This bakes that setup into the repo so the common path just works.

## What

- Add a committed `.cargo/config.toml` that adds the Homebrew Vulkan loader to the macOS link and runtime search paths:
  - `rustflags` with `-L native=` entries, scoped to `cfg(target_os = "macos")` so Linux/Windows builds are unaffected.
  - `[env] DYLD_FALLBACK_LIBRARY_PATH` so the freshly built binary can load `libvulkan` at launch. Cargo only applies it when the variable isn't already set, so an existing export still wins.
  - Both the Apple Silicon (`/opt/homebrew`) and Intel (`/usr/local`) prefixes are listed; non-existent search paths are ignored by the linker.
- Expand the macOS section of the README:
  - Add the previously missing `cmake` (needed to build `shaderc-sys`).
  - Explain what each dependency is for and note the LunarG SDK is only needed for validation layers.
  - Add build/run tips (`cargo run`, `cargo run --profile local`, `cargo build --release`).

## Notes for reviewers

- Committing `.cargo/config.toml` applies to every macOS contributor. The env var is only consumed on macOS, so it is a no-op elsewhere, but if you'd rather keep this per-developer it could instead live in `~/.cargo/config.toml`.
- The manual env-var fallback is kept in the README for non-standard Homebrew prefixes.