### PR TITLE
Fixed backspace key repeat in freeform text boxes

### DIFF
--- a/crates/deadsync-input-native/src/backend/w32_raw_input.rs
+++ b/crates/deadsync-input-native/src/backend/w32_raw_input.rs
@@ -1262,8 +1262,8 @@ pub fn run_keyboard_only(
 mod tests {
     use super::{
         KEYBOARD_CAPTURE_DISABLED, KEYBOARD_CAPTURE_ENABLED, KEYBOARD_CAPTURE_UNKNOWN,
-        RAW_KEY_HELD_SLOTS, RAWINPUTHEADER, hid_report_payload, keyboard_capture_sync_needed,
-        rawinput_uuid, remember_report, report_is_duplicate,
+        RAWINPUTHEADER, hid_report_payload, keyboard_capture_sync_needed, rawinput_uuid,
+        remember_report, report_is_duplicate,
     };
     use std::mem::size_of;
 

--- a/crates/deadsync-input-native/src/backend/w32_raw_input.rs
+++ b/crates/deadsync-input-native/src/backend/w32_raw_input.rs
@@ -964,19 +964,6 @@ where
 }
 
 #[inline(always)]
-const fn update_held_state(
-    held: &mut [bool; RAW_KEY_HELD_SLOTS],
-    slot: usize,
-    pressed: bool,
-) -> bool {
-    if held[slot] == pressed {
-        return false;
-    }
-    held[slot] = pressed;
-    true
-}
-
-#[inline(always)]
 fn handle_keyboard_input(ctx: &mut Ctx) {
     if !WINDOW_FOCUSED.load(Ordering::Relaxed) {
         return;
@@ -1004,14 +991,15 @@ fn handle_keyboard_input(ctx: &mut Ctx) {
         let Some((code, slot)) = raw_keyboard_code(keyboard) else {
             return;
         };
-        if !update_held_state(&mut ctx.held, slot, pressed) {
-            return;
-        }
+
+        let repeat = pressed && ctx.held[slot];
+        ctx.held[slot] = pressed;
+
         let (timestamp, host_nanos) = ctx.host.sample_time();
         (ctx.emit_key)(RawKeyboardEvent {
             code,
             pressed,
-            repeat: false,
+            repeat,
             timestamp,
             host_nanos,
         });
@@ -1275,7 +1263,7 @@ mod tests {
     use super::{
         KEYBOARD_CAPTURE_DISABLED, KEYBOARD_CAPTURE_ENABLED, KEYBOARD_CAPTURE_UNKNOWN,
         RAW_KEY_HELD_SLOTS, RAWINPUTHEADER, hid_report_payload, keyboard_capture_sync_needed,
-        rawinput_uuid, remember_report, report_is_duplicate, update_held_state,
+        rawinput_uuid, remember_report, report_is_duplicate,
     };
     use std::mem::size_of;
 
@@ -1295,16 +1283,6 @@ mod tests {
         let (payload, report_size) = hid_report_payload(&mut message, message_len).unwrap();
         assert_eq!(payload, [1, 2, 3, 4, 5, 6]);
         assert_eq!(payload.chunks_exact(report_size).len(), 2);
-    }
-
-    #[test]
-    fn held_state_gate_accepts_only_keyboard_edges() {
-        let mut held = [false; RAW_KEY_HELD_SLOTS];
-
-        assert!(update_held_state(&mut held, 7, true));
-        assert!(!update_held_state(&mut held, 7, true));
-        assert!(update_held_state(&mut held, 7, false));
-        assert!(!update_held_state(&mut held, 7, false));
     }
 
     #[test]

--- a/crates/deadsync-theme-simply-love/src/screens/options/download_packs.rs
+++ b/crates/deadsync-theme-simply-love/src/screens/options/download_packs.rs
@@ -551,6 +551,8 @@ fn handle_raw_input(
     let DownloadPacksOverlayState::Visible(data) = state else {
         return InputOutcome::None;
     };
+    // Text deletion may repeat; activation and confirmation need a fresh press.
+    let key = key.filter(|key| !key.repeat || key.code == KeyCode::Backspace);
     if data.confirm.is_some() {
         let Some(key) = key.filter(|key| key.pressed) else {
             return InputOutcome::None;
@@ -1896,6 +1898,87 @@ mod tests {
         };
         assert!(data.confirm.is_some());
         assert!(data.query.is_empty());
+    }
+
+    #[test]
+    fn held_enter_requires_a_fresh_press_to_confirm_download() {
+        let snapshot = test_snapshot(vec![test_pack(7, "Test Pack", None)]);
+        for code in [KeyCode::Enter, KeyCode::NumpadEnter] {
+            let mut state = DownloadPacksOverlayState::Hidden;
+            show_overlay(&mut state, &snapshot, &[]);
+            assert_eq!(
+                handle_raw_input(
+                    &mut state,
+                    Some(&raw_key(code, true, true)),
+                    None,
+                    &snapshot
+                ),
+                InputOutcome::None,
+            );
+            assert!(!overlay_confirming(&state));
+            assert_eq!(
+                handle_raw_input(
+                    &mut state,
+                    Some(&raw_key(code, true, false)),
+                    None,
+                    &snapshot
+                ),
+                InputOutcome::Activated,
+            );
+            assert!(overlay_confirming(&state));
+            assert_eq!(
+                handle_raw_input(
+                    &mut state,
+                    Some(&raw_key(code, true, true)),
+                    None,
+                    &snapshot
+                ),
+                InputOutcome::None,
+                "one physical Enter press must not also confirm the download",
+            );
+            assert!(overlay_confirming(&state));
+            assert_eq!(
+                handle_raw_input(
+                    &mut state,
+                    Some(&raw_key(code, false, false)),
+                    None,
+                    &snapshot
+                ),
+                InputOutcome::None,
+            );
+            assert_eq!(
+                handle_raw_input(
+                    &mut state,
+                    Some(&raw_key(code, true, false)),
+                    None,
+                    &snapshot
+                ),
+                InputOutcome::Download(7),
+            );
+        }
+    }
+
+    #[test]
+    fn backspace_repeat_edits_query() {
+        let snapshot = test_snapshot(vec![]);
+        let mut state = DownloadPacksOverlayState::Hidden;
+        show_overlay(&mut state, &snapshot, &[]);
+        handle_raw_input(&mut state, None, Some("abc"), &snapshot);
+        for repeat in [false, true] {
+            assert_eq!(
+                handle_raw_input(
+                    &mut state,
+                    Some(&raw_key(KeyCode::Backspace, true, repeat)),
+                    None,
+                    &snapshot
+                ),
+                InputOutcome::Edited,
+            );
+        }
+        let DownloadPacksOverlayState::Visible(data) = state else {
+            panic!("overlay hidden")
+        };
+        assert_eq!(data.query, "a");
     }
 
     #[test]

--- a/crates/deadsync-theme-simply-love/src/screens/pad_config.rs
+++ b/crates/deadsync-theme-simply-love/src/screens/pad_config.rs
@@ -3424,6 +3424,51 @@ mod tests {
     }
 
     #[test]
+    fn held_delete_requires_a_fresh_press_to_confirm_profile_deletion() {
+        use crate::screens::select_music;
+        use deadsync_input::{KeyCode, RawKeyboardEvent};
+        let mut pad = with_pad();
+        set_save_available(&mut pad, true);
+        begin_profiles(&mut pad);
+        set_profiles(
+            &mut pad,
+            vec![ProfileListEntry {
+                name: "Test Config".into(),
+                is_default: false,
+                is_active: false,
+            }],
+        );
+        apply_edit(&mut pad, &ev(VirtualAction::p1_down), false);
+        assert_eq!(selected_profile_name(&pad).as_deref(), Some("Test Config"));
+        let mut state = select_music::init_placeholder();
+        state.pad_config_overlay_visible = true;
+        state.pad_config_overlay = pad;
+        let mut effects = Vec::new();
+        let mut key = RawKeyboardEvent {
+            code: KeyCode::Delete,
+            pressed: true,
+            repeat: false,
+            timestamp: std::time::Instant::now(),
+            host_nanos: 0,
+        };
+        select_music::handle_raw_key_event(&mut state, Some(&key), None, &mut effects);
+        assert!(state.pad_config_overlay.delete_armed);
+        key.repeat = true;
+        select_music::handle_raw_key_event(&mut state, Some(&key), None, &mut effects);
+        assert!(
+            state.pad_config_overlay.delete_armed,
+            "a repeat must leave deletion awaiting a second physical press"
+        );
+        key.pressed = false;
+        key.repeat = false;
+        select_music::handle_raw_key_event(&mut state, Some(&key), None, &mut effects);
+        assert!(state.pad_config_overlay.delete_armed);
+        key.pressed = true;
+        select_music::handle_raw_key_event(&mut state, Some(&key), None, &mut effects);
+        assert!(!state.pad_config_overlay.delete_armed);
+    }
+
+    #[test]
     fn profiles_save_new_row_opens_the_save_box() {
         let mut s = with_pad();
         set_save_available(&mut s, true);

--- a/crates/deadsync-theme-simply-love/src/screens/select_music.rs
+++ b/crates/deadsync-theme-simply-love/src/screens/select_music.rs
@@ -11316,6 +11316,7 @@ fn handle_raw_key_event_impl(
         if pad_config::is_profiles_mode(&state.pad_config_overlay) {
             if let Some(k) = key
                 && k.pressed
+                && !k.repeat
             {
                 match k.code {
                     KeyCode::KeyR => {


### PR DESCRIPTION
On the pack download screen, the song search screen, new judgement palette screen, etc., key repeat works properly for other keys, but backspace has to be pressed multiple times to delete an entry. This fixes the issue, allowing the user to hold down backspace and quickly delete text.