### PR TITLE
Fixed Little modifier by using actual beat position

### DIFF
--- a/crates/deadsync-gameplay/src/chart_transforms.rs
+++ b/crates/deadsync-gameplay/src/chart_transforms.rs
@@ -2098,7 +2098,7 @@ pub fn apply_uncommon_masks_with_masks(
     _player: usize,
 ) {
     if (remove_mask & REMOVE_MASK_BIT_LITTLE) != 0 {
-        notes.retain(|note| (note.beat - note.beat.round()).abs() < 0.0001);
+        notes.retain(|note| beat_to_note_row(note.beat) % ROWS_PER_BEAT == 0);
     }
 
     if (holds_mask & HOLDS_MASK_BIT_NO_ROLLS) != 0 {

--- a/crates/deadsync-gameplay/src/chart_transforms.rs
+++ b/crates/deadsync-gameplay/src/chart_transforms.rs
@@ -2098,8 +2098,7 @@ pub fn apply_uncommon_masks_with_masks(
     _player: usize,
 ) {
     if (remove_mask & REMOVE_MASK_BIT_LITTLE) != 0 {
-        let rows_per_beat = ROWS_PER_BEAT.max(1) as usize;
-        notes.retain(|note| note.row_index % rows_per_beat == 0);
+        notes.retain(|note| (note.beat - note.beat.round()).abs() < 0.0001);
     }
 
     if (holds_mask & HOLDS_MASK_BIT_NO_ROLLS) != 0 {

--- a/crates/deadsync-gameplay/src/tests.rs
+++ b/crates/deadsync-gameplay/src/tests.rs
@@ -19081,7 +19081,7 @@ mod tests {
         assert!(
             notes
                 .iter()
-                .all(|note| note.row_index % ROWS_PER_BEAT as usize == 0)
+                .all(|note| beat_to_note_row(note.beat) % ROWS_PER_BEAT == 0)
         );
         assert!(notes.iter().all(|note| {
             !note.is_fake
@@ -19091,6 +19091,37 @@ mod tests {
                 && note.hold.is_none()
         }));
         assert!(count_tap_tracks_at_row(&notes, 0, 0, 4) <= 2);
+    }
+
+    #[test]
+    fn little_uses_itg_note_rows_for_compact_chart_indices() {
+        let timing = test_timing(1_000);
+        let near_quarter_beat = 249.0_f32 * 4.0 / 1_000.0;
+        assert_eq!(beat_to_note_row(near_quarter_beat), ROWS_PER_BEAT);
+
+        let mut notes = vec![
+            test_note_at(NoteType::Tap, None, false, 249, near_quarter_beat),
+            test_note_at(NoteType::Tap, None, false, 250, 1.0),
+            test_note_at(NoteType::Tap, None, false, 375, 1.5),
+        ];
+
+        apply_uncommon_masks_with_masks(
+            &mut notes,
+            0,
+            REMOVE_MASK_BIT_LITTLE,
+            0,
+            &timing,
+            0,
+            4,
+            &[],
+            None,
+            0,
+        );
+
+        assert_eq!(
+            notes.iter().map(|note| note.beat).collect::<Vec<_>>(),
+            vec![near_quarter_beat, 1.0]
+        );
     }
 
     #[test]


### PR DESCRIPTION
DeadSync's Little implementation was previously using row_index, which was incorrect because row_index is a compact sequential index rather than the note's actual position within the beat grid. It has been changed to use note.beat, which works properly because it represents the note's actual musical beat position.