### PR TITLE
fix(theme): pin AFT capture scratch Vec types to fix E0275 build error

### DIFF
--- a/crates/deadsync-theme-simply-love/src/screens/gameplay.rs
+++ b/crates/deadsync-theme-simply-love/src/screens/gameplay.rs
@@ -2477,13 +2477,13 @@ impl State {
             &song_lua_visuals.overlays,
             &song_lua_proxy_request_index.topology,
         );
-        let song_lua_background_aft_capture_scratch = song_lua_visuals
+        let song_lua_background_aft_capture_scratch: Vec<_> = song_lua_visuals
             .background_visual_layers
             .iter()
             .zip(song_lua_background_overlay_topology_indices.iter())
             .map(|(layer, topology)| SongLuaAftCaptureScratch::new(&layer.overlays, topology))
             .collect();
-        let song_lua_foreground_aft_capture_scratch = song_lua_visuals
+        let song_lua_foreground_aft_capture_scratch: Vec<_> = song_lua_visuals
             .foreground_visual_layers
             .iter()
             .zip(song_lua_foreground_proxy_request_indices.iter())


### PR DESCRIPTION
The bare `.collect()` calls left the background/foreground scratch types as inference variables when `.chain(&...)` needed `&_: IntoIterator`, and the trait solver recursed into objc2's `&Retained<T>: IntoIterator` blanket impl until it hit the recursion limit.