### PR TITLE
fix(player-options): let Left/Right edit values without dedicated menu buttons

### DIFF
--- a/crates/deadsync-theme-simply-love/src/screens/player_options/input.rs
+++ b/crates/deadsync-theme-simply-love/src/screens/player_options/input.rs
@@ -718,7 +718,7 @@ fn handle_input_inner(
     if state.policy.arcade_navigation || dedicated_three_key {
         screen_input::track_menu_lr_chord(&mut state.menu_lr_chord, ev);
     }
-    let three_key_action = (!dedicated_three_key)
+    let three_key_action = dedicated_three_key
         .then(|| screen_input::three_key_menu_action(&mut state.menu_lr_chord, ev, true))
         .flatten();
     if state.pane_transition.is_active() {

--- a/crates/deadsync-theme-simply-love/src/screens/player_options/tests.rs
+++ b/crates/deadsync-theme-simply-love/src/screens/player_options/tests.rs
@@ -2084,6 +2084,50 @@ pub(super) mod tests {
     }
 
     #[test]
+    fn keyboard_left_right_edit_values_without_dedicated_menu_buttons() {
+        // Regression: on a standard keyboard/pad without dedicated three-key
+        // menu buttons (dedicated_three_key_nav = false), Left/Right must edit
+        // the current row's value, not navigate between rows. Only real
+        // three-key cabinets (dedicated_three_key_nav = true) hijack Left/Right
+        // for Prev/Next row navigation.
+        ensure_i18n();
+        use deadsync_core::input::InputSource;
+        use deadsync_input::{InputEvent, VirtualAction};
+        use std::time::Instant;
+
+        let press = |action| {
+            let now = Instant::now();
+            InputEvent::new(action, 0, true, InputSource::Keyboard, now, 0, now, now)
+        };
+
+        let (mut state, asset_manager) = setup_state();
+        state.policy.dedicated_three_key_nav = false;
+        let speed_row = state
+            .pane()
+            .row_map
+            .display_order()
+            .iter()
+            .position(|&id| id == RowId::SpeedMod)
+            .expect("Speed Mod should be in Main pane");
+        state.pane_mut().selected_row[P1] = speed_row;
+        state.pane_mut().prev_selected_row[P1] = speed_row;
+
+        let before_val = state.speed_mod[P1].value;
+        super::super::input::handle_input(&mut state, &asset_manager, &press(VirtualAction::p1_right));
+
+        assert_eq!(
+            state.pane().selected_row[P1],
+            speed_row,
+            "Right must not move the row cursor without dedicated menu buttons"
+        );
+        assert!(
+            state.speed_mod[P1].value > before_val,
+            "Right must change the selected row's value (was {before_val}, now {})",
+            state.speed_mod[P1].value
+        );
+    }
+
+    #[test]
     fn dispatch_what_comes_next_cycles_and_mirrors() {
         ensure_i18n();
         let (mut state, asset_manager) = setup_state();


### PR DESCRIPTION
## Problem

On the **Player Options** screen, Left/Right were hijacked for Prev/Next **row** navigation on any device *without* dedicated three-key menu buttons — e.g. a standard keyboard where `P1_MenuLeft`/`Right` are unbound, so `policy.dedicated_three_key_nav = false`. As a result Left/Right moved the row cursor instead of editing the selected row's value.

Left/Right should **edit the current row's value**. Only real three-key arcade cabinets (`dedicated_three_key_nav = true`) should repurpose Left/Right for Prev/Next row navigation.

## Root cause

The gate in `handle_input_inner` (`player_options/input.rs`) was inverted:

```rust
let three_key_action = (!dedicated_three_key)
    .then(|| screen_input::three_key_menu_action(...))
    .flatten();
```

Every other screen (`options/input.rs`, `menu.rs`, `groovestats_login.rs`, `manage_local_profiles.rs`, `select_course.rs`, `pack_sync.rs`) enables three-key nav only when `dedicated_three_key_nav` is true. Player Options was the lone outlier.

## Fix

Drop the `!` so three-key nav only engages on dedicated cabinets. Added a regression test `keyboard_left_right_edit_values_without_dedicated_menu_buttons` asserting that with `dedicated_three_key_nav = false`, Right edits the selected row's value and does not move the row cursor.

## Testing

- `cargo test -p deadsync-theme-simply-love player_options::` → **78 passed, 0 failed** (includes the new regression test).
- The unrelated, pre-existing `eval_grades::exact_one_w2_uses_clipped_affluent_after_fade` failure on `main` is out of scope for this change.